### PR TITLE
Repo-wide cleanup: dead code, duplication, drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installs tmux with it if missing.
 go install github.com/YoanWai/agent-manager@latest
 ```
 
-Requires Go 1.24+ and tmux; installs to `$(go env GOPATH)/bin`.
+Requires Go 1.26+ and tmux; installs to `$(go env GOPATH)/bin`.
 
 ### Prebuilt binaries
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,10 +46,6 @@ func (d *Duration) UnmarshalText(text []byte) error {
 	return nil
 }
 
-func (d Duration) MarshalText() ([]byte, error) {
-	return []byte(d.Duration.String()), nil
-}
-
 func Dir() (string, error) {
 	base, err := os.UserConfigDir()
 	if err != nil {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -76,11 +76,6 @@ func NewEngine(cfg config.Config) (*Engine, error) {
 	return engine, nil
 }
 
-func (e *Engine) Derive(tool, pane string) string {
-	state, _ := e.Match(tool, pane)
-	return state
-}
-
 // Match derives a status and reports whether any signal matched, so the
 // caller can distinguish a real signal from the default fallback. Rules
 // run first, scoped to the current turn; when none hit, the newest turn
@@ -117,12 +112,20 @@ func (tr toolRules) matchScope(pane string) string {
 		return pane
 	}
 	lines := strings.Split(region, "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		if tr.turnEnd.MatchString(strings.TrimRight(lines[i], " \t")) {
-			return strings.Join(lines[i+1:], "\n")
-		}
+	if lastEnd := tr.lastTurnEndIndex(lines); lastEnd >= 0 {
+		return strings.Join(lines[lastEnd+1:], "\n")
 	}
 	return pane
+}
+
+// lastTurnEndIndex finds the newest turn_end marker line, -1 when absent.
+func (tr toolRules) lastTurnEndIndex(lines []string) int {
+	for i := len(lines) - 1; i >= 0; i-- {
+		if tr.turnEnd.MatchString(strings.TrimRight(lines[i], " \t")) {
+			return i
+		}
+	}
+	return -1
 }
 
 // ActivityRegion returns the pane content above the tool's input box
@@ -173,13 +176,7 @@ func (tr toolRules) turnState(pane string) (string, bool) {
 		return Waiting, true
 	}
 
-	lastEnd := -1
-	for i := len(lines) - 1; i >= 0; i-- {
-		if tr.turnEnd.MatchString(strings.TrimRight(lines[i], " \t")) {
-			lastEnd = i
-			break
-		}
-	}
+	lastEnd := tr.lastTurnEndIndex(lines)
 	if lastEnd < 0 || !tr.turnIsNewest(lines[lastEnd+1:]) {
 		return "", false
 	}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -27,7 +27,7 @@ func testEngine(t *testing.T) *Engine {
 	return engine
 }
 
-func TestDerive(t *testing.T) {
+func TestMatch(t *testing.T) {
 	engine := testEngine(t)
 	cases := []struct {
 		name string
@@ -43,8 +43,8 @@ func TestDerive(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := engine.Derive(tc.tool, tc.pane); got != tc.want {
-				t.Fatalf("Derive(%q)=%q want %q", tc.pane, got, tc.want)
+			if got, _ := engine.Match(tc.tool, tc.pane); got != tc.want {
+				t.Fatalf("Match(%q)=%q want %q", tc.pane, got, tc.want)
 			}
 		})
 	}
@@ -117,8 +117,8 @@ func TestDefaultRulesRealPanes(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := engine.Derive(tc.tool, tc.pane); got != tc.want {
-				t.Fatalf("Derive(%s) = %q want %q", tc.name, got, tc.want)
+			if got, _ := engine.Match(tc.tool, tc.pane); got != tc.want {
+				t.Fatalf("Match(%s) = %q want %q", tc.name, got, tc.want)
 			}
 		})
 	}
@@ -154,8 +154,8 @@ func TestLongTurnAndMidLineQuestion(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := engine.Derive(tc.tool, tc.pane); got != tc.want {
-				t.Fatalf("Derive(%s) = %q want %q", tc.name, got, tc.want)
+			if got, _ := engine.Match(tc.tool, tc.pane); got != tc.want {
+				t.Fatalf("Match(%s) = %q want %q", tc.name, got, tc.want)
 			}
 		})
 	}
@@ -178,8 +178,8 @@ func TestRealPaneEdgeCases(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := engine.Derive(tc.tool, tc.pane); got != tc.want {
-				t.Fatalf("Derive(%s) = %q want %q", tc.name, got, tc.want)
+			if got, _ := engine.Match(tc.tool, tc.pane); got != tc.want {
+				t.Fatalf("Match(%s) = %q want %q", tc.name, got, tc.want)
 			}
 		})
 	}
@@ -192,7 +192,7 @@ func TestRecapBelowSummary(t *testing.T) {
 		"※ recap: Setting up laptop-casting: twin box is done and proven, now deploying\n" +
 		"  plus ports. (disable recaps in /config)\n" +
 		"────\n❯ done, code is 431652\n────\n  ⏵⏵ bypass permissions on"
-	if got := engine.Derive("claude", pane); got != Finished {
+	if got, _ := engine.Match("claude", pane); got != Finished {
 		t.Fatalf("recap below summary should still be finished, got %q", got)
 	}
 }
@@ -218,8 +218,8 @@ func TestQuotedSignalsDoNotTrigger(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := engine.Derive(tc.tool, tc.pane); got != tc.want {
-				t.Fatalf("Derive(%s) = %q want %q", tc.name, got, tc.want)
+			if got, _ := engine.Match(tc.tool, tc.pane); got != tc.want {
+				t.Fatalf("Match(%s) = %q want %q", tc.name, got, tc.want)
 			}
 		})
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -63,7 +63,6 @@ CREATE TABLE IF NOT EXISTS sessions (
 );
 CREATE TABLE IF NOT EXISTS groups (
 	name       TEXT PRIMARY KEY,
-	collapsed  INTEGER NOT NULL DEFAULT 0,
 	sort_order INTEGER NOT NULL DEFAULT 0,
 	path       TEXT NOT NULL DEFAULT ''
 );

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -199,20 +199,3 @@ func (d *Driver) Panes() (map[string]int, error) {
 	}
 	return panes, nil
 }
-
-func (d *Driver) List() ([]string, error) {
-	out, err := exec.Command(d.bin, "list-sessions", "-F", "#{session_name}").CombinedOutput()
-	if err != nil {
-		if noServer(string(out)) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("tmux list-sessions: %w: %s", err, strings.TrimSpace(string(out)))
-	}
-	var ids []string
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if strings.HasPrefix(line, prefix) {
-			ids = append(ids, strings.TrimPrefix(line, prefix))
-		}
-	}
-	return ids, nil
-}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -111,18 +111,12 @@ func TestLifecycle(t *testing.T) {
 		t.Fatalf("captured pane missing marker: %q", pane)
 	}
 
-	ids, err := driver.List()
+	panes, err := driver.Panes()
 	if err != nil {
-		t.Fatalf("List: %v", err)
+		t.Fatalf("Panes: %v", err)
 	}
-	found := false
-	for _, got := range ids {
-		if got == id {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("List should include %q, got %v", id, ids)
+	if panes[id] <= 0 {
+		t.Fatalf("Panes should map %q to a pane pid, got %v", id, panes)
 	}
 
 	if err := driver.Kill(id); err != nil {

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -62,6 +62,21 @@ func sessionLabel(group, name string) string {
 	return group + " · " + name
 }
 
+// resolveExistingDir turns raw field input into a usable directory:
+// expand ~, fall back when empty, absolutize, and require it to exist.
+// The resolved value returns either way so error messages can show it.
+func resolveExistingDir(raw, fallback string) (string, bool) {
+	dir := expandHome(strings.TrimSpace(raw))
+	if dir == "" {
+		dir = fallback
+	}
+	if abs, err := filepath.Abs(dir); err == nil {
+		dir = abs
+	}
+	info, err := os.Stat(dir)
+	return dir, err == nil && info.IsDir()
+}
+
 func textField(placeholder string, limit int) textinput.Model {
 	in := textinput.New()
 	in.Placeholder = placeholder
@@ -81,20 +96,15 @@ func (m *Model) contextGroup() string {
 	return ""
 }
 
-// ancestorGroupPath finds the closest configured default path walking up
+// ancestorGroupDir finds the closest configured default path walking up
 // from the group to the root; empty when no ancestor has one.
-func (m *Model) ancestorGroupPath(group string) string {
-	for g := group; g != ""; {
+func (m *Model) ancestorGroupDir(group string) string {
+	for g := group; g != ""; g = parentGroup(g) {
 		if p := m.groupPaths[g]; p != "" {
 			if info, err := os.Stat(p); err == nil && info.IsDir() {
 				return p
 			}
 		}
-		idx := strings.LastIndex(g, "/")
-		if idx < 0 {
-			break
-		}
-		g = g[:idx]
 	}
 	return ""
 }
@@ -102,7 +112,7 @@ func (m *Model) ancestorGroupPath(group string) string {
 // groupDefaultDir resolves the working directory for a session in a group:
 // the nearest inherited default path, else the current directory.
 func (m *Model) groupDefaultDir(group string) string {
-	if p := m.ancestorGroupPath(group); p != "" {
+	if p := m.ancestorGroupDir(group); p != "" {
 		return p
 	}
 	cwd, err := os.Getwd()
@@ -259,7 +269,7 @@ func (m *Model) moveGroupCursor(delta int) {
 		m.form.dir.SetValue(m.groupDefaultDir(m.selectedGroupPath()))
 	}
 	if m.mode == modeGroupForm && m.groupForm.pathAuto {
-		m.groupForm.path.SetValue(m.ancestorGroupPath(m.selectedGroupPath()))
+		m.groupForm.path.SetValue(m.ancestorGroupDir(m.selectedGroupPath()))
 	}
 }
 
@@ -298,14 +308,9 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 	if name == "" {
 		name = toolName + "-" + newID()[:4]
 	}
-	dir := expandHome(strings.TrimSpace(m.form.dir.Value()))
-	if dir == "" {
-		dir, _ = os.Getwd()
-	}
-	if abs, err := filepath.Abs(dir); err == nil {
-		dir = abs
-	}
-	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+	cwd, _ := os.Getwd()
+	dir, ok := resolveExistingDir(m.form.dir.Value(), cwd)
+	if !ok {
 		m.err = "working directory does not exist: " + dir
 		return m, nil
 	}
@@ -483,14 +488,8 @@ func (m *Model) submitGroupForm() (tea.Model, tea.Cmd) {
 	if parent != "" {
 		full = parent + "/" + name
 	}
-	path := expandHome(strings.TrimSpace(m.groupForm.path.Value()))
-	if path == "" {
-		path = m.groupDefaultDir(parent)
-	}
-	if abs, err := filepath.Abs(path); err == nil {
-		path = abs
-	}
-	if info, err := os.Stat(path); err != nil || !info.IsDir() {
+	path, ok := resolveExistingDir(m.groupForm.path.Value(), m.groupDefaultDir(parent))
+	if !ok {
 		m.err = "default path does not exist: " + path
 		return m, nil
 	}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/status"
@@ -181,16 +180,9 @@ func (m *Model) swapSessionLocal(id string, delta int) {
 }
 
 func (m *Model) swapGroupLocal(path string, delta int) {
-	parent := ""
-	if idx := strings.LastIndex(path, "/"); idx >= 0 {
-		parent = path[:idx]
-	}
+	parent := parentGroup(path)
 	isSibling := func(name string) bool {
-		if parent == "" {
-			return !strings.Contains(name, "/")
-		}
-		rest, ok := strings.CutPrefix(name, parent+"/")
-		return ok && !strings.Contains(rest, "/")
+		return parentGroup(name) == parent
 	}
 	step := 1
 	if delta < 0 {
@@ -236,7 +228,7 @@ func (m *Model) attachSelected() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if !m.tmux.Exists(sess.ID) {
-		m.err = "session is not running (dead); delete or recreate it"
+		m.err = "session is dead - press v to revive"
 		return m, nil
 	}
 	m.err = ""
@@ -344,7 +336,7 @@ func (m *Model) prepareDelete() {
 	}
 	if !entry.isGroup {
 		m.confirm = confirmTarget{
-			label:    "delete " + entry.sess.Name + "? kills its tmux session. (y/n)",
+			label:    "delete " + entry.sess.Name + "? kills its tmux session.",
 			sessions: []store.Session{entry.sess},
 		}
 		m.mode = modeConfirmDelete
@@ -361,7 +353,7 @@ func (m *Model) prepareDelete() {
 			subgroups++
 		}
 	}
-	label := fmt.Sprintf("delete group %s (%d subgroups, %d sessions incl. archived)? kills their tmux sessions. (y/n)",
+	label := fmt.Sprintf("delete group %s (%d subgroups, %d sessions incl. archived)? kills their tmux sessions.",
 		entry.group, subgroups, len(subtree))
 	m.confirm = confirmTarget{isGroup: true, path: entry.group, label: label, sessions: subtree}
 	m.mode = modeConfirmDelete
@@ -496,24 +488,15 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if m.rename.isGroup {
-		dir := expandHome(strings.TrimSpace(m.rename.dir.Value()))
-		if dir == "" {
-			parent := ""
-			if idx := strings.LastIndex(m.rename.path, "/"); idx >= 0 {
-				parent = m.rename.path[:idx]
-			}
-			dir = m.groupDefaultDir(parent)
-		}
-		if abs, err := filepath.Abs(dir); err == nil {
-			dir = abs
-		}
-		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		parent := parentGroup(m.rename.path)
+		dir, ok := resolveExistingDir(m.rename.dir.Value(), m.groupDefaultDir(parent))
+		if !ok {
 			m.err = "default path does not exist: " + dir
 			return m, nil
 		}
 		newPath := name
-		if idx := strings.LastIndex(m.rename.path, "/"); idx >= 0 {
-			newPath = m.rename.path[:idx] + "/" + name
+		if parent != "" {
+			newPath = parent + "/" + name
 		}
 		if err := m.store.RenameGroup(m.rename.path, newPath); err != nil {
 			m.err = err.Error()
@@ -590,6 +573,13 @@ func (m *Model) openQuickMode() {
 	input.SetHeight(1)
 	input.Focus()
 	m.err = ""
+	names, index := m.defaultToolSelection()
+	m.quick = quickState{active: true, input: input, toolNames: names, toolIndex: index}
+}
+
+// defaultToolSelection returns the sorted tool names with the index of
+// the configured default, ready to seed a tool picker.
+func (m *Model) defaultToolSelection() ([]string, int) {
 	names := sortedToolNames(m.cfg)
 	current := m.defaultTool()
 	index := 0
@@ -598,7 +588,7 @@ func (m *Model) openQuickMode() {
 			index = i
 		}
 	}
-	m.quick = quickState{active: true, input: input, toolNames: names, toolIndex: index}
+	return names, index
 }
 
 // handleQuickKey runs while the quick bar is docked in the sidebar: arrows
@@ -678,11 +668,8 @@ func (m *Model) quickSpawn(group, prompt string) (tea.Model, tea.Cmd) {
 		m.err = "no tools configured"
 		return m, nil
 	}
-	dir := expandHome(m.groupPaths[group])
-	if dir == "" {
-		dir, _ = os.Getwd()
-	}
-	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+	dir, ok := resolveExistingDir(m.groupPaths[group], m.groupDefaultDir(group))
+	if !ok {
 		m.err = "group has no valid default path: " + dir
 		return m, nil
 	}
@@ -727,19 +714,12 @@ func (m *Model) defaultTool() string {
 }
 
 func (m *Model) openSettings() {
-	names := sortedToolNames(m.cfg)
-	if len(names) == 0 {
+	if len(m.cfg.Tools) == 0 {
 		m.err = "no tools configured"
 		return
 	}
 	m.err = ""
-	current := m.defaultTool()
-	index := 0
-	for i, name := range names {
-		if name == current {
-			index = i
-		}
-	}
+	names, index := m.defaultToolSelection()
 	m.settings = settingsState{toolNames: names, toolIndex: index}
 	m.mode = modeSettings
 }

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -63,8 +63,6 @@ func groupBadge(path string) string {
 	return lipgloss.NewStyle().Foreground(colorAccent2).Render(path)
 }
 
-// viewPathSuggestions renders the directory-completion dropdown under
-// a focused path field.
 func pathSuggestHint(chosen bool) string {
 	if chosen {
 		return "↑↓ pick · ↵/tab complete · esc close"
@@ -72,6 +70,8 @@ func pathSuggestHint(chosen bool) string {
 	return "↑↓ pick · tab complete · ↵ create · esc close"
 }
 
+// viewPathSuggestions renders the directory-completion dropdown under
+// a focused path field.
 func (m *Model) viewPathSuggestions() string {
 	var b strings.Builder
 	for i, path := range m.pathSugg.suggestions {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -40,11 +40,10 @@ type treeRow struct {
 }
 
 type Model struct {
-	cfg    config.Config
-	store  *store.Store
-	tmux   *tmux.Driver
-	engine *status.Engine
-	hooks  *hooks.Manager
+	cfg   config.Config
+	store *store.Store
+	tmux  *tmux.Driver
+	hooks *hooks.Manager
 
 	sessions   []store.Session
 	rows       []treeRow
@@ -157,7 +156,6 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 		cfg:       cfg,
 		store:     st,
 		tmux:      driver,
-		engine:    engine,
 		hooks:     hookManager,
 		poller:    newPoller(st, driver, engine, hookManager, statusSources, cfg.PollInterval.Duration),
 		collapsed: map[string]bool{},
@@ -446,7 +444,7 @@ func pathsWithSessions(paths map[string]bool, sessionsByGroup map[string][]store
 	kept := map[string]bool{}
 	for path := range paths {
 		for group := range sessionsByGroup {
-			if group == path || strings.HasPrefix(group, path+"/") {
+			if inGroupSubtree(group, path) {
 				kept[path] = true
 				break
 			}
@@ -464,10 +462,7 @@ func childIndex(paths map[string]bool, ordered []string) map[string][]string {
 	}
 	children := map[string][]string{}
 	for path := range paths {
-		parent := ""
-		if idx := strings.LastIndex(path, "/"); idx >= 0 {
-			parent = path[:idx]
-		}
+		parent := parentGroup(path)
 		children[parent] = append(children[parent], path)
 	}
 	for _, siblings := range children {

--- a/internal/ui/pathcomplete_test.go
+++ b/internal/ui/pathcomplete_test.go
@@ -112,10 +112,10 @@ func TestGroupFormInheritsParentPath(t *testing.T) {
 func TestAncestorGroupPathWalksUp(t *testing.T) {
 	root := t.TempDir()
 	m := &Model{groupPaths: map[string]string{"projects": root}}
-	if got := m.ancestorGroupPath("projects/api/auth"); got != root {
+	if got := m.ancestorGroupDir("projects/api/auth"); got != root {
 		t.Fatalf("got %q want %q", got, root)
 	}
-	if got := m.ancestorGroupPath("other"); got != "" {
+	if got := m.ancestorGroupDir("other"); got != "" {
 		t.Fatalf("got %q want empty", got)
 	}
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -39,7 +39,6 @@ var (
 	subtleStyle = lipgloss.NewStyle().Foreground(colorSubtle)
 	valueStyle  = lipgloss.NewStyle().Foreground(colorText)
 	labelStyle  = lipgloss.NewStyle().Foreground(colorDim)
-	footerStyle = lipgloss.NewStyle().Foreground(colorDim)
 	errStyle    = lipgloss.NewStyle().Foreground(colorErrored).Bold(true)
 	keyStyle    = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 )
@@ -76,12 +75,8 @@ func statusGlyph(s string) string {
 
 // titledPanel draws a rounded box with the title embedded in the top
 // border, its body clipped and padded to fill the given outer size.
-func titledPanel(title, body string, width, height int, accent bool) string {
-	border := colorBorder
-	if accent {
-		border = colorAccent
-	}
-	bs := lipgloss.NewStyle().Foreground(border)
+func titledPanel(title, body string, width, height int) string {
+	bs := lipgloss.NewStyle().Foreground(colorBorder)
 	inner := width - 4
 	if inner < 1 {
 		inner = 1

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -46,8 +46,8 @@ func (m *Model) View() string {
 	if listHeight >= 3 {
 		leftBody = padToHeight(m.viewList(listInner, listHeight), listHeight) + "\n" + stats
 	}
-	left := titledPanel("Sessions", leftBody, leftWidth, bodyHeight, false)
-	right := titledPanel(m.sidebarTitle(), m.viewSidebar(rightWidth-4, bodyHeight-2), rightWidth, bodyHeight, false)
+	left := titledPanel("Sessions", leftBody, leftWidth, bodyHeight)
+	right := titledPanel(m.sidebarTitle(), m.viewSidebar(rightWidth-4, bodyHeight-2), rightWidth, bodyHeight)
 	body := lipgloss.JoinHorizontal(lipgloss.Top, left, right)
 
 	return strings.Join([]string{m.viewHeader(), "", body, m.viewStatus(), footer}, "\n")
@@ -205,10 +205,16 @@ func treeGuides(depth int) string {
 	return subtleStyle.Render(strings.Repeat("│ ", depth))
 }
 
+// inGroupSubtree reports whether a session's group sits at or below the
+// given group in the tree.
+func inGroupSubtree(sessGroup, group string) bool {
+	return sessGroup == group || strings.HasPrefix(sessGroup, group+"/")
+}
+
 func (m *Model) groupSessionCount(path string) int {
 	count := 0
 	for _, sess := range m.visibleSessions() {
-		if sess.Group == path || strings.HasPrefix(sess.Group, path+"/") {
+		if inGroupSubtree(sess.Group, path) {
 			count++
 		}
 	}
@@ -285,13 +291,10 @@ func (m *Model) renamingGroup(group string) bool {
 }
 
 func (m *Model) renamingRow(entry treeRow) bool {
-	if m.mode != modeRename {
-		return false
-	}
 	if entry.isGroup {
-		return m.rename.isGroup && entry.group == m.rename.path
+		return m.renamingGroup(entry.group)
 	}
-	return !m.rename.isGroup && entry.sess.ID == m.rename.sessID
+	return m.mode == modeRename && !m.rename.isGroup && entry.sess.ID == m.rename.sessID
 }
 
 // renameRowInput renders the inline name editor in place of the row's
@@ -495,7 +498,7 @@ func (m *Model) groupStatusBreakdown(group string) string {
 func (m *Model) groupStatusCounts(group string) map[string]int {
 	counts := map[string]int{}
 	for _, sess := range m.visibleSessions() {
-		if sess.Group == group || strings.HasPrefix(sess.Group, group+"/") {
+		if inGroupSubtree(sess.Group, group) {
 			counts[sess.Status]++
 		}
 	}
@@ -527,7 +530,7 @@ func (m *Model) viewGroupAgents(group string, width, height int) string {
 		return padToHeight(b.String(), height)
 	}
 	for _, sess := range m.visibleSessions() {
-		if sess.Group != group && !strings.HasPrefix(sess.Group, group+"/") {
+		if !inGroupSubtree(sess.Group, group) {
 			continue
 		}
 		if shown >= height-2 && total > shown+1 {
@@ -707,13 +710,4 @@ func truncateTail(s string, max int) string {
 		return s
 	}
 	return "…" + string(runes[len(runes)-max+1:])
-}
-
-// clipLine keeps the start of the string (best for terminal output).
-func clipLine(s string, max int) string {
-	runes := []rune(s)
-	if len(runes) <= max || max <= 1 {
-		return s
-	}
-	return string(runes[:max-1]) + "…"
 }

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -102,11 +102,7 @@ func TestTruncateRuneSafe(t *testing.T) {
 	if !strings.HasPrefix(tail, "…") || len([]rune(tail)) != 10 {
 		t.Fatalf("truncateTail broken: %q (%d runes)", tail, len([]rune(tail)))
 	}
-	clipped := clipLine(hebrew, 10)
-	if !strings.HasSuffix(clipped, "…") || len([]rune(clipped)) != 10 {
-		t.Fatalf("clipLine broken: %q (%d runes)", clipped, len([]rune(clipped)))
-	}
-	if truncateTail("short", 10) != "short" || clipLine("short", 10) != "short" {
+	if truncateTail("short", 10) != "short" {
 		t.Fatal("short strings should pass through")
 	}
 }


### PR DESCRIPTION
Adversarially-verified cleanup pass (every finding grep/read-proven before applying). Net -72 lines.

- **Dead code removed**: `footerStyle`, `clipLine`, `titledPanel`'s always-false accent param, `tmux.Driver.List`, `config.Duration.MarshalText`, `status.Engine.Derive`, unread `Model.engine` field, unused `collapsed` column in the groups schema.
- **Duplication extracted**: `inGroupSubtree`, `parentGroup` reuse (5 inline copies), `resolveExistingDir` (4 copies), `defaultToolSelection`, `lastTurnEndIndex`.
- **Consistency**: dead-session attach message matches the revive hint, delete confirm shows y/n once, doc comment moved to its function, `ancestorGroupPath` → `ancestorGroupDir`, README Go version matches go.mod.
- **Bug fix**: quick-spawn on a subgroup now uses the inherited default path the group pane displays instead of falling back to the manager's cwd.

Gate: gofmt, vet, staticcheck, full test suite, and a live isolated-rig smoke (group create, quick-spawn, inline rename, archive scope, delete confirm) all clean.