### PR TITLE
Edit groups after creation: rename + default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 | `ctrl+q` | Inside a session: back to the manager |
 | `shift+↑` / `shift+↓` | Reorder session or group among its siblings |
 | `m` | Move session to another group |
-| `r` | Rename session or group |
+| `r` | Rename session / edit group (name and default path) |
 | `v` | Revive a dead session (`revive_command`, e.g. `claude --continue`, resumes the conversation) |
 | `a` / `u` | Archive / restore |
 | `d` | Delete session, or a group + its entire subtree |

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/status"
@@ -410,7 +411,9 @@ func (m *Model) openRename() {
 	input.Focus()
 	if entry.isGroup {
 		input.SetValue(baseName(entry.group))
-		m.rename = renameTarget{isGroup: true, path: entry.group, input: input}
+		dir := textField("default path (optional)", 400)
+		dir.SetValue(m.groupPaths[entry.group])
+		m.rename = renameTarget{isGroup: true, path: entry.group, input: input, dir: dir}
 	} else {
 		input.SetValue(entry.sess.Name)
 		m.rename = renameTarget{sessID: entry.sess.ID, input: input}
@@ -419,46 +422,85 @@ func (m *Model) openRename() {
 	m.err = ""
 }
 
+func (m *Model) renameFocus(delta int) {
+	m.rename.focus = (m.rename.focus + delta + 2) % 2
+	m.rename.input.Blur()
+	m.rename.dir.Blur()
+	if m.rename.focus == 0 {
+		m.rename.input.Focus()
+	} else {
+		m.rename.dir.Focus()
+	}
+}
+
 func (m *Model) handleRenameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
 		m.mode = modeList
 		return m, nil
-	case "enter":
-		name := strings.TrimSpace(m.rename.input.Value())
-		name = strings.ReplaceAll(name, "/", "-")
-		if name == "" {
-			m.err = "name cannot be empty"
+	case "tab", "up", "down":
+		if m.rename.isGroup {
+			m.renameFocus(1)
 			return m, nil
 		}
-		if m.rename.isGroup {
-			newPath := name
-			if idx := strings.LastIndex(m.rename.path, "/"); idx >= 0 {
-				newPath = m.rename.path[:idx] + "/" + name
-			}
-			if err := m.store.RenameGroup(m.rename.path, newPath); err != nil {
-				m.err = err.Error()
-				return m, nil
-			}
-			if m.collapsed[m.rename.path] {
-				delete(m.collapsed, m.rename.path)
-				m.collapsed[newPath] = true
-			}
-			m.relabelSubtree(newPath)
-		} else {
-			if err := m.store.RenameSession(m.rename.sessID, name); err != nil {
-				m.err = err.Error()
-				return m, nil
-			}
-			m.relabelSession(m.rename.sessID)
-		}
-		m.mode = modeList
-		m.requestRefresh()
-		return m, nil
+	case "enter":
+		return m.applyRename()
 	}
 	var cmd tea.Cmd
-	m.rename.input, cmd = m.rename.input.Update(msg)
+	if m.rename.focus == 0 {
+		m.rename.input, cmd = m.rename.input.Update(msg)
+	} else {
+		m.rename.dir, cmd = m.rename.dir.Update(msg)
+	}
 	return m, cmd
+}
+
+func (m *Model) applyRename() (tea.Model, tea.Cmd) {
+	name := strings.TrimSpace(m.rename.input.Value())
+	name = strings.ReplaceAll(name, "/", "-")
+	if name == "" {
+		m.err = "name cannot be empty"
+		return m, nil
+	}
+	if m.rename.isGroup {
+		dir := expandHome(strings.TrimSpace(m.rename.dir.Value()))
+		if dir != "" {
+			if abs, err := filepath.Abs(dir); err == nil {
+				dir = abs
+			}
+			if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+				m.err = "default path does not exist: " + dir
+				return m, nil
+			}
+		}
+		newPath := name
+		if idx := strings.LastIndex(m.rename.path, "/"); idx >= 0 {
+			newPath = m.rename.path[:idx] + "/" + name
+		}
+		if err := m.store.RenameGroup(m.rename.path, newPath); err != nil {
+			m.err = err.Error()
+			return m, nil
+		}
+		// CreateGroup upserts, so it doubles as the default-path setter.
+		if err := m.store.CreateGroup(newPath, dir); err != nil {
+			m.err = err.Error()
+			return m, nil
+		}
+		if m.collapsed[m.rename.path] {
+			delete(m.collapsed, m.rename.path)
+			m.collapsed[newPath] = true
+		}
+		m.relabelSubtree(newPath)
+	} else {
+		if err := m.store.RenameSession(m.rename.sessID, name); err != nil {
+			m.err = err.Error()
+			return m, nil
+		}
+		m.relabelSession(m.rename.sessID)
+	}
+	m.mode = modeList
+	m.requestRefresh()
+	return m, nil
 }
 
 func (m *Model) openQuickMode() {

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -129,16 +129,17 @@ func (m *Model) viewGroupForm() string {
 }
 
 func (m *Model) viewRename() string {
-	what := "Session"
-	sub := ""
-	if m.rename.isGroup {
-		what = "Group"
-		if idx := strings.LastIndex(m.rename.path, "/"); idx >= 0 {
-			sub = mutedStyle.Render("under "+m.rename.path[:idx]) + "\n\n"
-		}
+	if !m.rename.isGroup {
+		return m.card("✎ Rename Session", m.rename.input.View(), "↵ apply · esc cancel")
 	}
-	body := sub + m.rename.input.View()
-	return m.card("✎ Rename "+what, body, "↵ apply · esc cancel")
+	sub := ""
+	if idx := strings.LastIndex(m.rename.path, "/"); idx >= 0 {
+		sub = mutedStyle.Render("under "+m.rename.path[:idx]) + "\n\n"
+	}
+	body := sub +
+		formField("name", m.rename.input.View(), m.rename.focus == 0) +
+		formField("path", m.rename.dir.View(), m.rename.focus == 1)
+	return m.card("✎ Edit Group", strings.TrimRight(body, "\n"), "tab/↑↓ move · ↵ apply · esc cancel")
 }
 
 func (m *Model) viewSettings() string {
@@ -161,7 +162,7 @@ func (m *Model) viewHelp() string {
 		{"ctrl+q", "inside a session: back to manager"},
 		{"m", "move session to another group"},
 		{"g", "new group (name, parent, default path)"},
-		{"r", "rename session / group"},
+		{"r", "rename session / edit group (name + default path)"},
 		{"v", "revive dead session (resumes the agent)"},
 		{"a / u", "archive / restore"},
 		{"d", "delete session, or group + subtree"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -99,6 +99,8 @@ type renameTarget struct {
 	path    string
 	sessID  string
 	input   textinput.Model
+	dir     textinput.Model
+	focus   int
 }
 
 // quickState is the inline prompt bar docked under the preview: active

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -869,3 +869,60 @@ func TestQuickSpawnUsesTabCycledTool(t *testing.T) {
 		t.Fatalf("spawned tool = %q want claude-hooked", sessions[0].Tool)
 	}
 }
+
+func TestEditGroupRenamesAndSetsPath(t *testing.T) {
+	m := buildModel(t)
+	oldDir := t.TempDir()
+	newDir := t.TempDir()
+	if err := m.store.CreateGroup("backend", oldDir); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	for i, row := range m.rows {
+		if row.isGroup && row.group == "backend" {
+			m.cursor = i
+		}
+	}
+
+	m.openRename()
+	if m.mode != modeRename || !m.rename.isGroup {
+		t.Fatalf("edit group should open, mode = %v", m.mode)
+	}
+	if m.rename.dir.Value() != oldDir {
+		t.Fatalf("path prefill = %q want %q", m.rename.dir.Value(), oldDir)
+	}
+	m.rename.input.SetValue("platform")
+	m.rename.dir.SetValue(newDir)
+	if _, _ = m.applyRename(); m.err != "" {
+		t.Fatalf("apply: %q", m.err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+
+	if m.groupPaths["platform"] != newDir {
+		t.Fatalf("platform path = %q want %q", m.groupPaths["platform"], newDir)
+	}
+	if _, exists := m.groupPaths["backend"]; exists {
+		t.Fatal("old group name should be gone")
+	}
+}
+
+func TestEditGroupRejectsMissingPath(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("backend", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	for i, row := range m.rows {
+		if row.isGroup && row.group == "backend" {
+			m.cursor = i
+		}
+	}
+	m.openRename()
+	m.rename.dir.SetValue("/nope/definitely/missing")
+	if _, _ = m.applyRename(); m.err == "" {
+		t.Fatal("missing path should be rejected")
+	}
+	if m.mode != modeRename {
+		t.Fatal("modal should stay open on error")
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -416,7 +416,7 @@ func padToHeight(s string, height int) string {
 func (m *Model) viewFooter() string {
 	pairs := [][2]string{
 		{"↑↓", "navigate"}, {"↵", "attach"}, {"n", "new"}, {"g", "group"},
-		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"f", "fold"}, {"m", "move"}, {"r", "rename"},
+		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"f", "fold"}, {"m", "move"}, {"r", "rename/edit"},
 		{"v", "revive"}, {"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
 		{"t", "archived"}, {"s", "settings"}, {"ctrl+r", "refresh"}, {"?", "help"}, {"q", "quit"},
 	}


### PR DESCRIPTION
## What

`r` on a group row opens an **Edit Group** modal with the group's name and default path prefilled. Tab/arrows switch fields; enter applies both. Sessions keep the plain rename modal.

## Details

- The rename keeps the existing subtree relabeling and collapse-state carry-over.
- The path field goes through the same validation as the New Group form (empty allowed, must exist otherwise); the modal stays open on error.
- `CreateGroup`'s upsert doubles as the path setter, so no new store method.

## Testing

- e2e: rename + path change land in the store and the old group name disappears; missing path is rejected with the modal kept open.
- Live-verified: edited `backend` (path `/tmp/amqp/old`) into `platform` (path `/tmp/amqp/new`); tree row and the groups table both updated.

Replaces #4, which GitHub auto-closed when its base branch merged.