### PR TITLE
Group pane in the sidebar and a growing quick bar

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -9,8 +9,10 @@ import (
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/sysstat"
+	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -537,9 +539,18 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) openQuickMode() {
-	input := textinput.New()
+	input := textarea.New()
 	input.CharLimit = 2000
 	input.Placeholder = "type and press enter"
+	input.ShowLineNumbers = false
+	input.SetPromptFunc(2, func(lineIndex int) string {
+		if lineIndex == 0 {
+			return "> "
+		}
+		return ""
+	})
+	input.FocusedStyle.CursorLine = lipgloss.NewStyle()
+	input.SetHeight(1)
 	input.Focus()
 	m.err = ""
 	names := sortedToolNames(m.cfg)
@@ -573,6 +584,11 @@ func (m *Model) handleQuickKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		return m.submitQuick()
 	}
+	// Update repositions its viewport against the height set at the last
+	// render; a keystroke that adds a wrapped row would scroll that first
+	// row away for good. Full cap height here keeps the viewport pinned,
+	// and the next render shrinks the bar back to the rows the text needs.
+	m.quick.input.SetHeight(quickBarMaxRows)
 	var cmd tea.Cmd
 	m.quick.input, cmd = m.quick.input.Update(msg)
 	return m, cmd

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/sysstat"
 	"github.com/YoanWai/agent-manager/internal/tmux"
