### PR TITLE
feat: show pasted images as a name chip, not a raw path

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -663,11 +663,11 @@ func (m *Model) renameGroupLocally(old, newPath, dir string) {
 // image; tests swap it for a fake.
 var captureClipboardImage = clipboard.ReadImage
 
-// attachQuickImage saves a clipboard image to a temp file and inserts its
-// path into the prompt, so the agent in the target session can open it. It
-// reports whether it handled the keypress: an empty clipboard returns false
-// so the caller can fall back to a plain text paste, while a real failure is
-// surfaced through m.err.
+// attachQuickImage saves a clipboard image to a temp file and records it as
+// an attachment shown beside the prompt; its path is appended to the message
+// on submit so the agent can open it. It reports whether it handled the
+// keypress: an empty clipboard returns false so the caller can fall back to a
+// plain text paste, while a real failure is surfaced through m.err.
 func (m *Model) attachQuickImage() bool {
 	data, ext, err := captureClipboardImage()
 	if err != nil {
@@ -682,13 +682,23 @@ func (m *Model) attachQuickImage() bool {
 		m.err = err.Error()
 		return true
 	}
-	// InsertString alone leaves the viewport where it was; a no-op Update
-	// runs repositionView so the inserted path scrolls into view.
-	m.quick.input.SetHeight(quickBarMaxRows)
-	m.quick.input.InsertString(" " + path + " ")
-	m.quick.input, _ = m.quick.input.Update(nil)
+	m.quick.attachments = append(m.quick.attachments, path)
 	m.err = ""
 	return true
+}
+
+// quickMessage is the text delivered on submit: the typed prompt with any
+// attachment paths appended so the target agent can open them.
+func (m *Model) quickMessage() string {
+	text := strings.TrimSpace(m.quick.input.Value())
+	if len(m.quick.attachments) == 0 {
+		return text
+	}
+	paths := strings.Join(m.quick.attachments, " ")
+	if text == "" {
+		return paths
+	}
+	return text + " " + paths
 }
 
 func (m *Model) openQuickMode() {
@@ -769,7 +779,7 @@ func (m *Model) submitQuick() (tea.Model, tea.Cmd) {
 		m.err = "nothing selected"
 		return m, nil
 	}
-	text := strings.TrimSpace(m.quick.input.Value())
+	text := m.quickMessage()
 	if text == "" {
 		m.err = "prompt cannot be empty"
 		return m, nil
@@ -788,6 +798,7 @@ func (m *Model) submitQuick() (tea.Model, tea.Cmd) {
 	// The prompt is delivered: clear the input before anything else can
 	// fail, so a retry cannot send it twice.
 	m.quick.input.SetValue("")
+	m.quick.attachments = nil
 	m.err = ""
 	// A queued answer means the user expects a fresh finished alert.
 	if err := m.store.SetAcked(entry.sess.ID, false); err != nil {
@@ -818,6 +829,7 @@ func (m *Model) quickSpawn(group, prompt string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.quick.input.SetValue("")
+	m.quick.attachments = nil
 	m.err = ""
 	return m, m.refreshCmd()
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -116,10 +116,11 @@ type renameTarget struct {
 // across cursor moves, so the target follows the selection. The tool is
 // the spawn CLI for group targets, cycled with tab.
 type quickState struct {
-	active    bool
-	input     textarea.Model
-	toolNames []string
-	toolIndex int
+	active      bool
+	input       textarea.Model
+	toolNames   []string
+	toolIndex   int
+	attachments []string
 }
 
 type settingsState struct {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -990,7 +990,7 @@ func TestQuickPromptSendClearsAcked(t *testing.T) {
 	}
 }
 
-func TestQuickAttachImageInsertsPath(t *testing.T) {
+func TestQuickAttachImageRecordsAttachmentNotInput(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "answer-me", t.TempDir(), "")
 	m.selectSessionRow(t, "answer-me")
@@ -1008,18 +1008,54 @@ func TestQuickAttachImageInsertsPath(t *testing.T) {
 	if m.err != "" {
 		t.Fatalf("attach: %q", m.err)
 	}
-	value := strings.TrimSpace(m.quick.input.Value())
-	if value == "" {
-		t.Fatal("expected the image path to be inserted")
+	if m.quick.input.Value() != "" {
+		t.Fatal("the path should stay out of the typed input")
 	}
-	data, err := os.ReadFile(value)
+	if len(m.quick.attachments) != 1 {
+		t.Fatalf("want 1 attachment, got %d", len(m.quick.attachments))
+	}
+	path := m.quick.attachments[0]
+	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("inserted path is not a readable file: %v", err)
+		t.Fatalf("attachment path is not a readable file: %v", err)
 	}
 	if string(data) != "png-bytes" {
 		t.Fatalf("temp file holds %q", data)
 	}
-	os.Remove(value)
+	os.Remove(path)
+}
+
+func TestQuickAttachmentChipShowsBasename(t *testing.T) {
+	m := buildModel(t)
+	if got := m.quickAttachmentChip(80); got != "" {
+		t.Fatalf("no attachments should render nothing, got %q", got)
+	}
+	m.quick.attachments = []string{"/tmp/agent-manager-pastes/paste-123.png"}
+	chip := m.quickAttachmentChip(80)
+	if !strings.Contains(chip, "paste-123.png") {
+		t.Fatalf("chip should show the file name, got %q", chip)
+	}
+	if strings.Contains(chip, "/tmp/") {
+		t.Fatalf("chip should not show the full path, got %q", chip)
+	}
+}
+
+func TestQuickMessageAppendsAttachmentPaths(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "answer-me", t.TempDir(), "")
+	m.selectSessionRow(t, "answer-me")
+	m.openQuickMode()
+
+	m.quick.input.SetValue("look at this")
+	m.quick.attachments = []string{"/tmp/a.png", "/tmp/b.png"}
+	if got := m.quickMessage(); got != "look at this /tmp/a.png /tmp/b.png" {
+		t.Fatalf("compose = %q", got)
+	}
+
+	m.quick.input.SetValue("")
+	if got := m.quickMessage(); got != "/tmp/a.png /tmp/b.png" {
+		t.Fatalf("image-only compose = %q", got)
+	}
 }
 
 func TestQuickAttachImageNoImageFallsThrough(t *testing.T) {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -392,7 +393,25 @@ func (m *Model) viewQuickBar(width int) string {
 	}
 	m.quick.input.SetWidth(width)
 	m.quick.input.SetHeight(m.quickBarRows(width - 2))
-	return divider("Quick Prompt · "+target, width) + "\n" + m.quick.input.View()
+	bar := divider("Quick Prompt · "+target, width) + "\n" + m.quick.input.View()
+	if chip := m.quickAttachmentChip(width); chip != "" {
+		bar += "\n" + chip
+	}
+	return bar
+}
+
+// quickAttachmentChip renders the pasted images docked under the prompt as
+// a muted line of file names, so the raw temp paths stay out of the input.
+func (m *Model) quickAttachmentChip(width int) string {
+	if len(m.quick.attachments) == 0 {
+		return ""
+	}
+	names := make([]string, len(m.quick.attachments))
+	for i, path := range m.quick.attachments {
+		names[i] = filepath.Base(path)
+	}
+	line := "📎 " + strings.Join(names, "  ")
+	return mutedStyle.Render(ansi.Truncate(line, max(width, 1), "…"))
 }
 
 const quickBarMaxRows = 5


### PR DESCRIPTION
## What

Follow-up to #33. Pasting an image no longer dumps a long temp path into the quick-prompt input. Instead the image is recorded as an attachment and shown under the prompt as a muted `📎 name.png` chip.

## How

- `quickState` gains an `attachments []string`.
- `attachQuickImage` appends the temp-file path to `attachments` instead of inserting it into the textarea.
- `quickMessage` composes the delivered text: typed prompt + attachment paths, so the agent still opens the files. Submitting with only an image (no text) is allowed.
- `quickAttachmentChip` renders the file names (not the paths) under the input.
- Attachments clear after a successful send or spawn.

## Verification

`go test ./...` passes, including new tests for attachment recording, chip rendering (name shown, path hidden), and message composition.

## Before / after

Before: `/var/folders/.../paste-1207593156.png` typed inline in the prompt.
After: prompt stays clean; `📎 paste-1207593156.png` chip shown below it.