### PR TITLE
Persist group fold state and add fold-all shortcut

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -75,6 +75,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openQuickMode()
 	case "f":
 		m.toggleCollapse()
+	case "F":
+		m.toggleCollapseAll()
 	case "s":
 		m.openSettings()
 	case "t":
@@ -248,6 +250,25 @@ func (m *Model) toggleCollapse() {
 		return
 	}
 	m.collapsed[path] = !m.collapsed[path]
+	m.persistCollapsed()
+	m.rebuildRows()
+}
+
+// toggleCollapseAll folds every group when any is open, and unfolds all
+// when they are already collapsed, so one key flips the whole tree.
+func (m *Model) toggleCollapseAll() {
+	groups := groupClosure(m.groups, m.sessions)
+	anyOpen := false
+	for group := range groups {
+		if !m.collapsed[group] {
+			anyOpen = true
+			break
+		}
+	}
+	for group := range groups {
+		m.collapsed[group] = anyOpen
+	}
+	m.persistCollapsed()
 	m.rebuildRows()
 }
 
@@ -420,6 +441,7 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					delete(m.collapsed, path)
 				}
 			}
+			m.persistCollapsed()
 		}
 		m.confirm = confirmTarget{}
 		m.requestRefresh()
@@ -589,6 +611,7 @@ func (m *Model) renameGroupLocally(old, newPath, dir string) {
 			m.collapsed[renamed] = folded
 		}
 	}
+	m.persistCollapsed()
 }
 
 func (m *Model) openQuickMode() {

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -158,6 +158,7 @@ func (m *Model) viewHelp() string {
 		{"D", "review changes: whole-file diffs, comment lines, send to agent"},
 		{"s", "cycle diff scope: uncommitted / vs base / last commit / staged"},
 		{"f", "fold / unfold group"},
+		{"F", "fold / unfold all groups"},
 		{"s", "settings (quick spawn tool)"},
 		{"t", "toggle archived view"},
 		{"/", "search"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"hash/fnv"
 	"sort"
 	"strings"
@@ -166,8 +167,48 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 		hooks:     hookManager,
 		gitDrv:    gitDriver,
 		poller:    newPoller(st, driver, engine, hookManager, statusSources, cfg.PollInterval.Duration),
-		collapsed: map[string]bool{},
+		collapsed: loadCollapsed(st),
 		mode:      modeList,
+	}
+}
+
+const collapsedSetting = "collapsed_groups"
+
+// loadCollapsed restores the set of folded group paths persisted from a
+// previous run so the tree opens in the same shape the user left it.
+func loadCollapsed(st *store.Store) map[string]bool {
+	collapsed := map[string]bool{}
+	raw, err := st.Setting(collapsedSetting)
+	if err != nil || raw == "" {
+		return collapsed
+	}
+	var paths []string
+	if err := json.Unmarshal([]byte(raw), &paths); err != nil {
+		return collapsed
+	}
+	for _, path := range paths {
+		collapsed[path] = true
+	}
+	return collapsed
+}
+
+// persistCollapsed saves the currently folded group paths so the state
+// survives across launches.
+func (m *Model) persistCollapsed() {
+	paths := make([]string, 0, len(m.collapsed))
+	for path, folded := range m.collapsed {
+		if folded {
+			paths = append(paths, path)
+		}
+	}
+	sort.Strings(paths)
+	raw, err := json.Marshal(paths)
+	if err != nil {
+		m.err = err.Error()
+		return
+	}
+	if err := m.store.SetSetting(collapsedSetting, string(raw)); err != nil {
+		m.err = err.Error()
 	}
 }
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1443,3 +1443,51 @@ func TestDiffAnnotateAndSend(t *testing.T) {
 		t.Fatalf("prompt not delivered:\n%s", pane)
 	}
 }
+
+func TestCollapsedStatePersistsAcrossReload(t *testing.T) {
+	m := buildModel(t)
+	m.collapsed["backend"] = true
+	m.collapsed["backend/api"] = true
+	m.persistCollapsed()
+
+	restored := loadCollapsed(m.store)
+	if !restored["backend"] || !restored["backend/api"] {
+		t.Fatalf("collapsed groups not restored: %v", restored)
+	}
+
+	m.collapsed["backend"] = false
+	m.persistCollapsed()
+	restored = loadCollapsed(m.store)
+	if restored["backend"] {
+		t.Fatalf("expanded group leaked back as collapsed: %v", restored)
+	}
+	if !restored["backend/api"] {
+		t.Fatalf("still-folded group dropped: %v", restored)
+	}
+}
+
+func TestToggleCollapseAllFlipsEveryGroup(t *testing.T) {
+	m := buildModel(t)
+	m.sessions = []store.Session{{ID: "a", Group: "backend/api"}, {ID: "b", Group: "frontend"}}
+	want := []string{"backend", "backend/api", "frontend"}
+
+	m.toggleCollapseAll()
+	for _, group := range want {
+		if !m.collapsed[group] {
+			t.Fatalf("group %q not collapsed after fold-all", group)
+		}
+	}
+	if restored := loadCollapsed(m.store); len(restored) != 3 {
+		t.Fatalf("fold-all not persisted: %v", restored)
+	}
+
+	m.toggleCollapseAll()
+	for _, group := range want {
+		if m.collapsed[group] {
+			t.Fatalf("group %q still collapsed after unfold-all", group)
+		}
+	}
+	if restored := loadCollapsed(m.store); len(restored) != 0 {
+		t.Fatalf("unfold-all not persisted: %v", restored)
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -632,7 +632,7 @@ func padToHeight(s string, height int) string {
 func (m *Model) viewFooter() string {
 	pairs := [][2]string{
 		{"↑↓", "navigate"}, {"↵", "attach"}, {"n", "new"}, {"g", "group"},
-		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"D", "review"}, {"f", "fold"}, {"m", "move"}, {"r", "rename/edit"},
+		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"D", "review"}, {"f", "fold"}, {"F", "fold all"}, {"m", "move"}, {"r", "rename/edit"},
 		{"v", "revive"}, {"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
 		{"t", "archived"}, {"s", "settings"}, {"?", "help"}, {"q", "quit"},
 	}


### PR DESCRIPTION
## What

- Group fold state persists across launches. Stored in the `settings` table as a JSON list of collapsed paths, reloaded on startup, rewritten on every fold mutation (toggle, delete, rename, fold-all).
- New `F` shortcut folds or unfolds every group at once, flipping the whole tree based on whether any group is open. `f` still folds the selected group.

## Notes

Fold-all walks the full displayed tree (`groupClosure`), so ancestor paths synthesized from session groups fold too, not only store-registered groups.

## Tests

- `TestCollapsedStatePersistsAcrossReload`
- `TestToggleCollapseAllFlipsEveryGroup`