### PR TITLE
fix: stop review listing entries it cannot diff

### DIFF
--- a/docs/superpowers/plans/2026-07-20-diff-noise.md
+++ b/docs/superpowers/plans/2026-07-20-diff-noise.md
@@ -396,10 +396,10 @@ Expected: the command prints the new pull request URL
 
 ## Self-Review
 
-**Spec coverage.** The spec's Phase 1 lists three defects. Untracked directories map to Task 1, missing line counts to Task 2, binary labelling to Task 3. The spec's claim that header totals correct themselves is verified in Task 3 Step 5 and stated in the PR body. The spec's Phase 1 test list maps to the tests in Tasks 1 through 3, plus the real-repository check in Task 4.
+**Spec coverage.** The spec's Phase 1 lists three defects. Untracked directories map to Task 1, missing line counts to Task 2, binary labelling to Task 3. The spec's claim about header totals is verified by `TestHeaderTotalStableWithoutLazyLoad` in `internal/diff/diff_test.go`, which asserts every listed file carries its stat straight out of `BuildSet`, past the eager-load cap and with no lazy load, so the total the header sums is correct on the first paint and does not drift as the user scrolls. The spec's Phase 1 test list maps to the tests in Tasks 1 through 3, plus the real-repository check in Task 4.
 
 **Placeholders.** Every code step carries the actual code. No TBD, no "handle edge cases", no "similar to Task N".
 
-**Type consistency.** `countStat` returns `git.FileStat` and is called only from `loadFile`. `statKnown` is written in `BuildSet` and read in `loadFile`, both in package `diff`. `ChangedFile.Path` is the field filtered in Task 1 and asserted in its test. `FileDiff.Binary` is set in `loadFile` and read in `viewDiffFileList`.
+**Type consistency.** `Driver.CountWorkingLines` returns `git.LineCount` and is called only from `countUnknownStat`, which runs in `BuildSet` and writes `git.FileStat`. `statKnown` is written in `BuildSet`, preserved across `loadFile`, and read through `FileDiff.StatKnown` in `viewDiffFileList`. `ChangedFile.Path` is the field filtered in Task 1 and asserted in its test. `FileDiff.Binary` is set in `loadFile` and read in `viewDiffFileList`.
 
 One gap found and closed: Task 2's test needs `testRepo`/`write`/`commit` helpers, which live in `internal/git/git_test.go` and may not exist in `internal/diff/diff_test.go`. Step 1 now says to copy them if missing.

