### PR TITLE
Inline rename for sessions and groups

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -408,10 +408,12 @@ func (m *Model) openRename() {
 	}
 	input := textinput.New()
 	input.CharLimit = 60
+	input.Prompt = ""
 	input.Focus()
 	if entry.isGroup {
 		input.SetValue(baseName(entry.group))
 		dir := textField("default working directory", 400)
+		dir.Prompt = ""
 		dirValue := m.groupPaths[entry.group]
 		if dirValue == "" {
 			dirValue = m.groupDefaultDir(entry.group)
@@ -519,21 +521,55 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 			m.err = err.Error()
 			return m, nil
 		}
-		if m.collapsed[m.rename.path] {
-			delete(m.collapsed, m.rename.path)
-			m.collapsed[newPath] = true
-		}
+		m.renameGroupLocally(m.rename.path, newPath, dir)
 		m.relabelSubtree(newPath)
 	} else {
 		if err := m.store.RenameSession(m.rename.sessID, name); err != nil {
 			m.err = err.Error()
 			return m, nil
 		}
+		for i := range m.sessions {
+			if m.sessions[i].ID == m.rename.sessID {
+				m.sessions[i].Name = name
+			}
+		}
 		m.relabelSession(m.rename.sessID)
 	}
+	m.rebuildRows()
 	m.mode = modeList
 	m.requestRefresh()
 	return m, nil
