### PR TITLE
Revive dead sessions with v

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install tmux
+        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: gofmt
+        run: test -z "$(gofmt -l .)"
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test -race ./...
+      - name: Build
+        run: go build ./...

--- a/README.md
+++ b/README.md
@@ -6,20 +6,31 @@ A terminal UI to manage AI coding-agent sessions on your machine. Create and ent
 
 Status detection currently supports **Claude Code** and **OpenCode** out of the box. Any other CLI tool can run as a session; add a `[tools.<name>]` block with status rules to get live status for it (see [Configuration](#configuration)).
 
-## Requirements
-
-- Go 1.24+
-- tmux
-
 ## Install
 
+### Homebrew (macOS / Linux)
+
 ```bash
-git clone https://github.com/YoanWai/agent-manager.git
-cd agent-manager
-go install .
+brew install yoanwai/tap/agent-manager
 ```
 
-Installs `agent-manager` to `$(go env GOPATH)/bin`.
+Installs tmux with it if missing.
+
+### Go
+
+```bash
+go install github.com/YoanWai/agent-manager@latest
+```
+
+Requires Go 1.24+ and tmux; installs to `$(go env GOPATH)/bin`.
+
+### Prebuilt binaries
+
+Download from [Releases](https://github.com/YoanWai/agent-manager/releases) (macOS and Linux, amd64/arm64).
+
+### Windows
+
+Run inside [WSL2](https://learn.microsoft.com/windows/wsl/install): agent-manager lives on tmux, which is a Linux/macOS tool. In a WSL shell, install with Homebrew or grab the Linux binary from Releases.
 
 ## Usage
 
@@ -40,6 +51,7 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 | `shift+↑` / `shift+↓` | Reorder session or group among its siblings |
 | `m` | Move session to another group |
 | `r` | Rename session or group |
+| `v` | Revive a dead session (`revive_command`, e.g. `claude --continue`, resumes the conversation) |
 | `a` / `u` | Archive / restore |
 | `d` | Delete session, or a group + its entire subtree |
 | `space` | Collapse / expand group |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Rule struct {
 
 type Tool struct {
 	Command        string `toml:"command"`
+	ReviveCommand  string `toml:"revive_command"`
 	StatusSource   string `toml:"status_source"`
 	DefaultStatus  string `toml:"default_status"`
 	ActivityCutoff string `toml:"activity_cutoff"`
@@ -142,6 +143,8 @@ const defaultConfig = `poll_interval = "2s"
 
 [tools.claude]
 command = "claude"
+# used by revive (v) on a dead session; resumes the last conversation there
+revive_command = "claude --continue"
 # hooks report status events directly; the pane rules below stay as fallback
 status_source = "claude-hooks"
 default_status = "idle"
@@ -164,6 +167,7 @@ rules = [
 
 [tools.opencode]
 command = "opencode"
+revive_command = "opencode --continue"
 default_status = "idle"
 activity_cutoff = "(?m)^\\s*╹"
 turn_end = "^\\s*▣ +.+· [\\dhms. ]+\\s*$"

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -154,12 +154,20 @@ func (d *Driver) PanePID(id string) (int, error) {
 	return strconv.Atoi(line)
 }
 
+// noServer recognizes both messages tmux prints when no server is up:
+// "no server running on <socket>" and, on Linux since 3.4, "error
+// connecting to <socket> (No such file or directory)".
+func noServer(out string) bool {
+	return strings.Contains(out, "no server running") ||
+		strings.Contains(out, "error connecting to")
+}
+
 // Panes returns every managed session's pane pid in a single tmux call,
 // which doubles as a liveness check: a session absent from the map is gone.
 func (d *Driver) Panes() (map[string]int, error) {
 	out, err := exec.Command(d.bin, "list-panes", "-a", "-F", "#{session_name} #{pane_pid}").CombinedOutput()
 	if err != nil {
-		if strings.Contains(string(out), "no server running") {
+		if noServer(string(out)) {
 			return map[string]int{}, nil
 		}
 		return nil, fmt.Errorf("tmux list-panes: %w: %s", err, strings.TrimSpace(string(out)))
@@ -184,7 +192,7 @@ func (d *Driver) Panes() (map[string]int, error) {
 func (d *Driver) List() ([]string, error) {
 	out, err := exec.Command(d.bin, "list-sessions", "-F", "#{session_name}").CombinedOutput()
 	if err != nil {
-		if strings.Contains(string(out), "no server running") {
+		if noServer(string(out)) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("tmux list-sessions: %w: %s", err, strings.TrimSpace(string(out)))

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
@@ -298,20 +299,10 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 	group := m.selectedGroupPath()
 
 	id := newID()
-	command := tool.Command
-	var env map[string]string
-	if tool.StatusSource == hooks.StatusSourceClaude {
-		settingsPath, err := m.hooks.EnsureSettings()
-		if err != nil {
-			m.err = err.Error()
-			return m, nil
-		}
-		if err := m.hooks.Remove(id); err != nil {
-			m.err = err.Error()
-			return m, nil
-		}
-		env = map[string]string{hooks.EnvStatusFile: m.hooks.StatusFile(id)}
-		command = tool.Command + " --settings " + tmux.ShellQuote(settingsPath)
+	command, env, err := m.buildLaunch(tool, tool.Command, id)
+	if err != nil {
+		m.err = err.Error()
+		return m, nil
 	}
 	if err := m.tmux.Create(id, dir, command, env); err != nil {
 		m.err = err.Error()
@@ -336,6 +327,25 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 	}
 	m.mode = modeList
 	return m, m.refreshCmd()
+}
+
+// buildLaunch resolves the shell command and environment a session
+// launches with: tools backed by hooks get the generated settings file
+// and their status-file path, plus a clean slate from any earlier file
+// under the same id.
+func (m *Model) buildLaunch(tool config.Tool, baseCommand, id string) (string, map[string]string, error) {
+	if tool.StatusSource != hooks.StatusSourceClaude {
+		return baseCommand, nil, nil
+	}
+	settingsPath, err := m.hooks.EnsureSettings()
+	if err != nil {
+		return "", nil, err
+	}
+	if err := m.hooks.Remove(id); err != nil {
+		return "", nil, err
+	}
+	env := map[string]string{hooks.EnvStatusFile: m.hooks.StatusFile(id)}
+	return baseCommand + " --settings " + tmux.ShellQuote(settingsPath), env, nil
 }
 
 func (m *Model) openGroupForm() {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/status"
@@ -53,6 +54,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openForm()
 	case "g":
 		m.openGroupForm()
+	case "v":
+		return m.reviveSelected()
 	case "a":
 		return m.archiveSelected()
 	case "u":
@@ -240,6 +243,53 @@ func (m *Model) attachSelected() (tea.Model, tea.Cmd) {
 	return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 		return attachDoneMsg{err}
 	})
+}
+
+// reviveSelected relaunches a dead session's tmux session under the same
+// id, keeping its name, group, and history. Tools with a revive_command
+// resume where they left off (e.g. claude --continue).
+func (m *Model) reviveSelected() (tea.Model, tea.Cmd) {
+	sess, ok := m.selected()
+	if !ok {
+		return m, nil
+	}
+	if m.tmux.Exists(sess.ID) {
+		m.err = "session is still running; revive only applies to dead sessions"
+		return m, nil
+	}
+	tool, ok := m.cfg.Tools[sess.Tool]
+	if !ok {
+		m.err = "tool " + sess.Tool + " is no longer configured"
+		return m, nil
+	}
+	if info, err := os.Stat(sess.Cwd); err != nil || !info.IsDir() {
+		m.err = "working directory no longer exists: " + sess.Cwd
+		return m, nil
+	}
+	baseCommand := tool.ReviveCommand
+	if baseCommand == "" {
+		baseCommand = tool.Command
+	}
+	command, env, err := m.buildLaunch(tool, baseCommand, sess.ID)
+	if err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env); err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+	if err := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name)); err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+	if err := m.store.UpdateStatus(sess.ID, tool.DefaultStatus); err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+	m.err = ""
+	m.requestRefresh()
+	return m, nil
 }
 
 func (m *Model) archiveSelected() (tea.Model, tea.Cmd) {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -287,6 +287,12 @@ func (m *Model) reviveSelected() (tea.Model, tea.Cmd) {
 		m.err = err.Error()
 		return m, nil
 	}
+	// A leftover ack from the previous life must not swallow the revived
+	// agent's first finished alert.
+	if err := m.store.SetAcked(sess.ID, false); err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
 	m.err = ""
 	m.requestRefresh()
 	return m, nil

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -152,6 +152,7 @@ func (m *Model) viewHelp() string {
 		{"m", "move session to another group"},
 		{"g", "new group (name, parent, default path)"},
 		{"r", "rename session / group"},
+		{"v", "revive dead session (resumes the agent)"},
 		{"a / u", "archive / restore"},
 		{"d", "delete session, or group + subtree"},
 		{"shift+↑↓", "reorder row up / down"},

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -610,6 +610,10 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	}
 	m.selectSessionRow(t, "phoenix")
 
+	if err := m.store.SetAcked(sess.ID, true); err != nil {
+		t.Fatalf("set acked: %v", err)
+	}
+
 	if _, _ = m.reviveSelected(); m.err != "" {
 		t.Fatalf("revive: %q", m.err)
 	}
@@ -622,6 +626,9 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	}
 	if got.Status != status.Idle {
 		t.Fatalf("after revive, status = %q want %q", got.Status, status.Idle)
+	}
+	if got.Acked {
+		t.Fatal("revive should clear a leftover ack")
 	}
 }
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -596,3 +596,63 @@ func TestAttachKeepsWorking(t *testing.T) {
 		t.Fatalf("after attach, status = %q want %q", got.Status, status.Working)
 	}
 }
+
+func TestReviveRecreatesDeadSession(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "phoenix", t.TempDir(), "")
+
+	sess := m.sessionRows()[0]
+	if err := m.tmux.Kill(sess.ID); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	if m.tmux.Exists(sess.ID) {
+		t.Fatal("session should be dead before revive")
+	}
+	m.selectSessionRow(t, "phoenix")
+
+	if _, _ = m.reviveSelected(); m.err != "" {
+		t.Fatalf("revive: %q", m.err)
+	}
+	if !m.tmux.Exists(sess.ID) {
+		t.Fatal("revive should recreate the tmux session")
+	}
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != status.Idle {
+		t.Fatalf("after revive, status = %q want %q", got.Status, status.Idle)
+	}
+}
+
+func TestReviveRefusesLiveSession(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "alive", t.TempDir(), "")
+	m.selectSessionRow(t, "alive")
+
+	if _, _ = m.reviveSelected(); m.err == "" {
+		t.Fatal("revive on a live session should error")
+	}
+	if !m.tmux.Exists(m.sessionRows()[0].ID) {
+		t.Fatal("live session must keep running")
+	}
+}
+
+func TestReviveRefusesMissingDir(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	createSession(t, m, "homeless", dir, "")
+
+	sess := m.sessionRows()[0]
+	if err := m.tmux.Kill(sess.ID); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove dir: %v", err)
+	}
+	m.selectSessionRow(t, "homeless")
+
+	if _, _ = m.reviveSelected(); m.err == "" {
+		t.Fatal("revive without a working directory should error")
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -387,7 +387,7 @@ func (m *Model) viewFooter() string {
 	pairs := [][2]string{
 		{"↑↓", "navigate"}, {"↵", "attach"}, {"n", "new"}, {"g", "group"},
 		{"⇧↑↓", "reorder"}, {"space", "fold"}, {"m", "move"}, {"r", "rename"},
-		{"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
+		{"v", "revive"}, {"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
 		{"t", "archived"}, {"ctrl+r", "refresh"}, {"?", "help"}, {"q", "quit"},
 	}
 	sep := subtleStyle.Render(" · ")


### PR DESCRIPTION
## What

`v` on a dead session recreates its tmux session under the same id, keeping name, group, and ordering. Per-tool `revive_command` decides what launches: the defaults resume the agent's last conversation (`claude --continue`, `opencode --continue`), falling back to the plain `command` when unset. Hook-backed tools get their settings flag and status-file environment re-injected, and the row returns to the tool's default status until the next poll.

Guards: revive refuses sessions that are still running and working directories that no longer exist.

## Verification

- `go build`, `go vet`, `gofmt`, `go test ./...` green; new tests cover the revive round-trip against a real tmux server, the still-running guard, and the missing-directory guard.
- `claude --continue` resumption verified live: a Haiku conversation stored a codeword, a second `--continue` invocation in the same directory recalled it.