--- a/docs/superpowers/plans/2026-07-20-diff-noise.md
+++ b/docs/superpowers/plans/2026-07-20-diff-noise.md
@@ -226,6 +226,12 @@ git add internal/diff/diff.go internal/diff/diff_test.go
 git commit -m "fix: count lines for untracked files instead of showing zero"
 ```
 
+**Final implementation:** the shipped code counts newlines from the raw working-tree bytes in `countUnknownStat` at `BuildSet` time, not from `fd.Lines` in `loadFile`. Deriving the stat from the diff model reported a wrong number for any file past `maxFileLines`/`maxFileBytes`, because those caps truncate `Lines` before the count is taken; the raw byte scan stays correct at any size.
+
+The scan is bounded by `maxCountBytes` (8 MiB) in `internal/git/git.go`, so a pathological file degrades to a `?` marker instead of being re-scanned on every ~2s poll. `git.LineCount` carries `Counted` to distinguish "counted zero" from "not counted", and `FileDiff.statKnown` drives the `?` render. A read error on the file surfaces on `FileDiff.Err` and keeps the review open rather than failing the whole set.
+
+The count runs only for `git.Untracked` files: `git diff --numstat` covers every path `--name-status` lists, so tracked files in every scope always have a real stat, and the working tree is the wrong side to read for the staged, last-commit, and branch scopes.
+
 ---
 
 ### Task 3: Label binary files in the review list

--- a/docs/superpowers/plans/2026-07-20-diff-noise.md
+++ b/docs/superpowers/plans/2026-07-20-diff-noise.md
@@ -1,0 +1,405 @@
+# Diff Noise Implementation Plan (Phase 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop full-screen review from listing entries it cannot diff, and give untracked files real line counts instead of `+0 −0`.
+
+**Architecture:** Three isolated changes down the existing pipeline. `git.ChangedFiles` stops emitting untracked directories. `diff.loadFile` derives a file's stat from the diff it just built when `numstat` had no entry for it. The review file list renders `binary` where a byte-count is meaningless.
+
+**Tech Stack:** Go, `charmbracelet/bubbletea` + `lipgloss` for the TUI, the `git` CLI shelled out from `internal/git`.
+
+## Global Constraints
+
+- Work in the worktree `/tmp/am-rev` on branch `feat/review-ux`. Several agent sessions share the main checkout.
+- Stage explicit paths. Never `git add -A`.
+- Zero code comments unless a non-obvious WHY needs recording. Never describe WHAT the code does.
+- No AI attribution in commit messages.
+- `gofmt` clean, `go vet ./...` clean, `go test ./...` green before each commit.
+- Spec: `docs/superpowers/specs/2026-07-20-review-target-and-noise-design.md`
+
+---
+
+### Task 1: Drop untracked directories
+
+`git ls-files --others` emits a nested repository or worktree as a directory path with a trailing slash, because git will not descend into another repository. Those rows reach review as files, render `+0 −0`, and cannot be opened.
+
+**Files:**
+- Modify: `internal/git/git.go` (the `ScopeUncommitted` block in `ChangedFiles`, around line 272)
+- Test: `internal/git/git_test.go`
+
+**Interfaces:**
+- Consumes: `testRepo(t)`, `write(t, dir, name, content)`, `commit(t, dir, message)` — existing helpers in `git_test.go`.
+- Produces: no signature change. `ChangedFiles(root string, scope Scope, baseRef string) ([]ChangedFile, error)` keeps its shape and stops returning directory rows.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/git/git_test.go`:
+
+```go
+func TestChangedFilesSkipsNestedRepoDirectories(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "tracked.go", "package a\n")
+	commit(t, dir, "init")
+	write(t, dir, "untracked.go", "package a\n\nfunc B() {}\n")
+	initRepoAt(t, filepath.Join(dir, "nested"))
+
+	files, err := driver.ChangedFiles(dir, ScopeUncommitted, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file.Path, "/") {
+			t.Fatalf("directory entry leaked into the file list: %q", file.Path)
+		}
+		if file.Path == "nested" {
+			t.Fatal("nested repository should not be listed")
+		}
+	}
+	found := false
+	for _, file := range files {
+		if file.Path == "untracked.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("untracked file should still be listed, got %+v", files)
+	}
+}
+```
+
+Add `"strings"` to the test file's imports if it is not already there.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /tmp/am-rev && go test ./internal/git/ -run TestChangedFilesSkipsNestedRepoDirectories -v`
+Expected: FAIL with `directory entry leaked into the file list: "nested/"`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/git/git.go`, replace the untracked loop inside `ChangedFiles`:
+
+```go
+	if scope == ScopeUncommitted {
+		untracked, err := d.run(root, "ls-files", "--others", "--exclude-standard", "-z")
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range splitNUL(untracked) {
+			// git reports a nested repository as a directory it will not
+			// descend into; there is nothing to diff and its changes belong
+			// to that repository's own review.
+			if strings.HasSuffix(path, "/") {
+				continue
+			}
+			files = append(files, ChangedFile{Path: path, OldPath: path, Status: Untracked})
+		}
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /tmp/am-rev && go test ./internal/git/ -v`
+Expected: PASS, including the pre-existing `TestUncommittedScope`
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/am-rev
+git add internal/git/git.go internal/git/git_test.go
+git commit -m "fix: drop untracked directories from the review file list"
+```
+
+---
+
+### Task 2: Derive line counts for untracked files
+
+`BuildSet` reads each file's stat from the `numstat` map. `git diff --numstat` covers only tracked changes, so untracked files take the zero value and render `+0 −0`. When a file has no `numstat` entry, count the `Add` and `Del` lines of the diff that was just built.
+
+The count is derived only when `numstat` had no entry. A capped file's `Lines` are truncated, so for tracked files `numstat` stays authoritative.
+
+**Files:**
+- Modify: `internal/diff/diff.go` (`FileDiff` struct, `BuildSet` around line 100, `loadFile` around line 125)
+- Test: `internal/diff/diff_test.go`
+
+**Interfaces:**
+- Consumes: `git.FileStat{Adds, Dels int; Binary bool}`, `Line{Kind LineKind}` with kinds `Add`, `Del`, `Same` — all already defined.
+- Produces: `FileDiff` gains an unexported `statKnown bool` field, set by `BuildSet` from a comma-ok map read and consumed by `loadFile`. No exported signature changes.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/diff/diff_test.go`:
+
+```go
+func TestUntrackedFileGetsLineCount(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "tracked.go", "package a\n")
+	commit(t, dir, "init")
+	write(t, dir, "new.go", "package a\n\nfunc B() {}\n")
+	write(t, dir, "empty.go", "")
+
+	set, err := BuildSet(driver, dir, git.ScopeUncommitted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPath := map[string]FileDiff{}
+	for _, fd := range set.Files {
+		byPath[fd.File.Path] = fd
+	}
+	if got := byPath["new.go"].Stat.Adds; got != 3 {
+		t.Errorf("new.go adds = %d, want 3", got)
+	}
+	if got := byPath["new.go"].Stat.Dels; got != 0 {
+		t.Errorf("new.go dels = %d, want 0", got)
+	}
+	if got := byPath["empty.go"].Stat.Adds; got != 0 {
+		t.Errorf("empty.go adds = %d, want 0", got)
+	}
+}
+```
+
+If `testRepo`, `write`, and `commit` do not exist in `internal/diff/diff_test.go`, copy the versions from `internal/git/git_test.go` into it, renaming nothing.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /tmp/am-rev && go test ./internal/diff/ -run TestUntrackedFileGetsLineCount -v`
+Expected: FAIL with `new.go adds = 0, want 3`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/diff/diff.go`, add the field to `FileDiff` (next to the existing `Err error` field):
+
+```go
+	statKnown bool
+```
+
+In `BuildSet`, replace the loop body that builds each `FileDiff`:
+
+```go
+	for i, file := range files {
+		stat, known := stats[file.Path]
+		fd := FileDiff{File: file, Stat: stat, statKnown: known}
+		if i < maxEagerFiles {
+			loadFile(driver, repo.Root, scope, baseRef, &fd)
+		}
+		set.Files = append(set.Files, fd)
+	}
+```
+
+In `loadFile`, replace the final `BuildFile` line:
+
+```go
+	known := fd.statKnown
+	*fd = BuildFile(oldContent, newContent, fd.File, fd.Stat)
+	fd.statKnown = known
+	if !known {
+		fd.Stat = countStat(fd.Lines)
+	}
+```
+
+Add the helper below `loadFile`:
+
+```go
+func countStat(lines []Line) git.FileStat {
+	var stat git.FileStat
+	for _, line := range lines {
+		switch line.Kind {
+		case Add:
+			stat.Adds++
+		case Del:
+			stat.Dels++
+		}
+	}
+	return stat
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /tmp/am-rev && go test ./internal/diff/ -v`
+Expected: PASS, including pre-existing tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/am-rev
+git add internal/diff/diff.go internal/diff/diff_test.go
+git commit -m "fix: count lines for untracked files instead of showing zero"
+```
+
+---
+
+### Task 3: Label binary files in the review list
+
+A binary file has no line counts, so `+0 −0` reads as "no changes" rather than "not countable". `loadFile` already sets `Binary`; the list just needs to render it.
+
+**Files:**
+- Modify: `internal/ui/diffview.go` (`viewDiffFileList`, the `counts` assignment around line 1119)
+- Test: `internal/ui/review_regression_test.go`
+
+**Interfaces:**
+- Consumes: `FileDiff.Binary bool` from `internal/diff`, `mutedStyle` and `colorFinished`/`colorErrored` styles already defined in the `ui` package.
+- Produces: no signature change. `viewDiffFileList(width, height int) string` renders `binary` in place of the counts for binary rows.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/ui/review_regression_test.go`:
+
+```go
+func TestBinaryFileShowsBinaryNotZeroCounts(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	dir := gitRepoWithTwoChangedFiles(t)
+	if err := os.WriteFile(filepath.Join(dir, "logo.png"), []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\x00binary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	openReviewOn(t, m, "binary", dir)
+
+	rendered := m.viewDiffFileList(60, 20)
+	if !strings.Contains(rendered, "binary") {
+		t.Fatalf("binary file should be labelled binary, got:\n%s", rendered)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /tmp/am-rev && go test ./internal/ui/ -run TestBinaryFileShowsBinaryNotZeroCounts -v`
+Expected: FAIL with `binary file should be labelled binary`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/ui/diffview.go`, replace the `counts` assignment inside `viewDiffFileList`:
+
+```go
+		counts := lipgloss.NewStyle().Foreground(colorFinished).Render(fmt.Sprintf("+%d", fd.Stat.Adds)) +
+			" " + lipgloss.NewStyle().Foreground(colorErrored).Render(fmt.Sprintf("−%d", fd.Stat.Dels))
+		if fd.Binary {
+			counts = mutedStyle.Render("binary")
+		}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /tmp/am-rev && go test ./internal/ui/ -v -run 'TestBinary|TestReview|TestDiff'`
+Expected: PASS
+
+- [ ] **Step 5: Verify the whole suite and formatting**
+
+Run:
+```bash
+cd /tmp/am-rev
+gofmt -l internal/
+go vet ./...
+go test ./...
+```
+Expected: `gofmt` prints nothing, `go vet` prints nothing, every package reports `ok`
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /tmp/am-rev
+git add internal/ui/diffview.go internal/ui/review_regression_test.go
+git commit -m "fix: label binary files in the review list"
+```
+
+---
+
+### Task 4: Verify against the real repository and open the PR
+
+The bug was found on `mreshet/servers/gma2_master_node`, which has four nested worktree directories and several untracked screenshots. Confirm the fix there before opening the PR.
+
+**Files:**
+- No source changes. Verification and PR only.
+
+**Interfaces:**
+- Consumes: the `ChangedFiles` behaviour from Task 1 and the stats from Task 2.
+- Produces: a pull request against `main`.
+
+- [ ] **Step 1: Confirm the nested directories are gone**
+
+Run:
+```bash
+cd /tmp/am-rev
+cat > internal/git/zz_real_test.go <<'EOF'
+package git
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestZZRealRepo(t *testing.T) {
+	d, _ := New()
+	files, err := d.ChangedFiles("/Users/yoan/Desktop/projects/mreshet/servers/gma2_master_node", ScopeUncommitted, "")
+	if err != nil {
+		t.Skip(err)
+	}
+	for _, f := range files {
+		if strings.HasSuffix(f.Path, "/") {
+			t.Errorf("directory still listed: %s", f.Path)
+		}
+	}
+	fmt.Printf("%d entries, none of them directories\n", len(files))
+}
+EOF
+go test ./internal/git/ -run TestZZRealRepo -v
+rm internal/git/zz_real_test.go
+```
+Expected: no `directory still listed` errors, and the count drops from 20 by the four `.worktrees/GMN-*` rows
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+cd /tmp/am-rev
+git push -u origin feat/review-ux
+```
+
+- [ ] **Step 3: Open the pull request**
+
+```bash
+cd /tmp/am-rev
+gh pr create --title "fix: stop review listing entries it cannot diff" --body "$(cat <<'BODY'
+## Problem
+
+Review listed 20 files for a session where only 2 had reviewable changes. The other 18 rendered `+0 −0`:
+
+- `.worktrees/GMN-3117/` and three siblings are **directories**. `git ls-files --others` reports a nested repository as a directory because git will not descend into another repo. There is nothing to diff.
+- Untracked screenshots are **binary**, so no line counts exist.
+- Untracked text files showed `+0 −0` too, because `git diff --numstat` covers only tracked changes.
+
+The header total was wrong for the same reason: "20 files · +8 −4" counted only the 2 tracked files.
+
+## Fix
+
+- Skip untracked directory entries; a nested repo's changes belong to its own review.
+- When a file has no `numstat` entry, derive its counts from the diff just built. Tracked files keep using `numstat`, which stays authoritative for capped files.
+- Render `binary` instead of `+0 −0` where a line count is meaningless.
+
+Header totals correct themselves once the per-file stats are right.
+
+## Tests
+
+- A nested repository is omitted while untracked files are still listed.
+- An untracked text file reports its line count; an empty one stays at `+0 −0`.
+- A binary file is labelled `binary`.
+
+Full suite, `go vet`, `gofmt` clean.
+BODY
+)"
+```
+Expected: the command prints the new pull request URL
+
+---
+
+## Self-Review
+
+**Spec coverage.** The spec's Phase 1 lists three defects. Untracked directories map to Task 1, missing line counts to Task 2, binary labelling to Task 3. The spec's claim that header totals correct themselves is verified in Task 3 Step 5 and stated in the PR body. The spec's Phase 1 test list maps to the tests in Tasks 1 through 3, plus the real-repository check in Task 4.
+
+**Placeholders.** Every code step carries the actual code. No TBD, no "handle edge cases", no "similar to Task N".
+
+**Type consistency.** `countStat` returns `git.FileStat` and is called only from `loadFile`. `statKnown` is written in `BuildSet` and read in `loadFile`, both in package `diff`. `ChangedFile.Path` is the field filtered in Task 1 and asserted in its test. `FileDiff.Binary` is set in `loadFile` and read in `viewDiffFileList`.
+
+One gap found and closed: Task 2's test needs `testRepo`/`write`/`commit` helpers, which live in `internal/git/git_test.go` and may not exist in `internal/diff/diff_test.go`. Step 1 now says to copy them if missing.

--- a/docs/superpowers/specs/2026-07-20-review-target-and-noise-design.md
+++ b/docs/superpowers/specs/2026-07-20-review-target-and-noise-design.md
@@ -74,7 +74,9 @@ the repo, then set its base.
 
 Both validate before writing and fail loudly rather than storing something the
 review cannot use. `review-repo` requires a path that resolves to a git repo
-root; `review-base` requires a ref that resolves in the active repo.
+root. `review-base` requires a ref that resolves in the repo review would
+currently use for that session: the declared `review_repo` when set, otherwise
+the top of the dirty-first ranking.
 
 ### Storage
 
@@ -100,8 +102,8 @@ back, so the header never claims a comparison that did not happen.
 ### Pickers
 
 `r` opens a repo picker instead of cycling: the repos found under the session
-directory, filtered as you type, enter to select. A second key opens a branch
-picker over `refs/heads` and `refs/remotes` for the active repo, with the cursor
+directory, filtered as you type, enter to select. `b` opens a branch picker over
+`refs/heads` and `refs/remotes` for the active repo, with the cursor
 starting on the current base and an `auto` entry that clears the stored ref back
 to auto-detection.
 

--- a/docs/superpowers/specs/2026-07-20-review-target-and-noise-design.md
+++ b/docs/superpowers/specs/2026-07-20-review-target-and-noise-design.md
@@ -1,0 +1,150 @@
+# Review target and diff noise — design
+
+Two changes to full-screen review: let the agent declare what it is working on
+(repo and base branch) instead of making the human hunt for it, and stop listing
+entries that cannot be reviewed.
+
+## Problem
+
+Review currently guesses, and the guesses are noisy.
+
+A session's working directory is often an umbrella folder holding many repos
+(`mreshet` holds 20). Review ranks them and opens on the most-active one, with
+`r` cycling to the next. Cycling 20 repos to find the one the agent touched is
+backwards: the agent already knows which repo it is working in.
+
+The file list also carries entries that cannot be diffed. `git ls-files
+--others` reports untracked *directories* (a nested repo or worktree, which git
+refuses to descend into) alongside untracked files, and `git diff --numstat`
+covers only tracked changes, so every untracked entry renders as `+0 −0`. A real
+session showed 20 files where 18 were nested worktree directories and untracked
+screenshots, and the header total counted only the 2 tracked files.
+
+Separately, `Ctrl+R` opens review from inside a session but does nothing from the
+session list, where the key is `D`/`x`.
+
+## Decisions
+
+- The base ref persists per session, the way a session's name does, rather than
+  resetting each time review closes.
+- The base ref is stored per session *and* repo, so a sibling repo without that
+  branch keeps its own base.
+- The agent declares the active repo; blind cycling is removed.
+- The human can still change repo and base, through a filtered picker.
+- Selecting a base switches the scope to "vs base".
+
+## Phase 1 — Diff noise
+
+Three defects, all in how untracked entries are collected and counted.
+
+**Untracked directories.** `ChangedFiles` appends every line of `ls-files
+--others --exclude-standard -z` as a file. Git emits a nested repository or
+worktree as a directory path with a trailing slash, since it will not descend
+into another repository. Those entries are dropped: a directory has no content
+to diff, and a nested repo's changes belong to that repo's own review.
+
+**Missing line counts.** `BuildSet` reads each file's stat from the `numstat`
+map. Untracked files never appear there, so they take the zero value and render
+`+0 −0`. When a file's stat is absent, derive it from the diff that was just
+built: count the `Add` and `Del` line kinds. This keeps a genuinely empty file at
+`+0 −0` while giving a new 200-line file its `+200`.
+
+**Binary files.** `loadFile` already sets `Binary`, but the file list renders the
+zero stat as `+0 −0`. Render `binary` for those rows instead.
+
+The header totals are a sum over the file stats, so they correct themselves once
+the stats are right.
+
+## Phase 2 — Review target
+
+### Agent-declared repo and base
+
+Two subcommands, each mirroring `agent-manager rename`: the agent runs them
+inside its session, they resolve the session from `AGENT_MANAGER_SESSION_ID`,
+write a mailbox file, and the poller applies and deletes it.
+
+```
+agent-manager review-repo <path>    # the repo this session is working in
+agent-manager review-base <ref>     # what "vs base" compares against
+```
+
+`review-repo` records an absolute repo root on the session row. `review-base`
+records a ref for the session's currently active repo, so the two compose: set
+the repo, then set its base.
+
+Both validate before writing and fail loudly rather than storing something the
+review cannot use. `review-repo` requires a path that resolves to a git repo
+root; `review-base` requires a ref that resolves in the active repo.
+
+### Storage
+
+`review_repo` is a new column on the session row, alongside the name the rename
+command already writes.
+
+Base refs live in a small `review_bases(session_id, repo_root, base_ref)` table,
+keyed by session and repo. A column cannot express per-repo values, and a JSON
+blob in a column would need parsing on every load.
+
+### Resolving what to review
+
+`diffLoadCmd` resolves the repo in this order: the session's declared
+`review_repo`, then the repo the human picked this session (`repoSel`), then the
+top of the existing dirty-first ranking. The ranking stays as the fallback for
+sessions where nothing has been declared.
+
+For `ScopeBranch`, `BaseRef` uses the stored base for the active repo when one
+exists, and auto-detects `main`/`master`/`origin/HEAD` otherwise. A stored ref
+that no longer resolves surfaces as a review error rather than silently falling
+back, so the header never claims a comparison that did not happen.
+
+### Pickers
+
+`r` opens a repo picker instead of cycling: the repos found under the session
+directory, filtered as you type, enter to select. A second key opens a branch
+picker over `refs/heads` and `refs/remotes` for the active repo, with the cursor
+starting on the current base and an `auto` entry that clears the stored ref back
+to auto-detection.
+
+Both are the same filtered-list component, differing only in the rows they show
+and what selecting a row does. It follows the existing modal patterns (move,
+settings), which already own a mode, a key handler, and a render function.
+
+### Ctrl+R from the list
+
+Bind `ctrl+r` in list mode to open review for the selected session. `D` and `x`
+keep working. Escape returns to the list, as it does today; only the in-session
+path re-attaches to the session, which stays unchanged.
+
+The tmux root binding sends `C-r` through to the pane for any session not named
+`am_*`, so the key reaches the manager's own UI.
+
+## Testing
+
+Phase 1, in `internal/diff` and `internal/git`:
+
+- A repo containing a nested repository lists the tracked changes and omits the
+  nested directory.
+- An untracked text file reports its line count; an untracked empty file stays
+  at `+0 −0`.
+- An untracked binary file is marked binary.
+- Header totals match the sum of the listed files.
+
+Phase 2:
+
+- `review-repo` and `review-base` reject a missing session id, a path that is
+  not a repo, and a ref that does not resolve.
+- The poller applies a mailbox file to the session row and deletes it.
+- Review opens on the declared repo even when the ranking would pick another.
+- A stored base drives `vs base`; a base that stops resolving surfaces an error.
+- A base set on one repo does not apply to a sibling repo.
+- The repo picker filters and selects; the branch picker's `auto` entry clears
+  the stored ref.
+- `ctrl+r` from the list opens review on the selected session.
+
+## Sequencing
+
+Phase 1 ships as its own pull request, since it makes review readable again on
+its own. Phase 2 follows.
+
+Work happens in an isolated git worktree off `origin/main`, because several
+agent sessions share this repository's checkout.

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -100,7 +100,7 @@ func BuildSet(driver *git.Driver, cwd string, scope git.Scope) (Set, error) {
 	for i, file := range files {
 		stat, known := stats[file.Path]
 		fd := FileDiff{File: file, Stat: stat, statKnown: known}
-		if !known {
+		if !known && file.Status == git.Untracked {
 			if err := countUnknownStat(driver, repo.Root, &fd); err != nil {
 				fd.Err = err
 				set.Files = append(set.Files, fd)

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -43,6 +43,7 @@ type FileDiff struct {
 	Binary    bool
 	Truncated bool
 	Err       error
+	statKnown bool
 	rows      []Row
 }
 
@@ -97,7 +98,8 @@ func BuildSet(driver *git.Driver, cwd string, scope git.Scope) (Set, error) {
 	}
 
 	for i, file := range files {
-		fd := FileDiff{File: file, Stat: stats[file.Path]}
+		stat, known := stats[file.Path]
+		fd := FileDiff{File: file, Stat: stat, statKnown: known}
 		if i < maxEagerFiles {
 			loadFile(driver, repo.Root, scope, baseRef, &fd)
 		}
@@ -136,7 +138,25 @@ func loadFile(driver *git.Driver, root string, scope git.Scope, baseRef string, 
 		fd.Truncated = true
 		return
 	}
+	known := fd.statKnown
 	*fd = BuildFile(oldContent, newContent, fd.File, fd.Stat)
+	fd.statKnown = known
+	if !known {
+		fd.Stat = countStat(fd.Lines)
+	}
+}
+
+func countStat(lines []Line) git.FileStat {
+	var stat git.FileStat
+	for _, line := range lines {
+		switch line.Kind {
+		case Add:
+			stat.Adds++
+		case Del:
+			stat.Dels++
+		}
+	}
+	return stat
 }
 
 func fileSides(driver *git.Driver, root string, scope git.Scope, baseRef string, file git.ChangedFile) (oldContent, newContent []byte, err error) {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -100,6 +100,11 @@ func BuildSet(driver *git.Driver, cwd string, scope git.Scope) (Set, error) {
 	for i, file := range files {
 		stat, known := stats[file.Path]
 		fd := FileDiff{File: file, Stat: stat, statKnown: known}
+		if !known {
+			if err := countUnknownStat(driver, repo.Root, &fd); err != nil {
+				return Set{}, err
+			}
+		}
 		if i < maxEagerFiles {
 			loadFile(driver, repo.Root, scope, baseRef, &fd)
 		}
@@ -141,23 +146,25 @@ func loadFile(driver *git.Driver, root string, scope git.Scope, baseRef string, 
 	known := fd.statKnown
 	*fd = BuildFile(oldContent, newContent, fd.File, fd.Stat)
 	fd.statKnown = known
-	if !known {
-		fd.Stat = countStat(fd.Lines)
-	}
 }
 
-func countStat(lines []Line) git.FileStat {
-	var stat git.FileStat
-	for _, line := range lines {
-		switch line.Kind {
-		case Add:
-			stat.Adds++
-		case Del:
-			stat.Dels++
-		}
+// Counting raw bytes keeps untracked files correct past the diff model's caps.
+func countUnknownStat(driver *git.Driver, root string, fd *FileDiff) error {
+	count, err := driver.CountWorkingLines(root, fd.File.Path)
+	if err != nil {
+		return err
 	}
-	return stat
+	if !count.Counted {
+		return nil
+	}
+	fd.statKnown = true
+	fd.Stat = git.FileStat{Adds: count.Lines, Binary: count.Binary}
+	fd.Binary = count.Binary
+	return nil
 }
+
+// StatKnown reports whether Stat holds a real count rather than an unknown one.
+func (fd *FileDiff) StatKnown() bool { return fd.statKnown }
 
 func fileSides(driver *git.Driver, root string, scope git.Scope, baseRef string, file git.ChangedFile) (oldContent, newContent []byte, err error) {
 	oldRef, newRef := "", ""

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -102,7 +102,9 @@ func BuildSet(driver *git.Driver, cwd string, scope git.Scope) (Set, error) {
 		fd := FileDiff{File: file, Stat: stat, statKnown: known}
 		if !known {
 			if err := countUnknownStat(driver, repo.Root, &fd); err != nil {
-				return Set{}, err
+				fd.Err = err
+				set.Files = append(set.Files, fd)
+				continue
 			}
 		}
 		if i < maxEagerFiles {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,9 +1,11 @@
 package diff
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/YoanWai/agent-manager/internal/git"
@@ -174,7 +176,159 @@ func TestUntrackedFileGetsLineCount(t *testing.T) {
 	if got := byPath["new.go"].Stat.Dels; got != 0 {
 		t.Errorf("new.go dels = %d, want 0", got)
 	}
-	if got := byPath["empty.go"].Stat.Adds; got != 0 {
-		t.Errorf("empty.go adds = %d, want 0", got)
+	empty := byPath["empty.go"]
+	if !empty.StatKnown() {
+		t.Error("empty.go stat should be known, not an unknown count rendered as zero")
+	}
+	if empty.Stat.Adds != 0 || empty.Stat.Dels != 0 {
+		t.Errorf("empty.go stat = %+v, want zero", empty.Stat)
+	}
+}
+
+func linesOf(count int) string {
+	var b strings.Builder
+	for i := 0; i < count; i++ {
+		fmt.Fprintf(&b, "line %d\n", i)
+	}
+	return b.String()
+}
+
+// Regression guard: the capped model would report maxFileLines here.
+func TestUntrackedFileOverLineCapCountsTrueLines(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "tracked.go", "package a\n")
+	commit(t, dir, "init")
+
+	const total = maxFileLines + 2000
+	write(t, dir, "huge.txt", linesOf(total))
+
+	set, err := BuildSet(driver, dir, git.ScopeUncommitted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var huge *FileDiff
+	for i := range set.Files {
+		if set.Files[i].File.Path == "huge.txt" {
+			huge = &set.Files[i]
+		}
+	}
+	if huge == nil {
+		t.Fatal("huge.txt missing from the set")
+	}
+	if !huge.StatKnown() {
+		t.Fatal("huge.txt stat should be known")
+	}
+	if huge.Stat.Adds != total {
+		t.Errorf("huge.txt adds = %d, want %d (the capped model would say %d)", huge.Stat.Adds, total, maxFileLines)
+	}
+	if !huge.Truncated {
+		t.Error("huge.txt should still be marked truncated for display")
+	}
+}
+
+// Regression guard: the byte cap stops the diff model, not the count.
+func TestUntrackedFileOverByteCapStillCounts(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "tracked.go", "package a\n")
+	commit(t, dir, "init")
+
+	line := strings.Repeat("x", 200) + "\n"
+	total := (maxFileBytes / len(line)) + 500
+	write(t, dir, "wide.txt", strings.Repeat(line, total))
+
+	set, err := BuildSet(driver, dir, git.ScopeUncommitted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wide *FileDiff
+	for i := range set.Files {
+		if set.Files[i].File.Path == "wide.txt" {
+			wide = &set.Files[i]
+		}
+	}
+	if wide == nil {
+		t.Fatal("wide.txt missing from the set")
+	}
+	if !wide.StatKnown() {
+		t.Fatal("wide.txt stat should be known")
+	}
+	if wide.Stat.Adds != total {
+		t.Errorf("wide.txt adds = %d, want %d", wide.Stat.Adds, total)
+	}
+	if !wide.Truncated {
+		t.Error("wide.txt should be marked too large to diff")
+	}
+}
+
+// Invariant: numstat wins; the truncated model must not overwrite it.
+func TestTruncatedTrackedFileKeepsNumstat(t *testing.T) {
+	driver, dir := testRepo(t)
+	const total = maxFileLines + 2000
+	write(t, dir, "big.txt", linesOf(total))
+	commit(t, dir, "init")
+
+	changed := strings.Replace(linesOf(total), "line 11000\n", "line 11000 edited\n", 1)
+	if changed == linesOf(total) {
+		t.Fatal("test setup failed to change a line past the cap")
+	}
+	write(t, dir, "big.txt", changed)
+
+	set, err := BuildSet(driver, dir, git.ScopeUncommitted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(set.Files) != 1 {
+		t.Fatalf("files = %d, want 1", len(set.Files))
+	}
+	big := set.Files[0]
+	if big.Stat.Adds != 1 || big.Stat.Dels != 1 {
+		t.Errorf("big.txt stat = %+v, want 1 add 1 del from numstat", big.Stat)
+	}
+}
+
+// The header sums every file's Stat, so all must be set before any lazy load.
+func TestHeaderTotalStableWithoutLazyLoad(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "tracked.go", "package a\n")
+	commit(t, dir, "init")
+
+	const files, linesEach = maxEagerFiles + 5, 3
+	for i := 0; i < files; i++ {
+		write(t, dir, fmt.Sprintf("untracked%03d.txt", i), linesOf(linesEach))
+	}
+
+	set, err := BuildSet(driver, dir, git.ScopeUncommitted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(set.Files) != files {
+		t.Fatalf("files = %d, want %d", len(set.Files), files)
+	}
+
+	adds := 0
+	for i := range set.Files {
+		fd := set.Files[i]
+		if !fd.StatKnown() {
+			t.Fatalf("%s has no stat after BuildSet", fd.File.Path)
+		}
+		if fd.Stat.Adds != linesEach {
+			t.Errorf("%s adds = %d, want %d (index %d)", fd.File.Path, fd.Stat.Adds, linesEach, i)
+		}
+		adds += fd.Stat.Adds
+	}
+	if want := files * linesEach; adds != want {
+		t.Fatalf("total adds = %d, want %d", adds, want)
+	}
+
+	// Loading the files the eager pass skipped must not move the total.
+	for i := range set.Files {
+		EnsureFile(driver, &set, i)
+	}
+	after := 0
+	for _, fd := range set.Files {
+		after += fd.Stat.Adds
+	}
+	if after != adds {
+		t.Fatalf("total drifted after lazy loading: %d -> %d", adds, after)
 	}
 }

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -281,6 +281,9 @@ func TestTruncatedTrackedFileKeepsNumstat(t *testing.T) {
 		t.Fatalf("files = %d, want 1", len(set.Files))
 	}
 	big := set.Files[0]
+	if !big.StatKnown() {
+		t.Fatal("big.txt stat should stay known after the truncated load")
+	}
 	if big.Stat.Adds != 1 || big.Stat.Dels != 1 {
 		t.Errorf("big.txt stat = %+v, want 1 add 1 del from numstat", big.Stat)
 	}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -332,3 +332,45 @@ func TestHeaderTotalStableWithoutLazyLoad(t *testing.T) {
 		t.Fatalf("total drifted after lazy loading: %d -> %d", adds, after)
 	}
 }
+
+func TestUnreadableUntrackedFileDoesNotAbortSet(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads any file regardless of mode")
+	}
+	driver, dir := testRepo(t)
+	write(t, dir, "tracked.go", "package a\n")
+	commit(t, dir, "init")
+	write(t, dir, "readable.go", "package a\n\nfunc B() {}\n")
+	write(t, dir, "locked.go", "package a\n")
+	locked := filepath.Join(dir, "locked.go")
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(locked, 0o644) })
+
+	set, err := BuildSet(driver, dir, git.ScopeUncommitted)
+	if err != nil {
+		t.Fatalf("BuildSet aborted on one unreadable file: %v", err)
+	}
+	byPath := map[string]FileDiff{}
+	for _, fd := range set.Files {
+		byPath[fd.File.Path] = fd
+	}
+	readable, ok := byPath["readable.go"]
+	if !ok {
+		t.Fatal("readable.go missing from set")
+	}
+	if !readable.StatKnown() || readable.Stat.Adds != 3 {
+		t.Errorf("readable.go stat = %+v known=%v, want 3 adds", readable.Stat, readable.StatKnown())
+	}
+	bad, ok := byPath["locked.go"]
+	if !ok {
+		t.Fatal("locked.go missing from set")
+	}
+	if bad.Err == nil {
+		t.Error("locked.go should carry the count error")
+	}
+	if bad.StatKnown() {
+		t.Error("locked.go stat should stay unknown so the row renders ?")
+	}
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,10 +1,52 @@
 package diff
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/YoanWai/agent-manager/internal/git"
 )
+
+func testRepo(t *testing.T) (*git.Driver, string) {
+	t.Helper()
+	driver, err := git.New()
+	if err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-b", "main"},
+		{"config", "user.email", "test@test"},
+		{"config", "user.name", "test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	return driver, dir
+}
+
+func commit(t *testing.T, dir, message string) {
+	t.Helper()
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-m", message}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+}
+
+func write(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func buildTestFile(t *testing.T, oldText, newText string) FileDiff {
 	t.Helper()
@@ -108,5 +150,31 @@ func TestTabsExpanded(t *testing.T) {
 	fd := buildTestFile(t, "", "\tindented\n")
 	if fd.Lines[0].Text != "    indented" {
 		t.Fatalf("text = %q", fd.Lines[0].Text)
+	}
+}
+
+func TestUntrackedFileGetsLineCount(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "tracked.go", "package a\n")
+	commit(t, dir, "init")
+	write(t, dir, "new.go", "package a\n\nfunc B() {}\n")
+	write(t, dir, "empty.go", "")
+
+	set, err := BuildSet(driver, dir, git.ScopeUncommitted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPath := map[string]FileDiff{}
+	for _, fd := range set.Files {
+		byPath[fd.File.Path] = fd
+	}
+	if got := byPath["new.go"].Stat.Adds; got != 3 {
+		t.Errorf("new.go adds = %d, want 3", got)
+	}
+	if got := byPath["new.go"].Stat.Dels; got != 0 {
+		t.Errorf("new.go dels = %d, want 0", got)
+	}
+	if got := byPath["empty.go"].Stat.Adds; got != 0 {
+		t.Errorf("empty.go adds = %d, want 0", got)
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -275,9 +276,7 @@ func (d *Driver) ChangedFiles(root string, scope Scope, baseRef string) ([]Chang
 			return nil, err
 		}
 		for _, path := range splitNUL(untracked) {
-			// git reports a nested repository as a directory it will not
-			// descend into; there is nothing to diff and its changes belong
-			// to that repository's own review.
+			// a nested repository is listed as a directory and belongs to its own review
 			if strings.HasSuffix(path, "/") {
 				continue
 			}
@@ -391,6 +390,63 @@ func (d *Driver) ShowFile(root, ref, path string) ([]byte, error) {
 // IndexFile reads a file's staged content.
 func (d *Driver) IndexFile(root, path string) ([]byte, error) {
 	return d.ShowFile(root, ":0", path)
+}
+
+// maxCountBytes bounds the scan CountWorkingLines is willing to do.
+const maxCountBytes = 64 << 20
+
+// LineCount reports a file's lines; Counted is false when it could not be scanned.
+type LineCount struct {
+	Lines   int
+	Binary  bool
+	Counted bool
+}
+
+// CountWorkingLines streams a working-tree file, so files too big to diff still count.
+func (d *Driver) CountWorkingLines(root, path string) (LineCount, error) {
+	file, err := os.Open(filepath.Join(root, path))
+	if errors.Is(err, os.ErrNotExist) {
+		return LineCount{}, nil
+	}
+	if err != nil {
+		return LineCount{}, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return LineCount{}, err
+	}
+	if info.Size() > maxCountBytes {
+		return LineCount{}, nil
+	}
+
+	buf := make([]byte, 32*1024)
+	count := LineCount{Counted: true}
+	total := 0
+	var lastByte byte
+	for {
+		n, readErr := file.Read(buf)
+		if n > 0 {
+			chunk := buf[:n]
+			if total == 0 && IsBinary(chunk) {
+				return LineCount{Binary: true, Counted: true}, nil
+			}
+			total += n
+			count.Lines += bytes.Count(chunk, []byte{'\n'})
+			lastByte = chunk[n-1]
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return LineCount{}, readErr
+		}
+	}
+	if total > 0 && lastByte != '\n' {
+		count.Lines++
+	}
+	return count, nil
 }
 
 func (d *Driver) WorkingFile(root, path string) ([]byte, error) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -393,7 +393,7 @@ func (d *Driver) IndexFile(root, path string) ([]byte, error) {
 }
 
 // maxCountBytes bounds the scan CountWorkingLines is willing to do.
-const maxCountBytes = 64 << 20
+const maxCountBytes = 8 << 20
 
 // LineCount reports a file's lines; Counted is false when it could not be scanned.
 type LineCount struct {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -275,6 +275,12 @@ func (d *Driver) ChangedFiles(root string, scope Scope, baseRef string) ([]Chang
 			return nil, err
 		}
 		for _, path := range splitNUL(untracked) {
+			// git reports a nested repository as a directory it will not
+			// descend into; there is nothing to diff and its changes belong
+			// to that repository's own review.
+			if strings.HasSuffix(path, "/") {
+				continue
+			}
 			files = append(files, ChangedFile{Path: path, OldPath: path, Status: Untracked})
 		}
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -307,3 +307,110 @@ func TestChangedFilesSkipsNestedRepoDirectories(t *testing.T) {
 		t.Fatalf("untracked file should still be listed, got %+v", files)
 	}
 }
+
+func TestCountWorkingLines(t *testing.T) {
+	driver, dir := testRepo(t)
+	cases := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"empty", "", 0},
+		{"trailing newline", "a\nb\nc\n", 3},
+		{"no trailing newline", "a\nb\nc", 3},
+		{"one line", "only\n", 1},
+		{"blank lines counted", "\n\n\n", 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := strings.ReplaceAll(tc.name, " ", "_") + ".txt"
+			if err := os.WriteFile(filepath.Join(dir, path), []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			count, err := driver.CountWorkingLines(dir, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !count.Counted || count.Binary {
+				t.Fatalf("count = %+v, want a plain counted result", count)
+			}
+			if count.Lines != tc.want {
+				t.Errorf("lines = %d, want %d", count.Lines, tc.want)
+			}
+		})
+	}
+}
+
+// A count that spans more than one read buffer must still be right.
+func TestCountWorkingLinesAcrossBuffers(t *testing.T) {
+	driver, dir := testRepo(t)
+	var b strings.Builder
+	const want = 40000
+	for i := 0; i < want; i++ {
+		b.WriteString("some line of text\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "long.txt"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	count, err := driver.CountWorkingLines(dir, "long.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !count.Counted || count.Lines != want {
+		t.Fatalf("count = %+v, want %d counted lines", count, want)
+	}
+}
+
+func TestCountWorkingLinesBinary(t *testing.T) {
+	driver, dir := testRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "logo.png"), []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\x00binary\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	count, err := driver.CountWorkingLines(dir, "logo.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !count.Binary {
+		t.Fatalf("count = %+v, want binary", count)
+	}
+	if count.Lines != 0 {
+		t.Errorf("binary file got a line count of %d", count.Lines)
+	}
+}
+
+// Past the scan budget the count is reported unknown, never as zero.
+func TestCountWorkingLinesTooLarge(t *testing.T) {
+	driver, dir := testRepo(t)
+	path := filepath.Join(dir, "huge.bin")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(maxCountBytes + 1); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	file.Close()
+
+	count, err := driver.CountWorkingLines(dir, "huge.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count.Counted {
+		t.Fatalf("count = %+v, want an uncounted result past the budget", count)
+	}
+	if count.Lines != 0 {
+		t.Errorf("uncounted result carried %d lines", count.Lines)
+	}
+}
+
+func TestCountWorkingLinesMissingFileIsUncounted(t *testing.T) {
+	driver, dir := testRepo(t)
+	count, err := driver.CountWorkingLines(dir, "gone.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count.Counted {
+		t.Fatalf("count = %+v, want uncounted for a vanished file", count)
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -274,5 +275,35 @@ func TestIsBinary(t *testing.T) {
 	}
 	if !IsBinary([]byte{'a', 0, 'b'}) {
 		t.Fatal("NUL not flagged binary")
+	}
+}
+
+func TestChangedFilesSkipsNestedRepoDirectories(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "tracked.go", "package a\n")
+	commit(t, dir, "init")
+	write(t, dir, "untracked.go", "package a\n\nfunc B() {}\n")
+	initRepoAt(t, filepath.Join(dir, "nested"))
+
+	files, err := driver.ChangedFiles(dir, ScopeUncommitted, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file.Path, "/") {
+			t.Fatalf("directory entry leaked into the file list: %q", file.Path)
+		}
+		if file.Path == "nested" {
+			t.Fatal("nested repository should not be listed")
+		}
+	}
+	found := false
+	for _, file := range files {
+		if file.Path == "untracked.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("untracked file should still be listed, got %+v", files)
 	}
 }

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1118,6 +1118,9 @@ func (m *Model) viewDiffFileList(width, height int) string {
 		}
 		counts := lipgloss.NewStyle().Foreground(colorFinished).Render(fmt.Sprintf("+%d", fd.Stat.Adds)) +
 			" " + lipgloss.NewStyle().Foreground(colorErrored).Render(fmt.Sprintf("−%d", fd.Stat.Dels))
+		if !fd.StatKnown() {
+			counts = mutedStyle.Render("?")
+		}
 		if fd.Binary {
 			counts = mutedStyle.Render("binary")
 		}

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1118,6 +1118,9 @@ func (m *Model) viewDiffFileList(width, height int) string {
 		}
 		counts := lipgloss.NewStyle().Foreground(colorFinished).Render(fmt.Sprintf("+%d", fd.Stat.Adds)) +
 			" " + lipgloss.NewStyle().Foreground(colorErrored).Render(fmt.Sprintf("−%d", fd.Stat.Dels))
+		if fd.Binary {
+			counts = mutedStyle.Render("binary")
+		}
 		if count := notes[fd.File.Path]; count > 0 {
 			counts = lipgloss.NewStyle().Foreground(colorAccent).Render(fmt.Sprintf("¶%d ", count)) + counts
 		}

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1129,7 +1129,7 @@ func (m *Model) viewDiffFileList(width, height int) string {
 		if !fd.StatKnown() {
 			counts = mutedStyle.Render("?")
 		}
-		if fd.Binary {
+		if fd.Binary || fd.Stat.Binary {
 			counts = mutedStyle.Render("binary")
 		}
 		if count := notes[fd.File.Path]; count > 0 {

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1065,13 +1065,21 @@ func (m *Model) viewDiffHeader(sessName string) string {
 	}
 
 	adds, dels := 0, 0
+	uncounted := false
 	for _, fd := range m.diff.set.Files {
+		if !fd.StatKnown() {
+			uncounted = true
+			continue
+		}
 		adds += fd.Stat.Adds
 		dels += fd.Stat.Dels
 	}
 	right := mutedStyle.Render(fmt.Sprintf("%d files", len(m.diff.set.Files))) + subtleStyle.Render(" · ") +
 		lipgloss.NewStyle().Foreground(colorFinished).Render(fmt.Sprintf("+%d", adds)) + " " +
 		lipgloss.NewStyle().Foreground(colorErrored).Render(fmt.Sprintf("−%d", dels))
+	if uncounted {
+		right += " " + mutedStyle.Render("+?")
+	}
 	if count := len(m.diff.annotations[m.reviewKey()]); count > 0 {
 		right += subtleStyle.Render(" · ") + lipgloss.NewStyle().Foreground(colorAccent).Render(fmt.Sprintf("¶%d", count))
 	}

--- a/internal/ui/review_regression_test.go
+++ b/internal/ui/review_regression_test.go
@@ -468,7 +468,19 @@ func TestBinaryFileShowsBinaryNotZeroCounts(t *testing.T) {
 	openReviewOn(t, m, "binary", dir)
 
 	rendered := m.viewDiffFileList(60, 20)
-	if !strings.Contains(rendered, "binary") {
-		t.Fatalf("binary file should be labelled binary, got:\n%s", rendered)
+	row := ""
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, "logo.png") {
+			row = line
+		}
+	}
+	if row == "" {
+		t.Fatalf("logo.png missing from the file list:\n%s", rendered)
+	}
+	if !strings.Contains(row, "binary") {
+		t.Errorf("logo.png row should be labelled binary, got: %q", row)
+	}
+	if strings.Contains(row, "+0") || strings.Contains(row, "−0") {
+		t.Errorf("logo.png row still shows zero counts: %q", row)
 	}
 }

--- a/internal/ui/review_regression_test.go
+++ b/internal/ui/review_regression_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -482,6 +483,75 @@ func TestBinaryFileShowsBinaryNotZeroCounts(t *testing.T) {
 	}
 	if strings.Contains(row, "+0") || strings.Contains(row, "−0") {
 		t.Errorf("logo.png row still shows zero counts: %q", row)
+	}
+}
+
+// Rows past the eager-load cap are rendered before their content is read, so
+// the binary label has to come from numstat rather than the loaded file.
+func TestTrackedBinaryPastEagerCapShowsBinary(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	run("git", "init")
+	const filler = 250
+	for i := 0; i < filler; i++ {
+		write(fmt.Sprintf("f%03d.txt", i), "one\n")
+	}
+	write("zz.bin", "\x00\x01\x02initial")
+	run("git", "add", ".")
+	run("git", "commit", "-m", "init")
+	for i := 0; i < filler; i++ {
+		write(fmt.Sprintf("f%03d.txt", i), "two\n")
+	}
+	write("zz.bin", "\x00\x01\x02changed")
+	openReviewOn(t, m, "bigbin", dir)
+
+	files := m.diff.set.Files
+	index := -1
+	for i := range files {
+		if files[i].File.Path == "zz.bin" {
+			index = i
+		}
+	}
+	if index < 0 {
+		t.Fatal("zz.bin missing from the diff set")
+	}
+	if files[index].Lines != nil || files[index].Binary {
+		t.Fatalf("zz.bin at index %d was loaded; the test needs an unloaded row", index)
+	}
+
+	rendered := m.viewDiffFileList(60, len(files)+2)
+	row := ""
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, "zz.bin") {
+			row = line
+		}
+	}
+	if row == "" {
+		t.Fatalf("zz.bin missing from the file list:\n%s", rendered)
+	}
+	if !strings.Contains(row, "binary") {
+		t.Errorf("zz.bin row should be labelled binary, got: %q", row)
+	}
+	if strings.Contains(row, "+0") || strings.Contains(row, "−0") {
+		t.Errorf("zz.bin row still shows zero counts: %q", row)
 	}
 }
 

--- a/internal/ui/review_regression_test.go
+++ b/internal/ui/review_regression_test.go
@@ -484,3 +484,38 @@ func TestBinaryFileShowsBinaryNotZeroCounts(t *testing.T) {
 		t.Errorf("logo.png row still shows zero counts: %q", row)
 	}
 }
+
+// A file whose line count is unknown must not be silently summed as zero in
+// the header: the totals carry a marker instead of asserting an exact count.
+func TestHeaderMarksUncountedFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads any file regardless of mode")
+	}
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	dir := gitRepoWithTwoChangedFiles(t)
+	openReviewOn(t, m, "counted", dir)
+	if strings.Contains(m.viewDiffHeader("counted"), "?") {
+		t.Fatal("header should not flag unknown counts when every file is counted")
+	}
+
+	locked := filepath.Join(dir, "locked.go")
+	if err := os.WriteFile(locked, []byte("package a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(locked, 0o644) })
+
+	set, err := diff.BuildSet(m.gitDrv, dir, git.ScopeUncommitted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.diff.set = set
+	if !strings.Contains(m.viewDiffHeader("counted"), "+?") {
+		t.Fatalf("header should mark the uncounted file, got %q", m.viewDiffHeader("counted"))
+	}
+}

--- a/internal/ui/review_regression_test.go
+++ b/internal/ui/review_regression_test.go
@@ -455,3 +455,20 @@ func TestExcerptKeepsRuneBoundary(t *testing.T) {
 		t.Fatalf("short excerpt = %q", short)
 	}
 }
+
+func TestBinaryFileShowsBinaryNotZeroCounts(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	dir := gitRepoWithTwoChangedFiles(t)
+	if err := os.WriteFile(filepath.Join(dir, "logo.png"), []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\x00binary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	openReviewOn(t, m, "binary", dir)
+
+	rendered := m.viewDiffFileList(60, 20)
+	if !strings.Contains(rendered, "binary") {
+		t.Fatalf("binary file should be labelled binary, got:\n%s", rendered)
+	}
+}


### PR DESCRIPTION
## Problem

Review listed 20 files for a session where only 2 had reviewable changes. The other 18 rendered `+0 −0`:

- `.worktrees/TICKET-1/` and three siblings are **directories**. `git ls-files --others` reports a nested repository as a directory, because git will not descend into another repo. There was nothing to diff and the rows could not be opened.
- Untracked screenshots are **binary**, so no line counts exist.
- Untracked text files showed `+0 −0` too, because `git diff --numstat` covers only tracked changes.

The header total was wrong for the same reason: "20 files · +8 −4" counted only the 2 tracked files.

## Fix

- Skip untracked directory entries; a nested repo's changes belong to its own review.
- Count lines for files `numstat` does not cover, streamed from the working file at set-build time. Counting from raw bytes rather than from the built diff keeps the number true for files past the 10k-line display cap and the 1 MB byte cap, and doing it before the eager-load cap keeps the header total stable instead of climbing as you scroll.
- `numstat` stays authoritative wherever it had an entry, so a truncated tracked file keeps its real count.
- Render `binary` where a line count is meaningless, and `?` for a file too large to count, with the header marking the total incomplete rather than silently under-reporting.
- A working file that cannot be read marks that row and leaves the rest of the review open.

Header totals correct themselves once the per-file stats are right.

## Tests

- A nested repository is omitted while untracked files are still listed.
- An untracked file reports its true line count past both the line cap and the byte cap; an empty one stays at `+0 −0`.
- A truncated tracked file keeps its `numstat` value.
- The header total is correct before any lazy loading, and marks itself incomplete when a file is uncounted.
- An unreadable untracked file marks its own row without aborting the set.
- A binary file is labelled `binary` on its row.

Verified against `monorepo/servers/main-node`, where the four `.worktrees/TICKET-*` rows are gone.

Full suite, `go vet`, `gofmt` clean.