+}
+
+// renameGroupLocally rewrites the in-memory tree right away, so the
+// frames between saving and the poller's next refresh already show the
+// new name and path instead of flashing the stale ones.
+func (m *Model) renameGroupLocally(old, newPath, dir string) {
+	moved := func(group string) (string, bool) {
+		if group == old || strings.HasPrefix(group, old+"/") {
+			return newPath + group[len(old):], true
+		}
+		return group, false
+	}
+	for i := range m.groups {
+		m.groups[i], _ = moved(m.groups[i])
+	}
+	for i := range m.sessions {
+		m.sessions[i].Group, _ = moved(m.sessions[i].Group)
+	}
+	groupPaths := make(map[string]string, len(m.groupPaths))
+	for group, path := range m.groupPaths {
+		group, _ = moved(group)
+		groupPaths[group] = path
+	}
+	groupPaths[newPath] = dir
+	m.groupPaths = groupPaths
+	for group, folded := range m.collapsed {
+		if renamed, ok := moved(group); ok {
+			delete(m.collapsed, group)
+			m.collapsed[renamed] = folded
+		}
+	}
 }
 
 func (m *Model) openQuickMode() {

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -128,28 +128,6 @@ func (m *Model) viewGroupForm() string {
 	return m.card("✦ New Group", strings.TrimRight(b.String(), "\n"), hint)
 }
 
-func (m *Model) viewRename() string {
-	if !m.rename.isGroup {
-		return m.card("✎ Rename Session", m.rename.input.View(), "↵ apply · esc cancel")
-	}
-	sub := ""
-	if idx := strings.LastIndex(m.rename.path, "/"); idx >= 0 {
-		sub = mutedStyle.Render("under "+m.rename.path[:idx]) + "\n\n"
-	}
-	body := sub +
-		formField("name", m.rename.input.View(), m.rename.focus == 0) +
-		formField("path", m.rename.dir.View(), m.rename.focus == 1)
-	hint := "tab/↑↓ move · ↵ apply · esc cancel"
-	if m.rename.focus == 1 && m.pathSugg.active() {
-		body += m.viewPathSuggestions() + "\n"
-		hint = "↑↓ pick · tab complete · ↵ apply · esc close"
-		if m.pathSugg.chosen {
-			hint = "↑↓ pick · ↵/tab complete · esc close"
-		}
-	}
-	return m.card("✎ Edit Group", strings.TrimRight(body, "\n"), hint)
-}
-
 func (m *Model) viewSettings() string {
 	marker := lipgloss.NewStyle().Foreground(colorAccent).Render("❯ ")
 	label := lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("quick spawn tool")

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -20,8 +20,6 @@ func (m *Model) View() string {
 		return m.viewForm()
 	case modeHelp:
 		return m.viewHelp()
-	case modeRename:
-		return m.viewRename()
 	case modeSettings:
 		return m.viewSettings()
 	case modeMove:
@@ -241,6 +239,11 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 	}
 	guides := treeGuides(entry.depth)
 
+	if m.renamingRow(entry) {
+		line := bar + " " + guides + m.renameRowInput(entry, width-2-ansi.StringWidth(guides))
+		return selectedRowStyle.Render(padRight(line, width))
+	}
+
 	var content string
 	if entry.isGroup {
 		marker := "▾"
@@ -272,6 +275,34 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 		return selectedRowStyle.Render(line)
 	}
 	return line
+}
+
+func (m *Model) renamingGroup(group string) bool {
+	return m.mode == modeRename && m.rename.isGroup && m.rename.path == group
+}
+
+func (m *Model) renamingRow(entry treeRow) bool {
+	if m.mode != modeRename {
+		return false
+	}
+	if entry.isGroup {
+		return m.rename.isGroup && entry.group == m.rename.path
+	}
+	return !m.rename.isGroup && entry.sess.ID == m.rename.sessID
+}
+
+// renameRowInput renders the inline name editor in place of the row's
+// label, keeping the row's glyph so the edit reads in context.
+func (m *Model) renameRowInput(entry treeRow, width int) string {
+	lead := subtleStyle.Render("▾")
+	if !entry.isGroup {
+		lead = lipgloss.NewStyle().Foreground(statusColor(entry.sess.Status)).
+			Render(statusGlyph(entry.sess.Status))
+	}
+	if fieldWidth := width - 4; fieldWidth >= 5 {
+		m.rename.input.Width = fieldWidth
+	}
+	return lead + " " + m.rename.input.View()
 }
 
 // divider renders a labeled section rule that fills the given width.
@@ -392,14 +423,28 @@ func (m *Model) viewGroupDetail(group string, width int) string {
 	}
 	b.WriteString(pill("group", colorAccent2) + "  " + pill(countLabel, colorAccent) + "\n")
 
-	path := m.groupPaths[group]
-	source := ""
-	if path == "" {
-		path = m.groupDefaultDir(group)
-		source = subtleStyle.Render(" · inherited")
+	if m.renamingGroup(group) {
+		label := labelStyle
+		if m.rename.focus == 1 {
+			label = lipgloss.NewStyle().Foreground(colorAccent)
+		}
+		if fieldWidth := width - 8; fieldWidth >= 10 {
+			m.rename.dir.Width = fieldWidth
+		}
+		b.WriteString(label.Width(6).Render("path") + m.rename.dir.View() + "\n")
+		if m.rename.focus == 1 && m.pathSugg.active() {
+			b.WriteString(m.viewPathSuggestions() + "\n")
+		}
+	} else {
+		path := m.groupPaths[group]
+		source := ""
+		if path == "" {
+			path = m.groupDefaultDir(group)
+			source = subtleStyle.Render(" · inherited")
+		}
+		b.WriteString(labelStyle.Width(6).Render("path") +
+			valueStyle.Render(truncateTail(path, width-8)) + source + "\n")
 	}
-	b.WriteString(labelStyle.Width(6).Render("path") +
-		valueStyle.Render(truncateTail(path, width-8)) + source + "\n")
 
 	if group != "" {
 		b.WriteString(kv("group", displayGroup(parentGroup(group))))
@@ -566,6 +611,12 @@ func (m *Model) viewFooter() string {
 		pairs = [][2]string{
 			{"↵", "send"}, {"↑↓", "switch target"}, {"⇥", "tool: " + m.quickTool()},
 			{"esc", "close"},
+		}
+	}
+	if m.mode == modeRename {
+		pairs = [][2]string{{"↵", "save"}, {"esc", "cancel"}}
+		if m.rename.isGroup {
+			pairs = [][2]string{{"⇥", "name / path"}, {"↵", "save"}, {"esc", "cancel"}}
 		}
 	}
 	sep := subtleStyle.Render(" · ")


### PR DESCRIPTION
Pressing `r` edits the name directly in the tree row (status glyph / fold marker kept), replacing the modal. Group default paths edit in the group pane's `path` line with the autocomplete dropdown rendered in the pane; `tab` toggles name/path. Footer shows contextual save/cancel hints while editing.

Saving patches the in-memory tree immediately (groups, sessions, group paths, fold state), so no stale-name flicker between the store write and the poller's next refresh — verified frame-by-frame at 0.3s captures in an isolated tmux rig, plus the full suggestion-pick and save flows for both sessions and groups.