### PR TITLE
feat: archive a group and its whole subtree

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 | `m` | Move session to another group |
 | `r` | Rename session / edit group (name and default path) |
 | `v` | Revive a dead session (`revive_command`, e.g. `claude --continue`, resumes the conversation) |
-| `a` / `u` | Archive / restore |
+| `a` / `u` | Archive / restore a session, or a group and its entire subtree |
 | `d` | Delete session, or a group + its entire subtree |
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
 | `D` | Review the selected session's changes: full-screen whole-file diffs, line comments sent to the agent |

--- a/docs/superpowers/specs/2026-07-19-archive-group-design.md
+++ b/docs/superpowers/specs/2026-07-19-archive-group-design.md
@@ -1,0 +1,56 @@
+# Archive a group
+
+## Goal
+
+Let the user archive an entire group as one action: the group's label, all its
+descendant subgroups, and every session under it move out of the active tree and
+into the archived view. Restoring reverses it symmetrically.
+
+## Current state
+
+- Sessions carry an `archived` flag (`store.Session.Archived`, `sessions.archived`
+  column). `SetArchived(id, bool)` flips one session.
+- Groups have no archived flag. A group's label is derived: the active view shows
+  the full group skeleton (`groupClosure`), the archived view shows only groups
+  that still hold archived sessions (`pathsWithSessions`). So today a group label
+  never leaves the active tree, even when all its sessions are archived.
+- Keys: `a` archive, `u` restore, `t` toggle archived view, `d` delete. Group
+  delete (`prepareDelete`) already scopes to the whole subtree.
+
+## Design
+
+### Store
+
+- Add column `archived INTEGER NOT NULL DEFAULT 0` to the `groups` table, plus a
+  migration entry (ignored-on-duplicate, matching existing migrations).
+- `Group` struct gains `Archived bool`; `Groups()` selects and scans it.
+- `SetGroupArchived(path string, archived bool) error`: in a single transaction,
+  set `archived` on the group and every descendant group (`name = path OR name
+  LIKE path || '/%'`) and on every session in the subtree (same scoping as
+  `SessionsInSubtree`). Empty path is rejected.
+- Restore symmetry in `SetArchived(id, false)`: also clear `archived` on the
+  session's ancestor groups, so a restored session always lands in a live group.
+  (Archiving a single session leaves its group untouched, as today.)
+
+### UI
+
+- `refreshMsg` carries `archivedGroups map[string]bool`; the poller fills it from
+  `Groups()`.
+- `archiveSelected` / `restoreSelected` branch on `selectedRow().isGroup`: a group
+  row calls `SetGroupArchived(path, true/false)`; a session row keeps `SetArchived`.
+- `rebuildRows` filtering, driven by `archivedGroups`:
+  - Active view: drop any path that is an archived group or a descendant of one.
+  - Archived view: keep archived groups (even with zero sessions) in addition to
+    the existing "groups holding archived sessions" rule.
+
+### Tests
+
+- Store: archive a nested group flips the whole subtree (group + subgroup +
+  sessions); restore reverses it; restoring a lone session un-archives its
+  ancestor groups.
+- UI: `a` on a group row removes it from the active view and surfaces it under
+  `t`; `u` there restores the whole subtree.
+
+## Out of scope
+
+Partial-subtree archive, and any change to delete or move behavior.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -69,7 +69,8 @@ CREATE TABLE IF NOT EXISTS sessions (
 CREATE TABLE IF NOT EXISTS groups (
 	name       TEXT PRIMARY KEY,
 	sort_order INTEGER NOT NULL DEFAULT 0,
-	path       TEXT NOT NULL DEFAULT ''
+	path       TEXT NOT NULL DEFAULT '',
+	archived   INTEGER NOT NULL DEFAULT 0
 );
 CREATE TABLE IF NOT EXISTS settings (
 	key   TEXT PRIMARY KEY,
@@ -85,6 +86,7 @@ CREATE TABLE IF NOT EXISTS settings (
 		`ALTER TABLE sessions ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN acked INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN agent_session_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE groups ADD COLUMN archived INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, migration := range migrations {
 		if _, err := s.db.Exec(migration); err != nil {
@@ -250,7 +252,35 @@ func (s *Store) SetArchived(id string, archived bool) error {
 	if err != nil {
 		return err
 	}
-	return requireRow(res, id)
+	if err := requireRow(res, id); err != nil {
+		return err
+	}
+	// Restoring a session out of an archived group must leave it with a live
+	// home, so un-archive its group and every ancestor.
+	if !archived {
+		sess, err := s.Get(id)
+		if err != nil {
+			return err
+		}
+		return s.unarchiveAncestorGroups(sess.Group)
+	}
+	return nil
+}
+
+// unarchiveAncestorGroups clears the archived flag on a group path and each
+// of its ancestors, leaving descendants untouched.
+func (s *Store) unarchiveAncestorGroups(path string) error {
+	for path != "" {
+		if _, err := s.db.Exec(`UPDATE groups SET archived = 0 WHERE name = ?`, path); err != nil {
+			return err
+		}
+		idx := strings.LastIndex(path, "/")
+		if idx < 0 {
+			break
+		}
+		path = path[:idx]
+	}
+	return nil
 }
 
 func (s *Store) Delete(id string) error {
@@ -355,12 +385,13 @@ func (s *Store) DeleteGroup(path string) error {
 }
 
 type Group struct {
-	Name string
-	Path string
+	Name     string
+	Path     string
+	Archived bool
 }
 
 func (s *Store) Groups() ([]Group, error) {
-	rows, err := s.db.Query(`SELECT name, path FROM groups ORDER BY sort_order, name`)
+	rows, err := s.db.Query(`SELECT name, path, archived FROM groups ORDER BY sort_order, name`)
 	if err != nil {
 		return nil, err
 	}
@@ -368,12 +399,39 @@ func (s *Store) Groups() ([]Group, error) {
 	var groups []Group
 	for rows.Next() {
 		var g Group
-		if err := rows.Scan(&g.Name, &g.Path); err != nil {
+		var archived int
+		if err := rows.Scan(&g.Name, &g.Path, &archived); err != nil {
 			return nil, err
 		}
+		g.Archived = archived != 0
 		groups = append(groups, g)
 	}
 	return groups, rows.Err()
+}
+
+// SetGroupArchived flips the archived flag on a group, every descendant
+// group, and every session in the subtree, in one transaction.
+func (s *Store) SetGroupArchived(path string, archived bool) error {
+	if path == "" {
+		return fmt.Errorf("cannot archive the root group")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	flag := boolToInt(archived)
+	if _, err := tx.Exec(
+		`UPDATE groups SET archived = ? WHERE name = ? OR name LIKE ? || '/%'`,
+		flag, path, path); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`UPDATE sessions SET archived = ? WHERE group_name = ? OR group_name LIKE ? || '/%'`,
+		flag, path, path); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // ReorderSession moves a session one visible step among its group

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -329,17 +329,18 @@ func (s *Store) RenameGroup(oldPath, newPath string) error {
 		return err
 	}
 	defer tx.Rollback()
+	likeOld := escapeLike(oldPath)
 	_, err = tx.Exec(
 		`UPDATE groups SET name = ? || substr(name, length(?)+1)
-		 WHERE name = ? OR name LIKE ? || '/%'`,
-		newPath, oldPath, oldPath, oldPath)
+		 WHERE name = ? OR name LIKE ? || '/%' ESCAPE '\'`,
+		newPath, oldPath, oldPath, likeOld)
 	if err != nil {
 		return err
 	}
 	_, err = tx.Exec(
 		`UPDATE sessions SET group_name = ? || substr(group_name, length(?)+1)
-		 WHERE group_name = ? OR group_name LIKE ? || '/%'`,
-		newPath, oldPath, oldPath, oldPath)
+		 WHERE group_name = ? OR group_name LIKE ? || '/%' ESCAPE '\'`,
+		newPath, oldPath, oldPath, likeOld)
 	if err != nil {
 		return err
 	}
@@ -380,7 +381,7 @@ func (s *Store) DeleteGroup(path string) error {
 		return fmt.Errorf("cannot delete the root group")
 	}
 	_, err := s.db.Exec(
-		`DELETE FROM groups WHERE name = ? OR name LIKE ? || '/%'`, path, path)
+		`DELETE FROM groups WHERE name = ? OR name LIKE ? || '/%' ESCAPE '\'`, path, escapeLike(path))
 	return err
 }
 