+	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -108,7 +109,7 @@ type renameTarget struct {
 // the spawn CLI for group targets, cycled with tab.
 type quickState struct {
 	active    bool
-	input     textinput.Model
+	input     textarea.Model
 	toolNames []string
 	toolIndex int
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func buildModel(t *testing.T) *Model {
@@ -959,5 +960,38 @@ func TestGroupPathNeverEmpty(t *testing.T) {
 	m.applyCmd(t, m.refreshCmd())
 	if m.groupPaths["zone"] == "" {
 		t.Fatal("edited group should keep a resolved path when cleared")
+	}
+}
+
+func TestGroupRowRendersGroupPane(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("backend", dir); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "api-agent", dir, "backend")
+	for i, row := range m.rows {
+		if row.isGroup && row.group == "backend" {
+			m.cursor = i
+		}
+	}
+
+	detail := ansi.Strip(m.viewDetail(112))
+	if !strings.Contains(detail, dir) {
+		t.Fatalf("group detail missing path %q:\n%s", dir, detail)
+	}
+	if !strings.Contains(detail, "1 agent") {
+		t.Fatalf("group detail missing agent count:\n%s", detail)
+	}
+
+	agents := ansi.Strip(m.viewGroupAgents("backend", 112, 10))
+	if !strings.Contains(agents, "api-agent") {
+		t.Fatalf("agents list missing session:\n%s", agents)
+	}
+
+	inherited := ansi.Strip(m.viewGroupDetail("backend/sub", 112))
+	if !strings.Contains(inherited, dir) || !strings.Contains(inherited, "inherited") {
+		t.Fatalf("subgroup should inherit the ancestor path:\n%s", inherited)
 	}
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -297,8 +297,12 @@ func (m *Model) viewSidebar(width, height int) string {
 	}
 	detail := divider("Details", width) + "\n" + m.viewDetail(width)
 	body := detail
-	if previewHeight := height - lipgloss.Height(detail) - 1; previewHeight >= 3 {
-		body = detail + "\n" + m.viewPreview(width, previewHeight)
+	if rest := height - lipgloss.Height(detail) - 1; rest >= 3 {
+		if group, ok := m.selectedGroup(); ok {
+			body = detail + "\n" + m.viewGroupAgents(group, width, rest)
+		} else {
+			body = detail + "\n" + m.viewPreview(width, rest)
+		}
 	}
 	if bar == "" {
 		return body
@@ -317,12 +321,51 @@ func (m *Model) viewQuickBar(width int) string {
 			target = "answer " + entry.sess.Name
 		}
 	}
+	m.quick.input.SetWidth(width)
+	m.quick.input.SetHeight(m.quickBarRows(width - 2))
 	return divider("Quick Prompt · "+target, width) + "\n" + m.quick.input.View()
+}
+
+const quickBarMaxRows = 5
+
+// quickBarRows is the rows the typed text needs at the current width,
+// capped so the bar never swallows the sidebar. Single-line values (the
+// normal case) count exact soft-wrap rows; pasted multi-line values are
+// estimated, with the textarea scrolling to keep the cursor visible.
+func (m *Model) quickBarRows(textWidth int) int {
+	rows := 0
+	if m.quick.input.LineCount() == 1 {
+		rows = m.quick.input.LineInfo().Height
+	} else {
+		if textWidth < 1 {
+			textWidth = 1
+		}
+		for _, line := range strings.Split(m.quick.input.Value(), "\n") {
+			rows += 1 + (max(lipgloss.Width(line), 1)-1)/textWidth
+		}
+	}
+	if rows > quickBarMaxRows {
+		rows = quickBarMaxRows
+	}
+	if rows < 1 {
+		rows = 1
+	}
+	return rows
+}
+
+func (m *Model) selectedGroup() (string, bool) {
+	if entry, ok := m.selectedRow(); ok && entry.isGroup {
+		return entry.group, true
+	}
+	return "", false
 }
 
 func (m *Model) viewDetail(width int) string {
 	sess, ok := m.selected()
 	if !ok {
+		if group, isGroup := m.selectedGroup(); isGroup {
+			return m.viewGroupDetail(group, width)
+		}
 		return "\n" + mutedStyle.Render("Select a session to inspect it.")
 	}
 	var b strings.Builder
@@ -335,6 +378,105 @@ func (m *Model) viewDetail(width int) string {
 		b.WriteString(kv("proc", fmt.Sprintf("%.1f%% · %s", m.proc.CPUPercent, humanBytes(m.proc.RSS))))
 	}
 	return b.String()
+}
+
+// viewGroupDetail fills the details panel for a selected group: default
+// path (own or inherited), direct subgroup count, and a status breakdown
+// of every agent in the subtree.
+func (m *Model) viewGroupDetail(group string, width int) string {
+	var b strings.Builder
+	count := m.groupSessionCount(group)
+	countLabel := fmt.Sprintf("%d agents", count)
+	if count == 1 {
+		countLabel = "1 agent"
+	}
+	b.WriteString(pill("group", colorAccent2) + "  " + pill(countLabel, colorAccent) + "\n")
+
+	path := m.groupPaths[group]
+	source := ""
+	if path == "" {
+		path = m.groupDefaultDir(group)
+		source = subtleStyle.Render(" · inherited")
+	}
+	b.WriteString(labelStyle.Width(6).Render("path") +
+		valueStyle.Render(truncateTail(path, width-8)) + source + "\n")
+
+	if group != "" {
+		b.WriteString(kv("group", displayGroup(parentGroup(group))))
+	}
+	if subgroups := m.directSubgroupCount(group); subgroups > 0 {
+		b.WriteString(kv("subs", fmt.Sprintf("%d", subgroups)))
+	}
+	if breakdown := m.groupStatusBreakdown(group); breakdown != "" {
+		b.WriteString(labelStyle.Width(6).Render("state") + breakdown + "\n")
+	}
+	return b.String()
+}
+
+func parentGroup(group string) string {
+	if idx := strings.LastIndex(group, "/"); idx >= 0 {
+		return group[:idx]
+	}
+	return ""
+}
+
+func (m *Model) directSubgroupCount(group string) int {
+	count := 0
+	for path := range groupClosure(m.groups, m.sessions) {
+		if parentGroup(path) == group && path != group {
+			count++
+		}
+	}
+	return count
+}
+
+// groupStatusBreakdown renders "2 working · 1 waiting" for the subtree,
+// each count tinted in its status color, skipping zero statuses.
+func (m *Model) groupStatusBreakdown(group string) string {
+	counts := map[string]int{}
+	for _, sess := range m.sessions {
+		if sess.Group == group || strings.HasPrefix(sess.Group, group+"/") {
+			counts[sess.Status]++
+		}
+	}
+	var parts []string
+	for _, st := range []string{status.Working, status.Waiting, status.Finished, status.Errored, status.Idle, status.Dead} {
+		if counts[st] > 0 {
+			parts = append(parts, lipgloss.NewStyle().Foreground(statusColor(st)).
+				Render(fmt.Sprintf("%d %s", counts[st], st)))
+		}
+	}
+	return strings.Join(parts, subtleStyle.Render(" · "))
+}
+
+// viewGroupAgents lists the subtree's sessions where a session's pane
+// preview would sit, so a group row reads as a group pane.
+func (m *Model) viewGroupAgents(group string, width, height int) string {
+	var b strings.Builder
+	b.WriteString(divider("Agents", width) + "\n")
+	shown, total := 0, m.groupSessionCount(group)
+	if total == 0 {
+		b.WriteString(mutedStyle.Render("(no agents yet — press space to spawn one)"))
+		return padToHeight(b.String(), height)
+	}
+	for _, sess := range m.sessions {
+		if sess.Group != group && !strings.HasPrefix(sess.Group, group+"/") {
+			continue
+		}
+		if shown >= height-2 && total > shown+1 {
+			b.WriteString(subtleStyle.Render(fmt.Sprintf("  … %d more", total-shown)))
+			break
+		}
+		glyph := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
+		line := glyph + " " + valueStyle.Render(sess.Name) +
+			subtleStyle.Render("  "+sess.Tool+" · "+relTime(sess.CreatedAt))
+		if ansi.StringWidth(line) > width {
+			line = ansi.Truncate(line, width-1, "…")
+		}
+		b.WriteString(line + "\n")
+		shown++
+	}
+	return padToHeight(strings.TrimRight(b.String(), "\n"), height)
 }
 
 // viewPreview renders the tail of the selected session's tmux pane with


### PR DESCRIPTION
Selecting a group turns the side panel into a group pane: agent-count pill, default path (own or inherited, never empty), parent group, subgroup count, and a colored status breakdown of the subtree. The preview slot lists the subtree's agents with status glyph, tool, and age, and hints `space` to spawn when the group is empty.

The quick prompt bar is now a textarea that grows with the typed text (soft-wrap aware, capped at five rows), so longer prompts stay readable while typing.

Verified live in an isolated tmux rig: empty group pane, quick-spawn updates count/state/list, session rows keep the normal session pane. `TestGroupRowRendersGroupPane` covers the rendering; full suite green.