### PR TITLE
fix: return to the session when leaving a review opened from inside it

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -52,6 +52,12 @@ type diffState struct {
 	probeTick   int
 	hl          *hlCache
 	hlPending   hlKey
+
+	// reattachID is set when review was entered from inside a session via
+	// Ctrl+R; leaving review re-attaches that session instead of dropping to
+	// the list. Empty when review was opened from the list, where leaving
+	// returns to the list.
+	reattachID string
 }
 
 type diffLoadedMsg struct {
@@ -428,6 +434,14 @@ func (m *Model) handleDiffKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "esc":
 		m.mode = modeList
 		m.diff.active = false
+		// Review opened from inside a session returns to that session, not
+		// the list, so Ctrl+R then esc is a round trip back to where it began.
+		if id := m.diff.reattachID; id != "" {
+			m.diff.reattachID = ""
+			if cmd := m.reattach(id); cmd != nil {
+				return m, cmd
+			}
+		}
 	case "up", "k":
 		m.moveDiffCursor(-1, height)
 	case "down", "j":

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -53,10 +53,7 @@ type diffState struct {
 	hl          *hlCache
 	hlPending   hlKey
 
-	// reattachID is set when review was entered from inside a session via
-	// Ctrl+R; leaving review re-attaches that session instead of dropping to
-	// the list. Empty when review was opened from the list, where leaving
-	// returns to the list.
+	// Set when review opened from inside a session; leaving re-attaches it.
 	reattachID string
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -284,38 +284,46 @@ func (m *Model) attachSelected() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.err = ""
-	// Entering a finished session acknowledges the alert; the acked mark
-	// keeps it idle while the pane still shows the acknowledged turn.
-	if sess.Status == status.Finished {
-		if err := m.store.UpdateStatus(sess.ID, status.Idle); err != nil {
-			m.err = err.Error()
-			return m, nil
-		}
-		if err := m.store.SetAcked(sess.ID, true); err != nil {
-			m.err = err.Error()
-			return m, nil
-		}
+	if err := m.acknowledgeFinished(sess); err != nil {
+		m.err = err.Error()
+		return m, nil
 	}
 	return m, m.attachCmd(sess.ID)
 }
 
-// attachCmd suspends the TUI to attach the session's tmux pane, resuming on
-// detach with an attachDoneMsg. Shared by entering a session from the list
-// and by returning to it after an in-session review.
+// acknowledgeFinished marks a finished session idle and acked so entering it
+// clears the alert while the pane still shows the acknowledged turn.
+func (m *Model) acknowledgeFinished(sess store.Session) error {
+	if sess.Status != status.Finished {
+		return nil
+	}
+	if err := m.store.UpdateStatus(sess.ID, status.Idle); err != nil {
+		return err
+	}
+	return m.store.SetAcked(sess.ID, true)
+}
+
 func (m *Model) attachCmd(id string) tea.Cmd {
 	return tea.ExecProcess(m.tmux.AttachCommand(id), func(err error) tea.Msg {
 		return attachDoneMsg{err}
 	})
 }
 
-// reattach returns to a session after review, or reports it if it died
-// while the diff was open.
 func (m *Model) reattach(id string) tea.Cmd {
 	if !m.tmux.Exists(id) {
 		m.err = "session is dead - press v to revive"
 		return nil
 	}
 	m.err = ""
+	sess, err := m.store.Get(id)
+	if err != nil {
+		m.err = err.Error()
+		return nil
+	}
+	if err := m.acknowledgeFinished(sess); err != nil {
+		m.err = err.Error()
+		return nil
+	}
 	return m.attachCmd(id)
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -118,6 +118,9 @@ func (m *Model) openDiff() tea.Cmd {
 	m.diff.active = true
 	m.mode = modeDiff
 	m.err = ""
+	// Default to returning to the list; the in-session Ctrl+R path sets this
+	// afterward when review should return to the session instead.
+	m.diff.reattachID = ""
 	return m.retargetDiff(sess)
 }
 
@@ -293,10 +296,27 @@ func (m *Model) attachSelected() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	}
-	cmd := m.tmux.AttachCommand(sess.ID)
-	return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+	return m, m.attachCmd(sess.ID)
+}
+
+// attachCmd suspends the TUI to attach the session's tmux pane, resuming on
+// detach with an attachDoneMsg. Shared by entering a session from the list
+// and by returning to it after an in-session review.
+func (m *Model) attachCmd(id string) tea.Cmd {
+	return tea.ExecProcess(m.tmux.AttachCommand(id), func(err error) tea.Msg {
 		return attachDoneMsg{err}
 	})
+}
+
+// reattach returns to a session after review, or reports it if it died
+// while the diff was open.
+func (m *Model) reattach(id string) tea.Cmd {
+	if !m.tmux.Exists(id) {
+		m.err = "session is dead - press v to revive"
+		return nil
+	}
+	m.err = ""
+	return m.attachCmd(id)
 }
 
 // reviveSelected relaunches a dead session's tmux session under the same

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -383,7 +383,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if clearErr := m.tmux.ClearReviewRequest(); clearErr != nil {
 				m.err = clearErr.Error()
 			}
-			return m, m.openDiff()
+			sess, ok := m.selected()
+			cmd := m.openDiff()
+			// Remember the origin so leaving review returns to this session
+			// rather than the list; only when review actually opened.
+			if ok && m.mode == modeDiff {
+				m.diff.reattachID = sess.ID
+			}
+			return m, cmd
 		}
 		m.requestRefresh()
 		return m, nil

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -380,13 +380,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if err != nil {
 			m.err = err.Error()
 		} else if requested {
+			// A failed clear leaves the marker set, which would reopen review
+			// on every later detach, so surface it and stay in the list rather
+			// than letting openDiff reset m.err and hide it.
 			if clearErr := m.tmux.ClearReviewRequest(); clearErr != nil {
 				m.err = clearErr.Error()
+				m.requestRefresh()
+				return m, nil
 			}
 			sess, ok := m.selected()
 			cmd := m.openDiff()
-			// Remember the origin so leaving review returns to this session
-			// rather than the list; only when review actually opened.
 			if ok && m.mode == modeDiff {
 				m.diff.reattachID = sess.ID
 			}

--- a/internal/ui/review_reattach_test.go
+++ b/internal/ui/review_reattach_test.go
@@ -4,6 +4,7 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/YoanWai/agent-manager/internal/status"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -74,5 +75,46 @@ func TestListReviewLeavesToListWithoutReattach(t *testing.T) {
 	}
 	if cmd != nil {
 		t.Fatal("list review esc should not re-attach")
+	}
+}
+
+// Leaving review back into a session acknowledges a finished alert, matching
+// what entering the session from the list does.
+func TestReattachAcknowledgesFinished(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	createSession(t, m, "finisher", t.TempDir(), "")
+	m.selectSessionRow(t, "finisher")
+	sess, ok := m.selected()
+	if !ok {
+		t.Fatal("no session selected")
+	}
+	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+
+	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
+		t.Fatalf("set finished: %v", err)
+	}
+	if _, err := exec.Command("tmux", "set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	updated, _ := m.Update(attachDoneMsg{})
+	*m = *updated.(*Model)
+	if m.mode != modeDiff {
+		t.Fatalf("expected review, mode = %v, err = %q", m.mode, m.err)
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	*m = *updated.(*Model)
+	if cmd == nil {
+		t.Fatalf("esc should re-attach, err = %q", m.err)
+	}
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != status.Idle || !got.Acked {
+		t.Fatalf("re-attach should acknowledge finished: status = %q acked = %v", got.Status, got.Acked)
 	}
 }

--- a/internal/ui/review_reattach_test.go
+++ b/internal/ui/review_reattach_test.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"os/exec"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Ctrl+R inside a session opens review and remembers the session, so leaving
+// review returns to it rather than dropping to the list.
+func TestInSessionReviewRemembersOriginAndReattaches(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	createSession(t, m, "reviewme", t.TempDir(), "")
+	m.selectSessionRow(t, "reviewme")
+	sess, ok := m.selected()
+	if !ok {
+		t.Fatal("no session selected")
+	}
+	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+
+	if _, err := exec.Command("tmux", "set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	updated, _ := m.Update(attachDoneMsg{})
+	*m = *updated.(*Model)
+
+	if m.mode != modeDiff {
+		t.Fatalf("marker set should enter review, mode = %v, err = %q", m.mode, m.err)
+	}
+	if m.diff.reattachID != sess.ID {
+		t.Fatalf("review origin = %q, want %q", m.diff.reattachID, sess.ID)
+	}
+
+	// esc leaves review; the live origin session re-attaches.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	*m = *updated.(*Model)
+	if m.mode != modeList {
+		t.Fatalf("esc should leave review, mode = %v", m.mode)
+	}
+	if m.diff.reattachID != "" {
+		t.Fatalf("reattach origin should be consumed, got %q", m.diff.reattachID)
+	}
+	if cmd == nil {
+		t.Fatal("esc from in-session review should re-attach the session, got nil command")
+	}
+}
+
+// Review opened from the list has no origin, so esc returns to the list with
+// no re-attach.
+func TestListReviewLeavesToListWithoutReattach(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	createSession(t, m, "listreview", t.TempDir(), "")
+	m.selectSessionRow(t, "listreview")
+
+	m.applyCmd(t, m.openDiff())
+	if m.mode != modeDiff {
+		t.Fatalf("openDiff should enter review, mode = %v, err = %q", m.mode, m.err)
+	}
+	if m.diff.reattachID != "" {
+		t.Fatalf("list review should not set a reattach origin, got %q", m.diff.reattachID)
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	*m = *updated.(*Model)
+	if m.mode != modeList {
+		t.Fatalf("esc should return to list, mode = %v", m.mode)
+	}
+	if cmd != nil {
+		t.Fatal("list review esc should not re-attach")
+	}
+}


### PR DESCRIPTION
## Problem

`Ctrl+R` inside a session jumps to its diff review (#23). But leaving the review with `q`/`esc` always dropped to the manager list, stranding the user out of the session they were working in. A shortcut meant as a quick glance at the diff turned into a one-way trip.

## Fix

Remember where review was entered from and mirror it on the way out:

- The in-session `Ctrl+R` path records the origin session (`diffState.reattachID`).
- `q`/`esc` in review re-attaches that session instead of returning to the list.
- Reviews opened from the list (`D`) leave `reattachID` empty and still exit to the list.

`attachCmd` extracts the shared attach `ExecProcess` so first attach and re-attach take the same path.

## Tests

- `TestInSessionReviewRemembersOriginAndReattaches`: `Ctrl+R` review records the origin; `esc` leaves review, consumes the origin, and returns a re-attach command.
- `TestListReviewLeavesToListWithoutReattach`: `D` review sets no origin; `esc` returns to the list with no re-attach.

## Note on the reported "weird / not responsive"

I verified each layer of the in-session review round trip independently: the tmux `Ctrl+R` binding's compound `if-shell` command runs both `set-option` and `detach-client`; the marker set/clear round-trips; `attachDoneMsg` transitions to review mode; keys route to the diff handler. No key-level unresponsiveness reproduced in the Go logic. The concrete defect was the wrong exit destination, fixed here; the round trip is now `Ctrl+R -> review -> esc -> back in the session`.

Build, vet, gofmt, full suite green.