### PR TITLE
Claude Code hooks as an event-driven status source

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Rule struct {
 
 type Tool struct {
 	Command        string `toml:"command"`
+	StatusSource   string `toml:"status_source"`
 	DefaultStatus  string `toml:"default_status"`
 	ActivityCutoff string `toml:"activity_cutoff"`
 	TurnEnd        string `toml:"turn_end"`
@@ -141,6 +142,8 @@ const defaultConfig = `poll_interval = "2s"
 
 [tools.claude]
 command = "claude"
+# hooks report status events directly; the pane rules below stay as fallback
+status_source = "claude-hooks"
 default_status = "idle"
 activity_cutoff = "(?m)^❯"
 turn_end = "^[✻✳✶✽✢·✦✧+*] \\S+ for \\d.*$"

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,0 +1,133 @@
+// Package hooks wires Claude Code hook events into status files: each
+// managed session gets AGENT_MANAGER_STATUS_FILE in its environment, and
+// the generated settings file makes Claude Code write its lifecycle state
+// there. The poller reads these files as a tier-1 status source, ahead of
+// the pane-regex heuristics.
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+)
+
+const EnvStatusFile = "AGENT_MANAGER_STATUS_FILE"
+
+// StatusSourceClaude is the status_source config value that enables this
+// package for a tool.
+const StatusSourceClaude = "claude-hooks"
+
+const settingsName = "claude-settings.json"
+
+type Manager struct {
+	dir string
+}
+
+func NewManager(configDir string) *Manager {
+	return &Manager{dir: filepath.Join(configDir, "hooks")}
+}
+
+type hookCommand struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+type hookMatcher struct {
+	Matcher string        `json:"matcher,omitempty"`
+	Hooks   []hookCommand `json:"hooks"`
+}
+
+type settingsFile struct {
+	Hooks map[string][]hookMatcher `json:"hooks"`
+}
+
+// statusCommand always exits 0 and no-ops outside managed sessions, so
+// the settings file is harmless if Claude Code loads it elsewhere.
+func statusCommand(state string) string {
+	return `[ -z "$` + EnvStatusFile + `" ] || printf ` + state + ` > "$` + EnvStatusFile + `"`
+}
+
+// notificationCommand filters the payload on stdin: Claude Code fires
+// Notification both for permission prompts and for the 60-second idle
+// "waiting for your input" reminder, and only the former means the agent
+// is blocked.
+func notificationCommand() string {
+	return `[ -z "$` + EnvStatusFile + `" ] || grep -q "waiting for your input" || printf ` + status.Waiting + ` > "$` + EnvStatusFile + `"`
+}
+
+func settingsContent() ([]byte, error) {
+	report := func(matcher, state string) []hookMatcher {
+		return []hookMatcher{{Matcher: matcher, Hooks: []hookCommand{{Type: "command", Command: statusCommand(state)}}}}
+	}
+	content := settingsFile{Hooks: map[string][]hookMatcher{
+		"UserPromptSubmit": report("", status.Working),
+		"PreToolUse":       report("*", status.Working),
+		"PostToolUse":      report("*", status.Working),
+		"Notification":     {{Hooks: []hookCommand{{Type: "command", Command: notificationCommand()}}}},
+		"Stop":             report("", status.Finished),
+		// compact fires SessionStart in the middle of an active turn
+		"SessionStart": report("startup|resume|clear", status.Idle),
+		"SessionEnd": {{Hooks: []hookCommand{{
+			Type:    "command",
+			Command: `[ -z "$` + EnvStatusFile + `" ] || rm -f "$` + EnvStatusFile + `"`,
+		}}}},
+	}}
+	return json.MarshalIndent(content, "", "  ")
+}
+
+// EnsureSettings writes the hook settings file, refreshing it when the
+// wanted content changed (e.g. after an upgrade), and returns its path.
+func (m *Manager) EnsureSettings() (string, error) {
+	if err := os.MkdirAll(m.dir, 0o755); err != nil {
+		return "", err
+	}
+	wanted, err := settingsContent()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(m.dir, settingsName)
+	existing, err := os.ReadFile(path)
+	if err == nil && bytes.Equal(existing, wanted) {
+		return path, nil
+	}
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return "", err
+	}
+	if err := os.WriteFile(path, wanted, 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (m *Manager) StatusFile(id string) string {
+	return filepath.Join(m.dir, id+".status")
+}
+
+// Read returns the hook-reported status for a session. The file is
+// written by shell hooks, so anything but a known status is rejected.
+func (m *Manager) Read(id string) (string, bool) {
+	raw, err := os.ReadFile(m.StatusFile(id))
+	if err != nil {
+		return "", false
+	}
+	state := strings.TrimSpace(string(raw))
+	switch state {
+	case status.Working, status.Waiting, status.Finished, status.Idle:
+		return state, true
+	}
+	return "", false
+}
+
+func (m *Manager) Remove(id string) error {
+	err := os.Remove(m.StatusFile(id))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1,0 +1,149 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+)
+
+func TestEnsureSettingsWritesValidHookJSON(t *testing.T) {
+	manager := NewManager(t.TempDir())
+	path, err := manager.EnsureSettings()
+	if err != nil {
+		t.Fatalf("EnsureSettings: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var parsed struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("settings is not valid JSON: %v", err)
+	}
+	events := []string{"UserPromptSubmit", "PreToolUse", "PostToolUse", "Notification", "Stop", "SessionStart", "SessionEnd"}
+	if len(parsed.Hooks) != len(events) {
+		t.Fatalf("hooks has %d events, want %d: %v", len(parsed.Hooks), len(events), parsed.Hooks)
+	}
+	guard := `[ -z "$` + EnvStatusFile + `" ] ||`
+	for _, event := range events {
+		matchers, ok := parsed.Hooks[event]
+		if !ok {
+			t.Fatalf("event %s missing from settings", event)
+		}
+		for _, matcher := range matchers {
+			for _, hook := range matcher.Hooks {
+				if hook.Type != "command" {
+					t.Fatalf("event %s hook type = %q, want command", event, hook.Type)
+				}
+				if !strings.Contains(hook.Command, guard) {
+					t.Fatalf("event %s command lacks env guard: %q", event, hook.Command)
+				}
+			}
+		}
+	}
+	for _, event := range []string{"PreToolUse", "PostToolUse"} {
+		if got := parsed.Hooks[event][0].Matcher; got != "*" {
+			t.Fatalf("%s matcher = %q, want *", event, got)
+		}
+	}
+}
+
+func TestEnsureSettingsIdempotent(t *testing.T) {
+	manager := NewManager(t.TempDir())
+	first, err := manager.EnsureSettings()
+	if err != nil {
+		t.Fatalf("first EnsureSettings: %v", err)
+	}
+	info, err := os.Stat(first)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	second, err := manager.EnsureSettings()
+	if err != nil {
+		t.Fatalf("second EnsureSettings: %v", err)
+	}
+	if first != second {
+		t.Fatalf("paths differ: %q vs %q", first, second)
+	}
+	again, err := os.Stat(second)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if !info.ModTime().Equal(again.ModTime()) {
+		t.Fatal("unchanged settings should not be rewritten")
+	}
+}
+
+func TestStatusFilePath(t *testing.T) {
+	configDir := t.TempDir()
+	manager := NewManager(configDir)
+	want := filepath.Join(configDir, "hooks", "abcd1234.status")
+	if got := manager.StatusFile("abcd1234"); got != want {
+		t.Fatalf("StatusFile = %q, want %q", got, want)
+	}
+}
+
+func TestReadWhitelist(t *testing.T) {
+	manager := NewManager(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(manager.StatusFile("x")), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeStatus := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(manager.StatusFile("x"), []byte(content), 0o644); err != nil {
+			t.Fatalf("write status: %v", err)
+		}
+	}
+
+	for _, valid := range []string{status.Working, status.Waiting, status.Finished, status.Idle} {
+		writeStatus(valid)
+		got, ok := manager.Read("x")
+		if !ok || got != valid {
+			t.Fatalf("Read(%q) = %q, %v; want value, true", valid, got, ok)
+		}
+	}
+
+	writeStatus("working\n")
+	if got, ok := manager.Read("x"); !ok || got != status.Working {
+		t.Fatalf("trailing newline should trim to working, got %q, %v", got, ok)
+	}
+
+	for _, invalid := range []string{"garbage", "", "dead"} {
+		writeStatus(invalid)
+		if got, ok := manager.Read("x"); ok {
+			t.Fatalf("Read(%q) accepted %q, want rejection", invalid, got)
+		}
+	}
+
+	if _, ok := manager.Read("no-such-session"); ok {
+		t.Fatal("missing file should not read ok")
+	}
+}
+
+func TestRemoveIdempotent(t *testing.T) {
+	manager := NewManager(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(manager.StatusFile("x")), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(manager.StatusFile("x"), []byte(status.Working), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := manager.Remove("x"); err != nil {
+		t.Fatalf("first Remove: %v", err)
+	}
+	if err := manager.Remove("x"); err != nil {
+		t.Fatalf("second Remove should be a no-op: %v", err)
+	}
+}

--- a/internal/sysstat/sysstat.go
+++ b/internal/sysstat/sysstat.go
@@ -34,6 +34,7 @@ type Snapshot struct {
 type ProcStat struct {
 	CPUPercent float64
 	RSS        uint64
+	Procs      int
 	OK         bool
 }
 
@@ -129,6 +130,7 @@ func Trees(rootPIDs []int) map[int]ProcStat {
 				return
 			}
 			seen[pid] = true
+			stat.Procs++
 			stat.CPUPercent += procs[pid].cpu
 			stat.RSS += procs[pid].rss
 			for _, child := range children[pid] {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"fmt"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -33,7 +34,7 @@ func (d *Driver) run(args ...string) (string, error) {
 	return string(out), nil
 }
 
-func (d *Driver) Create(id, cwd, command string) error {
+func (d *Driver) Create(id, cwd, command string, env map[string]string) error {
 	name := sessionName(id)
 	if _, err := d.run("new-session", "-d", "-s", name, "-c", cwd); err != nil {
 		return err
@@ -41,12 +42,29 @@ func (d *Driver) Create(id, cwd, command string) error {
 	if err := d.installSessionUX(name); err != nil {
 		return err
 	}
-	if command != "" {
-		if _, err := d.run("send-keys", "-t", name, command, "Enter"); err != nil {
-			return err
-		}
+	if command == "" {
+		return nil
 	}
-	return nil
+	// env rides the command line as VAR=value prefixes because
+	// new-session -e needs tmux >= 3.2
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var line strings.Builder
+	for _, key := range keys {
+		line.WriteString(key + "=" + ShellQuote(env[key]) + " ")
+	}
+	line.WriteString(command)
+	_, err := d.run("send-keys", "-t", name, line.String(), "Enter")
+	return err
+}
+
+// ShellQuote wraps a string in single quotes for POSIX sh; the config
+// dir on macOS contains a space, so paths sent into panes must be quoted.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // installSessionUX adds a status-bar hint and a Ctrl+Q detach binding.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -40,6 +40,7 @@ func (d *Driver) Create(id, cwd, command string, env map[string]string) error {
 		return err
 	}
 	if err := d.installSessionUX(name); err != nil {
+		_ = d.Kill(id)
 		return err
 	}
 	if command == "" {
@@ -57,8 +58,11 @@ func (d *Driver) Create(id, cwd, command string, env map[string]string) error {
 		line.WriteString(key + "=" + ShellQuote(env[key]) + " ")
 	}
 	line.WriteString(command)
-	_, err := d.run("send-keys", "-t", name, line.String(), "Enter")
-	return err
+	if _, err := d.run("send-keys", "-t", name, line.String(), "Enter"); err != nil {
+		_ = d.Kill(id)
+		return err
+	}
+	return nil
 }
 
 // ShellQuote wraps a string in single quotes for POSIX sh; the config

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -23,7 +23,7 @@ func requireTmux(t *testing.T) *Driver {
 func TestSetLabelNeutralizesFormatStrings(t *testing.T) {
 	driver := requireTmux(t)
 	id := "lbl" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
-	if err := driver.Create(id, "/tmp", ""); err != nil {
+	if err := driver.Create(id, "/tmp", "", nil); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	t.Cleanup(func() { driver.Kill(id) })
@@ -51,7 +51,7 @@ func TestLifecycle(t *testing.T) {
 	id := "test" + time.Now().Format("150405.000000")
 	id = strings.ReplaceAll(id, ".", "")
 
-	if err := driver.Create(id, "/tmp", "printf 'hello-pane-marker'"); err != nil {
+	if err := driver.Create(id, "/tmp", "printf 'hello-pane-marker'", nil); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	t.Cleanup(func() { driver.Kill(id) })

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -6,7 +6,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/tmux"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -296,7 +298,22 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 	group := m.selectedGroupPath()
 
 	id := newID()
-	if err := m.tmux.Create(id, dir, tool.Command); err != nil {
+	command := tool.Command
+	var env map[string]string
+	if tool.StatusSource == hooks.StatusSourceClaude {
+		settingsPath, err := m.hooks.EnsureSettings()
+		if err != nil {
+			m.err = err.Error()
+			return m, nil
+		}
+		if err := m.hooks.Remove(id); err != nil {
+			m.err = err.Error()
+			return m, nil
+		}
+		env = map[string]string{hooks.EnvStatusFile: m.hooks.StatusFile(id)}
+		command = tool.Command + " --settings " + tmux.ShellQuote(settingsPath)
+	}
+	if err := m.tmux.Create(id, dir, command, env); err != nil {
 		m.err = err.Error()
 		return m, nil
 	}
@@ -310,6 +327,7 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 	}
 	if err := m.store.CreateSession(sess); err != nil {
 		_ = m.tmux.Kill(id)
+		_ = m.hooks.Remove(id)
 		m.err = err.Error()
 		return m, nil
 	}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -311,6 +311,9 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.err = err.Error()
 				return m, nil
 			}
+			if err := m.hooks.Remove(sess.ID); err != nil {
+				m.err = err.Error()
+			}
 		}
 		if m.confirm.isGroup {
 			if err := m.store.DeleteGroup(m.confirm.path); err != nil {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -307,12 +307,13 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.err = err.Error()
 				return m, nil
 			}
-			if err := m.store.Delete(sess.ID); err != nil {
+			if err := m.hooks.Remove(sess.ID); err != nil {
 				m.err = err.Error()
 				return m, nil
 			}
-			if err := m.hooks.Remove(sess.ID); err != nil {
+			if err := m.store.Delete(sess.ID); err != nil {
 				m.err = err.Error()
+				return m, nil
 			}
 		}
 		if m.confirm.isGroup {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/YoanWai/agent-manager/internal/config"
+	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/sysstat"
@@ -41,6 +42,7 @@ type Model struct {
 	store  *store.Store
 	tmux   *tmux.Driver
 	engine *status.Engine
+	hooks  *hooks.Manager
 
 	sessions   []store.Session
 	rows       []treeRow
@@ -125,13 +127,18 @@ type errMsg struct{ err error }
 
 type attachDoneMsg struct{ err error }
 
-func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status.Engine) *Model {
+func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status.Engine, hookManager *hooks.Manager) *Model {
+	statusSources := make(map[string]string, len(cfg.Tools))
+	for name, tool := range cfg.Tools {
+		statusSources[name] = tool.StatusSource
+	}
 	return &Model{
 		cfg:       cfg,
 		store:     st,
 		tmux:      driver,
 		engine:    engine,
-		poller:    newPoller(st, driver, engine, cfg.PollInterval.Duration),
+		hooks:     hookManager,
+		poller:    newPoller(st, driver, engine, hookManager, statusSources, cfg.PollInterval.Duration),
 		collapsed: map[string]bool{},
 		mode:      modeList,
 	}

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/sysstat"
@@ -17,11 +18,13 @@ import (
 // inside a tmux attach. The UI receives the results as refreshMsg values
 // and merely renders them.
 type poller struct {
-	store    *store.Store
-	tmux     *tmux.Driver
-	engine   *status.Engine
-	interval time.Duration
-	poke     chan struct{}
+	store         *store.Store
+	tmux          *tmux.Driver
+	engine        *status.Engine
+	hooks         *hooks.Manager
+	statusSources map[string]string
+	interval      time.Duration
+	poke          chan struct{}
 
 	mu              sync.Mutex
 	includeArchived bool
@@ -34,14 +37,16 @@ type poller struct {
 	tick       int
 }
 
-func newPoller(st *store.Store, driver *tmux.Driver, engine *status.Engine, interval time.Duration) *poller {
+func newPoller(st *store.Store, driver *tmux.Driver, engine *status.Engine, hookManager *hooks.Manager, statusSources map[string]string, interval time.Duration) *poller {
 	return &poller{
-		store:      st,
-		tmux:       driver,
-		engine:     engine,
-		interval:   interval,
-		poke:       make(chan struct{}, 1),
-		paneHashes: map[string]uint64{},
+		store:         st,
+		tmux:          driver,
+		engine:        engine,
+		hooks:         hookManager,
+		statusSources: statusSources,
+		interval:      interval,
+		poke:          make(chan struct{}, 1),
+		paneHashes:    map[string]uint64{},
 	}
 }
 
@@ -136,7 +141,8 @@ func (p *poller) refreshOnce() tea.Msg {
 		}
 		newStatus := status.Dead
 		if pid := panes[sess.ID]; pid > 0 {
-			if stat := trees[pid]; stat.OK {
+			stat := trees[pid]
+			if stat.OK {
 				agents.count++
 				agents.cpu += stat.CPUPercent
 				agents.rss += stat.RSS
@@ -144,8 +150,16 @@ func (p *poller) refreshOnce() tea.Msg {
 					proc = stat
 				}
 			}
+			// The pane pid is the shell; the agent runs as its child. A
+			// tree of one process means the agent is gone. A failed ps
+			// sample proves nothing, so it counts as alive.
+			agentAlive := !stat.OK || stat.Procs > 1
 			if pane, err := p.tmux.CapturePane(sess.ID); err == nil {
-				newStatus = p.derivePaneStatus(sess, pane, paneHashes)
+				derived, err := p.derivePaneStatus(sess, pane, agentAlive, paneHashes)
+				if err != nil {
+					return errMsg{err}
+				}
+				newStatus = derived
 				// Any real transition re-arms the finished alert.
 				if sess.Acked && newStatus != status.Idle && newStatus != status.Finished {
 					if err := p.store.SetAcked(sess.ID, false); err != nil {
@@ -201,20 +215,57 @@ func (p *poller) refreshOnce() tea.Msg {
 // since the previous poll, the session counts as working. Finished is an
 // alert: entering the session acknowledges it (acked), and the pane keeps
 // deriving finished until the next turn, so acked maps it back to idle.
-func (p *poller) derivePaneStatus(sess store.Session, pane string, paneHashes map[string]uint64) string {
+func (p *poller) derivePaneStatus(sess store.Session, pane string, agentAlive bool, paneHashes map[string]uint64) (string, error) {
 	text := ansi.Strip(pane)
-	newStatus, matched := p.engine.Match(sess.Tool, text)
-	if region, ok := p.engine.ActivityRegion(sess.Tool, text); ok {
-		hash := hashString(region)
-		paneHashes[sess.ID] = hash
-		if !matched {
-			if previous, seen := p.paneHashes[sess.ID]; seen && previous != hash {
-				newStatus = status.Working
+	region, hasRegion := p.engine.ActivityRegion(sess.Tool, text)
+	var regionHash uint64
+	if hasRegion {
+		regionHash = hashString(region)
+		paneHashes[sess.ID] = regionHash
+	}
+	if p.statusSources[sess.Tool] == hooks.StatusSourceClaude {
+		if hookStatus, ok := p.hooks.Read(sess.ID); ok {
+			if agentAlive {
+				return p.applyHookStatus(sess, text, hookStatus), nil
 			}
+			// The agent died without its SessionEnd cleanup hook
+			// (crash, SIGKILL); a stale file must not mask the pane.
+			if err := p.hooks.Remove(sess.ID); err != nil {
+				return "", err
+			}
+		}
+	}
+	newStatus, matched := p.engine.Match(sess.Tool, text)
+	if hasRegion && !matched {
+		if previous, seen := p.paneHashes[sess.ID]; seen && previous != regionHash {
+			newStatus = status.Working
 		}
 	}
 	if newStatus == status.Finished && sess.Acked {
 		newStatus = status.Idle
 	}
-	return newStatus
+	return newStatus, nil
+}
+
+// applyHookStatus trusts the hook-reported status over pane heuristics
+// for the states hooks can see. They cannot see a plain-text question,
+// an interrupt banner, or an error line, so a matched pane verdict
+// upgrades finished to waiting or errored, and working to waiting (an
+// Esc interrupt fires no Stop event).
+func (p *poller) applyHookStatus(sess store.Session, text, hookStatus string) string {
+	paneStatus, matched := p.engine.Match(sess.Tool, text)
+	switch hookStatus {
+	case status.Finished:
+		if matched && (paneStatus == status.Waiting || paneStatus == status.Errored) {
+			return paneStatus
+		}
+		if sess.Acked {
+			return status.Idle
+		}
+	case status.Working:
+		if matched && paneStatus == status.Waiting {
+			return status.Waiting
+		}
+	}
+	return hookStatus
 }

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -224,15 +224,14 @@ func (p *poller) derivePaneStatus(sess store.Session, pane string, agentAlive bo
 		paneHashes[sess.ID] = regionHash
 	}
 	if p.statusSources[sess.Tool] == hooks.StatusSourceClaude {
-		if hookStatus, ok := p.hooks.Read(sess.ID); ok {
-			if agentAlive {
-				return p.applyHookStatus(sess, text, hookStatus), nil
-			}
+		if !agentAlive {
 			// The agent died without its SessionEnd cleanup hook
 			// (crash, SIGKILL); a stale file must not mask the pane.
 			if err := p.hooks.Remove(sess.ID); err != nil {
 				return "", err
 			}
+		} else if hookStatus, ok := p.hooks.Read(sess.ID); ok {
+			return p.applyHookStatus(sess, text, hookStatus), nil
 		}
 	}
 	newStatus, matched := p.engine.Match(sess.Tool, text)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,12 +1,14 @@
 package ui
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/YoanWai/agent-manager/internal/config"
+	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
@@ -21,6 +23,17 @@ func buildModel(t *testing.T) *Model {
 	cfg := config.Config{
 		Tools: map[string]config.Tool{
 			"claude": {Command: "cat", DefaultStatus: status.Idle},
+			"claude-hooked": {
+				Command:        "cat",
+				StatusSource:   "claude-hooks",
+				DefaultStatus:  status.Idle,
+				ActivityCutoff: "(?m)^❯",
+				TurnEnd:        `^[✻✳✶✽✢·✦✧+*] \S+ for \d.*$`,
+				Rules: []config.Rule{
+					{State: status.Waiting, Pattern: "Enter to confirm"},
+					{State: status.Errored, Pattern: `(?im)^\s*error:`},
+				},
+			},
 		},
 	}
 	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
@@ -38,7 +51,7 @@ func buildModel(t *testing.T) *Model {
 		t.Fatalf("engine: %v", err)
 	}
 
-	m := New(cfg, st, driver, engine)
+	m := New(cfg, st, driver, engine, hooks.NewManager(t.TempDir()))
 	m.width = 120
 	m.height = 40
 	t.Cleanup(func() {
@@ -436,6 +449,100 @@ func TestGroupDefaultPathFillsSessionDir(t *testing.T) {
 	m.moveGroupCursor(0) // re-resolve dir for the selected group
 	if got := m.form.dir.Value(); got != groupDir {
 		t.Fatalf("session dir should default to the group path %q, got %q", groupDir, got)
+	}
+}
+
+func writeHookStatus(t *testing.T, m *Model, id, state string) {
+	t.Helper()
+	path := m.hooks.StatusFile(id)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(state), 0o644); err != nil {
+		t.Fatalf("write hook status: %v", err)
+	}
+}
+
+func deriveStatus(t *testing.T, m *Model, sess store.Session, pane string, agentAlive bool) string {
+	t.Helper()
+	got, err := m.poller.derivePaneStatus(sess, pane, agentAlive, map[string]uint64{})
+	if err != nil {
+		t.Fatalf("derivePaneStatus: %v", err)
+	}
+	return got
+}
+
+func TestHookStatusDerivesFinishedAndIdleWhenAcked(t *testing.T) {
+	m := buildModel(t)
+	sess := store.Session{ID: "hooked01", Tool: "claude-hooked"}
+	pane := "some output\n❯ \n"
+	writeHookStatus(t, m, sess.ID, status.Finished)
+
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Finished {
+		t.Fatalf("hook finished should derive finished, got %q", got)
+	}
+
+	sess.Acked = true
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Idle {
+		t.Fatalf("acked hook finished should derive idle, got %q", got)
+	}
+}
+
+func TestHookWorkingWinsOverUnmatchedPane(t *testing.T) {
+	m := buildModel(t)
+	sess := store.Session{ID: "hooked02", Tool: "claude-hooked"}
+	writeHookStatus(t, m, sess.ID, status.Working)
+
+	pane := "plain streaming text no rule matches\n❯ \n"
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Working {
+		t.Fatalf("hook working should win, got %q", got)
+	}
+}
+
+func TestHookFinishedUpgradesToWaitingOnQuestionTurn(t *testing.T) {
+	m := buildModel(t)
+	sess := store.Session{ID: "hooked03", Tool: "claude-hooked"}
+	writeHookStatus(t, m, sess.ID, status.Finished)
+
+	pane := "Do you want me to proceed?\n\n✻ Baked for 5s\n\n❯ \n"
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Waiting {
+		t.Fatalf("question turn should upgrade hook finished to waiting, got %q", got)
+	}
+}
+
+func TestHookFinishedUpgradesToErroredOnErrorLine(t *testing.T) {
+	m := buildModel(t)
+	sess := store.Session{ID: "hooked04", Tool: "claude-hooked"}
+	writeHookStatus(t, m, sess.ID, status.Finished)
+
+	pane := "error: something broke\n❯ \n"
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Errored {
+		t.Fatalf("error line should upgrade hook finished to errored, got %q", got)
+	}
+}
+
+func TestHookWorkingUpgradesToWaitingOnPaneMatch(t *testing.T) {
+	m := buildModel(t)
+	sess := store.Session{ID: "hooked05", Tool: "claude-hooked"}
+	writeHookStatus(t, m, sess.ID, status.Working)
+
+	pane := "Enter to confirm\n❯ \n"
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Waiting {
+		t.Fatalf("waiting pane verdict should upgrade hook working, got %q", got)
+	}
+}
+
+func TestStaleHookFileFallsBackToPaneRules(t *testing.T) {
+	m := buildModel(t)
+	sess := store.Session{ID: "hooked06", Tool: "claude-hooked"}
+	writeHookStatus(t, m, sess.ID, status.Working)
+
+	pane := "shell prompt after a crash\n❯ \n"
+	if got := deriveStatus(t, m, sess, pane, false); got != status.Idle {
+		t.Fatalf("dead agent should fall back to pane rules, got %q", got)
+	}
+	if _, ok := m.hooks.Read(sess.ID); ok {
+		t.Fatal("stale hook status file should be removed")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/YoanWai/agent-manager/internal/config"
+	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
@@ -49,7 +50,7 @@ func run() error {
 	}
 	defer st.Close()
 
-	model := ui.New(cfg, st, driver, engine)
+	model := ui.New(cfg, st, driver, engine, hooks.NewManager(dir))
 	program := tea.NewProgram(model, tea.WithAltScreen())
 	model.StartPoller(program.Send)
 	_, err = program.Run()


### PR DESCRIPTION
## What

Claude Code sessions now report their status through hooks instead of pane scraping. A tool configured with `status_source = "claude-hooks"` (the default for `claude`) launches with a generated hook settings file and a per-session status file path in its environment; hook events write the status directly:

| Event | Status |
|-------|--------|
| UserPromptSubmit, Pre/PostToolUse | `working` |
| Notification (permission asks; the 60s idle reminder is filtered out) | `waiting` |
| Stop | `finished` |
| SessionStart (startup/resume/clear) | `idle` |
| SessionEnd | removes the file |

The poller reads the file as tier-1 status while the agent process is alive (pane process tree > 1). A stale file from a crashed agent is removed and pane heuristics take over. Pane analysis still refines hook statuses for signals hooks cannot see: plain-text questions, interrupt banners, and error lines.

## Notes

- Env rides the send-keys command line as `VAR='value'` prefixes, so any tmux version works; sessions whose default shell is fish need a POSIX shell for the launch line.
- Non-hook tools (OpenCode, custom CLIs) keep the existing pane-heuristic path unchanged.

## Verification

- `go build`, `go vet`, `gofmt`, `go test ./...` all green (new: `internal/hooks` unit tests, poller hook-precedence tests, stale-file fallback test).
- Live end-to-end against a real Claude Code (Haiku) session in tmux: startup wrote `idle`, prompt wrote `working`, turn end wrote `finished`, a permission dialog wrote `waiting`, approval resumed to `finished`, `/exit` removed the status file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code lifecycle hook integration for more accurate session statuses, including Working, Waiting, Idle, and Finished.
  * Claude sessions now automatically configure and maintain status tracking.
  * Added process counts to system statistics.
  * Improved command-session environment handling with safe variable quoting.

* **Bug Fixes**
  * Stale session status data is now cleaned up automatically.
  * Status detection better combines hook reports with visible session activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->