### PR TITLE
feat: attach clipboard images in the quick prompt for any provider

### DIFF
--- a/docs/superpowers/specs/2026-07-19-paste-images-quick-prompt-design.md
+++ b/docs/superpowers/specs/2026-07-19-paste-images-quick-prompt-design.md
@@ -1,0 +1,41 @@
+# Paste images in the quick prompt
+
+## Goal
+
+Let a user attach a clipboard image while the quick-prompt bar is open, and have the image reach whatever agent runs in the target session, regardless of provider (claude, codex, grok, opencode, or any future tool).
+
+## Approach
+
+Agent-manager always spawns agents in local tmux on the same host, so any file the TUI writes is readable by the agent. On a `Ctrl+V` keypress in the quick bar, read the OS clipboard for image data, write it to a temp file, and insert that file's absolute path into the prompt text. On submit the existing `SendText` delivers the whole prompt (path included) via `send-keys`; the agent opens the local path.
+
+Nothing is tool-specific: every agent reads a local image path from prompt text. This is the only provider-agnostic mechanism and needs no per-tool config.
+
+## Components
+
+### `internal/clipboard`
+
+- `ReadImage() ([]byte, string, error)` returns raw image bytes and an extension (`png`).
+  - macOS: an `osascript` snippet coerces the clipboard to `«class PNGf»` and writes it to a temp file, which is then read back. A clipboard with no image errors.
+  - Linux: `wl-paste --type image/png` (Wayland) or `xclip -selection clipboard -t image/png -o` (X11), whichever binary is present. Missing both returns a "install wl-clipboard or xclip" error.
+  - Other OS: an "unsupported" error.
+  - `goos`, `lookPath`, and `runCmd` are package vars so tests inject fakes without touching a real clipboard.
+- `SaveToTemp(data []byte, ext string) (string, error)` writes bytes to `os.TempDir()/agent-manager-pastes/paste-*.<ext>` and returns the absolute path.
+
+### `internal/ui`
+
+- `captureClipboardImage` is a package var defaulting to `clipboard.ReadImage`, overridable in tests.
+- `handleQuickKey` intercepts `ctrl+v` before the textarea sees it and calls `attachQuickImage`.
+- `attachQuickImage` reads the clipboard image, saves it to a temp file, and inserts the padded absolute path at the cursor. On any error it sets `m.err` to the error text and leaves the input unchanged.
+
+## Error handling
+
+No silent fallbacks. An empty clipboard, a missing Linux clipboard tool, and an unsupported OS each produce a distinct error surfaced through `m.err`.
+
+## Testing
+
+- `clipboard`: `SaveToTemp` writes the bytes with the right extension; the darwin and linux branches invoke the expected command and return injected bytes; the linux branch errors when no tool is present.
+- `ui`: `ctrl+v` with a fake image inserts an existing temp-file path into the quick input; `ctrl+v` with no image sets `m.err` and leaves the input empty.
+
+## Scope
+
+One image per paste. macOS and Linux. No drag-drop, no Windows, no inline thumbnail.

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -1,0 +1,115 @@
+// Package clipboard reads image data off the OS clipboard so the quick
+// prompt can attach a pasted screenshot to an agent session.
+package clipboard
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"os/exec"
+)
+
+// ErrNoImage means the clipboard held no image when it was read.
+var ErrNoImage = errors.New("no image in clipboard")
+
+// Overridable seams so tests can drive the platform branches without a
+// real clipboard.
+var (
+	goos     = runtime.GOOS
+	lookPath = exec.LookPath
+	runCmd   = func(name string, args ...string) ([]byte, error) {
+		return exec.Command(name, args...).Output()
+	}
+)
+
+// ReadImage returns the clipboard image as raw bytes plus its file
+// extension. It errors when the clipboard holds no image, the platform
+// tooling is missing, or the OS is unsupported.
+func ReadImage() ([]byte, string, error) {
+	switch goos {
+	case "darwin":
+		return readDarwin()
+	case "linux":
+		return readLinux()
+	default:
+		return nil, "", fmt.Errorf("clipboard image paste is not supported on %s", goos)
+	}
+}
+
+// readDarwin coerces the clipboard to PNG through osascript, which writes
+// the bytes to a temp file we read back. A clipboard without image data
+// makes the coercion fail, which we report as ErrNoImage.
+func readDarwin() ([]byte, string, error) {
+	dst, err := os.CreateTemp("", "clip-*.png")
+	if err != nil {
+		return nil, "", err
+	}
+	path := dst.Name()
+	dst.Close()
+	defer os.Remove(path)
+
+	script := `on run argv
+	set outFile to (item 1 of argv)
+	set pngData to (the clipboard as «class PNGf»)
+	set fh to open for access (POSIX file outFile) with write permission
+	set eof fh to 0
+	write pngData to fh
+	close access fh
+end run`
+	if _, err := runCmd("osascript", "-e", script, path); err != nil {
+		return nil, "", ErrNoImage
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(data) == 0 {
+		return nil, "", ErrNoImage
+	}
+	return data, "png", nil
+}
+
+// readLinux pulls PNG bytes from whichever clipboard tool is installed,
+// preferring the Wayland one.
+func readLinux() ([]byte, string, error) {
+	if _, err := lookPath("wl-paste"); err == nil {
+		data, err := runCmd("wl-paste", "--type", "image/png")
+		if err != nil || len(data) == 0 {
+			return nil, "", ErrNoImage
+		}
+		return data, "png", nil
+	}
+	if _, err := lookPath("xclip"); err == nil {
+		data, err := runCmd("xclip", "-selection", "clipboard", "-t", "image/png", "-o")
+		if err != nil || len(data) == 0 {
+			return nil, "", ErrNoImage
+		}
+		return data, "png", nil
+	}
+	return nil, "", errors.New("install wl-clipboard or xclip to paste images")
+}
+
+// SaveToTemp writes image bytes to a uniquely named file under a shared
+// pastes directory and returns its absolute path.
+func SaveToTemp(data []byte, ext string) (string, error) {
+	dir := filepath.Join(os.TempDir(), "agent-manager-pastes")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	file, err := os.CreateTemp(dir, "paste-*."+ext)
+	if err != nil {
+		return "", err
+	}
+	if _, err := file.Write(data); err != nil {
+		file.Close()
+		os.Remove(file.Name())
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	return file.Name(), nil
+}

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,0 +1,141 @@
+package clipboard
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func restore() func() {
+	origGOOS, origLook, origRun := goos, lookPath, runCmd
+	return func() {
+		goos, lookPath, runCmd = origGOOS, origLook, origRun
+	}
+}
+
+func TestReadImageDarwinWritesAndReadsBytes(t *testing.T) {
+	defer restore()()
+	goos = "darwin"
+	want := []byte("fake-png-bytes")
+	var sawScript bool
+	runCmd = func(name string, args ...string) ([]byte, error) {
+		if name != "osascript" {
+			t.Fatalf("expected osascript, got %q", name)
+		}
+		sawScript = true
+		path := args[len(args)-1]
+		if err := os.WriteFile(path, want, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return nil, nil
+	}
+	data, ext, err := ReadImage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sawScript {
+		t.Fatal("osascript was not invoked")
+	}
+	if string(data) != string(want) || ext != "png" {
+		t.Fatalf("got %q/%q", data, ext)
+	}
+}
+
+func TestReadImageDarwinNoImage(t *testing.T) {
+	defer restore()()
+	goos = "darwin"
+	runCmd = func(name string, args ...string) ([]byte, error) {
+		return nil, errors.New("coercion failed")
+	}
+	if _, _, err := ReadImage(); !errors.Is(err, ErrNoImage) {
+		t.Fatalf("want ErrNoImage, got %v", err)
+	}
+}
+
+func TestReadImageLinuxWayland(t *testing.T) {
+	defer restore()()
+	goos = "linux"
+	want := []byte("wayland-png")
+	lookPath = func(name string) (string, error) {
+		if name == "wl-paste" {
+			return "/usr/bin/wl-paste", nil
+		}
+		return "", errors.New("not found")
+	}
+	runCmd = func(name string, args ...string) ([]byte, error) {
+		if name != "wl-paste" {
+			t.Fatalf("expected wl-paste, got %q", name)
+		}
+		return want, nil
+	}
+	data, ext, err := ReadImage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(want) || ext != "png" {
+		t.Fatalf("got %q/%q", data, ext)
+	}
+}
+
+func TestReadImageLinuxXclipFallback(t *testing.T) {
+	defer restore()()
+	goos = "linux"
+	lookPath = func(name string) (string, error) {
+		if name == "xclip" {
+			return "/usr/bin/xclip", nil
+		}
+		return "", errors.New("not found")
+	}
+	var used string
+	runCmd = func(name string, args ...string) ([]byte, error) {
+		used = name
+		return []byte("x11-png"), nil
+	}
+	if _, _, err := ReadImage(); err != nil {
+		t.Fatal(err)
+	}
+	if used != "xclip" {
+		t.Fatalf("expected xclip, used %q", used)
+	}
+}
+
+func TestReadImageLinuxNoTool(t *testing.T) {
+	defer restore()()
+	goos = "linux"
+	lookPath = func(name string) (string, error) { return "", errors.New("not found") }
+	_, _, err := ReadImage()
+	if err == nil || errors.Is(err, ErrNoImage) {
+		t.Fatalf("want a missing-tool error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "wl-clipboard") {
+		t.Fatalf("error should name the tools to install, got %v", err)
+	}
+}
+
+func TestReadImageUnsupportedOS(t *testing.T) {
+	defer restore()()
+	goos = "plan9"
+	if _, _, err := ReadImage(); err == nil {
+		t.Fatal("expected unsupported-OS error")
+	}
+}
+
+func TestSaveToTempWritesBytes(t *testing.T) {
+	path, err := SaveToTemp([]byte("payload"), "png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+	if filepath.Ext(path) != ".png" {
+		t.Fatalf("want .png, got %q", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "payload" {
+		t.Fatalf("got %q", data)
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -663,22 +664,31 @@ func (m *Model) renameGroupLocally(old, newPath, dir string) {
 var captureClipboardImage = clipboard.ReadImage
 
 // attachQuickImage saves a clipboard image to a temp file and inserts its
-// path into the prompt, so the agent in the target session can open it.
-// Any failure leaves the input untouched and surfaces the reason.
-func (m *Model) attachQuickImage() (tea.Model, tea.Cmd) {
+// path into the prompt, so the agent in the target session can open it. It
+// reports whether it handled the keypress: an empty clipboard returns false
+// so the caller can fall back to a plain text paste, while a real failure is
+// surfaced through m.err.
+func (m *Model) attachQuickImage() bool {
 	data, ext, err := captureClipboardImage()
 	if err != nil {
+		if errors.Is(err, clipboard.ErrNoImage) {
+			return false
+		}
 		m.err = err.Error()
-		return m, nil
+		return true
 	}
 	path, err := clipboard.SaveToTemp(data, ext)
 	if err != nil {
 		m.err = err.Error()
-		return m, nil
+		return true
 	}
+	// InsertString alone leaves the viewport where it was; a no-op Update
+	// runs repositionView so the inserted path scrolls into view.
+	m.quick.input.SetHeight(quickBarMaxRows)
 	m.quick.input.InsertString(" " + path + " ")
+	m.quick.input, _ = m.quick.input.Update(nil)
 	m.err = ""
-	return m, nil
+	return true
 }
 
 func (m *Model) openQuickMode() {
@@ -732,7 +742,11 @@ func (m *Model) handleQuickKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "ctrl+v":
-		return m.attachQuickImage()
+		if m.attachQuickImage() {
+			return m, nil
+		}
+		// No image on the clipboard: fall through so the textarea's own
+		// ctrl+v text paste still works.
 	case "enter":
 		return m.submitQuick()
 	}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/sysstat"
@@ -657,6 +658,29 @@ func (m *Model) renameGroupLocally(old, newPath, dir string) {
 	m.persistCollapsed()
 }
 
+// captureClipboardImage is the seam the quick bar uses to read a pasted
+// image; tests swap it for a fake.
+var captureClipboardImage = clipboard.ReadImage
+
+// attachQuickImage saves a clipboard image to a temp file and inserts its
+// path into the prompt, so the agent in the target session can open it.
+// Any failure leaves the input untouched and surfaces the reason.
+func (m *Model) attachQuickImage() (tea.Model, tea.Cmd) {
+	data, ext, err := captureClipboardImage()
+	if err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+	path, err := clipboard.SaveToTemp(data, ext)
+	if err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+	m.quick.input.InsertString(" " + path + " ")
+	m.err = ""
+	return m, nil
+}
+
 func (m *Model) openQuickMode() {
 	input := textarea.New()
 	input.CharLimit = 2000
@@ -707,6 +731,8 @@ func (m *Model) handleQuickKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.quick.toolIndex = (m.quick.toolIndex + 1) % len(m.quick.toolNames)
 		}
 		return m, nil
+	case "ctrl+v":
+		return m.attachQuickImage()
 	case "enter":
 		return m.submitQuick()
 	}

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -167,6 +167,7 @@ func (m *Model) viewHelp() string {
 		{"shift+↑↓", "reorder row up / down"},
 		{"space", "quick prompt: answer session / spawn agent in group"},
 		{"⇥", "in quick prompt: switch spawn tool"},
+		{"^v", "in quick prompt: attach a clipboard image"},
 		{"D", "review changes: whole-file diffs, comment lines, send to agent"},
 		{"s", "in review: cycle scope (uncommitted / vs base / last commit / staged)"},
 		{"F", "fold / unfold all groups"},

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -990,7 +991,10 @@ func TestQuickAttachImageInsertsPath(t *testing.T) {
 		return []byte("png-bytes"), "png", nil
 	}
 
-	if _, _ = m.attachQuickImage(); m.err != "" {
+	if !m.attachQuickImage() {
+		t.Fatal("attachQuickImage should report it handled the image")
+	}
+	if m.err != "" {
 		t.Fatalf("attach: %q", m.err)
 	}
 	value := strings.TrimSpace(m.quick.input.Value())
@@ -1007,7 +1011,7 @@ func TestQuickAttachImageInsertsPath(t *testing.T) {
 	os.Remove(value)
 }
 
-func TestQuickAttachImageNoImageSetsError(t *testing.T) {
+func TestQuickAttachImageNoImageFallsThrough(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "answer-me", t.TempDir(), "")
 	m.selectSessionRow(t, "answer-me")
@@ -1019,11 +1023,52 @@ func TestQuickAttachImageNoImageSetsError(t *testing.T) {
 		return nil, "", clipboard.ErrNoImage
 	}
 
-	if _, _ = m.attachQuickImage(); m.err != clipboard.ErrNoImage.Error() {
-		t.Fatalf("err = %q", m.err)
+	if m.attachQuickImage() {
+		t.Fatal("an empty clipboard should not be handled, so text paste can run")
+	}
+	if m.err != "" {
+		t.Fatalf("an empty clipboard is not an error, err = %q", m.err)
 	}
 	if m.quick.input.Value() != "" {
 		t.Fatal("input should stay empty when no image is present")
+	}
+}
+
+func TestQuickCtrlVNoImageReachesTextPaste(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "answer-me", t.TempDir(), "")
+	m.selectSessionRow(t, "answer-me")
+	m.openQuickMode()
+
+	orig := captureClipboardImage
+	defer func() { captureClipboardImage = orig }()
+	captureClipboardImage = func() ([]byte, string, error) {
+		return nil, "", clipboard.ErrNoImage
+	}
+
+	_, cmd := m.handleQuickKey(tea.KeyMsg{Type: tea.KeyCtrlV})
+	if cmd == nil {
+		t.Fatal("ctrl+v with no image should fall through to the textarea's paste command")
+	}
+}
+
+func TestQuickAttachImageRealErrorSurfaces(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "answer-me", t.TempDir(), "")
+	m.selectSessionRow(t, "answer-me")
+	m.openQuickMode()
+
+	orig := captureClipboardImage
+	defer func() { captureClipboardImage = orig }()
+	captureClipboardImage = func() ([]byte, string, error) {
+		return nil, "", errors.New("install wl-clipboard or xclip to paste images")
+	}
+
+	if !m.attachQuickImage() {
+		t.Fatal("a real clipboard error should be handled, not fall through")
+	}
+	if m.err == "" {
+		t.Fatal("a real clipboard error should surface through m.err")
 	}
 }
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/status"
@@ -974,6 +975,55 @@ func TestQuickPromptSendClearsAcked(t *testing.T) {
 	}
 	if got.Acked {
 		t.Fatal("quick prompt send should clear the acked flag")
+	}
+}
+
+func TestQuickAttachImageInsertsPath(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "answer-me", t.TempDir(), "")
+	m.selectSessionRow(t, "answer-me")
+	m.openQuickMode()
+
+	orig := captureClipboardImage
+	defer func() { captureClipboardImage = orig }()
+	captureClipboardImage = func() ([]byte, string, error) {
+		return []byte("png-bytes"), "png", nil
+	}
+
+	if _, _ = m.attachQuickImage(); m.err != "" {
+		t.Fatalf("attach: %q", m.err)
+	}
+	value := strings.TrimSpace(m.quick.input.Value())
+	if value == "" {
+		t.Fatal("expected the image path to be inserted")
+	}
+	data, err := os.ReadFile(value)
+	if err != nil {
+		t.Fatalf("inserted path is not a readable file: %v", err)
+	}
+	if string(data) != "png-bytes" {
+		t.Fatalf("temp file holds %q", data)
+	}
+	os.Remove(value)
+}
+
+func TestQuickAttachImageNoImageSetsError(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "answer-me", t.TempDir(), "")
+	m.selectSessionRow(t, "answer-me")
+	m.openQuickMode()
+
+	orig := captureClipboardImage
+	defer func() { captureClipboardImage = orig }()
+	captureClipboardImage = func() ([]byte, string, error) {
+		return nil, "", clipboard.ErrNoImage
+	}
+
+	if _, _ = m.attachQuickImage(); m.err != clipboard.ErrNoImage.Error() {
+		t.Fatalf("err = %q", m.err)
+	}
+	if m.quick.input.Value() != "" {
+		t.Fatal("input should stay empty when no image is present")
 	}
 }
 


### PR DESCRIPTION
## What

Adds `Ctrl+V` in the quick-prompt bar to attach a clipboard image. The image is written to a temp file and its local path is inserted into the prompt, so the agent in the target session opens it on submit.

## Why provider-agnostic

Agent-manager spawns agents in local tmux on the same host, so any file the TUI writes is readable by the agent. Passing the image as a local path in the prompt text means every provider (claude, codex, grok, opencode, and future tools) reads it with no per-tool config.

## How

- New `internal/clipboard` package: `ReadImage()` reads the OS clipboard image, `SaveToTemp()` writes it under a shared pastes dir.
  - macOS: `osascript` coerces the clipboard to PNG.
  - Linux: `wl-paste` (Wayland) or `xclip` (X11), whichever is installed.
  - `goos` / `lookPath` / `runCmd` are injectable so tests drive every branch without a real clipboard.
- `handleQuickKey` intercepts `ctrl+v` and calls `attachQuickImage`, which surfaces a clear error on an empty clipboard, a missing Linux tool, or an unsupported OS.
- Help modal documents the keybind.

## Verification

- `go test ./...` passes.
- macOS clipboard read verified live end-to-end: a PNG on the clipboard is written byte-identical; a text clipboard errors and returns `ErrNoImage` with no file created.

## Scope

One image per paste, macOS + Linux. No drag-drop, Windows, or inline thumbnail.