### PR TITLE
Wrap the cursor around the list ends

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -96,13 +96,16 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // fetch for the newly selected session, so the sidebar follows the
 // cursor without waiting for the next poll tick.
 func (m *Model) moveCursor(delta int) tea.Cmd {
+	if len(m.rows) == 0 {
+		return nil
+	}
 	previous := m.cursor
 	m.cursor += delta
 	if m.cursor < 0 {
-		m.cursor = 0
+		m.cursor = len(m.rows) - 1
 	}
 	if m.cursor >= len(m.rows) {
-		m.cursor = len(m.rows) - 1
+		m.cursor = 0
 	}
 	if m.cursor == previous {
 		return nil

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -995,3 +995,27 @@ func TestGroupRowRendersGroupPane(t *testing.T) {
 		t.Fatalf("subgroup should inherit the ancestor path:\n%s", inherited)
 	}
 }
+
+func TestCursorWrapsAroundTheList(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	createSession(t, m, "first", dir, "")
+	createSession(t, m, "second", dir, "")
+
+	m.cursor = 0
+	m.moveCursor(-1)
+	if m.cursor != len(m.rows)-1 {
+		t.Fatalf("up from the top should wrap to the bottom, cursor = %d", m.cursor)
+	}
+	m.moveCursor(1)
+	if m.cursor != 0 {
+		t.Fatalf("down from the bottom should wrap to the top, cursor = %d", m.cursor)
+	}
+
+	m.rows = nil
+	m.cursor = 0
+	m.moveCursor(1)
+	if m.cursor != 0 {
+		t.Fatalf("empty list should leave the cursor alone, cursor = %d", m.cursor)
+	}
+}


### PR DESCRIPTION
Up from the first row lands on the last, down from the last lands on the first — everywhere arrows navigate, quick-prompt targeting included. Empty list leaves the cursor alone. Covered by `TestCursorWrapsAroundTheList`.