### PR TITLE
fix: resolve review repo when session cwd is an umbrella of repos

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -94,6 +95,97 @@ func (d *Driver) OpenRepo(dir string) (Repo, error) {
 		repo.Detached = false
 	}
 	return repo, nil
+}
+
+// maxRepoDepth bounds how far ResolveRepos descends into an umbrella folder
+// looking for nested repos.
+const maxRepoDepth = 3
+
+// skipDirs are directories ResolveRepos never descends into while hunting for
+// nested repos: dependency trees, build output, and agent-manager's own
+// worktree scratch dirs would only add noise or duplicate a repo already found.
+var skipDirs = map[string]bool{
+	"node_modules":    true,
+	".worktrees":      true,
+	".archive":        true,
+	"dist":            true,
+	"build":           true,
+	"vendor":          true,
+	".playwright-mcp": true,
+}
+
+// ResolveRepos returns the git repo roots reachable from cwd, most-active
+// first. When cwd is itself a repo, that is the only root. When cwd is an
+// umbrella folder holding several repos, each nested repo root is returned
+// ranked with dirty working trees before clean ones, then by most recent
+// commit, so review lands on the repo the agent is most likely editing.
+func (d *Driver) ResolveRepos(cwd string) ([]string, error) {
+	root, err := d.run(cwd, "rev-parse", "--show-toplevel")
+	if err == nil {
+		return []string{root}, nil
+	}
+	if !errors.Is(err, ErrNotARepo) {
+		return nil, err
+	}
+	roots := d.discoverRepos(cwd)
+	if len(roots) == 0 {
+		return nil, ErrNotARepo
+	}
+	d.rankRepos(roots)
+	return roots, nil
+}
+
+func (d *Driver) discoverRepos(dir string) []string {
+	var roots []string
+	var walk func(path string, depth int)
+	walk = func(path string, depth int) {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return
+		}
+		for _, entry := range entries {
+			if entry.Name() == ".git" {
+				roots = append(roots, path)
+				return
+			}
+		}
+		if depth >= maxRepoDepth {
+			return
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() || skipDirs[entry.Name()] {
+				continue
+			}
+			walk(filepath.Join(path, entry.Name()), depth+1)
+		}
+	}
+	walk(dir, 0)
+	return roots
+}
+
+func (d *Driver) rankRepos(roots []string) {
+	type meta struct {
+		dirty bool
+		when  int64
+	}
+	info := make(map[string]meta, len(roots))
+	for _, root := range roots {
+		var m meta
+		if out, err := d.run(root, "status", "--porcelain"); err == nil && strings.TrimSpace(out) != "" {
+			m.dirty = true
+		}
+		if out, err := d.run(root, "log", "-1", "--format=%ct"); err == nil {
+			m.when, _ = strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		}
+		info[root] = m
+	}
+	sort.SliceStable(roots, func(i, j int) bool {
+		a, b := info[roots[i]], info[roots[j]]
+		if a.dirty != b.dirty {
+			return a.dirty
+		}
+		return a.when > b.when
+	})
 }
 
 // BaseRef finds the merge base against the repo's main branch for the

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -56,6 +56,75 @@ func TestNotARepo(t *testing.T) {
 	}
 }
 