@@ -421,14 +422,15 @@ func (s *Store) SetGroupArchived(path string, archived bool) error {
 	}
 	defer tx.Rollback()
 	flag := boolToInt(archived)
+	likePath := escapeLike(path)
 	if _, err := tx.Exec(
-		`UPDATE groups SET archived = ? WHERE name = ? OR name LIKE ? || '/%'`,
-		flag, path, path); err != nil {
+		`UPDATE groups SET archived = ? WHERE name = ? OR name LIKE ? || '/%' ESCAPE '\'`,
+		flag, path, likePath); err != nil {
 		return err
 	}
 	if _, err := tx.Exec(
-		`UPDATE sessions SET archived = ? WHERE group_name = ? OR group_name LIKE ? || '/%'`,
-		flag, path, path); err != nil {
+		`UPDATE sessions SET archived = ? WHERE group_name = ? OR group_name LIKE ? || '/%' ESCAPE '\'`,
+		flag, path, likePath); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -588,6 +590,14 @@ func requireRow(res sql.Result, id string) error {
 		return fmt.Errorf("session %s not found", id)
 	}
 	return nil
+}
+
+// escapeLike escapes the LIKE metacharacters so a group path is matched
+// literally in a `? || '/%'` prefix pattern, paired with ESCAPE '\'. Group
+// names may contain '_' or '%', which LIKE would otherwise treat as
+// wildcards and let one group's subtree bleed into another's.
+func escapeLike(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(s)
 }
 
 func boolToInt(b bool) int {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -116,6 +116,85 @@ func listIDs(t *testing.T, st *Store, includeArchived bool) []string {
 	return ids
 }
 
+func groupArchived(t *testing.T, st *Store, path string) bool {
+	t.Helper()
+	groups, err := st.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	for _, g := range groups {
+		if g.Name == path {
+			return g.Archived
+		}
+	}
+	t.Fatalf("group %q not found", path)
+	return false
+}
+
+func sessionArchived(t *testing.T, st *Store, id string) bool {
+	t.Helper()
+	sess, err := st.Get(id)
+	if err != nil {
+		t.Fatalf("get %s: %v", id, err)
+	}
+	return sess.Archived
+}
+
+func TestSetGroupArchivedFlipsSubtree(t *testing.T) {
+	st := newTestStore(t)
+	st.CreateGroup("proj", "")
+	st.CreateGroup("proj/sub", "")
+	st.CreateSession(sample("a", "proj"))
+	st.CreateSession(sample("b", "proj/sub"))
+
+	if err := st.SetGroupArchived("proj", true); err != nil {
+		t.Fatalf("archive group: %v", err)
+	}
+	if !groupArchived(t, st, "proj") || !groupArchived(t, st, "proj/sub") {
+		t.Fatal("group and subgroup should be archived")
+	}
+	if !sessionArchived(t, st, "a") || !sessionArchived(t, st, "b") {
+		t.Fatal("sessions in subtree should be archived")
+	}
+
+	if err := st.SetGroupArchived("proj", false); err != nil {
+		t.Fatalf("restore group: %v", err)
+	}
+	if groupArchived(t, st, "proj") || groupArchived(t, st, "proj/sub") {
+		t.Fatal("group and subgroup should be restored")
+	}
+	if sessionArchived(t, st, "a") || sessionArchived(t, st, "b") {
+		t.Fatal("sessions in subtree should be restored")
+	}
+}
+
+func TestSetGroupArchivedEmptyPathErrors(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.SetGroupArchived("", true); err == nil {
+		t.Fatal("archiving the root group should error")
+	}
+}
+
+func TestRestoreSessionUnarchivesAncestorGroups(t *testing.T) {
+	st := newTestStore(t)
+	st.CreateGroup("proj", "")
+	st.CreateGroup("proj/sub", "")
+	st.CreateSession(sample("a", "proj/sub"))
+	if err := st.SetGroupArchived("proj", true); err != nil {
+		t.Fatalf("archive group: %v", err)
+	}
+
+	if err := st.SetArchived("a", false); err != nil {
+		t.Fatalf("restore session: %v", err)
+	}
+	if sessionArchived(t, st, "a") {
+		t.Fatal("session should be active after restore")
+	}
+	if groupArchived(t, st, "proj") || groupArchived(t, st, "proj/sub") {
+		t.Fatal("ancestor groups should be un-archived so the session has a live home")
+	}
+}
+
 func TestReorderSession(t *testing.T) {
 	st := newTestStore(t)
 	st.CreateSession(sample("a", "g1"))

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -168,6 +168,25 @@ func TestSetGroupArchivedFlipsSubtree(t *testing.T) {
 	}
 }
 
+func TestSetGroupArchivedUnderscoreDoesNotBleed(t *testing.T) {
+	st := newTestStore(t)
+	st.CreateGroup("my_proj", "")
+	st.CreateGroup("myXproj/sub", "")
+	st.CreateSession(sample("a", "my_proj"))
+	st.CreateSession(sample("b", "myXproj/sub"))
+
+	if err := st.SetGroupArchived("my_proj", true); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	if !groupArchived(t, st, "my_proj") || !sessionArchived(t, st, "a") {
+		t.Fatal("my_proj and its session should be archived")
+	}
+	// "my_proj/%" with an unescaped underscore matches "myXproj/sub".
+	if groupArchived(t, st, "myXproj/sub") || sessionArchived(t, st, "b") {
+		t.Fatal("myXproj/sub must not be caught by the my_proj archive (LIKE _ wildcard bleed)")
+	}
+}
+
 func TestSetGroupArchivedEmptyPathErrors(t *testing.T) {
 	st := newTestStore(t)
 	if err := st.SetGroupArchived("", true); err == nil {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -387,27 +387,31 @@ func (m *Model) reviveSelected() (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) archiveSelected() (tea.Model, tea.Cmd) {
-	sess, ok := m.selected()
-	if !ok {
-		return m, nil
-	}
-	if err := m.store.SetArchived(sess.ID, true); err != nil {
-		m.err = err.Error()
-		return m, nil
-	}
-	m.requestRefresh()
-	return m, nil
+	return m.setSelectedArchived(true)
 }
 
 func (m *Model) restoreSelected() (tea.Model, tea.Cmd) {
-	sess, ok := m.selected()
+	return m.setSelectedArchived(false)
+}
+
+// setSelectedArchived archives or restores the selected row: a group row
+// takes its whole subtree, a session row takes just that session.
+func (m *Model) setSelectedArchived(archived bool) (tea.Model, tea.Cmd) {
+	entry, ok := m.selectedRow()
 	if !ok {
 		return m, nil
 	}
-	if err := m.store.SetArchived(sess.ID, false); err != nil {
+	var err error
+	if entry.isGroup {
+		err = m.store.SetGroupArchived(entry.group, archived)
+	} else {
+		err = m.store.SetArchived(entry.sess.ID, archived)
+	}
+	if err != nil {
 		m.err = err.Error()
 		return m, nil
 	}
+	m.err = ""
 	m.requestRefresh()
 	return m, nil
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -49,15 +49,16 @@ type Model struct {
 	hooks  *hooks.Manager
 	gitDrv *git.Driver
 
-	sessions   []store.Session
-	rows       []treeRow
-	groups     []string
-	groupPaths map[string]string
-	snap       sysstat.Snapshot
-	proc       sysstat.ProcStat
-	procFor    string
-	preview    string
-	agents     agentStats
+	sessions       []store.Session
+	rows           []treeRow
+	groups         []string
+	groupPaths     map[string]string
+	archivedGroups map[string]bool
+	snap           sysstat.Snapshot
+	proc           sysstat.ProcStat
+	procFor        string
+	preview        string
+	agents         agentStats
 
 	netUp       uint64
 	netDown     uint64
@@ -139,15 +140,16 @@ type agentStats struct {
 }
 
 type refreshMsg struct {
-	sessions   []store.Session
-	groups     []string
-	groupPaths map[string]string
-	snap       sysstat.Snapshot
-	snapOK     bool
-	proc       sysstat.ProcStat
-	procFor    string
-	preview    string
-	agents     agentStats
+	sessions       []store.Session
+	groups         []string
+	groupPaths     map[string]string
+	archivedGroups map[string]bool
+	snap           sysstat.Snapshot
+	snapOK         bool
+	proc           sysstat.ProcStat
+	procFor        string
+	preview        string
+	agents         agentStats
 }
 
 type previewMsg struct {
@@ -360,6 +362,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.sessions = msg.sessions
 		m.groups = msg.groups
 		m.groupPaths = msg.groupPaths
+		m.archivedGroups = msg.archivedGroups
 		m.agents = msg.agents
 		if msg.snapOK {
 			m.snap = msg.snap
@@ -508,10 +511,27 @@ func (m *Model) rebuildRows() {
 	}
 
 	paths := groupClosure(m.groups, m.sessions)
-	// The archived view keeps only groups that hold archived sessions,
-	// instead of the full (mostly empty) tree skeleton.
-	if query != "" || m.showArchived {
-		paths = pathsWithSessions(paths, sessionsByGroup)
+	if m.showArchived {
+		// The archived view keeps groups that hold archived sessions plus any
+		// group whose subtree was archived as a whole (even with no sessions),
+		// instead of the full tree skeleton.
+		kept := pathsWithSessions(paths, sessionsByGroup)
+		for path := range paths {
+			if m.groupEffectivelyArchived(path) {
+				addWithAncestors(kept, path)
+			}
+		}
+		paths = kept
+	} else {
+		// The active view hides any archived group and its whole subtree.
+		for path := range paths {
+			if m.groupEffectivelyArchived(path) {
+				delete(paths, path)
+			}
+		}
+		if query != "" {
+			paths = pathsWithSessions(paths, sessionsByGroup)
+		}
 	}
 	children := childIndex(paths, m.groups)
 
@@ -579,6 +599,33 @@ func groupClosure(groups []string, sessions []store.Session) map[string]bool {
 		add(sess.Group)
 	}
 	return paths
+}
+
+// groupEffectivelyArchived reports whether a group path was archived, either
+// directly or by an ancestor group being archived as a whole.
+func (m *Model) groupEffectivelyArchived(path string) bool {
+	for path != "" {
+		if m.archivedGroups[path] {
+			return true
+		}
+		idx := strings.LastIndex(path, "/")
+		if idx < 0 {
+			break
+		}
+		path = path[:idx]
+	}
+	return false
+}
+
+func addWithAncestors(set map[string]bool, path string) {
+	for path != "" {
+		set[path] = true
+		idx := strings.LastIndex(path, "/")
+		if idx < 0 {
+			break
+		}
+		path = path[:idx]
+	}
 }
 
 func pathsWithSessions(paths map[string]bool, sessionsByGroup map[string][]store.Session) map[string]bool {

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -249,19 +249,24 @@ func (p *poller) refreshOnce() tea.Msg {
 	}
 	names := make([]string, len(groups))
 	paths := make(map[string]string, len(groups))
+	archivedGroups := make(map[string]bool, len(groups))
 	for i, g := range groups {
 		names[i] = g.Name
 		paths[g.Name] = g.Path
+		if g.Archived {
+			archivedGroups[g.Name] = true
+		}
 	}
 
 	msg := refreshMsg{
-		sessions:   sessions,
-		groups:     names,
-		groupPaths: paths,
-		proc:       proc,
-		procFor:    selectedID,
-		preview:    preview,
-		agents:     agents,
+		sessions:       sessions,
+		groups:         names,
+		groupPaths:     paths,
+		archivedGroups: archivedGroups,
+		proc:           proc,
+		procFor:        selectedID,
+		preview:        preview,
+		agents:         agents,
 	}
 	if sampleStats {
 		msg.snap = sysstat.Sample("/")

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -111,6 +111,27 @@ func (m *Model) selectSessionRow(t *testing.T, name string) {
 	t.Fatalf("no session row named %q", name)
 }
 
+func (m *Model) selectGroupRow(t *testing.T, path string) {
+	t.Helper()
+	for i, r := range m.rows {
+		if r.isGroup && r.group == path {
+			m.cursor = i
+			return
+		}
+	}
+	t.Fatalf("no group row for %q", path)
+}
+
+func (m *Model) groupRowPaths() []string {
+	var paths []string
+	for _, r := range m.rows {
+		if r.isGroup {
+			paths = append(paths, r.group)
+		}
+	}
+	return paths
+}
+
 func pickGroup(t *testing.T, m *Model, path string) {
 	t.Helper()
 	for i, opt := range m.form.groups {
@@ -1420,6 +1441,75 @@ func TestArchivedViewShowsOnlyArchivedSessions(t *testing.T) {
 	m.applyCmd(t, m.refreshCmd())
 	if names := sessionNames(m); len(names) != 1 || names[0] != "old-one" {
 		t.Fatalf("archived view = %v want [old-one]", names)
+	}
+}
+
+func TestArchiveGroupMovesWholeSubtree(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("proj", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := m.store.CreateGroup("proj/sub", ""); err != nil {
+		t.Fatalf("create subgroup: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "top", dir, "proj")
+	createSession(t, m, "deep", dir, "proj/sub")
+
+	m.selectGroupRow(t, "proj")
+	_, cmd := m.archiveSelected()
+	m.applyCmd(t, cmd)
+
+	if paths := m.groupRowPaths(); len(paths) != 0 {
+		t.Fatalf("active view still shows group rows %v", paths)
+	}
+	if names := sessionNames(m); len(names) != 0 {
+		t.Fatalf("active view still shows sessions %v", names)
+	}
+
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	gotGroups := m.groupRowPaths()
+	if len(gotGroups) != 2 || gotGroups[0] != "proj" || gotGroups[1] != "proj/sub" {
+		t.Fatalf("archived view groups = %v want [proj proj/sub]", gotGroups)
+	}
+	if names := sessionNames(m); len(names) != 2 {
+		t.Fatalf("archived view sessions = %v want 2", names)
+	}
+
+	m.selectGroupRow(t, "proj")
+	_, cmd = m.restoreSelected()
+	m.applyCmd(t, cmd)
+	m.showArchived = false
+	m.applyCmd(t, m.refreshCmd())
+	if paths := m.groupRowPaths(); len(paths) != 2 {
+		t.Fatalf("after restore, active groups = %v want 2", paths)
+	}
+	if names := sessionNames(m); len(names) != 2 {
+		t.Fatalf("after restore, active sessions = %v want 2", names)
+	}
+}
+
+func TestArchiveGroupKeepsEmptyGroupInArchivedView(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("empty", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+
+	m.selectGroupRow(t, "empty")
+	_, cmd := m.archiveSelected()
+	m.applyCmd(t, cmd)
+
+	if paths := m.groupRowPaths(); len(paths) != 0 {
+		t.Fatalf("archived empty group still in active view: %v", paths)
+	}
+
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	if paths := m.groupRowPaths(); len(paths) != 1 || paths[0] != "empty" {
+		t.Fatalf("archived view groups = %v want [empty]", paths)
 	}
 }
 


### PR DESCRIPTION
## What

Archiving a group now moves the **group label, every descendant subgroup, and all sessions under it** into the archived view as one action, mirroring how group delete already scopes the subtree. Previously `a`/`u` only touched a single session, so a group's label never left the active tree even when all its sessions were archived.

## Behavior

- `a` / `u` on a **group** row archives / restores the whole subtree.
- `a` / `u` on a **session** row is unchanged.
- Restoring a lone session out of an archived group un-archives its ancestor groups, so it always lands in a live group.
- Active view hides archived groups and their subtree; archived view shows archived groups even when they hold no sessions.

## Implementation

- `groups` table gains an `archived` column (+ migration); `store.Group.Archived` and `Groups()` carry it.
- `SetGroupArchived(path, archived)` flips the group, descendant groups, and subtree sessions in one transaction.
- `SetArchived(id, false)` un-archives the session's ancestor groups.
- The archived-group set flows through the poller into `rebuildRows`, which drives the active/archived tree filter.
- `a`/`u` branch on group vs session row.

## Tests

New: store subtree flip + restore, empty-path guard, ancestor-restore on session restore; UI whole-subtree archive/restore and empty-archived-group visibility. Full `go test ./...` green on an isolated tmux socket; `go vet` and `gofmt` clean.