### PR TITLE
Drop redundant single-group fold key

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -73,8 +73,6 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.prepareDelete()
 	case " ", "space":
 		m.openQuickMode()
-	case "f":
-		m.toggleCollapse()
 	case "F":
 		m.toggleCollapseAll()
 	case "s":

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -157,7 +157,6 @@ func (m *Model) viewHelp() string {
 		{"⇥", "in quick prompt: switch spawn tool"},
 		{"D", "review changes: whole-file diffs, comment lines, send to agent"},
 		{"s", "cycle diff scope: uncommitted / vs base / last commit / staged"},
-		{"f", "fold / unfold group"},
 		{"F", "fold / unfold all groups"},
 		{"s", "settings (quick spawn tool)"},
 		{"t", "toggle archived view"},

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -632,7 +632,7 @@ func padToHeight(s string, height int) string {
 func (m *Model) viewFooter() string {
 	pairs := [][2]string{
 		{"↑↓", "navigate"}, {"↵", "attach"}, {"n", "new"}, {"g", "group"},
-		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"D", "review"}, {"f", "fold"}, {"F", "fold all"}, {"m", "move"}, {"r", "rename/edit"},
+		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"D", "review"}, {"F", "fold all"}, {"m", "move"}, {"r", "rename/edit"},
 		{"v", "revive"}, {"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
 		{"t", "archived"}, {"s", "settings"}, {"?", "help"}, {"q", "quit"},
 	}


### PR DESCRIPTION
Enter on a focused group already folds/unfolds it, so the single-group `f` binding was redundant. Removed it and its help/footer entries. Fold-all stays on `F`.