### PR TITLE
Quick prompt: answer sessions and spawn agents with a prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 
 | Key | Action |
 |-----|--------|
-| `n` | New session (name, tool, directory, group picker) |
+| `n` | New session (name, tool, directory, optional starting prompt, group picker) |
 | `g` | New group (name, parent, default path) |
 | `enter` | Attach session / fold group |
 | `ctrl+q` | Inside a session: back to the manager |
@@ -56,12 +56,16 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 | `v` | Revive a dead session (`revive_command`, e.g. `claude --continue`, resumes the conversation) |
 | `a` / `u` | Archive / restore |
 | `d` | Delete session, or a group + its entire subtree |
-| `space` | Collapse / expand group |
+| `space` | Quick prompt to session / fold group |
 | `t` | Toggle archived view |
 | `/` | Search |
 | `ctrl+r` | Force refresh |
 | `?` | Help |
 | `q` | Quit (sessions keep running) |
+
+### Quick prompt
+
+Press `space` on a session to type a one-line message into a modal and send it straight into the session's pane, so the agent gets it as a user message without you attaching. The new-session form's optional `prompt` field launches the agent already working on a task; tools whose CLI takes the prompt behind a flag declare it with `prompt_flag` (see [Configuration](#configuration)).
 
 ### Groups
 
@@ -103,6 +107,8 @@ rules = [
 ```
 
 Rules match top-down against the visible pane text; first match wins, and `default_status` applies when nothing matches. Optional per-tool fields refine detection: `activity_cutoff` (regex locating the tool's input box, everything above it is turn content), `turn_end` (a turn-summary line marking the turn as over), `chrome_line`, `blocked_line`, and `trailing_note`. The generated config's `claude` and `opencode` blocks show all of them in use.
+
+`prompt_flag` controls how the new-session form's optional prompt is embedded into the launch command. Tools that take the prompt as a positional argument (Claude Code: `claude 'the prompt'`) leave it empty; tools whose positional argument means something else declare the flag (OpenCode: `prompt_flag = "--prompt"`, since its positional argument is the project path). The prompt only shapes the launch command; revive (`v`) uses `revive_command` untouched.
 
 State is stored next to the config in `state.db` (SQLite).
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 | `v` | Revive a dead session (`revive_command`, e.g. `claude --continue`, resumes the conversation) |
 | `a` / `u` | Archive / restore |
 | `d` | Delete session, or a group + its entire subtree |
-| `space` | Quick prompt to session / fold group |
+| `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
+| `f` | Fold / unfold group |
+| `s` | Settings (default tool for quick spawn) |
 | `t` | Toggle archived view |
 | `/` | Search |
 | `ctrl+r` | Force refresh |
@@ -65,7 +67,12 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 
 ### Quick prompt
 
-Press `space` on a session to type a one-line message into a modal and send it straight into the session's pane, so the agent gets it as a user message without you attaching. The new-session form's optional `prompt` field launches the agent already working on a task; tools whose CLI takes the prompt behind a flag declare it with `prompt_flag` (see [Configuration](#configuration)).
+Press `space` to dock a prompt bar at the bottom of the sidebar. The target follows the cursor while the bar is open (`↑↓` still navigate):
+
+- On a **session** row, `enter` sends the typed text straight into the session's pane, so the agent gets it as a user message without you attaching. The bar stays open and clears, ready for the next answer.
+- On a **group** row, `enter` spawns a new agent in that group with the prompt embedded, using the group's default path and the default tool from Settings (`s`). The agent starts working on the prompt immediately.
+
+`esc` closes the bar. The new-session form's optional `prompt` field launches an agent the same way; tools whose CLI takes the prompt behind a flag declare it with `prompt_flag` (see [Configuration](#configuration)).
 
 ### Groups
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 Press `space` to dock a prompt bar at the bottom of the sidebar. The target follows the cursor while the bar is open (`↑↓` still navigate):
 
 - On a **session** row, `enter` sends the typed text straight into the session's pane, so the agent gets it as a user message without you attaching. The bar stays open and clears, ready for the next answer.
-- On a **group** row, `enter` spawns a new agent in that group with the prompt embedded, using the group's default path and the default tool from Settings (`s`). The agent starts working on the prompt immediately.
+- On a **group** row, `enter` spawns a new agent in that group with the prompt embedded, using the group's default path. The spawn tool starts at the Settings (`s`) default and `tab` cycles it (claude ↔ opencode ↔ any configured tool); the footer shows the current pick. The agent starts working on the prompt immediately.
 
 `esc` closes the bar. The new-session form's optional `prompt` field launches an agent the same way; tools whose CLI takes the prompt behind a flag declare it with `prompt_flag` (see [Configuration](#configuration)).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Rule struct {
 type Tool struct {
 	Command        string `toml:"command"`
 	ReviveCommand  string `toml:"revive_command"`
+	PromptFlag     string `toml:"prompt_flag"`
 	StatusSource   string `toml:"status_source"`
 	DefaultStatus  string `toml:"default_status"`
 	ActivityCutoff string `toml:"activity_cutoff"`
@@ -168,6 +169,9 @@ rules = [
 [tools.opencode]
 command = "opencode"
 revive_command = "opencode --continue"
+# opencode's positional argument is the project path, so the optional
+# session prompt travels behind this flag
+prompt_flag = "--prompt"
 default_status = "idle"
 activity_cutoff = "(?m)^\\s*╹"
 turn_end = "^\\s*▣ +.+· [\\dhms. ]+\\s*$"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,12 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if cfg.Tools["claude"].Command != "claude" {
 		t.Fatalf("claude command = %q", cfg.Tools["claude"].Command)
 	}
+	if got := cfg.Tools["opencode"].PromptFlag; got != "--prompt" {
+		t.Fatalf("opencode prompt_flag = %q want --prompt", got)
+	}
+	if got := cfg.Tools["claude"].PromptFlag; got != "" {
+		t.Fatalf("claude prompt_flag = %q want empty (positional prompt)", got)
+	}
 }
 
 func TestApplyDefaults(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -66,6 +66,10 @@ CREATE TABLE IF NOT EXISTS groups (
 	collapsed  INTEGER NOT NULL DEFAULT 0,
 	sort_order INTEGER NOT NULL DEFAULT 0,
 	path       TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE IF NOT EXISTS settings (
+	key   TEXT PRIMARY KEY,
+	value TEXT NOT NULL
 );`)
 	if err != nil {
 		return err
@@ -85,6 +89,22 @@ CREATE TABLE IF NOT EXISTS groups (
 		}
 	}
 	return nil
+}
+
+func (s *Store) Setting(key string) (string, error) {
+	var value string
+	err := s.db.QueryRow(`SELECT value FROM settings WHERE key = ?`, key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return value, err
+}
+
+func (s *Store) SetSetting(key, value string) error {
+	_, err := s.db.Exec(
+		`INSERT INTO settings (key, value) VALUES (?, ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`, key, value)
+	return err
 }
 
 func (s *Store) CreateSession(sess Session) error {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -93,6 +93,17 @@ func (d *Driver) installSessionUX(name string) error {
 	return nil
 }
 
+// SendText types text into the session's pane as literal keystrokes and
+// presses Enter, so the agent inside receives it as a user message.
+func (d *Driver) SendText(id, text string) error {
+	name := sessionName(id)
+	if _, err := d.run("send-keys", "-t", name, "-l", "--", text); err != nil {
+		return err
+	}
+	_, err := d.run("send-keys", "-t", name, "Enter")
+	return err
+}
+
 // SetLabel puts the session's name and group path in the status bar's
 // left side, replacing the hidden window list.
 func (d *Driver) SetLabel(id, label string) error {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -46,6 +46,36 @@ func TestSetLabelNeutralizesFormatStrings(t *testing.T) {
 	}
 }
 
+func TestSendText(t *testing.T) {
+	driver := requireTmux(t)
+	id := "send" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "cat", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+
+	if err := driver.SendText(id, "hello world"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var pane string
+	for time.Now().Before(deadline) {
+		var err error
+		pane, err = driver.CapturePane(id)
+		if err != nil {
+			t.Fatalf("CapturePane: %v", err)
+		}
+		if strings.Count(pane, "hello world") >= 2 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if strings.Count(pane, "hello world") < 2 {
+		t.Fatalf("cat should echo the sent line, pane: %q", pane)
+	}
+}
+
 func TestLifecycle(t *testing.T) {
 	driver := requireTmux(t)
 	id := "test" + time.Now().Format("150405.000000")

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -18,6 +18,7 @@ const (
 	fieldName = iota
 	fieldTool
 	fieldDir
+	fieldPrompt
 	fieldGroup
 	fieldCount
 )
@@ -37,6 +38,7 @@ type groupOption struct {
 type form struct {
 	name       textinput.Model
 	dir        textinput.Model
+	prompt     textinput.Model
 	dirAuto    bool
 	toolNames  []string
 	toolIndex  int
@@ -118,10 +120,12 @@ func (m *Model) openForm() {
 	name.Focus()
 
 	dir := textField("", 400)
+	prompt := textField("first task (optional)", 2000)
 
 	m.form = form{
 		name:      name,
 		dir:       dir,
+		prompt:    prompt,
 		dirAuto:   true,
 		toolNames: tools,
 		focus:     fieldName,
@@ -232,6 +236,8 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.form.dir, cmd = m.form.dir.Update(msg)
 		m.form.dirAuto = false
 		m.pathSugg.recompute(m.form.dir.Value())
+	case fieldPrompt:
+		m.form.prompt, cmd = m.form.prompt.Update(msg)
 	}
 	return m, cmd
 }
@@ -257,11 +263,14 @@ func (m *Model) formFocus(delta int) {
 	m.form.focus = (m.form.focus + delta + fieldCount) % fieldCount
 	m.form.name.Blur()
 	m.form.dir.Blur()
+	m.form.prompt.Blur()
 	switch m.form.focus {
 	case fieldName:
 		m.form.name.Focus()
 	case fieldDir:
 		m.form.dir.Focus()
+	case fieldPrompt:
+		m.form.prompt.Focus()
 	}
 }
 
@@ -297,9 +306,14 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	group := m.selectedGroupPath()
+	prompt := strings.TrimSpace(m.form.prompt.Value())
+	if strings.HasPrefix(prompt, "-") {
+		m.err = `prompt cannot start with "-": the tool would read it as a flag`
+		return m, nil
+	}
 
 	id := newID()
-	command, env, err := m.buildLaunch(tool, tool.Command, id)
+	command, env, err := m.buildLaunch(tool, withPrompt(tool, tool.Command, prompt), id)
 	if err != nil {
 		m.err = err.Error()
 		return m, nil
@@ -327,6 +341,19 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 	}
 	m.mode = modeList
 	return m, m.refreshCmd()
+}
+
+// withPrompt embeds an optional starting prompt into a tool's launch
+// command; tools whose positional argument is not a prompt route it
+// through their prompt_flag.
+func withPrompt(tool config.Tool, command, prompt string) string {
+	if prompt == "" {
+		return command
+	}
+	if tool.PromptFlag != "" {
+		return command + " " + tool.PromptFlag + " " + tmux.ShellQuote(prompt)
+	}
+	return command + " " + tmux.ShellQuote(prompt)
 }
 
 // buildLaunch resolves the shell command and environment a session

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -112,9 +112,14 @@ func (m *Model) groupDefaultDir(group string) string {
 	return cwd
 }
 
+func sortedToolNames(cfg config.Config) []string {
+	names := cfg.ToolNames()
+	sort.Strings(names)
+	return names
+}
+
 func (m *Model) openForm() {
-	tools := m.cfg.ToolNames()
-	sort.Strings(tools)
+	tools := sortedToolNames(m.cfg)
 
 	name := textField("my-session", 60)
 	name.Focus()
@@ -288,7 +293,6 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	toolName := m.form.toolNames[m.form.toolIndex]
-	tool := m.cfg.Tools[toolName]
 
 	name := strings.TrimSpace(m.form.name.Value())
 	if name == "" {
@@ -312,15 +316,25 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	id := newID()
-	command, env, err := m.buildLaunch(tool, withPrompt(tool, tool.Command, prompt), id)
-	if err != nil {
+	if err := m.spawnSession(toolName, name, dir, group, prompt); err != nil {
 		m.err = err.Error()
 		return m, nil
 	}
+	m.mode = modeList
+	return m, m.refreshCmd()
+}
+
+// spawnSession creates the tmux session and its store record for both
+// the New Session form and quick spawn.
+func (m *Model) spawnSession(toolName, name, dir, group, prompt string) error {
+	tool := m.cfg.Tools[toolName]
+	id := newID()
+	command, env, err := m.buildLaunch(tool, withPrompt(tool, tool.Command, prompt), id)
+	if err != nil {
+		return err
+	}
 	if err := m.tmux.Create(id, dir, command, env); err != nil {
-		m.err = err.Error()
-		return m, nil
+		return err
 	}
 	sess := store.Session{
 		ID:     id,
@@ -333,14 +347,9 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 	if err := m.store.CreateSession(sess); err != nil {
 		_ = m.tmux.Kill(id)
 		_ = m.hooks.Remove(id)
-		m.err = err.Error()
-		return m, nil
+		return err
 	}
-	if err := m.tmux.SetLabel(id, sessionLabel(group, name)); err != nil {
-		m.err = err.Error()
-	}
-	m.mode = modeList
-	return m, m.refreshCmd()
+	return m.tmux.SetLabel(id, sessionLabel(group, name))
 }
 
 // withPrompt embeds an optional starting prompt into a tool's launch

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -20,6 +20,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleConfirmKey(msg)
 	case modeRename:
 		return m.handleRenameKey(msg)
+	case modeQuickPrompt:
+		return m.handleQuickPromptKey(msg)
 	case modeMove:
 		return m.handleMoveKey(msg)
 	case modeGroupForm:
@@ -62,7 +64,11 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.restoreSelected()
 	case "d":
 		m.prepareDelete()
-	case "space":
+	case " ", "space":
+		if entry, ok := m.selectedRow(); ok && !entry.isGroup {
+			m.openQuickPrompt(entry.sess)
+			return m, nil
+		}
 		m.toggleCollapse()
 	case "t":
 		m.showArchived = !m.showArchived
@@ -449,6 +455,48 @@ func (m *Model) handleRenameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	var cmd tea.Cmd
 	m.rename.input, cmd = m.rename.input.Update(msg)
+	return m, cmd
+}
+
+func (m *Model) openQuickPrompt(sess store.Session) {
+	if !m.tmux.Exists(sess.ID) {
+		m.err = "session is dead - press v to revive"
+		return
+	}
+	input := textinput.New()
+	input.CharLimit = 2000
+	input.Focus()
+	m.quickPrompt = quickPromptTarget{sessID: sess.ID, sessName: sess.Name, input: input}
+	m.mode = modeQuickPrompt
+	m.err = ""
+}
+
+func (m *Model) handleQuickPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.mode = modeList
+		return m, nil
+	case "enter":
+		text := strings.TrimSpace(m.quickPrompt.input.Value())
+		if text == "" {
+			m.err = "prompt cannot be empty"
+			return m, nil
+		}
+		if err := m.tmux.SendText(m.quickPrompt.sessID, text); err != nil {
+			m.err = err.Error()
+			return m, nil
+		}
+		// A queued answer means the user expects a fresh finished alert.
+		if err := m.store.SetAcked(m.quickPrompt.sessID, false); err != nil {
+			m.err = err.Error()
+			return m, nil
+		}
+		m.mode = modeList
+		m.requestRefresh()
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.quickPrompt.input, cmd = m.quickPrompt.input.Update(msg)
 	return m, cmd
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -20,8 +20,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleConfirmKey(msg)
 	case modeRename:
 		return m.handleRenameKey(msg)
-	case modeQuickPrompt:
-		return m.handleQuickPromptKey(msg)
+	case modeSettings:
+		return m.handleSettingsKey(msg)
 	case modeMove:
 		return m.handleMoveKey(msg)
 	case modeGroupForm:
@@ -33,6 +33,9 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	if m.searching {
 		return m.handleSearchKey(msg)
+	}
+	if m.quick.active {
+		return m.handleQuickKey(msg)
 	}
 
 	switch msg.String() {
@@ -65,11 +68,11 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "d":
 		m.prepareDelete()
 	case " ", "space":
-		if entry, ok := m.selectedRow(); ok && !entry.isGroup {
-			m.openQuickPrompt(entry.sess)
-			return m, nil
-		}
+		m.openQuickMode()
+	case "f":
 		m.toggleCollapse()
+	case "s":
+		m.openSettings()
 	case "t":
 		m.showArchived = !m.showArchived
 		m.requestRefresh()
@@ -458,46 +461,144 @@ func (m *Model) handleRenameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m *Model) openQuickPrompt(sess store.Session) {
-	if !m.tmux.Exists(sess.ID) {
-		m.err = "session is dead - press v to revive"
-		return
-	}
+func (m *Model) openQuickMode() {
 	input := textinput.New()
 	input.CharLimit = 2000
+	input.Placeholder = "type and press enter"
 	input.Focus()
-	m.quickPrompt = quickPromptTarget{sessID: sess.ID, sessName: sess.Name, input: input}
-	m.mode = modeQuickPrompt
+	m.quick = quickState{active: true, input: input}
 	m.err = ""
 }
 
-func (m *Model) handleQuickPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+// handleQuickKey runs while the quick bar is docked in the sidebar: arrows
+// keep moving the selection (the target follows the cursor), enter submits
+// against whatever is selected, and every other key is typed text.
+func (m *Model) handleQuickKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
-		m.mode = modeList
+		m.quick.active = false
 		return m, nil
+	case "up":
+		return m, m.moveCursor(-1)
+	case "down":
+		return m, m.moveCursor(1)
 	case "enter":
-		text := strings.TrimSpace(m.quickPrompt.input.Value())
-		if text == "" {
-			m.err = "prompt cannot be empty"
-			return m, nil
-		}
-		if err := m.tmux.SendText(m.quickPrompt.sessID, text); err != nil {
-			m.err = err.Error()
-			return m, nil
-		}
-		// A queued answer means the user expects a fresh finished alert.
-		if err := m.store.SetAcked(m.quickPrompt.sessID, false); err != nil {
-			m.err = err.Error()
-			return m, nil
-		}
-		m.mode = modeList
-		m.requestRefresh()
-		return m, nil
+		return m.submitQuick()
 	}
 	var cmd tea.Cmd
-	m.quickPrompt.input, cmd = m.quickPrompt.input.Update(msg)
+	m.quick.input, cmd = m.quick.input.Update(msg)
 	return m, cmd
+}
+
+// submitQuick answers the selected session, or spawns a new session with
+// the prompt embedded when a group is selected. The bar stays active so
+// consecutive prompts flow without re-arming.
+func (m *Model) submitQuick() (tea.Model, tea.Cmd) {
+	entry, ok := m.selectedRow()
+	if !ok {
+		m.err = "nothing selected"
+		return m, nil
+	}
+	text := strings.TrimSpace(m.quick.input.Value())
+	if text == "" {
+		m.err = "prompt cannot be empty"
+		return m, nil
+	}
+	if entry.isGroup {
+		return m.quickSpawn(entry.group, text)
+	}
+	if !m.tmux.Exists(entry.sess.ID) {
+		m.err = "session is dead - press v to revive"
+		return m, nil
+	}
+	if err := m.tmux.SendText(entry.sess.ID, text); err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+	// A queued answer means the user expects a fresh finished alert.
+	if err := m.store.SetAcked(entry.sess.ID, false); err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+	m.quick.input.SetValue("")
+	m.requestRefresh()
+	return m, nil
+}
+
+func (m *Model) quickSpawn(group, prompt string) (tea.Model, tea.Cmd) {
+	if strings.HasPrefix(prompt, "-") {
+		m.err = `prompt cannot start with "-": the tool would read it as a flag`
+		return m, nil
+	}
+	toolName := m.defaultTool()
+	if toolName == "" {
+		m.err = "no tools configured"
+		return m, nil
+	}
+	dir := expandHome(m.groupPaths[group])
+	if dir == "" {
+		dir, _ = os.Getwd()
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		m.err = "group has no valid default path: " + dir
+		return m, nil
+	}
+	name := toolName + "-" + newID()[:4]
+	if err := m.spawnSession(toolName, name, dir, group, prompt); err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+	m.quick.input.SetValue("")
+	return m, m.refreshCmd()
+}
+
+// defaultTool is the CLI quick spawn launches: the settings choice when it
+// still exists in the config, else the first tool alphabetically.
+func (m *Model) defaultTool() string {
+	names := sortedToolNames(m.cfg)
+	if len(names) == 0 {
+		return ""
+	}
+	chosen, err := m.store.Setting("default_tool")
+	if err == nil && chosen != "" {
+		if _, ok := m.cfg.Tools[chosen]; ok {
+			return chosen
+		}
+	}
+	return names[0]
+}
+
+func (m *Model) openSettings() {
+	names := sortedToolNames(m.cfg)
+	if len(names) == 0 {
+		m.err = "no tools configured"
+		return
+	}
+	current := m.defaultTool()
+	index := 0
+	for i, name := range names {
+		if name == current {
+			index = i
+		}
+	}
+	m.settings = settingsState{toolNames: names, toolIndex: index}
+	m.mode = modeSettings
+	m.err = ""
+}
+
+func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "left", "h":
+		m.settings.toolIndex = (m.settings.toolIndex + len(m.settings.toolNames) - 1) % len(m.settings.toolNames)
+	case "right", "l":
+		m.settings.toolIndex = (m.settings.toolIndex + 1) % len(m.settings.toolNames)
+	case "enter", "esc":
+		if err := m.store.SetSetting("default_tool", m.settings.toolNames[m.settings.toolIndex]); err != nil {
+			m.err = err.Error()
+		}
+		m.mode = modeList
+	}
+	return m, nil
 }
 
 func (m *Model) openMove() {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -466,7 +466,14 @@ func (m *Model) openQuickMode() {
 	input.CharLimit = 2000
 	input.Placeholder = "type and press enter"
 	input.Focus()
-	m.quick = quickState{active: true, input: input}
+	names := sortedToolNames(m.cfg)
+	index := 0
+	for i, name := range names {
+		if name == m.defaultTool() {
+			index = i
+		}
+	}
+	m.quick = quickState{active: true, input: input, toolNames: names, toolIndex: index}
 	m.err = ""
 }
 
@@ -482,6 +489,11 @@ func (m *Model) handleQuickKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.moveCursor(-1)
 	case "down":
 		return m, m.moveCursor(1)
+	case "tab":
+		if len(m.quick.toolNames) > 0 {
+			m.quick.toolIndex = (m.quick.toolIndex + 1) % len(m.quick.toolNames)
+		}
+		return m, nil
 	case "enter":
 		return m.submitQuick()
 	}
@@ -530,7 +542,7 @@ func (m *Model) quickSpawn(group, prompt string) (tea.Model, tea.Cmd) {
 		m.err = `prompt cannot start with "-": the tool would read it as a flag`
 		return m, nil
 	}
-	toolName := m.defaultTool()
+	toolName := m.quickTool()
 	if toolName == "" {
 		m.err = "no tools configured"
 		return m, nil
@@ -550,6 +562,15 @@ func (m *Model) quickSpawn(group, prompt string) (tea.Model, tea.Cmd) {
 	}
 	m.quick.input.SetValue("")
 	return m, m.refreshCmd()
+}
+
+// quickTool is the spawn CLI for the current quick-mode run: the settings
+// default until tab cycles it.
+func (m *Model) quickTool() string {
+	if len(m.quick.toolNames) == 0 {
+		return ""
+	}
+	return m.quick.toolNames[m.quick.toolIndex]
 }
 
 // defaultTool is the CLI quick spawn launches: the settings choice when it

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -467,9 +467,10 @@ func (m *Model) openQuickMode() {
 	input.Placeholder = "type and press enter"
 	input.Focus()
 	names := sortedToolNames(m.cfg)
+	current := m.defaultTool()
 	index := 0
 	for i, name := range names {
-		if name == m.defaultTool() {
+		if name == current {
 			index = i
 		}
 	}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -466,6 +466,7 @@ func (m *Model) openQuickMode() {
 	input.CharLimit = 2000
 	input.Placeholder = "type and press enter"
 	input.Focus()
+	m.err = ""
 	names := sortedToolNames(m.cfg)
 	current := m.defaultTool()
 	index := 0
@@ -475,7 +476,6 @@ func (m *Model) openQuickMode() {
 		}
 	}
 	m.quick = quickState{active: true, input: input, toolNames: names, toolIndex: index}
-	m.err = ""
 }
 
 // handleQuickKey runs while the quick bar is docked in the sidebar: arrows
@@ -528,12 +528,14 @@ func (m *Model) submitQuick() (tea.Model, tea.Cmd) {
 		m.err = err.Error()
 		return m, nil
 	}
+	// The prompt is delivered: clear the input before anything else can
+	// fail, so a retry cannot send it twice.
+	m.quick.input.SetValue("")
+	m.err = ""
 	// A queued answer means the user expects a fresh finished alert.
 	if err := m.store.SetAcked(entry.sess.ID, false); err != nil {
-		m.err = err.Error()
-		return m, nil
+		m.err = "prompt sent, but clearing the alert ack failed: " + err.Error()
 	}
-	m.quick.input.SetValue("")
 	m.requestRefresh()
 	return m, nil
 }
@@ -562,6 +564,7 @@ func (m *Model) quickSpawn(group, prompt string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.quick.input.SetValue("")
+	m.err = ""
 	return m, m.refreshCmd()
 }
 
@@ -575,14 +578,19 @@ func (m *Model) quickTool() string {
 }
 
 // defaultTool is the CLI quick spawn launches: the settings choice when it
-// still exists in the config, else the first tool alphabetically.
+// still exists in the config, else the first tool alphabetically. A store
+// error still yields the fallback but is surfaced, never swallowed.
 func (m *Model) defaultTool() string {
 	names := sortedToolNames(m.cfg)
 	if len(names) == 0 {
 		return ""
 	}
 	chosen, err := m.store.Setting("default_tool")
-	if err == nil && chosen != "" {
+	if err != nil {
+		m.err = "reading default tool setting: " + err.Error()
+		return names[0]
+	}
+	if chosen != "" {
 		if _, ok := m.cfg.Tools[chosen]; ok {
 			return chosen
 		}
@@ -596,6 +604,7 @@ func (m *Model) openSettings() {
 		m.err = "no tools configured"
 		return
 	}
+	m.err = ""
 	current := m.defaultTool()
 	index := 0
 	for i, name := range names {
@@ -605,7 +614,6 @@ func (m *Model) openSettings() {
 	}
 	m.settings = settingsState{toolNames: names, toolIndex: index}
 	m.mode = modeSettings
-	m.err = ""
 }
 
 func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -489,7 +489,7 @@ func (m *Model) handleQuickKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.moveCursor(-1)
 	case "down":
 		return m, m.moveCursor(1)
-	case "tab":
+	case "tab", "alt+m":
 		if len(m.quick.toolNames) > 0 {
 			m.quick.toolIndex = (m.quick.toolIndex + 1) % len(m.quick.toolNames)
 		}

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -141,9 +141,13 @@ func (m *Model) viewRename() string {
 	return m.card("✎ Rename "+what, body, "↵ apply · esc cancel")
 }
 
-func (m *Model) viewQuickPrompt() string {
-	body := mutedStyle.Render(m.quickPrompt.sessName) + "\n\n" + m.quickPrompt.input.View()
-	return m.card("▷ Quick Prompt", body, "↵ send · esc cancel")
+func (m *Model) viewSettings() string {
+	marker := lipgloss.NewStyle().Foreground(colorAccent).Render("❯ ")
+	label := lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("quick spawn tool")
+	tool := subtleStyle.Render("◂ ") +
+		valueStyle.Render(m.settings.toolNames[m.settings.toolIndex]) +
+		subtleStyle.Render(" ▸")
+	return m.card("⚙ Settings", marker+label+"  "+tool, "←→ change · ↵/esc save")
 }
 
 func (m *Model) viewMove() string {
@@ -162,7 +166,9 @@ func (m *Model) viewHelp() string {
 		{"a / u", "archive / restore"},
 		{"d", "delete session, or group + subtree"},
 		{"shift+↑↓", "reorder row up / down"},
-		{"space", "quick prompt to session / fold group"},
+		{"space", "quick prompt: answer session / spawn agent in group"},
+		{"f", "fold / unfold group"},
+		{"s", "settings (quick spawn tool)"},
 		{"t", "toggle archived view"},
 		{"/", "search"},
 		{"ctrl+r", "force refresh"},

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -167,6 +167,7 @@ func (m *Model) viewHelp() string {
 		{"d", "delete session, or group + subtree"},
 		{"shift+↑↓", "reorder row up / down"},
 		{"space", "quick prompt: answer session / spawn agent in group"},
+		{"⇥", "in quick prompt: switch spawn tool"},
 		{"f", "fold / unfold group"},
 		{"s", "settings (quick spawn tool)"},
 		{"t", "toggle archived view"},

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -42,6 +42,7 @@ func (m *Model) viewForm() string {
 	if m.form.focus == fieldDir && m.pathSugg.active() {
 		b.WriteString(m.viewPathSuggestions() + "\n")
 	}
+	b.WriteString(formField("prompt", m.form.prompt.View(), m.form.focus == fieldPrompt))
 	b.WriteString(formField("group", groupBadge(displayGroup(m.form.groups[m.form.groupIndex].path)), m.form.focus == fieldGroup))
 
 	if m.form.focus == fieldGroup {
@@ -140,6 +141,11 @@ func (m *Model) viewRename() string {
 	return m.card("✎ Rename "+what, body, "↵ apply · esc cancel")
 }
 
+func (m *Model) viewQuickPrompt() string {
+	body := mutedStyle.Render(m.quickPrompt.sessName) + "\n\n" + m.quickPrompt.input.View()
+	return m.card("▷ Quick Prompt", body, "↵ send · esc cancel")
+}
+
 func (m *Model) viewMove() string {
 	return m.card("⇄ Move to group", m.viewGroupPicker(), "↑↓ pick · ↵ move · esc cancel")
 }
@@ -156,7 +162,7 @@ func (m *Model) viewHelp() string {
 		{"a / u", "archive / restore"},
 		{"d", "delete session, or group + subtree"},
 		{"shift+↑↓", "reorder row up / down"},
-		{"space", "collapse / expand group"},
+		{"space", "quick prompt to session / fold group"},
 		{"t", "toggle archived view"},
 		{"/", "search"},
 		{"ctrl+r", "force refresh"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -28,7 +28,7 @@ const (
 	modeRename
 	modeMove
 	modeGroupForm
-	modeQuickPrompt
+	modeSettings
 )
 
 type treeRow struct {
@@ -71,13 +71,14 @@ type Model struct {
 	search       string
 	searching    bool
 
-	form        form
-	groupForm   groupForm
-	pathSugg    pathComplete
-	confirm     confirmTarget
-	rename      renameTarget
-	quickPrompt quickPromptTarget
-	moveID      string
+	form      form
+	groupForm groupForm
+	pathSugg  pathComplete
+	confirm   confirmTarget
+	rename    renameTarget
+	quick     quickState
+	settings  settingsState
+	moveID    string
 
 	width    int
 	height   int
@@ -100,10 +101,16 @@ type renameTarget struct {
 	input   textinput.Model
 }
 
-type quickPromptTarget struct {
-	sessID   string
-	sessName string
-	input    textinput.Model
+// quickState is the inline prompt bar docked under the preview: active
+// across cursor moves, so the target follows the selection.
+type quickState struct {
+	active bool
+	input  textinput.Model
+}
+
+type settingsState struct {
+	toolNames []string
+	toolIndex int
 }
 
 // agentStats aggregates process-tree usage across all live sessions.

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -102,10 +102,13 @@ type renameTarget struct {
 }
 
 // quickState is the inline prompt bar docked under the preview: active
-// across cursor moves, so the target follows the selection.
+// across cursor moves, so the target follows the selection. The tool is
+// the spawn CLI for group targets, cycled with tab.
 type quickState struct {
-	active bool
-	input  textinput.Model
+	active    bool
+	input     textinput.Model
+	toolNames []string
+	toolIndex int
 }
 
 type settingsState struct {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -28,6 +28,7 @@ const (
 	modeRename
 	modeMove
 	modeGroupForm
+	modeQuickPrompt
 )
 
 type treeRow struct {
@@ -70,12 +71,13 @@ type Model struct {
 	search       string
 	searching    bool
 
-	form      form
-	groupForm groupForm
-	pathSugg  pathComplete
-	confirm   confirmTarget
-	rename    renameTarget
-	moveID    string
+	form        form
+	groupForm   groupForm
+	pathSugg    pathComplete
+	confirm     confirmTarget
+	rename      renameTarget
+	quickPrompt quickPromptTarget
+	moveID      string
 
 	width    int
 	height   int
@@ -96,6 +98,12 @@ type renameTarget struct {
 	path    string
 	sessID  string
 	input   textinput.Model
+}
+
+type quickPromptTarget struct {
+	sessID   string
+	sessName string
+	input    textinput.Model
 }
 
 // agentStats aggregates process-tree usage across all live sessions.

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -832,3 +832,40 @@ func TestFormRejectsDashLeadingPrompt(t *testing.T) {
 		t.Fatalf("no session should be created, got %d", len(m.sessionRows()))
 	}
 }
+
+func TestQuickSpawnUsesTabCycledTool(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("backend", dir); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	for i, row := range m.rows {
+		if row.isGroup && row.group == "backend" {
+			m.cursor = i
+		}
+	}
+
+	m.openQuickMode()
+	if m.quickTool() != "claude" {
+		t.Fatalf("quick tool starts at %q want claude", m.quickTool())
+	}
+	if _, _ = m.handleQuickKey(tea.KeyMsg{Type: tea.KeyTab}); m.quickTool() != "claude-hooked" {
+		t.Fatalf("after tab, quick tool = %q want claude-hooked", m.quickTool())
+	}
+
+	m.quick.input.SetValue("build the api")
+	_, cmd := m.submitQuick()
+	if m.err != "" {
+		t.Fatalf("quick spawn: %q", m.err)
+	}
+	m.applyCmd(t, cmd)
+
+	sessions := m.sessionRows()
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %d want 1", len(sessions))
+	}
+	if sessions[0].Tool != "claude-hooked" {
+		t.Fatalf("spawned tool = %q want claude-hooked", sessions[0].Tool)
+	}
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -674,12 +674,16 @@ func TestQuickPromptDeadSessionSetsError(t *testing.T) {
 	}
 	m.selectSessionRow(t, "gone")
 
-	m.openQuickPrompt(sess)
-	if m.mode != modeList {
-		t.Fatal("quick prompt on a dead session should not open the modal")
-	}
-	if m.err != "session is dead - press v to revive" {
+	m.openQuickMode()
+	m.quick.input.SetValue("hello?")
+	if _, _ = m.submitQuick(); m.err != "session is dead - press v to revive" {
 		t.Fatalf("err = %q", m.err)
+	}
+	if !m.quick.active {
+		t.Fatal("quick mode should stay open after a failed send")
+	}
+	if _, err := m.store.Get(sess.ID); err != nil {
+		t.Fatalf("session record should survive: %v", err)
 	}
 }
 
@@ -693,16 +697,19 @@ func TestQuickPromptSendClearsAcked(t *testing.T) {
 	}
 	m.selectSessionRow(t, "answer-me")
 
-	m.openQuickPrompt(sess)
-	if m.mode != modeQuickPrompt {
-		t.Fatalf("quick prompt should open, err = %q", m.err)
+	m.openQuickMode()
+	if !m.quick.active {
+		t.Fatalf("quick mode should activate, err = %q", m.err)
 	}
-	m.quickPrompt.input.SetValue("carry on with the plan")
-	if _, _ = m.handleQuickPromptKey(tea.KeyMsg{Type: tea.KeyEnter}); m.err != "" {
+	m.quick.input.SetValue("carry on with the plan")
+	if _, _ = m.submitQuick(); m.err != "" {
 		t.Fatalf("send: %q", m.err)
 	}
-	if m.mode != modeList {
-		t.Fatal("modal should close after send")
+	if !m.quick.active {
+		t.Fatal("quick mode should stay active after a send")
+	}
+	if m.quick.input.Value() != "" {
+		t.Fatal("input should clear after a send")
 	}
 	got, err := m.store.Get(sess.ID)
 	if err != nil {
@@ -710,6 +717,56 @@ func TestQuickPromptSendClearsAcked(t *testing.T) {
 	}
 	if got.Acked {
 		t.Fatal("quick prompt send should clear the acked flag")
+	}
+}
+
+func TestQuickSpawnOnGroupCreatesSession(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("backend", dir); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := m.store.SetSetting("default_tool", "claude"); err != nil {
+		t.Fatalf("set setting: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	for i, row := range m.rows {
+		if row.isGroup && row.group == "backend" {
+			m.cursor = i
+		}
+	}
+
+	m.openQuickMode()
+	m.quick.input.SetValue("build the api")
+	_, cmd := m.submitQuick()
+	if m.err != "" {
+		t.Fatalf("quick spawn: %q", m.err)
+	}
+	m.applyCmd(t, cmd)
+
+	sessions := m.sessionRows()
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %d want 1", len(sessions))
+	}
+	spawned := sessions[0]
+	if spawned.Group != "backend" || spawned.Tool != "claude" || spawned.Cwd != dir {
+		t.Fatalf("spawned session fields wrong: %+v", spawned)
+	}
+	if !m.tmux.Exists(spawned.ID) {
+		t.Fatal("tmux session should exist after quick spawn")
+	}
+	if m.quick.input.Value() != "" {
+		t.Fatal("input should clear after a spawn")
+	}
+}
+
+func TestDefaultToolFallsBackWhenSettingStale(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.SetSetting("default_tool", "deleted-tool"); err != nil {
+		t.Fatalf("set setting: %v", err)
+	}
+	if got := m.defaultTool(); got != "claude" {
+		t.Fatalf("defaultTool = %q want claude (alphabetical fallback)", got)
 	}
 }
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -664,6 +664,76 @@ func TestReviveRefusesMissingDir(t *testing.T) {
 	}
 }
 
+func TestQuickPromptDeadSessionSetsError(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "gone", t.TempDir(), "")
+
+	sess := m.sessionRows()[0]
+	if err := m.tmux.Kill(sess.ID); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	m.selectSessionRow(t, "gone")
+
+	m.openQuickPrompt(sess)
+	if m.mode != modeList {
+		t.Fatal("quick prompt on a dead session should not open the modal")
+	}
+	if m.err != "session is dead - press v to revive" {
+		t.Fatalf("err = %q", m.err)
+	}
+}
+
+func TestQuickPromptSendClearsAcked(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "answer-me", t.TempDir(), "")
+
+	sess := m.sessionRows()[0]
+	if err := m.store.SetAcked(sess.ID, true); err != nil {
+		t.Fatalf("set acked: %v", err)
+	}
+	m.selectSessionRow(t, "answer-me")
+
+	m.openQuickPrompt(sess)
+	if m.mode != modeQuickPrompt {
+		t.Fatalf("quick prompt should open, err = %q", m.err)
+	}
+	m.quickPrompt.input.SetValue("carry on with the plan")
+	if _, _ = m.handleQuickPromptKey(tea.KeyMsg{Type: tea.KeyEnter}); m.err != "" {
+		t.Fatalf("send: %q", m.err)
+	}
+	if m.mode != modeList {
+		t.Fatal("modal should close after send")
+	}
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Acked {
+		t.Fatal("quick prompt send should clear the acked flag")
+	}
+}
+
+func TestFormPromptComposesWithSettings(t *testing.T) {
+	m := buildModel(t)
+	tool := m.cfg.Tools["claude-hooked"]
+
+	command, _, err := m.buildLaunch(tool, withPrompt(tool, tool.Command, "fix the bug"), "prompt01")
+	if err != nil {
+		t.Fatalf("buildLaunch: %v", err)
+	}
+	if !strings.HasPrefix(command, "cat 'fix the bug' --settings '") {
+		t.Fatalf("command = %q", command)
+	}
+
+	flagged := config.Tool{Command: "opencode", PromptFlag: "--prompt"}
+	if got := withPrompt(flagged, flagged.Command, "do it"); got != "opencode --prompt 'do it'" {
+		t.Fatalf("flagged compose = %q", got)
+	}
+	if got := withPrompt(tool, tool.Command, ""); got != "cat" {
+		t.Fatalf("empty prompt should leave the command untouched, got %q", got)
+	}
+}
+
 func TestRefreshWithStaleSelectionFetchesPreview(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "fresh-one", t.TempDir(), "")
@@ -684,5 +754,24 @@ func TestRefreshWithStaleSelectionFetchesPreview(t *testing.T) {
 	}
 	if m.preview != "pane text" {
 		t.Fatalf("preview = %q want %q", m.preview, "pane text")
+	}
+}
+
+func TestFormRejectsDashLeadingPrompt(t *testing.T) {
+	m := buildModel(t)
+	m.openForm()
+	m.form.name.SetValue("flagged")
+	m.form.dir.SetValue(t.TempDir())
+	m.form.toolIndex = 0
+	m.form.prompt.SetValue("--version")
+
+	if _, _ = m.submitForm(); m.err == "" {
+		t.Fatal("dash-leading prompt should be rejected")
+	}
+	if m.mode != modeForm {
+		t.Fatalf("form should stay open, mode = %v", m.mode)
+	}
+	if len(m.sessionRows()) != 0 {
+		t.Fatalf("no session should be created, got %d", len(m.sessionRows()))
 	}
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -22,6 +22,8 @@ func (m *Model) View() string {
 		return m.viewHelp()
 	case modeRename:
 		return m.viewRename()
+	case modeQuickPrompt:
+		return m.viewQuickPrompt()
 	case modeMove:
 		return m.viewMove()
 	case modeGroupForm:
@@ -386,7 +388,7 @@ func padToHeight(s string, height int) string {
 func (m *Model) viewFooter() string {
 	pairs := [][2]string{
 		{"↑↓", "navigate"}, {"↵", "attach"}, {"n", "new"}, {"g", "group"},
-		{"⇧↑↓", "reorder"}, {"space", "fold"}, {"m", "move"}, {"r", "rename"},
+		{"⇧↑↓", "reorder"}, {"space", "prompt/fold"}, {"m", "move"}, {"r", "rename"},
 		{"v", "revive"}, {"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
 		{"t", "archived"}, {"ctrl+r", "refresh"}, {"?", "help"}, {"q", "quit"},
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -310,14 +310,12 @@ func (m *Model) viewQuickBar(width int) string {
 	target := "no selection"
 	if entry, ok := m.selectedRow(); ok {
 		if entry.isGroup {
-			target = "new " + m.defaultTool() + " agent in " + displayGroup(entry.group)
+			target = "new " + m.quickTool() + " agent in " + displayGroup(entry.group)
 		} else {
 			target = "answer " + entry.sess.Name
 		}
 	}
-	return divider("Quick Prompt · "+target, width) + "\n" +
-		m.quick.input.View() + "\n" +
-		subtleStyle.Render("↵ send · ↑↓ switch target · esc close")
+	return divider("Quick Prompt · "+target, width) + "\n" + m.quick.input.View()
 }
 
 func (m *Model) viewDetail(width int) string {
@@ -419,6 +417,12 @@ func (m *Model) viewFooter() string {
 		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"f", "fold"}, {"m", "move"}, {"r", "rename"},
 		{"v", "revive"}, {"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
 		{"t", "archived"}, {"s", "settings"}, {"ctrl+r", "refresh"}, {"?", "help"}, {"q", "quit"},
+	}
+	if m.quick.active {
+		pairs = [][2]string{
+			{"↵", "send"}, {"↑↓", "switch target"}, {"⇥", "tool: " + m.quickTool()},
+			{"esc", "close"},
+		}
 	}
 	sep := subtleStyle.Render(" · ")
 	sepWidth := ansi.StringWidth(sep)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -291,7 +291,9 @@ func (m *Model) viewSidebar(width, height int) string {
 	bar := ""
 	if m.quick.active {
 		bar = m.viewQuickBar(width)
-		height -= lipgloss.Height(bar) + 1
+		if height -= lipgloss.Height(bar) + 1; height < 3 {
+			height = 3
+		}
 	}
 	detail := divider("Details", width) + "\n" + m.viewDetail(width)
 	body := detail

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -22,8 +22,8 @@ func (m *Model) View() string {
 		return m.viewHelp()
 	case modeRename:
 		return m.viewRename()
-	case modeQuickPrompt:
-		return m.viewQuickPrompt()
+	case modeSettings:
+		return m.viewSettings()
 	case modeMove:
 		return m.viewMove()
 	case modeGroupForm:
@@ -167,6 +167,9 @@ func (m *Model) sidebarTitle() string {
 	if sess, ok := m.selected(); ok {
 		return "Session · " + sess.Name
 	}
+	if entry, ok := m.selectedRow(); ok && entry.isGroup {
+		return "Group · " + displayGroup(entry.group)
+	}
 	return "Session"
 }
 
@@ -282,14 +285,39 @@ func divider(label string, width int) string {
 }
 
 // viewSidebar lays out session details on top, with the live preview
-// filling the rest of the panel below.
+// filling the rest of the panel below. The quick bar, when active, docks
+// at the very bottom in the same spot for sessions and groups alike.
 func (m *Model) viewSidebar(width, height int) string {
-	detail := divider("Details", width) + "\n" + m.viewDetail(width)
-	previewHeight := height - lipgloss.Height(detail) - 1
-	if previewHeight < 3 {
-		return detail
+	bar := ""
+	if m.quick.active {
+		bar = m.viewQuickBar(width)
+		height -= lipgloss.Height(bar) + 1
 	}
-	return detail + "\n" + m.viewPreview(width, previewHeight)
+	detail := divider("Details", width) + "\n" + m.viewDetail(width)
+	body := detail
+	if previewHeight := height - lipgloss.Height(detail) - 1; previewHeight >= 3 {
+		body = detail + "\n" + m.viewPreview(width, previewHeight)
+	}
+	if bar == "" {
+		return body
+	}
+	return padToHeight(body, height) + "\n" + bar
+}
+
+// viewQuickBar is the docked prompt input: enter answers the selected
+// session, or spawns a fresh agent when a group row is selected.
+func (m *Model) viewQuickBar(width int) string {
+	target := "no selection"
+	if entry, ok := m.selectedRow(); ok {
+		if entry.isGroup {
+			target = "new " + m.defaultTool() + " agent in " + displayGroup(entry.group)
+		} else {
+			target = "answer " + entry.sess.Name
+		}
+	}
+	return divider("Quick Prompt · "+target, width) + "\n" +
+		m.quick.input.View() + "\n" +
+		subtleStyle.Render("↵ send · ↑↓ switch target · esc close")
 }
 
 func (m *Model) viewDetail(width int) string {
@@ -388,9 +416,9 @@ func padToHeight(s string, height int) string {
 func (m *Model) viewFooter() string {
 	pairs := [][2]string{
 		{"↑↓", "navigate"}, {"↵", "attach"}, {"n", "new"}, {"g", "group"},
-		{"⇧↑↓", "reorder"}, {"space", "prompt/fold"}, {"m", "move"}, {"r", "rename"},
+		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"f", "fold"}, {"m", "move"}, {"r", "rename"},
 		{"v", "revive"}, {"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
-		{"t", "archived"}, {"ctrl+r", "refresh"}, {"?", "help"}, {"q", "quit"},
+		{"t", "archived"}, {"s", "settings"}, {"ctrl+r", "refresh"}, {"?", "help"}, {"q", "quit"},
 	}
 	sep := subtleStyle.Render(" · ")
 	sepWidth := ansi.StringWidth(sep)


### PR DESCRIPTION
## What

- **Quick mode**: `space` docks a prompt bar at the bottom of the sidebar (under the preview, same spot for groups). Arrows keep navigating while it is open, so the target follows the cursor:
  - **Session row** + `enter`: the text is sent into the session's tmux pane as literal keystrokes plus Enter — answer a waiting agent without attaching. The bar clears and stays armed for the next answer.
  - **Group row** + `enter`: spawns a new agent in that group with the prompt embedded, using the group's default path and the default tool from Settings. It starts working immediately.
- **Settings panel** (`s`): choose the default CLI for quick spawn; persisted in a new `settings` table in `state.db`, falling back to the first configured tool when unset or stale.
- **Form prompt**: the New Session form gains an optional `prompt` field embedded into the launch command via the per-tool `prompt_flag` config (opencode `--prompt` since its positional arg is the project path; claude stays positional).
- Group folding moves to `f` (`enter` still folds); sidebar titles group rows.

## Details

- A quick send clears the session's acked flag, so the next finished alert fires.
- Dead sessions get "press v to revive" instead of a silent no-op.
- Dash-leading prompts are rejected: the launched tool would parse them as CLI flags.
- The prompt affects only the launch command; revive stays prompt-free.
- Fixes a latent binding bug: bubbletea reports space as a literal " " character, so the previous fold-on-space case never matched a real keypress.

## Testing

- e2e tests against a real tmux server: SendText echo, dead-session error, acked clearing, quick spawn into a group (tool/dir/group asserted), stale default-tool fallback, command composition with hooks `--settings`, dash-prompt rejection.
- Live-verified in an isolated environment: bar docked under the preview, target flipped between "answer catty" and "new echo agent in backend" while navigating, answer landed in the pane, group spawn ran `echo got: 'build the api'` in the group's default path.