### PR TITLE
fix: fit session previews to the sidebar and keep attach full-width

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -43,7 +43,7 @@ func (d *Driver) Create(id, cwd, command string, env map[string]string, width, h
 	args := []string{"new-session", "-d", "-s", name, "-c", cwd}
 	// A detached session sizes to tmux's 80x24 default and holds it until a
 	// client attaches, so its pane preview renders narrow. Booting at the
-	// manager's terminal size makes the preview fill from the first frame.
+	// preview panel's size makes the preview fit from the first frame.
 	if width > 0 && height > 0 {
 		args = append(args, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height))
 	}
@@ -219,14 +219,25 @@ func (d *Driver) CapturePane(id string) (string, error) {
 	return d.run("capture-pane", "-p", "-e", "-t", sessionName(id))
 }
 
-// Resize sets a detached session's window to the given dimensions so its
-// preview capture tracks the manager's terminal. A client attach overrides
-// this; on detach tmux keeps the last size, so live sessions stay in sync.
+// Resize pins a detached session's window to the given dimensions so its
+// preview capture fits the manager's preview panel. resize-window forces
+// window-size to manual, which is what keeps the detached window fixed;
+// PrepareAttach flips it back to auto before a client attaches so the
+// window fills the terminal instead of leaving a dotted overlay gap.
 func (d *Driver) Resize(id string, width, height int) error {
 	if width <= 0 || height <= 0 {
 		return nil
 	}
 	_, err := d.run("resize-window", "-t", sessionName(id), "-x", strconv.Itoa(width), "-y", strconv.Itoa(height))
+	return err
+}
+
+// PrepareAttach restores automatic window sizing so the session fills the
+// attaching client and tracks terminal resizes while attached. Without it,
+// the manual size Resize pinned for the preview would leave the client's
+// extra columns painted with tmux's out-of-bounds dotted overlay.
+func (d *Driver) PrepareAttach(id string) error {
+	_, err := d.run("set-window-option", "-t", sessionName(id), "window-size", "latest")
 	return err
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -20,6 +20,41 @@ func requireTmux(t *testing.T) *Driver {
 	return driver
 }
 
+func windowSizeOption(t *testing.T, id string) string {
+	t.Helper()
+	out, err := exec.Command("tmux", "show-window-options", "-v", "-t", "am_"+id, "window-size").CombinedOutput()
+	if err != nil {
+		t.Fatalf("show-window-options: %v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// Resize pins the detached window to a manual size for the preview, and
+// PrepareAttach flips it back to auto so the attaching client fills it
+// instead of leaving tmux's dotted out-of-bounds overlay on the right.
+func TestPrepareAttachRestoresAutoSize(t *testing.T) {
+	driver := requireTmux(t)
+	id := "attach" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "", nil, 100, 30); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+
+	if err := driver.Resize(id, 80, 24); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+	if got := windowSizeOption(t, id); got != "manual" {
+		t.Fatalf("after Resize, window-size = %q, want manual", got)
+	}
+
+	if err := driver.PrepareAttach(id); err != nil {
+		t.Fatalf("PrepareAttach: %v", err)
+	}
+	if got := windowSizeOption(t, id); got != "latest" {
+		t.Fatalf("after PrepareAttach, window-size = %q, want latest", got)
+	}
+}
+
 func TestSetLabelNeutralizesFormatStrings(t *testing.T) {
 	driver := requireTmux(t)
 	id := "lbl" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -398,7 +398,7 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 	if err != nil {
 		return err
 	}
-	if err := m.tmux.Create(id, dir, command, env, m.width, m.height); err != nil {
+	if err := m.tmux.Create(id, dir, command, env, m.previewPaneWidth(), m.height); err != nil {
 		return err
 	}
 	sess := store.Session{

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -304,8 +304,14 @@ func (m *Model) acknowledgeFinished(sess store.Session) error {
 }
 
 func (m *Model) attachCmd(id string) tea.Cmd {
+	// Flip the window back to auto-sizing so it fills the terminal on attach;
+	// attachDoneMsg re-pins it to the preview width on detach.
+	if err := m.tmux.PrepareAttach(id); err != nil {
+		m.err = err.Error()
+		return nil
+	}
 	return tea.ExecProcess(m.tmux.AttachCommand(id), func(err error) tea.Msg {
-		return attachDoneMsg{err}
+		return attachDoneMsg{sessID: id, err: err}
 	})
 }
 
@@ -363,7 +369,7 @@ func (m *Model) reviveSelected() (tea.Model, tea.Cmd) {
 		m.err = err.Error()
 		return m, nil
 	}
-	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.width, m.height); err != nil {
+	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.previewPaneWidth(), m.height); err != nil {
 		m.err = err.Error()
 		return m, nil
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -85,11 +85,14 @@ type Model struct {
 	settings  settingsState
 	moveID    string
 
-	width    int
-	height   int
-	err      string
-	errShown string
-	errAge   int
+	width  int
+	height int
+	// sessionsSized flips after the first refresh shrinks sessions left
+	// over from a previous manager run to the preview panel's width.
+	sessionsSized bool
+	err           string
+	errShown      string
+	errAge        int
 }
 
 type confirmTarget struct {
@@ -158,7 +161,10 @@ type previewMsg struct {
 
 type errMsg struct{ err error }
 
-type attachDoneMsg struct{ err error }
+type attachDoneMsg struct {
+	sessID string
+	err    error
+}
 
 func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status.Engine, hookManager *hooks.Manager) *Model {
 	statusSources := make(map[string]string, len(cfg.Tools))
@@ -329,15 +335,15 @@ func (m *Model) refreshCmd() tea.Cmd {
 	}
 }
 
-// resizeSessions syncs every live session's tmux window to the current
-// terminal size, so a detached session's preview tracks the manager instead
-// of waiting for its first attach. Dead sessions error harmlessly and skip.
+// resizeSessions syncs every live session's tmux window to the preview
+// panel's width, so a detached session's capture fits the panel instead of
+// getting clipped on the right. Dead sessions error harmlessly and skip.
 func (m *Model) resizeSessions() {
 	for _, sess := range m.sessions {
 		if sess.Archived {
 			continue
 		}
-		_ = m.tmux.Resize(sess.ID, m.width, m.height)
+		_ = m.tmux.Resize(sess.ID, m.previewPaneWidth(), m.height)
 	}
 }
 
@@ -364,6 +370,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.snapOK {
 			m.snap = msg.snap
 			m.updateNetRates(msg.snap)
+		}
+		if !m.sessionsSized && m.width > 0 && len(m.sessions) > 0 {
+			m.sessionsSized = true
+			m.resizeSessions()
 		}
 		m.rebuildRows()
 		// A pass that ran with a stale selection (a session created this
@@ -400,6 +410,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case attachDoneMsg:
+		// The attach client sized the window to the full terminal and tmux
+		// keeps that size on detach; shrink it back to the preview panel so
+		// the capture is not clipped on the right.
+		_ = m.tmux.Resize(msg.sessID, m.previewPaneWidth(), m.height)
 		if msg.err != nil {
 			m.err = msg.err.Error()
 			m.requestRefresh()

--- a/internal/ui/resize_guard_test.go
+++ b/internal/ui/resize_guard_test.go
@@ -25,6 +25,35 @@ func windowSize(t *testing.T, id string) (int, int) {
 	return w, h
 }
 
+// Sessions left over from a previous manager run keep that run's window
+// size; the first refresh after startup must shrink them to the preview
+// panel so their captures fit without a terminal resize.
+func TestFirstRefreshResizesExistingSessions(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "leftover", t.TempDir(), "")
+	id := m.sessionRows()[0].ID
+
+	// Drift the window as if an older manager had sized it to the terminal.
+	if _, err := exec.Command("tmux", "resize-window", "-t", "am_"+id, "-x", "191", "-y", "55").CombinedOutput(); err != nil {
+		t.Fatalf("resize-window: %v", err)
+	}
+
+	m.sessionsSized = false
+	m.applyCmd(t, m.refreshCmd())
+	if w, _ := windowSize(t, id); w != m.previewPaneWidth() {
+		t.Fatalf("after first refresh, window width = %d, want %d", w, m.previewPaneWidth())
+	}
+
+	// Later refreshes leave sizes alone (attach keeps its own resync path).
+	if _, err := exec.Command("tmux", "resize-window", "-t", "am_"+id, "-x", "100", "-y", "30").CombinedOutput(); err != nil {
+		t.Fatalf("resize-window: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	if w, _ := windowSize(t, id); w != 100 {
+		t.Fatalf("later refresh should not resize, window width = %d, want 100", w)
+	}
+}
+
 // A WindowSizeMsg carrying the current size (as a tmux-attach resume does)
 // skips the per-session tmux resize; a real size change still applies it.
 func TestUnchangedWindowSizeSkipsResize(t *testing.T) {
@@ -44,10 +73,10 @@ func TestUnchangedWindowSizeSkipsResize(t *testing.T) {
 		t.Fatalf("unchanged size should skip resize, session is %dx%d, want 100x30", w, h)
 	}
 
-	// A real resize propagates to the session.
+	// A real resize propagates the preview panel width to the session.
 	updated, _ = m.Update(tea.WindowSizeMsg{Width: 150, Height: 45})
 	*m = *updated.(*Model)
-	if w, h := windowSize(t, id); w != 150 || h != 45 {
-		t.Fatalf("changed size should resize session, got %dx%d, want 150x45", w, h)
+	if w, h := windowSize(t, id); w != m.previewPaneWidth() || h != 45 {
+		t.Fatalf("changed size should resize session, got %dx%d, want %dx45", w, h, m.previewPaneWidth())
 	}
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -149,21 +149,21 @@ func windowWidth(t *testing.T, id string) int {
 	return w
 }
 
-// A detached session must boot at the manager's terminal width so its pane
-// preview fills immediately, and follow later terminal resizes, rather than
-// staying at tmux's 80-column default until the first attach.
-func TestSessionSizesToTerminal(t *testing.T) {
+// A detached session must boot at the preview panel's width so its pane
+// preview fills without cropping on the right, and follow later terminal
+// resizes, rather than staying at tmux's 80-column default until attach.
+func TestSessionSizesToPreviewPane(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "sized", t.TempDir(), "")
 	id := m.sessionRows()[0].ID
 
-	if w := windowWidth(t, id); w != m.width {
-		t.Fatalf("new session window width = %d, want %d", w, m.width)
+	if w := windowWidth(t, id); w != m.previewPaneWidth() {
+		t.Fatalf("new session window width = %d, want %d", w, m.previewPaneWidth())
 	}
 
 	m.Update(tea.WindowSizeMsg{Width: 150, Height: 45})
-	if w := windowWidth(t, id); w != 150 {
-		t.Fatalf("after resize, window width = %d, want 150", w)
+	if w := windowWidth(t, id); w != m.previewPaneWidth() {
+		t.Fatalf("after resize, window width = %d, want %d", w, m.previewPaneWidth())
 	}
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -30,11 +30,7 @@ func (m *Model) View() string {
 		return m.viewDiffFull()
 	}
 
-	leftWidth := m.width * 34 / 100
-	if leftWidth < 30 {
-		leftWidth = 30
-	}
-	rightWidth := m.width - leftWidth
+	leftWidth, rightWidth := m.splitWidths()
 	footer := m.viewFooter()
 	bodyHeight := m.height - 4 - lipgloss.Height(footer)
 	if bodyHeight < 3 {
@@ -53,6 +49,24 @@ func (m *Model) View() string {
 	body := lipgloss.JoinHorizontal(lipgloss.Top, left, right)
 
 	return strings.Join([]string{m.viewHeader(), "", body, m.viewStatus(), footer}, "\n")
+}
+
+// splitWidths is the body's horizontal split: the sessions panel takes 34%
+// of the terminal (30 columns minimum) and the sidebar the rest.
+func (m *Model) splitWidths() (int, int) {
+	leftWidth := m.width * 34 / 100
+	if leftWidth < 30 {
+		leftWidth = 30
+	}
+	return leftWidth, m.width - leftWidth
+}
+
+// previewPaneWidth is the sidebar's inner content width: the columns the
+// pane preview can actually show. Sessions size to it so captured lines
+// fit the panel instead of getting clipped on the right.
+func (m *Model) previewPaneWidth() int {
+	_, rightWidth := m.splitWidths()
+	return rightWidth - 4
 }
 
 // viewStatus is the transient message line: prompts, search, and


### PR DESCRIPTION
## What

Two preview-width bugs, both from sizing tmux windows to the full terminal.

- **Right side cropped in the preview.** The preview panel is only the sidebar's inner width, so full-terminal captures overflowed and `previewLine` clipped them. Sessions now size to `previewPaneWidth()` on create, revive, terminal resize, and once on startup for sessions left over from a previous manager run.
- **Dotted overlay on the right when attached.** `resize-window` forces `window-size manual`, so an attaching full-terminal client left the extra columns painted with tmux's out-of-bounds dots. `PrepareAttach` flips `window-size` back to `latest` before attach; detach re-pins the preview width.

## Tests

- `TestSessionSizesToPreviewPane`, `TestFirstRefreshResizesExistingSessions`, updated resize-guard test
- `TestPrepareAttachRestoresAutoSize`

Full suite green (serial; parallel packages share one tmux server), build + vet clean.