### PR TITLE
fix: in-session review usable on existing sessions, full footer, no detach lag

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -82,22 +82,29 @@ func ShellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-// installSessionUX adds a status-bar hint and a Ctrl+Q detach binding.
-// The bind is server-global but only detaches inside am_* sessions;
-// everywhere else Ctrl+Q passes through to the pane untouched.
+// installSessionUX styles a new session's status bar, seeds an empty label
+// until SetLabel runs, and installs the server-global key bindings.
 func (d *Driver) installSessionUX(name string) error {
+	if err := d.EnsureBindings(); err != nil {
+		return err
+	}
+	if err := d.styleStatusBar(name); err != nil {
+		return err
+	}
+	_, err := d.run("set-option", "-t", name, "status-left", "")
+	return err
+}
+
+// styleStatusBar sets a session's status bar chrome, leaving status-left (the
+// name label) untouched so re-styling a live session keeps its label.
+func (d *Driver) styleStatusBar(name string) error {
 	options := [][]string{
 		{"set-option", "-t", name, "status", "on"},
-		{"set-option", "-t", name, "status-left", ""},
 		{"set-option", "-t", name, "status-right", " agent-manager · Ctrl+Q = back · Ctrl+R = review "},
 		{"set-option", "-t", name, "status-style", "bg=colour236,fg=colour249"},
 		// hide the "0:windowname*" window list; it reads as noise here
 		{"set-option", "-t", name, "window-status-format", ""},
 		{"set-option", "-t", name, "window-status-current-format", ""},
-		{"bind-key", "-n", "C-q", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "detach-client", "send-keys C-q"},
-		// Ctrl+R inside an am_* session leaves a marker and detaches; the
-		// manager reads the marker on return and jumps straight to review.
-		{"bind-key", "-n", "C-r", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "set-option -g " + reviewOption + " 1 ; detach-client", "send-keys C-r"},
 	}
 	for _, args := range options {
 		if _, err := d.run(args...); err != nil {
@@ -105,6 +112,30 @@ func (d *Driver) installSessionUX(name string) error {
 		}
 	}
 	return nil
+}
+
+// EnsureBindings installs the server-global Ctrl+Q detach and Ctrl+R review
+// bindings. Both only act inside am_* sessions; elsewhere the key passes
+// through to the pane. Idempotent, so it is safe to re-run for sessions that
+// predate a binding.
+func (d *Driver) EnsureBindings() error {
+	binds := [][]string{
+		{"bind-key", "-n", "C-q", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "detach-client", "send-keys C-q"},
+		{"bind-key", "-n", "C-r", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "set-option -g " + reviewOption + " 1 ; detach-client", "send-keys C-r"},
+	}
+	for _, args := range binds {
+		if _, err := d.run(args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RefreshChrome re-applies the status bar chrome to a live session so a
+// session created before a manager update picks up the current footer,
+// without disturbing its name label.
+func (d *Driver) RefreshChrome(id string) error {
+	return d.styleStatusBar(sessionName(id))
 }
 
 // SendText types text into the session's pane as literal keystrokes and

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -100,7 +100,10 @@ func (d *Driver) installSessionUX(name string) error {
 func (d *Driver) styleStatusBar(name string) error {
 	options := [][]string{
 		{"set-option", "-t", name, "status", "on"},
-		{"set-option", "-t", name, "status-right", " agent-manager · Ctrl+Q = back · Ctrl+R = review "},
+		// The default status-right-length of 40 truncates the hint before the
+		// Ctrl+R part, so widen it to fit the whole footer.
+		{"set-option", "-t", name, "status-right-length", "80"},
+		{"set-option", "-t", name, "status-right", " agent-manager · Ctrl+q = back · Ctrl+r = review "},
 		{"set-option", "-t", name, "status-style", "bg=colour236,fg=colour249"},
 		// hide the "0:windowname*" window list; it reads as noise here
 		{"set-option", "-t", name, "window-status-format", ""},

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -139,8 +139,15 @@ func TestRefreshChromeKeepsLabelAndAddsReviewHint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("status-right: %v", err)
 	}
-	if !strings.Contains(string(right), "Ctrl+R = review") {
+	if !strings.Contains(string(right), "Ctrl+r = review") {
 		t.Fatalf("footer should advertise review, got %q", right)
+	}
+	length, err := exec.Command("tmux", "show-option", "-t", "am_"+id, "-v", "status-right-length").CombinedOutput()
+	if err != nil {
+		t.Fatalf("status-right-length: %v", err)
+	}
+	if strings.TrimSpace(string(length)) != "80" {
+		t.Fatalf("status-right-length should fit the footer, got %q", length)
 	}
 	left, err := exec.Command("tmux", "display-message", "-p", "-t", "am_"+id, "#{T:status-left}").CombinedOutput()
 	if err != nil {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -120,6 +120,37 @@ func TestReviewRequestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRefreshChromeKeepsLabelAndAddsReviewHint(t *testing.T) {
+	driver := requireTmux(t)
+	id := "chr" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "", nil, 0, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+
+	if err := driver.SetLabel(id, "my-session"); err != nil {
+		t.Fatalf("SetLabel: %v", err)
+	}
+	if err := driver.RefreshChrome(id); err != nil {
+		t.Fatalf("RefreshChrome: %v", err)
+	}
+
+	right, err := exec.Command("tmux", "display-message", "-p", "-t", "am_"+id, "#{T:status-right}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("status-right: %v", err)
+	}
+	if !strings.Contains(string(right), "Ctrl+R = review") {
+		t.Fatalf("footer should advertise review, got %q", right)
+	}
+	left, err := exec.Command("tmux", "display-message", "-p", "-t", "am_"+id, "#{T:status-left}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("status-left: %v", err)
+	}
+	if !strings.Contains(string(left), "my-session") {
+		t.Fatalf("re-styling should keep the name label, got %q", left)
+	}
+}
+
 func TestLifecycle(t *testing.T) {
 	driver := requireTmux(t)
 	id := "test" + time.Now().Format("150405.000000")

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -247,6 +247,32 @@ func (m *Model) requestRefresh() {
 
 func (m *Model) Init() tea.Cmd {
 	m.syncPollInput()
+	return m.refreshExistingSessionUX
+}
+
+// refreshExistingSessionUX re-applies the tmux bindings and status bar to
+// sessions that were already running when the manager started, so a session
+// created before an update still gets the current key bindings (the
+// server-global Ctrl+R review key) and footer.
+func (m *Model) refreshExistingSessionUX() tea.Msg {
+	if err := m.tmux.EnsureBindings(); err != nil {
+		return errMsg{err}
+	}
+	sessions, err := m.store.ListSessions(true)
+	if err != nil {
+		return errMsg{err}
+	}
+	for _, sess := range sessions {
+		if !m.tmux.Exists(sess.ID) {
+			continue
+		}
+		if err := m.tmux.RefreshChrome(sess.ID); err != nil {
+			return errMsg{err}
+		}
+		if err := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name)); err != nil {
+			return errMsg{err}
+		}
+	}
 	return nil
 }
 
@@ -319,6 +345,12 @@ func (m *Model) resizeSessions() {
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		// Resuming from a tmux attach re-sends the current size unchanged; only
+		// a real resize needs the per-session tmux resize calls, so an
+		// unchanged size skips them and keeps detach latency flat.
+		if msg.Width == m.width && msg.Height == m.height {
+			return m, nil
+		}
 		m.width = msg.Width
 		m.height = msg.Height
 		m.resizeSessions()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -266,12 +266,11 @@ func (m *Model) refreshExistingSessionUX() tea.Msg {
 		if !m.tmux.Exists(sess.ID) {
 			continue
 		}
-		if err := m.tmux.RefreshChrome(sess.ID); err != nil {
-			return errMsg{err}
-		}
-		if err := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name)); err != nil {
-			return errMsg{err}
-		}
+		// Best-effort per session: one that dies between the check and here
+		// errors harmlessly and must not abort the rest, and the bindings that
+		// matter are already installed above.
+		_ = m.tmux.RefreshChrome(sess.ID)
+		_ = m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name))
 	}
 	return nil
 }

--- a/internal/ui/resize_guard_test.go
+++ b/internal/ui/resize_guard_test.go
@@ -1,0 +1,53 @@
+package ui
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func windowSize(t *testing.T, id string) (int, int) {
+	t.Helper()
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", "am_"+id,
+		"#{window_width} #{window_height}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("display-message: %v: %s", err, out)
+	}
+	parts := strings.Fields(string(out))
+	if len(parts) != 2 {
+		t.Fatalf("unexpected size output %q", out)
+	}
+	w, _ := strconv.Atoi(parts[0])
+	h, _ := strconv.Atoi(parts[1])
+	return w, h
+}
+
+// A WindowSizeMsg carrying the current size (as a tmux-attach resume does)
+// skips the per-session tmux resize; a real size change still applies it.
+func TestUnchangedWindowSizeSkipsResize(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "sized", t.TempDir(), "")
+	id := m.sessionRows()[0].ID
+
+	// Drift the session window away from the manager size behind its back.
+	if _, err := exec.Command("tmux", "resize-window", "-t", "am_"+id, "-x", "100", "-y", "30").CombinedOutput(); err != nil {
+		t.Fatalf("resize-window: %v", err)
+	}
+
+	// Same size as the model: the resume case, which must not touch sessions.
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
+	*m = *updated.(*Model)
+	if w, h := windowSize(t, id); w != 100 || h != 30 {
+		t.Fatalf("unchanged size should skip resize, session is %dx%d, want 100x30", w, h)
+	}
+
+	// A real resize propagates to the session.
+	updated, _ = m.Update(tea.WindowSizeMsg{Width: 150, Height: 45})
+	*m = *updated.(*Model)
+	if w, h := windowSize(t, id); w != 150 || h != 45 {
+		t.Fatalf("changed size should resize session, got %dx%d, want 150x45", w, h)
+	}
+}


### PR DESCRIPTION
Issues reported on the in-session `Ctrl+r` review, all root-caused with evidence.

## 1. Footer showed only the detach key; review key never appeared

Two causes:
- The `Ctrl+r` binding is server-global and the footer is per-session, both installed **only at session creation**. Sessions already running when the manager updated never got them. Fixed by re-applying bindings + status bar to every live session on startup (`Model.Init`); `installSessionUX` splits into `EnsureBindings`, `styleStatusBar` (keeps the name label), and `RefreshChrome`.
- Even on new sessions the hint was cut off: the footer is 49 columns but `status-right-length` defaults to **40**, truncating it before the `Ctrl+r` part. Widened to 80.

Keys are labeled lowercase (`Ctrl+q` / `Ctrl+r`) to match the actual no-shift bindings.

## 2. Entering review / leaving a session lagged

Returning from a tmux attach, bubbletea's `RestoreTerminal` calls `checkResize`, re-sending a `WindowSizeMsg` with the **unchanged** size (verified in bubbletea v1.3.10 `exec.go`/`tty.go`). `resizeSessions` then ran a synchronous `tmux resize-window` per live session on every detach, so latency scaled with session count. Fixed by skipping `resizeSessions` when the size has not changed.

## Tests

- `TestRefreshChromeKeepsLabelAndAddsReviewHint`: re-styling a live session advertises review, keeps its label, and sets `status-right-length` wide enough.
- `TestUnchangedWindowSizeSkipsResize`: an unchanged-size `WindowSizeMsg` leaves a drifted session window untouched; a changed size resizes it. Fails without the guard.

Build, vet, gofmt, full suite green.

Takes effect after `go install` + restarting the manager; existing sessions pick up the footer and review key on that next launch.