### PR TITLE
Group path autocomplete in edit + paths always resolve

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -389,12 +389,12 @@ func (m *Model) openGroupForm() {
 	name.Focus()
 	m.groupForm = groupForm{
 		name:     name,
-		path:     textField("default working directory (optional)", 400),
+		path:     textField("default working directory", 400),
 		pathAuto: true,
 		focus:    gfName,
 	}
 	m.rebuildGroupOptions(m.contextGroup())
-	m.groupForm.path.SetValue(m.ancestorGroupPath(m.selectedGroupPath()))
+	m.groupForm.path.SetValue(m.groupDefaultDir(m.selectedGroupPath()))
 	m.pathSugg.reset()
 	m.mode = modeGroupForm
 	m.err = ""
@@ -484,14 +484,15 @@ func (m *Model) submitGroupForm() (tea.Model, tea.Cmd) {
 		full = parent + "/" + name
 	}
 	path := expandHome(strings.TrimSpace(m.groupForm.path.Value()))
-	if path != "" {
-		if abs, err := filepath.Abs(path); err == nil {
-			path = abs
-		}
-		if info, err := os.Stat(path); err != nil || !info.IsDir() {
-			m.err = "default path does not exist: " + path
-			return m, nil
-		}
+	if path == "" {
+		path = m.groupDefaultDir(parent)
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	if info, err := os.Stat(path); err != nil || !info.IsDir() {
+		m.err = "default path does not exist: " + path
+		return m, nil
 	}
 	if err := m.store.CreateGroup(full, path); err != nil {
 		m.err = err.Error()

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -411,8 +411,13 @@ func (m *Model) openRename() {
 	input.Focus()
 	if entry.isGroup {
 		input.SetValue(baseName(entry.group))
-		dir := textField("default path (optional)", 400)
-		dir.SetValue(m.groupPaths[entry.group])
+		dir := textField("default working directory", 400)
+		dirValue := m.groupPaths[entry.group]
+		if dirValue == "" {
+			dirValue = m.groupDefaultDir(entry.group)
+		}
+		dir.SetValue(dirValue)
+		m.pathSugg.reset()
 		m.rename = renameTarget{isGroup: true, path: entry.group, input: input, dir: dir}
 	} else {
 		input.SetValue(entry.sess.Name)
@@ -423,6 +428,7 @@ func (m *Model) openRename() {
 }
 
 func (m *Model) renameFocus(delta int) {
+	m.pathSugg.reset()
 	m.rename.focus = (m.rename.focus + delta + 2) % 2
 	m.rename.input.Blur()
 	m.rename.dir.Blur()
@@ -434,16 +440,37 @@ func (m *Model) renameFocus(delta int) {
 }
 
 func (m *Model) handleRenameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	pathSuggesting := m.rename.isGroup && m.rename.focus == 1 && m.pathSugg.active()
 	switch msg.String() {
 	case "esc":
+		if pathSuggesting {
+			m.pathSugg.reset()
+			return m, nil
+		}
 		m.mode = modeList
 		return m, nil
 	case "tab", "up", "down":
-		if m.rename.isGroup {
-			m.renameFocus(1)
+		if !m.rename.isGroup {
+			break
+		}
+		if pathSuggesting {
+			switch msg.String() {
+			case "tab":
+				m.applyPathSuggestion()
+			case "up":
+				m.pathSugg.move(-1)
+			case "down":
+				m.pathSugg.move(1)
+			}
 			return m, nil
 		}
+		m.renameFocus(1)
+		return m, nil
 	case "enter":
+		if pathSuggesting && m.pathSugg.chosen {
+			m.applyPathSuggestion()
+			return m, nil
+		}
 		return m.applyRename()
 	}
 	var cmd tea.Cmd
@@ -451,6 +478,7 @@ func (m *Model) handleRenameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.rename.input, cmd = m.rename.input.Update(msg)
 	} else {
 		m.rename.dir, cmd = m.rename.dir.Update(msg)
+		m.pathSugg.recompute(m.rename.dir.Value())
 	}
 	return m, cmd
 }
@@ -464,14 +492,19 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 	}
 	if m.rename.isGroup {
 		dir := expandHome(strings.TrimSpace(m.rename.dir.Value()))
-		if dir != "" {
-			if abs, err := filepath.Abs(dir); err == nil {
-				dir = abs
+		if dir == "" {
+			parent := ""
+			if idx := strings.LastIndex(m.rename.path, "/"); idx >= 0 {
+				parent = m.rename.path[:idx]
 			}
-			if info, err := os.Stat(dir); err != nil || !info.IsDir() {
-				m.err = "default path does not exist: " + dir
-				return m, nil
-			}
+			dir = m.groupDefaultDir(parent)
+		}
+		if abs, err := filepath.Abs(dir); err == nil {
+			dir = abs
+		}
+		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+			m.err = "default path does not exist: " + dir
+			return m, nil
 		}
 		newPath := name
 		if idx := strings.LastIndex(m.rename.path, "/"); idx >= 0 {

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -139,7 +139,15 @@ func (m *Model) viewRename() string {
 	body := sub +
 		formField("name", m.rename.input.View(), m.rename.focus == 0) +
 		formField("path", m.rename.dir.View(), m.rename.focus == 1)
-	return m.card("✎ Edit Group", strings.TrimRight(body, "\n"), "tab/↑↓ move · ↵ apply · esc cancel")
+	hint := "tab/↑↓ move · ↵ apply · esc cancel"
+	if m.rename.focus == 1 && m.pathSugg.active() {
+		body += m.viewPathSuggestions() + "\n"
+		hint = "↑↓ pick · tab complete · ↵ apply · esc close"
+		if m.pathSugg.chosen {
+			hint = "↑↓ pick · ↵/tab complete · esc close"
+		}
+	}
+	return m.card("✎ Edit Group", strings.TrimRight(body, "\n"), hint)
 }
 
 func (m *Model) viewSettings() string {

--- a/internal/ui/pathcomplete.go
+++ b/internal/ui/pathcomplete.go
@@ -108,6 +108,9 @@ func (m *Model) applyPathSuggestion() {
 		m.groupForm.path.SetValue(path)
 		m.groupForm.path.CursorEnd()
 		m.groupForm.pathAuto = false
+	case modeRename:
+		m.rename.dir.SetValue(path)
+		m.rename.dir.CursorEnd()
 	}
 	m.pathSugg.recompute(path)
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -926,3 +926,38 @@ func TestEditGroupRejectsMissingPath(t *testing.T) {
 		t.Fatal("modal should stay open on error")
 	}
 }
+
+func TestGroupPathNeverEmpty(t *testing.T) {
+	m := buildModel(t)
+	m.openGroupForm()
+	if m.groupForm.path.Value() == "" {
+		t.Fatal("group form path should prefill with a resolved directory")
+	}
+	m.groupForm.name.SetValue("zone")
+	m.groupForm.path.SetValue("")
+	if _, _ = m.submitGroupForm(); m.err != "" {
+		t.Fatalf("submit: %q", m.err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	if m.groupPaths["zone"] == "" {
+		t.Fatal("created group should get a resolved default path, not empty")
+	}
+
+	for i, row := range m.rows {
+		if row.isGroup && row.group == "zone" {
+			m.cursor = i
+		}
+	}
+	m.openRename()
+	if m.rename.dir.Value() == "" {
+		t.Fatal("edit modal should prefill the path")
+	}
+	m.rename.dir.SetValue("")
+	if _, _ = m.applyRename(); m.err != "" {
+		t.Fatalf("apply: %q", m.err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	if m.groupPaths["zone"] == "" {
+		t.Fatal("edited group should keep a resolved path when cleared")
+	}
+}


### PR DESCRIPTION
## What

- The Edit Group modal's path field gets the same directory autocomplete as the New Group form: dropdown under the field, tab completes, arrows pick, esc closes the dropdown before the modal.
- Group default paths always resolve to a real directory. Both forms prefill with the effective path (nearest ancestor's path, else the manager's cwd), and a cleared field resolves the same way on submit. Every group now carries a concrete, validated directory.

## Testing

- e2e: form prefills non-empty; submitting an emptied path stores a resolved directory in both create and edit flows.
- Live-verified: creating `backend` with the prefilled path stored `/tmp/amqp/work`; editing typed `/tmp/amqp/pro`, the dropdown suggested `projects`, tab completed, picked `alpha`, and the store ended with `/tmp/amqp/projects/alpha`.