### PR TITLE
fix: capture agent session ids in launch order so revives don't swap

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -124,7 +124,7 @@ func (s *Store) CreateSession(sess Session) error {
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 		         (SELECT COALESCE(MAX(sort_order)+1, 0) FROM sessions WHERE group_name = ?))`,
 		sess.ID, sess.Name, sess.Tool, sess.Cwd, sess.Group, sess.Status,
-		boolToInt(sess.Archived), sess.CreatedAt.Unix(), sess.LastStatusAt.Unix(), sess.AgentSessionID, sess.Group,
+		boolToInt(sess.Archived), encodeTime(sess.CreatedAt), encodeTime(sess.LastStatusAt), sess.AgentSessionID, sess.Group,
 	)
 	if err != nil {
 		return err
@@ -183,8 +183,8 @@ func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
 		}
 		sess.Archived = archived != 0
 		sess.Acked = acked != 0
-		sess.CreatedAt = time.Unix(created, 0)
-		sess.LastStatusAt = time.Unix(lastStatus, 0)
+		sess.CreatedAt = decodeTime(created)
+		sess.LastStatusAt = decodeTime(lastStatus)
 		sessions = append(sessions, sess)
 	}
 	return sessions, rows.Err()
@@ -204,15 +204,15 @@ func (s *Store) Get(id string) (Session, error) {
 	}
 	sess.Archived = archived != 0
 	sess.Acked = acked != 0
-	sess.CreatedAt = time.Unix(created, 0)
-	sess.LastStatusAt = time.Unix(lastStatus, 0)
+	sess.CreatedAt = decodeTime(created)
+	sess.LastStatusAt = decodeTime(lastStatus)
 	return sess, nil
 }
 
 func (s *Store) UpdateStatus(id, newStatus string) error {
 	res, err := s.db.Exec(
 		`UPDATE sessions SET status = ?, last_status_at = ? WHERE id = ?`,
-		newStatus, time.Now().Unix(), id)
+		newStatus, encodeTime(time.Now()), id)
 	if err != nil {
 		return err
 	}
@@ -537,4 +537,33 @@ func boolToInt(b bool) int {
 		return 1
 	}
 	return 0
+}
+
+// secondsCeiling separates the two timestamp encodings the sessions table
+// has held. Values below it are Unix seconds written before nanosecond
+// precision (a seconds timestamp stays under it until the year 33658); at
+// or above it are Unix nanoseconds (any real nanosecond timestamp since
+// 1970 far exceeds it). This lets decodeTime read old rows without a data
+// migration.
+const secondsCeiling int64 = 1e12
+
+// encodeTime stores a timestamp as Unix nanoseconds so sessions launched in
+// the same second keep a distinct, ordered launch time. The zero time
+// encodes as 0.
+func encodeTime(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+// decodeTime reverses encodeTime, reading pre-precision rows as seconds.
+func decodeTime(v int64) time.Time {
+	if v == 0 {
+		return time.Time{}
+	}
+	if v < secondsCeiling {
+		return time.Unix(v, 0)
+	}
+	return time.Unix(0, v)
 }

--- a/internal/store/timeenc_test.go
+++ b/internal/store/timeenc_test.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDecodeTimeReadsBothEncodings(t *testing.T) {
+	seconds := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	if got := decodeTime(seconds.Unix()); !got.Equal(seconds) {
+		t.Errorf("legacy seconds: got %v, want %v", got, seconds)
+	}
+	nanos := time.Date(2026, 7, 18, 12, 0, 0, 123456789, time.UTC)
+	if got := decodeTime(nanos.UnixNano()); !got.Equal(nanos) {
+		t.Errorf("nanoseconds: got %v, want %v", got, nanos)
+	}
+	if got := decodeTime(0); !got.IsZero() {
+		t.Errorf("zero: got %v, want zero time", got)
+	}
+}
+
+// A session's launch time keeps sub-second precision across the store, so
+// two sessions started in the same second stay distinguishable and ordered.
+func TestCreatedAtKeepsSubSecondPrecision(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	launch := time.Now().Truncate(time.Second).Add(250 * time.Millisecond)
+	if err := st.CreateSession(Session{ID: "s1", Name: "n", Tool: "codex", Cwd: "/x", Group: "g", Status: "idle", CreatedAt: launch}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.Get("s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CreatedAt.UnixNano() != launch.UnixNano() {
+		t.Fatalf("CreatedAt round-trip lost precision: got %d, want %d",
+			got.CreatedAt.UnixNano(), launch.UnixNano())
+	}
+}

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -235,20 +236,9 @@ func (p *poller) refreshOnce() tea.Msg {
 			}
 			sessions[i].Status = newStatus
 		}
-		// Once a tool that mints its own id has a live pane, read the id it
-		// wrote so a later revive resumes that exact conversation. Captured
-		// once; nothing to do for tools launched with an id we chose.
-		if panes[sess.ID] > 0 && sessions[i].AgentSessionID == "" {
-			if storeName := p.sessionStores[sess.Tool]; storeName != "" {
-				if agentID, ok := agentsession.Capture(storeName, sess.Cwd, sess.CreatedAt, claimed); ok {
-					if err := p.store.SetAgentSessionID(sess.ID, agentID); err != nil {
-						return errMsg{err}
-					}
-					sessions[i].AgentSessionID = agentID
-					claimed[agentID] = true
-				}
-			}
-		}
+	}
+	if err := p.captureAgentSessionIDs(sessions, panes, claimed); err != nil {
+		return errMsg{err}
 	}
 	p.paneHashes = paneHashes
 	p.sweepDirectives(sessions)
@@ -278,6 +268,42 @@ func (p *poller) refreshOnce() tea.Msg {
 		msg.snapOK = true
 	}
 	return msg
+}
+
+// captureAgentSessionIDs binds each not-yet-captured id-minting session
+// (codex, opencode) to the conversation its CLI wrote. Sessions are
+// processed in launch order so the earliest one claims the earliest
+// unclaimed rollout in its directory; a later session started in the same
+// directory then skips that rollout via claimed and captures its own.
+// Capturing out of launch order would let a later session claim an earlier
+// one's conversation. CreatedAt is second-resolution, so two sessions
+// launched in the same directory within one second can still tie.
+func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[string]int, claimed map[string]bool) error {
+	pending := make([]int, 0, len(sessions))
+	for i, sess := range sessions {
+		if sess.Archived || panes[sess.ID] == 0 || sess.AgentSessionID != "" {
+			continue
+		}
+		if p.sessionStores[sess.Tool] != "" {
+			pending = append(pending, i)
+		}
+	}
+	sort.SliceStable(pending, func(a, b int) bool {
+		return sessions[pending[a]].CreatedAt.Before(sessions[pending[b]].CreatedAt)
+	})
+	for _, i := range pending {
+		sess := sessions[i]
+		agentID, ok := agentsession.Capture(p.sessionStores[sess.Tool], sess.Cwd, sess.CreatedAt, claimed)
+		if !ok {
+			continue
+		}
+		if err := p.store.SetAgentSessionID(sess.ID, agentID); err != nil {
+			return err
+		}
+		sessions[i].AgentSessionID = agentID
+		claimed[agentID] = true
+	}
+	return nil
 }
 
 // maybeSendDirective delivers the deferred rename directive once the

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -276,8 +276,8 @@ func (p *poller) refreshOnce() tea.Msg {
 // unclaimed rollout in its directory; a later session started in the same
 // directory then skips that rollout via claimed and captures its own.
 // Capturing out of launch order would let a later session claim an earlier
-// one's conversation. CreatedAt is second-resolution, so two sessions
-// launched in the same directory within one second can still tie.
+// one's conversation. CreatedAt carries nanosecond precision, so sessions
+// launched a moment apart in the same directory still order deterministically.
 func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[string]int, claimed map[string]bool) error {
 	pending := make([]int, 0, len(sessions))
 	for i, sess := range sessions {

--- a/internal/ui/poller_capture_test.go
+++ b/internal/ui/poller_capture_test.go
@@ -23,9 +23,11 @@ func writeCodexRollout(t *testing.T, path, sessionID, cwd string, modTime time.T
 	}
 }
 
-// Two codex sessions share a directory, A launched before B. The poller
-// receives them in store order (B first), not launch order. Capture must
-// still bind each to its own conversation instead of swapping them.
+// Two codex sessions share a directory, A launched a fraction of a second
+// before B, both within the same wall-clock second. The poller receives
+// them in store order (B first), not launch order. Sub-second launch times
+// must survive the store round-trip so capture binds each to its own
+// conversation instead of swapping them.
 func TestCaptureAgentSessionIDsAssignsInLaunchOrder(t *testing.T) {
 	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
 	if err != nil {
@@ -37,14 +39,17 @@ func TestCaptureAgentSessionIDsAssignsInLaunchOrder(t *testing.T) {
 	t.Setenv("CODEX_HOME", codexHome)
 	cwd := t.TempDir()
 
-	base := time.Now().Add(-time.Minute)
-	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-A.jsonl"), "A-id", cwd, base)
-	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-B.jsonl"), "B-id", cwd, base.Add(2*time.Second))
+	// A whole second, so A and B share it and only nanoseconds separate them.
+	base := time.Now().Truncate(time.Second).Add(-time.Minute)
+	aLaunch := base.Add(100 * time.Millisecond)
+	bLaunch := base.Add(600 * time.Millisecond)
+	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-A.jsonl"), "A-id", cwd, aLaunch)
+	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-B.jsonl"), "B-id", cwd, bLaunch)
 
-	if err := st.CreateSession(store.Session{ID: "sess-A", Name: "a", Tool: "codex", Cwd: cwd, Group: "g", Status: "idle", CreatedAt: base}); err != nil {
+	if err := st.CreateSession(store.Session{ID: "sess-A", Name: "a", Tool: "codex", Cwd: cwd, Group: "g", Status: "idle", CreatedAt: aLaunch}); err != nil {
 		t.Fatal(err)
 	}
-	if err := st.CreateSession(store.Session{ID: "sess-B", Name: "b", Tool: "codex", Cwd: cwd, Group: "g", Status: "idle", CreatedAt: base.Add(2 * time.Second)}); err != nil {
+	if err := st.CreateSession(store.Session{ID: "sess-B", Name: "b", Tool: "codex", Cwd: cwd, Group: "g", Status: "idle", CreatedAt: bLaunch}); err != nil {
 		t.Fatal(err)
 	}
 	sessA, err := st.Get("sess-A")

--- a/internal/ui/poller_capture_test.go
+++ b/internal/ui/poller_capture_test.go
@@ -1,0 +1,72 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/store"
+)
+
+func writeCodexRollout(t *testing.T, path, sessionID, cwd string, modTime time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"session_meta","payload":{"session_id":"` + sessionID + `","cwd":"` + cwd + `"}}` + "\n"
+	if err := os.WriteFile(path, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Two codex sessions share a directory, A launched before B. The poller
+// receives them in store order (B first), not launch order. Capture must
+// still bind each to its own conversation instead of swapping them.
+func TestCaptureAgentSessionIDsAssignsInLaunchOrder(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	cwd := t.TempDir()
+
+	base := time.Now().Add(-time.Minute)
+	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-A.jsonl"), "A-id", cwd, base)
+	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-B.jsonl"), "B-id", cwd, base.Add(2*time.Second))
+
+	if err := st.CreateSession(store.Session{ID: "sess-A", Name: "a", Tool: "codex", Cwd: cwd, Group: "g", Status: "idle", CreatedAt: base}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CreateSession(store.Session{ID: "sess-B", Name: "b", Tool: "codex", Cwd: cwd, Group: "g", Status: "idle", CreatedAt: base.Add(2 * time.Second)}); err != nil {
+		t.Fatal(err)
+	}
+	sessA, err := st.Get("sess-A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessB, err := st.Get("sess-B")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessions := []store.Session{sessB, sessA} // store order, not launch order
+	p := &poller{store: st, sessionStores: map[string]string{"codex": "codex"}}
+	panes := map[string]int{"sess-A": 123, "sess-B": 456}
+	if err := p.captureAgentSessionIDs(sessions, panes, map[string]bool{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := sessions[1].AgentSessionID; got != "A-id" {
+		t.Fatalf("session A captured %q, want A-id", got)
+	}
+	if got := sessions[0].AgentSessionID; got != "B-id" {
+		t.Fatalf("session B captured %q, want B-id", got)
+	}
+}


### PR DESCRIPTION
## Problem

Revive is meant to resume each session's own conversation. For tools that mint their own id (codex, opencode), the poller reads the id back from the CLI's session store after launch. That capture ran inside the main poll loop, which iterates sessions in store order (group, sort_order) rather than launch order.

`Capture` returns the earliest **unclaimed** rollout in the session's directory after its launch. So when two sessions share a directory and the later-launched one is processed first, it claims the earlier session's rollout, and the two sessions swap conversation ids. Revive then resumes the wrong conversation, the exact bug this feature set out to fix.

Verified with a repro: capturing the later session first returned the earlier session's id.

## Fix

Two commits:

1. **Capture in launch order.** Move capture into `captureAgentSessionIDs`, a pass after the poll loop that processes eligible sessions in `CreatedAt` order. The earliest-launched session claims the earliest rollout first; later same-directory sessions skip it via `claimed` and capture their own.

2. **Nanosecond launch times.** The store wrote timestamps as Unix seconds, so two sessions launched in one directory within the same second tied and could still swap. Session timestamps now encode as Unix nanoseconds; `decodeTime` reads values below a seconds ceiling as legacy seconds, so existing databases keep working with no data migration.

## Tests

- `TestCaptureAgentSessionIDsAssignsInLaunchOrder`: two same-cwd codex sessions a sub-second apart within one wall-clock second, fed to the poller in store order (later first), each keeps its own id. Confirmed it fails without the sort (`session A captured "B-id"`) and passes with it.
- `TestCreatedAtKeepsSubSecondPrecision`: launch time survives the store round-trip to nanosecond precision.
- `TestDecodeTimeReadsBothEncodings`: legacy-seconds and nanosecond values both decode correctly.

Build, vet, gofmt, full suite green.