+func initRepoAt(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init", "-b", "main"},
+		{"config", "user.email", "test@test"},
+		{"config", "user.name", "test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+}
+
+func TestResolveReposSingle(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "a.go", "package a\n")
+	commit(t, dir, "init")
+	roots, err := driver.ResolveRepos(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("want 1 root, got %v", roots)
+	}
+}
+
+func TestResolveReposUmbrellaRanksDirtyFirst(t *testing.T) {
+	driver, err := New()
+	if err != nil {
+		t.Skip("git not installed")
+	}
+	umbrella := t.TempDir()
+	clean := filepath.Join(umbrella, "clean")
+	dirty := filepath.Join(umbrella, "dirty")
+	initRepoAt(t, clean)
+	write(t, clean, "a.go", "package a\n")
+	commit(t, clean, "init")
+	initRepoAt(t, dirty)
+	write(t, dirty, "a.go", "package a\n")
+	commit(t, dirty, "init")
+	write(t, dirty, "b.go", "package a\n")
+
+	roots, err := driver.ResolveRepos(umbrella)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 2 {
+		t.Fatalf("want 2 roots, got %v", roots)
+	}
+	if filepath.Base(roots[0]) != "dirty" {
+		t.Fatalf("want dirty repo first, got %v", roots)
+	}
+}
+
+func TestResolveReposNone(t *testing.T) {
+	driver, err := New()
+	if err != nil {
+		t.Skip("git not installed")
+	}
+	if _, err := driver.ResolveRepos(t.TempDir()); err != ErrNotARepo {
+		t.Fatalf("want ErrNotARepo, got %v", err)
+	}
+}
+
 func TestUncommittedScope(t *testing.T) {
 	driver, dir := testRepo(t)
 	write(t, dir, "a.go", "package a\n\nfunc A() {}\n")

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -25,8 +25,8 @@ type annotation struct {
 
 // diffState drives the diff panel and the full-screen review mode. The
 // panel follows the tree cursor like the pane preview; fullscreen pins
-// the session. Annotations and reviewed marks are keyed by session so
-// cursor moves never lose them.
+// the session. Annotations and reviewed marks are keyed by session and repo
+// so cursor moves never lose them.
 type diffState struct {
 	active     bool
 	scope      git.Scope
@@ -56,9 +56,13 @@ type diffState struct {
 
 	// repoRoots holds the git repos found under the session cwd; when the cwd
 	// is an umbrella of several repos, repoIdx selects the one under review and
-	// the r key cycles between them.
+	// the r key cycles between them. repoSel is the selected repo's root path,
+	// the stable identity carried across reloads since ResolveRepos re-ranks the
+	// list each call; review state (comments, reviewed marks) is keyed by it so
+	// a same-named file in a sibling repo never inherits the wrong marks.
 	repoRoots []string
 	repoIdx   int
+	repoSel   string
 
 	// Set when review opened from inside a session; leaving re-attaches it.
 	reattachID string
@@ -87,12 +91,17 @@ type diffHLMsg struct {
 }
 
 type diffProbeMsg struct {
-	sessID string
-	scope  git.Scope
-	fp     uint64
+	sessID   string
+	scope    git.Scope
+	repoRoot string
+	fp       uint64
 }
 
-func (m *Model) diffLoadCmd(sess store.Session, scope git.Scope, gen, repoIdx int, refresh bool) tea.Cmd {
+// diffLoadCmd resolves the repos under the session cwd and loads the diff for
+// the wanted repo. repoWant is the previously selected repo root, matched by
+// path so the selection survives ResolveRepos re-ranking the list between
+// loads; an empty or vanished path falls back to the top-ranked repo.
+func (m *Model) diffLoadCmd(sess store.Session, scope git.Scope, gen int, repoWant string, refresh bool) tea.Cmd {
 	driver := m.gitDrv
 	return func() tea.Msg {
 		msg := diffLoadedMsg{sessID: sess.ID, scope: scope, gen: gen, refresh: refresh}
@@ -101,8 +110,12 @@ func (m *Model) diffLoadCmd(sess store.Session, scope git.Scope, gen, repoIdx in
 			msg.err = err
 			return msg
 		}
-		if repoIdx >= len(roots) {
-			repoIdx = 0
+		repoIdx := 0
+		for i, root := range roots {
+			if root == repoWant {
+				repoIdx = i
+				break
+			}
 		}
 		msg.repoRoots = roots
 		msg.repoIdx = repoIdx
@@ -134,9 +147,9 @@ func (m *Model) diffProbeCmd(sess store.Session, scope git.Scope) tea.Cmd {
 		}
 		fp, err := driver.Fingerprint(root, scope, baseRef)
 		if err != nil {
-			return diffProbeMsg{sessID: sess.ID, scope: scope, fp: 0}
+			return diffProbeMsg{sessID: sess.ID, scope: scope, repoRoot: root, fp: 0}
 		}
-		return diffProbeMsg{sessID: sess.ID, scope: scope, fp: fp}
+		return diffProbeMsg{sessID: sess.ID, scope: scope, repoRoot: root, fp: fp}
 	}
 }
 
@@ -153,7 +166,8 @@ func (m *Model) retargetDiff(sess store.Session) tea.Cmd {
 	m.diff.cursorLine = 0
 	m.diff.repoRoots = nil
 	m.diff.repoIdx = 0
-	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoIdx, false)
+	m.diff.repoSel = ""
+	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, false)
 }
 
 func (m *Model) cycleDiffScope() tea.Cmd {
@@ -171,11 +185,13 @@ func (m *Model) cycleDiffScope() tea.Cmd {
 	m.diff.fileIdx = 0
 	m.diff.scroll = 0
 	m.diff.cursorLine = 0
-	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoIdx, false)
+	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, false)
 }
 
 // cycleDiffRepo advances to the next repo when the session cwd is an umbrella
-// of several. It is a no-op for a plain single-repo cwd.
+// of several. It is a no-op for a plain single-repo cwd. The next repo is
+// pinned by path so the fresh ResolveRepos ranking cannot land on a different
+// repo than the one the cycle stepped to.
 func (m *Model) cycleDiffRepo() tea.Cmd {
 	if !m.diff.active || len(m.diff.repoRoots) < 2 {
 		return nil
@@ -184,14 +200,21 @@ func (m *Model) cycleDiffRepo() tea.Cmd {
 	if !ok {
 		return nil
 	}
-	m.diff.repoIdx = (m.diff.repoIdx + 1) % len(m.diff.repoRoots)
+	next := (m.diff.repoIdx + 1) % len(m.diff.repoRoots)
+	m.diff.repoSel = m.diff.repoRoots[next]
 	m.diff.gen++
 	m.diff.loading = true
 	m.diff.errText = ""
 	m.diff.fileIdx = 0
 	m.diff.scroll = 0
 	m.diff.cursorLine = 0
-	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoIdx, false)
+	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, false)
+}
+
+// reviewKey scopes a session's comments and reviewed marks to the repo under
+// review, so cycling repos never leaks marks between same-named files.
+func (m *Model) reviewKey() string {
+	return m.diff.sessID + "\x00" + m.diff.repoSel
 }
 
 // diffSession resolves the session the diff is pinned to.
@@ -228,6 +251,7 @@ func (m *Model) handleDiffLoaded(msg diffLoadedMsg) tea.Cmd {
 	m.diff.errText = ""
 	m.diff.repoRoots = msg.repoRoots
 	m.diff.repoIdx = msg.repoIdx
+	m.diff.repoSel = msg.repoRoots[msg.repoIdx]
 	previousPath := ""
 	if fd := m.currentFileDiff(); fd != nil {
 		previousPath = fd.File.Path
@@ -266,6 +290,12 @@ func (m *Model) handleDiffProbe(msg diffProbeMsg) tea.Cmd {
 	if !m.diff.active || msg.sessID != m.diff.sessID || msg.scope != m.diff.scope {
 		return nil
 	}
+	// A probe fired against the previously selected repo can land after an r
+	// cycle; its fingerprint is for the old repo, so ignore it rather than let
+	// the mismatch trigger a spurious refresh-reanchor on the new repo.
+	if msg.repoRoot != m.diff.repoSel {
+		return nil
+	}
 	if msg.fp == 0 || msg.fp == m.diff.fingerprint {
 		return nil
 	}
@@ -274,7 +304,7 @@ func (m *Model) handleDiffProbe(msg diffProbeMsg) tea.Cmd {
 		return nil
 	}
 	m.diff.gen++
-	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoIdx, true)
+	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, true)
 }
 
 // diffRefreshCmd is the poller piggyback: every second tick while the
@@ -327,10 +357,10 @@ func (m *Model) currentHL() *fileHL {
 	return m.diff.hl.get(hlKey{sessID: m.diff.sessID, scope: m.diff.scope, path: fd.File.Path, hash: contentHash(fd)})
 }
 
-// scrollKey scopes a file's saved scroll to the session and scope it was
-// taken in, so positions never leak across sessions or diff scopes.
+// scrollKey scopes a file's saved scroll to the session, repo, and scope it
+// was taken in, so positions never leak across sessions, repos, or diff scopes.
 func (m *Model) scrollKey(path string) string {
-	return m.diff.sessID + "\x00" + m.diff.scope.String() + "\x00" + path
+	return m.reviewKey() + "\x00" + m.diff.scope.String() + "\x00" + path
 }
 
 func (m *Model) switchDiffFile(delta int) tea.Cmd {
@@ -561,7 +591,7 @@ func (m *Model) handleDiffKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "d":
 		m.removeAnnotation()
 	case "C":
-		if len(m.diff.annotations[m.diff.sessID]) == 0 {
+		if len(m.diff.annotations[m.reviewKey()]) == 0 {
 			m.err = "no comments to send - press c on a line first"
 		} else {
 			m.diff.sendConfirm = true
@@ -575,10 +605,10 @@ func (m *Model) toggleReviewed() tea.Cmd {
 	if fd == nil {
 		return nil
 	}
-	marks := m.diff.reviewed[m.diff.sessID]
+	marks := m.diff.reviewed[m.reviewKey()]
 	if marks == nil {
 		marks = map[string]bool{}
-		m.diff.reviewed[m.diff.sessID] = marks
+		m.diff.reviewed[m.reviewKey()] = marks
 	}
 	marks[fd.File.Path] = !marks[fd.File.Path]
 	if !marks[fd.File.Path] {
@@ -597,7 +627,7 @@ func (m *Model) toggleReviewed() tea.Cmd {
 }
 
 func (m *Model) fileReviewed(path string) bool {
-	return m.diff.reviewed[m.diff.sessID][path]
+	return m.diff.reviewed[m.reviewKey()][path]
 }
 
 func (m *Model) openAnnotate() {
@@ -650,7 +680,7 @@ func (m *Model) annotationRows(fd *diff.FileDiff, lineIdx, width int) []string {
 
 func (m *Model) annotationAt(path string, line diff.Line) *annotation {
 	num, deleted := annotationLine(line)
-	notes := m.diff.annotations[m.diff.sessID]
+	notes := m.diff.annotations[m.reviewKey()]
 	for i := range notes {
 		if notes[i].file == path && notes[i].line == num && notes[i].deleted == deleted {
 			return &notes[i]
@@ -664,7 +694,7 @@ func (m *Model) annotationAt(path string, line diff.Line) *annotation {
 // edits while the user reviews), choosing the nearest match. A comment
 // whose line vanished entirely keeps its number as the best guess.
 func (m *Model) reanchorAnnotations() {
-	notes := m.diff.annotations[m.diff.sessID]
+	notes := m.diff.annotations[m.reviewKey()]
 	for i := range notes {
 		note := &notes[i]
 		// A blank line's excerpt is empty and would match every blank line;
@@ -697,7 +727,7 @@ func (m *Model) reanchorAnnotations() {
 // annotationOccupies reports whether a note other than self already anchors
 // on the given file line, so re-anchoring never stacks two comments there.
 func (m *Model) annotationOccupies(file string, line int, deleted bool, self int) bool {
-	notes := m.diff.annotations[m.diff.sessID]
+	notes := m.diff.annotations[m.reviewKey()]
 	for i := range notes {
 		if i != self && notes[i].file == file && notes[i].line == line && notes[i].deleted == deleted {
 			return true
@@ -755,7 +785,7 @@ func (m *Model) saveAnnotation() {
 	if text == "" {
 		return
 	}
-	m.diff.annotations[m.diff.sessID] = append(m.diff.annotations[m.diff.sessID], annotation{
+	m.diff.annotations[m.reviewKey()] = append(m.diff.annotations[m.reviewKey()], annotation{
 		file:    fd.File.Path,
 		line:    num,
 		deleted: deleted,
@@ -774,10 +804,10 @@ func (m *Model) removeAnnotation() {
 		return
 	}
 	num, deleted := annotationLine(fd.Lines[lineIdx])
-	notes := m.diff.annotations[m.diff.sessID]
+	notes := m.diff.annotations[m.reviewKey()]
 	for i := range notes {
 		if notes[i].file == fd.File.Path && notes[i].line == num && notes[i].deleted == deleted {
-			m.diff.annotations[m.diff.sessID] = append(notes[:i], notes[i+1:]...)
+			m.diff.annotations[m.reviewKey()] = append(notes[:i], notes[i+1:]...)
 			return
 		}
 	}
@@ -796,7 +826,7 @@ func (m *Model) sendAnnotations() (tea.Model, tea.Cmd) {
 		m.err = "session is dead - press v to revive"
 		return m, nil
 	}
-	notes := m.diff.annotations[sess.ID]
+	notes := m.diff.annotations[m.reviewKey()]
 	var parts []string
 	for i, note := range notes {
 		location := fmt.Sprintf("%s:%d", note.file, note.line)
@@ -815,7 +845,7 @@ func (m *Model) sendAnnotations() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	count := len(notes)
-	delete(m.diff.annotations, sess.ID)
+	delete(m.diff.annotations, m.reviewKey())
 	m.diff.notice = fmt.Sprintf("sent %d review %s to %s", count, commentNoun(count), sess.Name)
 	if err := m.store.SetAcked(sess.ID, false); err != nil {
 		m.diff.notice = ""
@@ -1042,7 +1072,7 @@ func (m *Model) viewDiffHeader(sessName string) string {
 	right := mutedStyle.Render(fmt.Sprintf("%d files", len(m.diff.set.Files))) + subtleStyle.Render(" · ") +
 		lipgloss.NewStyle().Foreground(colorFinished).Render(fmt.Sprintf("+%d", adds)) + " " +
 		lipgloss.NewStyle().Foreground(colorErrored).Render(fmt.Sprintf("−%d", dels))
-	if count := len(m.diff.annotations[m.diff.sessID]); count > 0 {
+	if count := len(m.diff.annotations[m.reviewKey()]); count > 0 {
 		right += subtleStyle.Render(" · ") + lipgloss.NewStyle().Foreground(colorAccent).Render(fmt.Sprintf("¶%d", count))
 	}
 	right += " "
@@ -1073,7 +1103,7 @@ func (m *Model) viewDiffFileList(width, height int) string {
 		b.WriteString(subtleStyle.Render(fmt.Sprintf("  ↑ %d more", start)) + "\n")
 	}
 	notes := map[string]int{}
-	for _, note := range m.diff.annotations[m.diff.sessID] {
+	for _, note := range m.diff.annotations[m.reviewKey()] {
 		notes[note.file]++
 	}
 	for i := start; i < end; i++ {
@@ -1256,7 +1286,7 @@ func (m *Model) viewDiffStatus() string {
 		return padRight(lipgloss.NewStyle().Foreground(colorFinished).Render(" ✔ "+m.diff.notice), m.width)
 	}
 	if m.diff.sendConfirm {
-		count := len(m.diff.annotations[m.diff.sessID])
+		count := len(m.diff.annotations[m.reviewKey()])
 		return padRight(errStyle.Render(fmt.Sprintf(" ¶ send %d %s to the agent?", count, commentNoun(count)))+
 			subtleStyle.Render("  ↵/y send · esc cancel"), m.width)
 	}
@@ -1274,7 +1304,7 @@ func (m *Model) viewDiffFooter() string {
 	if len(m.diff.repoRoots) > 1 {
 		pairs = append(pairs, [2]string{"r", "repo: " + filepath.Base(m.diff.repoRoots[m.diff.repoIdx])})
 	}
-	if count := len(m.diff.annotations[m.diff.sessID]); count > 0 {
+	if count := len(m.diff.annotations[m.reviewKey()]); count > 0 {
 		pairs = append(pairs, [2]string{"C", fmt.Sprintf("send %d", count)}, [2]string{"d", "remove"})
 	}
 	pairs = append(pairs, [2]string{"esc", "close"})

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/diff"
@@ -53,6 +54,12 @@ type diffState struct {
 	hl          *hlCache
 	hlPending   hlKey
 
+	// repoRoots holds the git repos found under the session cwd; when the cwd
+	// is an umbrella of several repos, repoIdx selects the one under review and
+	// the r key cycles between them.
+	repoRoots []string
+	repoIdx   int
+
 	// Set when review opened from inside a session; leaving re-attaches it.
 	reattachID string
 }
@@ -64,6 +71,10 @@ type diffLoadedMsg struct {
 	set    diff.Set
 	fp     uint64
 	err    error
+	// repoRoots and repoIdx report which repo the load resolved to, so the UI
+	// can show the repo name and enable cycling when the cwd holds several.
+	repoRoots []string
+	repoIdx   int
 	// refresh marks a silent reload of the same session and scope (the agent
 	// edited the file under review), the only case where saved comments
 	// re-anchor. Scope cycles and session switches load a different file set.
@@ -81,11 +92,21 @@ type diffProbeMsg struct {
 	fp     uint64
 }
 
-func (m *Model) diffLoadCmd(sess store.Session, scope git.Scope, gen int, refresh bool) tea.Cmd {
+func (m *Model) diffLoadCmd(sess store.Session, scope git.Scope, gen, repoIdx int, refresh bool) tea.Cmd {
 	driver := m.gitDrv
 	return func() tea.Msg {
 		msg := diffLoadedMsg{sessID: sess.ID, scope: scope, gen: gen, refresh: refresh}
-		msg.set, msg.err = diff.BuildSet(driver, sess.Cwd, scope)
+		roots, err := driver.ResolveRepos(sess.Cwd)
+		if err != nil {
+			msg.err = err
+			return msg
+		}
+		if repoIdx >= len(roots) {
+			repoIdx = 0
+		}
+		msg.repoRoots = roots
+		msg.repoIdx = repoIdx
+		msg.set, msg.err = diff.BuildSet(driver, roots[repoIdx], scope)
 		if msg.err == nil {
 			baseRef := ""
 			if scope == git.ScopeBranch {
@@ -119,7 +140,8 @@ func (m *Model) diffProbeCmd(sess store.Session, scope git.Scope) tea.Cmd {
 	}
 }
 
-// retargetDiff points the open diff at a session, reloading its set.
+// retargetDiff points the open diff at a session, reloading its set. A new
+// session resets the repo selection so the load re-ranks from scratch.
 func (m *Model) retargetDiff(sess store.Session) tea.Cmd {
 	m.diff.sessID = sess.ID
 	m.diff.gen++
@@ -129,7 +151,9 @@ func (m *Model) retargetDiff(sess store.Session) tea.Cmd {
 	m.diff.fileIdx = 0
 	m.diff.scroll = 0
 	m.diff.cursorLine = 0
-	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, false)
+	m.diff.repoRoots = nil
+	m.diff.repoIdx = 0
+	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoIdx, false)
 }
 
 func (m *Model) cycleDiffScope() tea.Cmd {
@@ -147,7 +171,27 @@ func (m *Model) cycleDiffScope() tea.Cmd {
 	m.diff.fileIdx = 0
 	m.diff.scroll = 0
 	m.diff.cursorLine = 0
-	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, false)
+	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoIdx, false)
+}
+
+// cycleDiffRepo advances to the next repo when the session cwd is an umbrella
+// of several. It is a no-op for a plain single-repo cwd.
+func (m *Model) cycleDiffRepo() tea.Cmd {
+	if !m.diff.active || len(m.diff.repoRoots) < 2 {
+		return nil
+	}
+	sess, ok := m.diffSession()
+	if !ok {
+		return nil
+	}
+	m.diff.repoIdx = (m.diff.repoIdx + 1) % len(m.diff.repoRoots)
+	m.diff.gen++
+	m.diff.loading = true
+	m.diff.errText = ""
+	m.diff.fileIdx = 0
+	m.diff.scroll = 0
+	m.diff.cursorLine = 0
+	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoIdx, false)
 }
 
 // diffSession resolves the session the diff is pinned to.
@@ -178,9 +222,12 @@ func (m *Model) handleDiffLoaded(msg diffLoadedMsg) tea.Cmd {
 	if msg.err != nil {
 		m.diff.errText = msg.err.Error()
 		m.diff.set = diff.Set{}
+		m.diff.repoRoots = nil
 		return nil
 	}
 	m.diff.errText = ""
+	m.diff.repoRoots = msg.repoRoots
+	m.diff.repoIdx = msg.repoIdx
 	previousPath := ""
 	if fd := m.currentFileDiff(); fd != nil {
 		previousPath = fd.File.Path
@@ -227,7 +274,7 @@ func (m *Model) handleDiffProbe(msg diffProbeMsg) tea.Cmd {
 		return nil
 	}
 	m.diff.gen++
-	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, true)
+	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoIdx, true)
 }
 
 // diffRefreshCmd is the poller piggyback: every second tick while the
@@ -501,6 +548,8 @@ func (m *Model) handleDiffKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.jumpChange(-1)
 	case "s":
 		return m, m.cycleDiffScope()
+	case "r":
+		return m, m.cycleDiffRepo()
 	case "u":
 		lineIdx := m.cursorDiffLine()
 		m.diff.sideBySide = !m.diff.sideBySide
@@ -977,6 +1026,10 @@ func (m *Model) viewDiffHeader(sessName string) string {
 	}
 	left := badgeStyle.Render("◆ Review · "+sessName) + "  " +
 		pill(m.diff.scope.String(), colorAccent2) + "  " + pill(layout, colorAccent)
+	if len(m.diff.repoRoots) > 1 {
+		name := filepath.Base(m.diff.repoRoots[m.diff.repoIdx])
+		left += "  " + pill(fmt.Sprintf("%s %d/%d", name, m.diff.repoIdx+1, len(m.diff.repoRoots)), colorAccent)
+	}
 	if m.diff.set.BaseDesc != "" && m.diff.scope == git.ScopeBranch {
 		left += "  " + subtleStyle.Render(m.diff.set.BaseDesc)
 	}
@@ -1217,6 +1270,9 @@ func (m *Model) viewDiffFooter() string {
 	pairs := [][2]string{
 		{"↑↓", "scroll"}, {"J/K", "file"}, {"n/N", "change"}, {"space", "reviewed"},
 		{"u", "layout"}, {"s", "scope: " + m.diff.scope.String()}, {"c", "comment"},
+	}
+	if len(m.diff.repoRoots) > 1 {
+		pairs = append(pairs, [2]string{"r", "repo: " + filepath.Base(m.diff.repoRoots[m.diff.repoIdx])})
 	}
 	if count := len(m.diff.annotations[m.diff.sessID]); count > 0 {
 		pairs = append(pairs, [2]string{"C", fmt.Sprintf("send %d", count)}, [2]string{"d", "remove"})

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -169,6 +169,7 @@ func (m *Model) viewHelp() string {
 		{"⇥", "in quick prompt: switch spawn tool"},
 		{"D", "review changes: whole-file diffs, comment lines, send to agent"},
 		{"s", "in review: cycle scope (uncommitted / vs base / last commit / staged)"},
+		{"r", "in review: cycle repo when the session dir holds several"},
 		{"F", "fold / unfold all groups"},
 		{"s", "settings (quick spawn tool, review layout)"},
 		{"t", "toggle archived view"},

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -408,7 +408,12 @@ func turnInFlight(current string) bool {
 // for the states hooks can see. They cannot see a plain-text question,
 // an interrupt banner, or an error line, so a matched pane verdict
 // upgrades finished to waiting or errored, and working to waiting (an
-// Esc interrupt fires no Stop event).
+// Esc interrupt fires no Stop event). A working hook also reconciles to
+// the pane verdict when the pane shows the turn already ended: background
+// subagents write working via PreToolUse/PostToolUse but fire no Stop
+// when they finish, so the file would otherwise stay pinned at working
+// forever. The pane only reports finished/waiting/errored once the newest
+// turn is quiet, so this never fires while the agent is still streaming.
 func (p *poller) applyHookStatus(sess store.Session, text, hookStatus string) string {
 	paneStatus, matched := p.engine.Match(sess.Tool, text)
 	switch hookStatus {
@@ -420,8 +425,11 @@ func (p *poller) applyHookStatus(sess store.Session, text, hookStatus string) st
 			return status.Idle
 		}
 	case status.Working:
-		if matched && paneStatus == status.Waiting {
-			return status.Waiting
+		if matched && (paneStatus == status.Waiting || paneStatus == status.Finished || paneStatus == status.Errored) {
+			if paneStatus == status.Finished && sess.Acked {
+				return status.Idle
+			}
+			return paneStatus
 		}
 	}
 	return hookStatus

--- a/internal/ui/review_regression_test.go
+++ b/internal/ui/review_regression_test.go
@@ -41,6 +41,73 @@ func gitRepoWithTwoChangedFiles(t *testing.T) string {
 	return dir
 }
 
+// umbrellaWithTwoRepos makes a dir that is not itself a repo but holds two
+// nested repos, the second one dirty so it ranks first.
+func umbrellaWithTwoRepos(t *testing.T) (umbrella, dirtyName string) {
+	t.Helper()
+	umbrella = t.TempDir()
+	run := func(dir string, args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+	for _, name := range []string{"alpha", "bravo"} {
+		dir := filepath.Join(umbrella, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("package a\n\nfunc A() int { return 1 }\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		run(dir, "git", "init")
+		run(dir, "git", "add", ".")
+		run(dir, "git", "commit", "-m", "init")
+	}
+	dirty := filepath.Join(umbrella, "bravo")
+	if err := os.WriteFile(filepath.Join(dirty, "a.go"), []byte("package a\n\nfunc A() int { return 99 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return umbrella, "bravo"
+}
+
+// A session whose cwd is an umbrella of several repos opens review on the
+// most-active repo, shows the repo in the header, and the r key cycles.
+func TestReviewCyclesReposUnderUmbrella(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	umbrella, dirtyName := umbrellaWithTwoRepos(t)
+	openReviewOn(t, m, "umbrella", umbrella)
+
+	if len(m.diff.repoRoots) != 2 {
+		t.Fatalf("want 2 repos resolved, got %v (err=%q)", m.diff.repoRoots, m.diff.errText)
+	}
+	if got := filepath.Base(m.diff.repoRoots[m.diff.repoIdx]); got != dirtyName {
+		t.Fatalf("want dirty repo %q selected first, got %q", dirtyName, got)
+	}
+	if !strings.Contains(m.viewDiffHeader("umbrella"), dirtyName) {
+		t.Fatalf("header should name the selected repo %q", dirtyName)
+	}
+
+	m.pressDiffKey(t, 'r')
+	if got := filepath.Base(m.diff.repoRoots[m.diff.repoIdx]); got != "alpha" {
+		t.Fatalf("r should cycle to the other repo, got %q", got)
+	}
+	if !strings.Contains(m.viewDiffHeader("umbrella"), "alpha") {
+		t.Fatal("header should follow the repo cycle")
+	}
+	m.pressDiffKey(t, 'r')
+	if got := filepath.Base(m.diff.repoRoots[m.diff.repoIdx]); got != dirtyName {
+		t.Fatalf("r should wrap back, got %q", got)
+	}
+}
+
 // drainCmds runs a command chain to exhaustion, feeding every message back
 // into Update, so async follow-ups (diff loads, highlights) all land.
 func (m *Model) drainCmds(t *testing.T, cmd tea.Cmd) {
@@ -167,7 +234,7 @@ func (m *Model) refreshDiff(t *testing.T) {
 		t.Fatal("no diff session")
 	}
 	m.diff.gen++
-	m.drainCmds(t, m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, true))
+	m.drainCmds(t, m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoIdx, true))
 }
 
 // A silent same-scope reload that shifts line numbers re-points saved comments

--- a/internal/ui/review_regression_test.go
+++ b/internal/ui/review_regression_test.go
@@ -108,6 +108,65 @@ func TestReviewCyclesReposUnderUmbrella(t *testing.T) {
 	}
 }
 
+// A reviewed mark placed on a path in one repo must not bleed onto a
+// same-named path in a sibling repo when cycling with r.
+func TestReviewMarksIsolatedPerRepo(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	umbrella, dirtyName := umbrellaWithTwoRepos(t)
+	openReviewOn(t, m, "umbrella", umbrella)
+	if got := filepath.Base(m.diff.repoSel); got != dirtyName {
+		t.Fatalf("want %q selected, got %q", dirtyName, got)
+	}
+	if fd := m.currentFileDiff(); fd == nil || fd.File.Path != "a.go" {
+		t.Fatalf("want a.go under review in the dirty repo, got %v", fd)
+	}
+	m.drainCmds(t, m.toggleReviewed())
+	if !m.fileReviewed("a.go") {
+		t.Fatal("a.go should be reviewed in the dirty repo")
+	}
+
+	m.pressDiffKey(t, 'r')
+	if filepath.Base(m.diff.repoSel) != "alpha" {
+		t.Fatalf("r should select alpha, got %q", m.diff.repoSel)
+	}
+	if m.fileReviewed("a.go") {
+		t.Fatal("a.go reviewed mark leaked into the sibling repo")
+	}
+
+	m.pressDiffKey(t, 'r')
+	if !m.fileReviewed("a.go") {
+		t.Fatal("cycling back should restore the dirty repo's reviewed mark")
+	}
+}
+
+// The selected repo is pinned by path, so a reload whose fresh ranking would
+// put a different repo first keeps the user on the repo they chose.
+func TestRepoSelectionSurvivesReload(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	umbrella, _ := umbrellaWithTwoRepos(t)
+	openReviewOn(t, m, "umbrella", umbrella)
+
+	m.pressDiffKey(t, 'r')
+	if filepath.Base(m.diff.repoSel) != "alpha" {
+		t.Fatalf("want alpha selected, got %q", m.diff.repoSel)
+	}
+	// A scope cycle reloads through ResolveRepos, which ranks the dirty repo
+	// first; the path pin must keep alpha selected regardless.
+	m.pressDiffKey(t, 's')
+	if got := filepath.Base(m.diff.repoSel); got != "alpha" {
+		t.Fatalf("reload should keep alpha pinned, got %q", got)
+	}
+	if got := filepath.Base(m.diff.repoRoots[m.diff.repoIdx]); got != "alpha" {
+		t.Fatalf("repoIdx should track the pinned repo after re-rank, got %q", got)
+	}
+}
+
 // drainCmds runs a command chain to exhaustion, feeding every message back
 // into Update, so async follow-ups (diff loads, highlights) all land.
 func (m *Model) drainCmds(t *testing.T, cmd tea.Cmd) {
@@ -234,7 +293,7 @@ func (m *Model) refreshDiff(t *testing.T) {
 		t.Fatal("no diff session")
 	}
 	m.diff.gen++
-	m.drainCmds(t, m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoIdx, true))
+	m.drainCmds(t, m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, true))
 }
 
 // A silent same-scope reload that shifts line numbers re-points saved comments
@@ -250,7 +309,7 @@ func TestAnnotationsReanchorAfterRefresh(t *testing.T) {
 	m.openAnnotate()
 	m.diff.annInput.SetValue("note")
 	m.saveAnnotation()
-	notes := m.diff.annotations[m.diff.sessID]
+	notes := m.diff.annotations[m.reviewKey()]
 	if len(notes) != 1 || notes[0].line != 3 {
 		t.Fatalf("annotation = %+v, want line 3", notes)
 	}
@@ -260,7 +319,7 @@ func TestAnnotationsReanchorAfterRefresh(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.refreshDiff(t)
-	if notes = m.diff.annotations[m.diff.sessID]; len(notes) != 1 || notes[0].line != 4 {
+	if notes = m.diff.annotations[m.reviewKey()]; len(notes) != 1 || notes[0].line != 4 {
 		t.Fatalf("annotation after refresh = %+v, want line 4", notes)
 	}
 }
@@ -277,10 +336,10 @@ func TestScopeCycleDoesNotReanchor(t *testing.T) {
 	m.openAnnotate()
 	m.diff.annInput.SetValue("note")
 	m.saveAnnotation()
-	before := m.diff.annotations[m.diff.sessID][0].line
+	before := m.diff.annotations[m.reviewKey()][0].line
 
 	m.drainCmds(t, m.cycleDiffScope())
-	if got := m.diff.annotations[m.diff.sessID][0].line; got != before {
+	if got := m.diff.annotations[m.reviewKey()][0].line; got != before {
 		t.Fatalf("scope cycle rewrote the comment line: %d -> %d", before, got)
 	}
 }
@@ -293,7 +352,7 @@ func TestReanchorKeepsAmbiguousAndAvoidsCollapse(t *testing.T) {
 		t.Skip("git not installed")
 	}
 	m.diff.sessID = "s1"
-	m.diff.annotations = map[string][]annotation{"s1": {
+	m.diff.annotations = map[string][]annotation{m.reviewKey(): {
 		{file: "f.go", line: 2, excerpt: "", text: "blank"},
 		{file: "f.go", line: 5, excerpt: "}", text: "first brace"},
 		{file: "f.go", line: 9, excerpt: "}", text: "second brace"},
@@ -311,7 +370,7 @@ func TestReanchorKeepsAmbiguousAndAvoidsCollapse(t *testing.T) {
 		},
 	}}}
 	m.reanchorAnnotations()
-	notes := m.diff.annotations["s1"]
+	notes := m.diff.annotations[m.reviewKey()]
 	if notes[0].line != 2 {
 		t.Errorf("blank excerpt should not move: line=%d", notes[0].line)
 	}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -632,6 +632,17 @@ func TestHookWorkingUpgradesToWaitingOnPaneMatch(t *testing.T) {
 	}
 }
 
+func TestHookWorkingReconcilesToFinishedOnEndedTurn(t *testing.T) {
+	m := buildModel(t)
+	sess := store.Session{ID: "hooked07", Tool: "claude-hooked", Status: status.Working}
+	writeHookStatus(t, m, sess.ID, status.Working)
+
+	pane := "here is the result\n\n✻ Baked for 5s\n\n❯ \n"
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Finished {
+		t.Fatalf("stale working hook over an ended turn should reconcile to finished, got %q", got)
+	}
+}
+
 func TestStaleHookFileFallsBackToPaneRules(t *testing.T) {
 	m := buildModel(t)
 	sess := store.Session{ID: "hooked06", Tool: "claude-hooked"}
@@ -1622,13 +1633,13 @@ func TestDiffAnnotateAndSend(t *testing.T) {
 	m.openAnnotate()
 	m.diff.annInput.SetValue("use fmt.Println here")
 	m.saveAnnotation()
-	if len(m.diff.annotations[m.diff.sessID]) != 1 {
+	if len(m.diff.annotations[m.reviewKey()]) != 1 {
 		t.Fatalf("annotations = %+v", m.diff.annotations)
 	}
 
 	_, cmd := m.sendAnnotations()
 	m.applyCmd(t, cmd)
-	if len(m.diff.annotations[m.diff.sessID]) != 0 {
+	if len(m.diff.annotations[m.reviewKey()]) != 0 {
 		t.Fatal("annotations should clear after send")
 	}
 	if !strings.Contains(m.diff.notice, "review comment") {


### PR DESCRIPTION
## Problem

Review showed **"not a git repository"** for any session whose working directory is a container folder holding several repos, not a repo itself. Real cases from live sessions:

- `monorepo` (9 sessions) → 20 nested repos (`servers/main-node`, `apps/`, `libs/`, …)
- `MySpaze` (1) → `myspaze-app`, `myspaze-api`, `myspaze-admin`
- `projects` (1) → every project underneath

The diff loader ran git in the cwd, which is genuinely not a repo, so review was dead for all of these.

## Fix

When the cwd is not a repo, `ResolveRepos` discovers the nested repos (depth ≤ 3, skips `node_modules` / `.worktrees` / build output) and ranks them **dirty working tree first, then most recent commit**, so review opens on the repo the agent is most likely editing.

- `r` cycles between repos in the umbrella.
- Header pill and footer show the selected repo and `i/n`.
- A cwd that is itself a repo behaves exactly as before (no pill, no cycle).

Verified ranking on the real dirs: monorepo → `main-node`, MySpaze → `myspaze-app`, projects → `agent-manager`.

## Tests

- `git`: `ResolveRepos` single / umbrella-ranks-dirty-first / no-repo.
- `ui`: umbrella session opens on the active repo, header names it, `r` cycles and wraps — driven through the real `Update` loop.

Full suite, `go vet`, `gofmt` all clean.
