### PR TITLE
feat: add CPU/GPU temperature readings to Computer stats

### DIFF
--- a/internal/sysstat/sysstat.go
+++ b/internal/sysstat/sysstat.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shirou/gopsutil/v4/disk"
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/shirou/gopsutil/v4/net"
+	"github.com/shirou/gopsutil/v4/sensors"
 )
 
 type Snapshot struct {
@@ -29,6 +30,12 @@ type Snapshot struct {
 	NetSent     uint64
 	NetRecv     uint64
 	NetOK       bool
+	CPUTemp     float64
+	CPUTempOK   bool
+	GPUTemp     float64
+	GPUTempOK   bool
+	SoCTemp     float64
+	SoCTempOK   bool
 }
 
 type ProcStat struct {
@@ -78,7 +85,67 @@ func Sample(diskPath string) Snapshot {
 		snap.NetOK = true
 	}
 
+	sampleTemps(&snap)
+
 	return snap
+}
+
+// sampleTemps categorizes hardware temperature sensors into CPU and GPU
+// readings. Sensor names differ by platform: Intel Macs expose SMC keys
+// (TC0D/TG0D), Linux exposes hwmon labels (coretemp/amdgpu), and Apple
+// Silicon exposes only unlabeled per-chiplet die temperatures. When no
+// CPU/GPU split is available (Apple Silicon), the hottest die temperature
+// is reported as a single SoC reading. Each category keeps the hottest
+// matching sensor.
+func sampleTemps(snap *Snapshot) {
+	temps, err := sensors.SensorsTemperatures()
+	if err != nil || len(temps) == 0 {
+		return
+	}
+	var cpu, gpu, die float64
+	for _, sensor := range temps {
+		if sensor.Temperature <= 0 {
+			continue
+		}
+		key := strings.ToLower(sensor.SensorKey)
+		switch {
+		case isGPUSensor(key):
+			if sensor.Temperature > gpu {
+				gpu = sensor.Temperature
+			}
+			snap.GPUTempOK = true
+		case isCPUSensor(key):
+			if sensor.Temperature > cpu {
+				cpu = sensor.Temperature
+			}
+			snap.CPUTempOK = true
+		case strings.Contains(key, "tdie"):
+			if sensor.Temperature > die {
+				die = sensor.Temperature
+			}
+		}
+	}
+	snap.CPUTemp = cpu
+	snap.GPUTemp = gpu
+	if !snap.CPUTempOK && !snap.GPUTempOK && die > 0 {
+		snap.SoCTemp = die
+		snap.SoCTempOK = true
+	}
+}
+
+func isGPUSensor(key string) bool {
+	return strings.Contains(key, "gpu") ||
+		strings.Contains(key, "tg0") ||
+		strings.Contains(key, "nvidia") ||
+		strings.Contains(key, "radeon")
+}
+
+func isCPUSensor(key string) bool {
+	return strings.Contains(key, "cpu") ||
+		strings.Contains(key, "tc0") ||
+		strings.Contains(key, "coretemp") ||
+		strings.Contains(key, "k10temp") ||
+		strings.Contains(key, "package")
 }
 
 // Trees reports the combined CPU and resident memory of each requested

--- a/internal/sysstat/sysstat_test.go
+++ b/internal/sysstat/sysstat_test.go
@@ -13,6 +13,42 @@ func TestSample(t *testing.T) {
 	if snap.DiskOK && snap.DiskTotal == 0 {
 		t.Fatal("disk reported OK but total is zero")
 	}
+	if snap.CPUTempOK && snap.CPUTemp <= 0 {
+		t.Fatal("cpu temp reported OK but not positive")
+	}
+	if snap.GPUTempOK && snap.GPUTemp <= 0 {
+		t.Fatal("gpu temp reported OK but not positive")
+	}
+	if snap.SoCTempOK && snap.SoCTemp <= 0 {
+		t.Fatal("soc temp reported OK but not positive")
+	}
+	if snap.SoCTempOK && (snap.CPUTempOK || snap.GPUTempOK) {
+		t.Fatal("soc temp should only be set when cpu/gpu split is unavailable")
+	}
+}
+
+func TestSensorCategories(t *testing.T) {
+	gpuKeys := []string{"tg0d", "gpu 0", "amdgpu", "nvidia gpu", "radeon"}
+	for _, key := range gpuKeys {
+		if !isGPUSensor(key) {
+			t.Fatalf("expected %q to be a GPU sensor", key)
+		}
+		if isCPUSensor(key) {
+			t.Fatalf("expected %q not to be a CPU sensor", key)
+		}
+	}
+	cpuKeys := []string{"tc0d", "cpu 0", "coretemp_packageid0", "k10temp", "package id 0"}
+	for _, key := range cpuKeys {
+		if !isCPUSensor(key) {
+			t.Fatalf("expected %q to be a CPU sensor", key)
+		}
+	}
+	dieKeys := []string{"pmu tdie1", "pmu2 tdie8"}
+	for _, key := range dieKeys {
+		if isCPUSensor(key) || isGPUSensor(key) {
+			t.Fatalf("apple silicon die key %q should be neither cpu nor gpu", key)
+		}
+	}
 }
 
 func TestTreesSelf(t *testing.T) {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -171,6 +171,20 @@ func (m *Model) viewComputer(width int) string {
 	}
 	b.WriteString(meter("disk", snap.DiskPercent, snap.DiskOK,
 		humanBytes(snap.DiskTotal-snap.DiskUsed)+" free"))
+	var temps []string
+	if snap.CPUTempOK {
+		temps = append(temps, fmt.Sprintf("cpu %.0f°C", snap.CPUTemp))
+	}
+	if snap.GPUTempOK {
+		temps = append(temps, fmt.Sprintf("gpu %.0f°C", snap.GPUTemp))
+	}
+	if snap.SoCTempOK {
+		temps = append(temps, fmt.Sprintf("soc %.0f°C", snap.SoCTemp))
+	}
+	if len(temps) > 0 {
+		b.WriteString(labelStyle.Width(5).Render("temp") +
+			valueStyle.Render(strings.Join(temps, "  ")) + "\n")
+	}
 	if m.netRates {
 		b.WriteString(labelStyle.Width(5).Render("net") +
 			valueStyle.Render("↓ "+humanBytes(m.netDown)+"/s") +


### PR DESCRIPTION
## What

Adds hardware temperature readings to the **Computer** gauge block in the Sessions panel.

## How

- `sysstat.Sample` now calls `gopsutil/v4/sensors` (already a dependency) — pure Go, no sudo, no CGO.
- Sensors are categorized into CPU / GPU by name, which differs per platform:
  - **macOS Intel**: SMC keys `TC0D` (CPU), `TG0D` (GPU) — clean split.
  - **Linux**: hwmon labels `coretemp`/`k10temp` (CPU), `amdgpu`/`nvidia` (GPU).
  - **macOS Apple Silicon**: exposes only unlabeled per-chiplet die temps, so the hottest die is shown as a single `soc` reading. A real CPU/GPU split there requires the private IOReport framework, which this stays clear of.
- Rendered as a `temp` line (e.g. `cpu 58°C  gpu 61°C`, or `soc 59°C` on Apple Silicon). The line is omitted when no usable sensor is present.

## Verification

- `go build ./...`, `go vet`, `go test ./internal/sysstat/...` all pass.
- Ran `Sample` on this Apple Silicon Mac: reports `soc 59°C`, no false cpu/gpu split.
- Sampling cost ~64ms/call against a 2s background poll.