### PR TITLE
fix: keep archived and search views reachable inside folded groups

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -438,6 +438,11 @@ func (m *Model) rebuildRows() {
 	}
 	children := childIndex(paths, m.groups)
 
+	// Folds are a browsing convenience for the active tree; the archived
+	// and search views already prune to matching groups, so honoring folds
+	// there would hide the very sessions the user came to act on.
+	honorFolds := query == "" && !m.showArchived
+
 	rows := make([]treeRow, 0, len(m.sessions)+len(paths))
 	for _, sess := range sessionsByGroup[""] {
 		rows = append(rows, treeRow{sess: sess})
@@ -445,7 +450,7 @@ func (m *Model) rebuildRows() {
 	var walk func(path string, depth int)
 	walk = func(path string, depth int) {
 		rows = append(rows, treeRow{isGroup: true, group: path, depth: depth})
-		if m.collapsed[path] {
+		if honorFolds && m.collapsed[path] {
 			return
 		}
 		for _, sess := range sessionsByGroup[path] {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -188,6 +188,41 @@ func TestCreateArchiveRestoreDelete(t *testing.T) {
 	}
 }
 
+func TestArchivedViewIgnoresFold(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+
+	if err := m.store.CreateGroup("work", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "alpha", dir, "work")
+
+	m.selectSessionRow(t, "alpha")
+	_, cmd := m.archiveSelected()
+	m.applyCmd(t, cmd)
+
+	m.collapsed["work"] = true
+
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	if len(m.sessionRows()) != 1 {
+		t.Fatalf("archived session inside a folded group should still show, got %d rows", len(m.sessionRows()))
+	}
+
+	m.selectSessionRow(t, "alpha")
+	_, cmd = m.restoreSelected()
+	m.applyCmd(t, cmd)
+
+	active, err := m.store.ListSessions(false)
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("after restore, active sessions in store = %d want 1", len(active))
+	}
+}
+
 func TestNestedGroupsTree(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Problem

Unarchiving stopped working. An archived session inside a folded group could not be selected or restored.

## Root cause

Persisted group folds (#20) were honored in every view. The archived and search views prune the tree to groups holding matching sessions, but a folded group still hid its children. So a folded group containing an archived session hid that session, leaving no row to select and no way to restore it.

## Fix

Honor folds only in the active tree. The archived and search views always expand groups, so matching sessions stay reachable.

## Test

Added `TestArchivedViewIgnoresFold`: archives a session in a folded group, enters the archived view, restores it. Fails before the fix, passes after. Full suite green.