### PR TITLE
Scope the archived view to archived sessions

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -193,6 +193,20 @@ func (m *Model) Init() tea.Cmd {
 	return nil
 }
 
+// visibleSessions filters to the sessions the current view scope shows:
+// active ones normally, archived ones in the archived view. It also
+// covers the frames between a scope toggle and the next refresh, when
+// m.sessions still carries the other scope's list.
+func (m *Model) visibleSessions() []store.Session {
+	visible := make([]store.Session, 0, len(m.sessions))
+	for _, sess := range m.sessions {
+		if sess.Archived == m.showArchived {
+			visible = append(visible, sess)
+		}
+	}
+	return visible
+}
+
 func (m *Model) selected() (store.Session, bool) {
 	if m.cursor < 0 || m.cursor >= len(m.rows) || m.rows[m.cursor].isGroup {
 		return store.Session{}, false
@@ -352,7 +366,7 @@ func (m *Model) rebuildRows() {
 	// m.sessions arrives ordered by the store (group, sort_order), so
 	// per-group slices inherit the user's manual order.
 	sessionsByGroup := map[string][]store.Session{}
-	for _, sess := range m.sessions {
+	for _, sess := range m.visibleSessions() {
 		if query != "" && !matchesSearch(sess, query) {
 			continue
 		}
@@ -360,7 +374,9 @@ func (m *Model) rebuildRows() {
 	}
 
 	paths := groupClosure(m.groups, m.sessions)
-	if query != "" {
+	// The archived view keeps only groups that hold archived sessions,
+	// instead of the full (mostly empty) tree skeleton.
+	if query != "" || m.showArchived {
 		paths = pathsWithSessions(paths, sessionsByGroup)
 	}
 	children := childIndex(paths, m.groups)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1019,3 +1019,32 @@ func TestCursorWrapsAroundTheList(t *testing.T) {
 		t.Fatalf("empty list should leave the cursor alone, cursor = %d", m.cursor)
 	}
 }
+
+func TestArchivedViewShowsOnlyArchivedSessions(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	createSession(t, m, "live-one", dir, "")
+	createSession(t, m, "old-one", dir, "")
+
+	m.selectSessionRow(t, "old-one")
+	_, cmd := m.archiveSelected()
+	m.applyCmd(t, cmd)
+
+	if names := sessionNames(m); len(names) != 1 || names[0] != "live-one" {
+		t.Fatalf("active view = %v want [live-one]", names)
+	}
+
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	if names := sessionNames(m); len(names) != 1 || names[0] != "old-one" {
+		t.Fatalf("archived view = %v want [old-one]", names)
+	}
+}
+
+func sessionNames(m *Model) []string {
+	var names []string
+	for _, sess := range m.sessionRows() {
+		names = append(names, sess.Name)
+	}
+	return names
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -174,6 +174,9 @@ func (m *Model) sidebarTitle() string {
 func (m *Model) viewList(width, height int) string {
 	if len(m.rows) == 0 {
 		hint := "Press " + keyStyle.Render("n") + mutedStyle.Render(" to create a session.")
+		if m.showArchived {
+			hint = mutedStyle.Render("No archived sessions. ") + keyStyle.Render("t") + mutedStyle.Render(" goes back.")
+		}
 		if strings.TrimSpace(m.search) != "" {
 			hint = mutedStyle.Render("No matches for ") + valueStyle.Render("\""+m.search+"\"")
 		}
@@ -204,7 +207,7 @@ func treeGuides(depth int) string {
 
 func (m *Model) groupSessionCount(path string) int {
 	count := 0
-	for _, sess := range m.sessions {
+	for _, sess := range m.visibleSessions() {
 		if sess.Group == path || strings.HasPrefix(sess.Group, path+"/") {
 			count++
 		}
@@ -263,11 +266,7 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 		name := nameStyle.Render(sess.Name)
 		state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(sess.Status)
 		meta := state + subtleStyle.Render(" · "+sess.Tool+" · "+relTime(sess.CreatedAt))
-		archived := ""
-		if sess.Archived {
-			archived = subtleStyle.Render(" ⋅ archived")
-		}
-		content = glyph + " " + name + "  " + meta + archived
+		content = glyph + " " + name + "  " + meta
 	}
 
 	line := bar + " " + guides + content
@@ -495,7 +494,7 @@ func (m *Model) groupStatusBreakdown(group string) string {
 
 func (m *Model) groupStatusCounts(group string) map[string]int {
 	counts := map[string]int{}
-	for _, sess := range m.sessions {
+	for _, sess := range m.visibleSessions() {
 		if sess.Group == group || strings.HasPrefix(sess.Group, group+"/") {
 			counts[sess.Status]++
 		}
@@ -527,7 +526,7 @@ func (m *Model) viewGroupAgents(group string, width, height int) string {
 		b.WriteString(mutedStyle.Render("(no agents yet — press space to spawn one)"))
 		return padToHeight(b.String(), height)
 	}
-	for _, sess := range m.sessions {
+	for _, sess := range m.visibleSessions() {
 		if sess.Group != group && !strings.HasPrefix(sess.Group, group+"/") {
 			continue
 		}


### PR DESCRIPTION
`t` listed active and archived together, so with nothing archived both views looked identical. The view now scopes cleanly: rows, group counts, rollups, and the group pane agent list filter to the current scope, the archived tree keeps only groups holding archived sessions, and the empty archived view says so with a hint back. Covered by `TestArchivedViewShowsOnlyArchivedSessions`.