### PR TITLE
feat: Ctrl+R inside a session jumps to its diff review

### DIFF
--- a/docs/superpowers/specs/2026-07-18-in-session-review-shortcut-design.md
+++ b/docs/superpowers/specs/2026-07-18-in-session-review-shortcut-design.md
@@ -1,0 +1,88 @@
+# In-session review shortcut (Ctrl+R)
+
+## Problem
+
+Review mode (the full-screen diff, `modeDiff`) is reachable only from the
+session list, via `D`/`x` on the selected row. Once a user has attached into a
+session's tmux pane (Enter → `attachSelected`), the only way to review that
+session's diff is to detach with Ctrl+Q and press `D`. We want a single
+keystroke from inside the pane that lands directly in that session's review.
+
+## Approach
+
+The manager (a Bubble Tea program) is not running inside the tmux pane, so the
+only channel back to it is tmux itself. This mirrors the existing Ctrl+Q
+"detach back to manager" binding installed by `installSessionUX`: a scoped,
+server-global key that acts only inside `am_*` sessions and passes through
+everywhere else.
+
+Ctrl+R inside an `am_*` session sets a global tmux marker option and detaches.
+The detach unblocks the manager's `tea.ExecProcess`, which delivers
+`attachDoneMsg`. On that message the manager reads the marker; if set, it clears
+it and opens the diff for the session it just attached (still the selected row,
+since selection cannot change during a blocking attach).
+
+## Changes
+
+### tmux driver (`internal/tmux/tmux.go`)
+
+- **Binding** in `installSessionUX`, mirroring the Ctrl+Q shape:
+  ```
+  bind-key -n C-r if-shell -F '#{m:am_*,#{session_name}}' \
+    'set-option -g @am_review 1 ; detach-client' 'send-keys C-r'
+  ```
+  Inside `am_*` sessions Ctrl+R sets the marker and detaches; anywhere else it
+  passes Ctrl+R through to the pane untouched.
+- **Status hint**: `status-right` becomes
+  ` agent-manager · Ctrl+Q = back · Ctrl+R = review `.
+- **`ReviewRequested() (bool, error)`**: runs `show-option -gqv @am_review`,
+  returns true when the value is `1`. `-q` keeps it quiet when unset; an absent
+  server yields false, not an error (reuse the existing `noServer` handling).
+- **`ClearReviewRequest() error`**: runs `set-option -gu @am_review` to unset
+  the global option.
+
+The marker is a global option rather than per-session because the manager only
+needs to know "a review was requested"; it already knows which session it
+attached.
+
+### manager (`internal/ui/model.go`)
+
+In the `attachDoneMsg` case, before the existing refresh:
+
+- Call `m.tmux.ReviewRequested()`. On error, surface it (`m.err`) and fall
+  through to current behavior.
+- If true: `m.tmux.ClearReviewRequest()` (surface any error), then
+  `return m, m.openDiff()` for the selected session. `openDiff` already guards
+  the git driver and selection, sets `modeDiff`, and loads the diff.
+- If false: current behavior (refresh).
+
+No config schema change. No new mode.
+
+## Edge cases
+
+- **Ctrl+R with nothing selected**: `openDiff` already sets a "select a session
+  to diff" error and stays in the list. Cannot happen from this path (we only
+  arrive here after attaching a selected session) but is handled.
+- **git not in PATH**: `openDiff` already surfaces "git not found in PATH".
+- **Stale marker**: if `@am_review` were somehow set before an attach without
+  Ctrl+R, the next detach would open review spuriously. `ClearReviewRequest`
+  runs on every consume; the binding is the only setter. Low risk, self-healing
+  on the next clear.
+- **No tmux server**: `ReviewRequested` returns false via `noServer`, never
+  errors the UI.
+
+## Tests
+
+- **`internal/tmux/tmux_test.go`**: create a session, set `@am_review 1`
+  directly, assert `ReviewRequested()` is true, `ClearReviewRequest()` then
+  makes it false. Assert `ReviewRequested()` on a clean marker is false.
+- **`internal/ui/ui_test.go`**: the harness uses a real `*tmux.Driver` (tests
+  skip when tmux is absent). Set `@am_review 1` via tmux, select a session, feed
+  `attachDoneMsg{}` to `Update`, assert `m.mode == modeDiff`; with the marker
+  cleared, assert it stays `modeList`. `gitDrv` is non-nil (built in `New`),
+  so `openDiff` proceeds.
+
+## Out of scope
+
+Configurable keybinding, reviewing a session other than the attached one,
+surfacing the shortcut anywhere but the status hint.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -10,6 +10,10 @@ import (
 
 const prefix = "am_"
 
+// reviewOption is the global tmux user option the in-session Ctrl+R binding
+// sets to signal the manager to open review for the session it just detached.
+const reviewOption = "@am_review"
+
 type Driver struct {
 	bin string
 }
@@ -78,12 +82,15 @@ func (d *Driver) installSessionUX(name string) error {
 	options := [][]string{
 		{"set-option", "-t", name, "status", "on"},
 		{"set-option", "-t", name, "status-left", ""},
-		{"set-option", "-t", name, "status-right", " agent-manager · Ctrl+Q = back "},
+		{"set-option", "-t", name, "status-right", " agent-manager · Ctrl+Q = back · Ctrl+R = review "},
 		{"set-option", "-t", name, "status-style", "bg=colour236,fg=colour249"},
 		// hide the "0:windowname*" window list; it reads as noise here
 		{"set-option", "-t", name, "window-status-format", ""},
 		{"set-option", "-t", name, "window-status-current-format", ""},
 		{"bind-key", "-n", "C-q", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "detach-client", "send-keys C-q"},
+		// Ctrl+R inside an am_* session leaves a marker and detaches; the
+		// manager reads the marker on return and jumps straight to review.
+		{"bind-key", "-n", "C-r", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "set-option -g " + reviewOption + " 1 ; detach-client", "send-keys C-r"},
 	}
 	for _, args := range options {
 		if _, err := d.run(args...); err != nil {
@@ -127,6 +134,25 @@ func sanitizeFormat(s string) string {
 		return r
 	}, s)
 	return strings.ReplaceAll(s, "#", "##")
+}
+
+// ReviewRequested reports whether the in-session Ctrl+R binding set the
+// review marker before detaching. A missing tmux server means no request.
+func (d *Driver) ReviewRequested() (bool, error) {
+	out, err := exec.Command(d.bin, "show-option", "-gqv", reviewOption).CombinedOutput()
+	if err != nil {
+		if noServer(string(out)) {
+			return false, nil
+		}
+		return false, fmt.Errorf("tmux show-option %s: %w: %s", reviewOption, err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)) == "1", nil
+}
+
+// ClearReviewRequest unsets the review marker so it fires once per request.
+func (d *Driver) ClearReviewRequest() error {
+	_, err := d.run("set-option", "-gu", reviewOption)
+	return err
 }
 
 func (d *Driver) AttachCommand(id string) *exec.Cmd {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -76,6 +76,50 @@ func TestSendText(t *testing.T) {
 	}
 }
 
+func TestReviewRequestRoundTrip(t *testing.T) {
+	driver := requireTmux(t)
+	// A live server is needed for global options to stick.
+	id := "rev" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "", nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+	t.Cleanup(func() { driver.ClearReviewRequest() })
+
+	if err := driver.ClearReviewRequest(); err != nil {
+		t.Fatalf("ClearReviewRequest: %v", err)
+	}
+	requested, err := driver.ReviewRequested()
+	if err != nil {
+		t.Fatalf("ReviewRequested: %v", err)
+	}
+	if requested {
+		t.Fatal("no request expected on a clean marker")
+	}
+
+	if _, err := exec.Command("tmux", "set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	requested, err = driver.ReviewRequested()
+	if err != nil {
+		t.Fatalf("ReviewRequested: %v", err)
+	}
+	if !requested {
+		t.Fatal("marker set to 1 should read as requested")
+	}
+
+	if err := driver.ClearReviewRequest(); err != nil {
+		t.Fatalf("ClearReviewRequest: %v", err)
+	}
+	requested, err = driver.ReviewRequested()
+	if err != nil {
+		t.Fatalf("ReviewRequested: %v", err)
+	}
+	if requested {
+		t.Fatal("clear should drop the marker")
+	}
+}
+
 func TestLifecycle(t *testing.T) {
 	driver := requireTmux(t)
 	id := "test" + time.Now().Format("150405.000000")

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -348,6 +348,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case attachDoneMsg:
 		if msg.err != nil {
 			m.err = msg.err.Error()
+			m.requestRefresh()
+			return m, nil
+		}
+		// Ctrl+R inside the session sets a marker before detaching; consume
+		// it here and jump straight to review for the session just attached.
+		requested, err := m.tmux.ReviewRequested()
+		if err != nil {
+			m.err = err.Error()
+		} else if requested {
+			if clearErr := m.tmux.ClearReviewRequest(); clearErr != nil {
+				m.err = clearErr.Error()
+			}
+			return m, m.openDiff()
 		}
 		m.requestRefresh()
 		return m, nil

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -673,6 +673,48 @@ func TestLiveQuietTurnResolvesFinished(t *testing.T) {
 	waitStatus(status.Finished)
 }
 
+func TestAttachDoneOpensReviewWhenMarkerSet(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	createSession(t, m, "reviewme", t.TempDir(), "")
+	m.selectSessionRow(t, "reviewme")
+	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+
+	if _, err := exec.Command("tmux", "set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	updated, _ := m.Update(attachDoneMsg{})
+	*m = *updated.(*Model)
+	if m.mode != modeDiff {
+		t.Fatalf("marker set should enter review, mode = %v, err = %q", m.mode, m.err)
+	}
+
+	requested, err := m.tmux.ReviewRequested()
+	if err != nil {
+		t.Fatalf("ReviewRequested: %v", err)
+	}
+	if requested {
+		t.Fatal("opening review should consume the marker")
+	}
+}
+
+func TestAttachDoneStaysInListWithoutMarker(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "plainexit", t.TempDir(), "")
+	m.selectSessionRow(t, "plainexit")
+	if err := m.tmux.ClearReviewRequest(); err != nil {
+		t.Fatalf("clear marker: %v", err)
+	}
+
+	updated, _ := m.Update(attachDoneMsg{})
+	*m = *updated.(*Model)
+	if m.mode != modeList {
+		t.Fatalf("no marker should stay in list, mode = %v", m.mode)
+	}
+}
+
 func TestAttachAcknowledgesFinished(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "alert-me", t.TempDir(), "")


### PR DESCRIPTION
## What

Ctrl+R while attached inside a session detaches and lands directly in that session's full-screen diff review. The status bar hint becomes `Ctrl+Q = back · Ctrl+R = review`.

## Why

Attaching into a session's pane left no path back into review except detaching with Ctrl+Q and pressing `D`. This closes that gap with a single keystroke.

## How

The manager is not running inside the tmux pane, so tmux is the only channel back. Ctrl+R inside `am_*` sessions sets a global tmux marker (`@am_review`) and detaches, mirroring the existing Ctrl+Q detach binding. On the resulting `attachDoneMsg` the manager reads the marker, clears it, and opens the diff for the session it just left. Selection cannot change during a blocking attach, so the target is always correct.

`ReviewRequested` / `ClearReviewRequest` on the tmux driver keep the UI tmux-agnostic and make the round-trip testable.

## Tests

- `internal/tmux`: marker set/read/clear round-trip.
- `internal/ui`: `attachDoneMsg` with the marker set enters review; without it, stays in the list.
- Verified the installed root binding and status hint live on an isolated tmux socket.

Spec: `docs/superpowers/specs/2026-07-18-in-session-review-shortcut-design.md`