### PR TITLE
fix: deleting a group in the archived view only clears its archive

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -292,17 +292,12 @@ func (s *Store) SetArchived(id string, archived bool) error {
 // unarchiveAncestorGroups clears the archived flag on a group path and each
 // of its ancestors, leaving descendants untouched.
 func (s *Store) unarchiveAncestorGroups(path string) error {
-	for path != "" {
-		if _, err := s.db.Exec(`UPDATE groups SET archived = 0 WHERE name = ?`, path); err != nil {
-			return err
-		}
-		idx := strings.LastIndex(path, "/")
-		if idx < 0 {
-			break
-		}
-		path = path[:idx]
-	}
-	return nil
+	var err error
+	eachAncestor(path, func(ancestor string) bool {
+		_, err = s.db.Exec(`UPDATE groups SET archived = 0 WHERE name = ?`, ancestor)
+		return err == nil
+	})
+	return err
 }
 
 func (s *Store) Delete(id string) error {
@@ -322,7 +317,7 @@ func (s *Store) SessionsInSubtree(path string) ([]Session, error) {
 	}
 	var matched []Session
 	for _, sess := range sessions {
-		if sess.Group == path || strings.HasPrefix(sess.Group, path+"/") {
+		if inSubtree(sess.Group, path) {
 			matched = append(matched, sess)
 		}
 	}
@@ -397,14 +392,99 @@ func (s *Store) RenameSession(id, name string) error {
 	return requireRow(res, id)
 }
 
-// DeleteGroup removes a group and all its descendant groups.
-func (s *Store) DeleteGroup(path string) error {
+// DeleteGroup removes a group and all its descendant groups, reporting
+// the paths it removed.
+func (s *Store) DeleteGroup(path string) ([]string, error) {
 	if path == "" {
-		return fmt.Errorf("cannot delete the root group")
+		return nil, fmt.Errorf("cannot delete the root group")
 	}
-	_, err := s.db.Exec(
-		`DELETE FROM groups WHERE name = ? OR name LIKE ? || '/%' ESCAPE '\'`, path, escapeLike(path))
-	return err
+	groups, err := s.Groups()
+	if err != nil {
+		return nil, err
+	}
+	return s.deleteGroups(groups, func(g Group) bool { return inSubtree(g.Name, path) })
+}
+
+// PruneArchivedGroups removes the groups in a subtree that are archived,
+// directly or through an archived ancestor, and hold no session anywhere
+// beneath them, reporting the paths it removed. A group that still holds
+// a session stays, and so does each of its ancestors, so no session is
+// left without a home. Deleting a group from the archived view runs this
+// instead of DeleteGroup: it clears the group rows that emptying the
+// archive left behind while the live tree keeps its own.
+func (s *Store) PruneArchivedGroups(root string) ([]string, error) {
+	sessions, err := s.ListSessions(true)
+	if err != nil {
+		return nil, err
+	}
+	occupied := map[string]bool{}
+	for _, sess := range sessions {
+		eachAncestor(sess.Group, func(path string) bool {
+			occupied[path] = true
+			return true
+		})
+	}
+	groups, err := s.Groups()
+	if err != nil {
+		return nil, err
+	}
+	archived := map[string]bool{}
+	for _, g := range groups {
+		if g.Archived {
+			archived[g.Name] = true
+		}
+	}
+	return s.deleteGroups(groups, func(g Group) bool {
+		return inSubtree(g.Name, root) && !occupied[g.Name] && EffectivelyArchived(archived, g.Name)
+	})
+}
+
+// deleteGroups removes every group the predicate selects, reporting the
+// paths it removed.
+func (s *Store) deleteGroups(groups []Group, selected func(Group) bool) ([]string, error) {
+	var removed []string
+	for _, g := range groups {
+		if !selected(g) {
+			continue
+		}
+		if _, err := s.db.Exec(`DELETE FROM groups WHERE name = ?`, g.Name); err != nil {
+			return removed, err
+		}
+		removed = append(removed, g.Name)
+	}
+	return removed, nil
+}
+
+// EffectivelyArchived reports whether a group path counts as archived,
+// either directly or because an ancestor group was archived as a whole.
+func EffectivelyArchived(archived map[string]bool, path string) bool {
+	found := false
+	eachAncestor(path, func(ancestor string) bool {
+		found = archived[ancestor]
+		return !found
+	})
+	return found
+}
+
+// inSubtree reports whether a group path is the root itself or any group
+// nested under it.
+func inSubtree(path, root string) bool {
+	return path == root || strings.HasPrefix(path, root+"/")
+}
+
+// eachAncestor visits a group path and then each of its ancestors,
+// stopping early when the visitor returns false.
+func eachAncestor(path string, visit func(string) bool) {
+	for path != "" {
+		if !visit(path) {
+			return
+		}
+		idx := strings.LastIndex(path, "/")
+		if idx < 0 {
+			return
+		}
+		path = path[:idx]
+	}
 }
 
 type Group struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"path/filepath"
+	"sort"
 	"testing"
 )
 
@@ -131,6 +132,20 @@ func groupArchived(t *testing.T, st *Store, path string) bool {
 	return false
 }
 
+func groupPaths(t *testing.T, st *Store) []string {
+	t.Helper()
+	groups, err := st.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	paths := make([]string, len(groups))
+	for i, g := range groups {
+		paths[i] = g.Name
+	}
+	sort.Strings(paths)
+	return paths
+}
+
 func sessionArchived(t *testing.T, st *Store, id string) bool {
 	t.Helper()
 	sess, err := st.Get(id)
@@ -184,6 +199,52 @@ func TestSetGroupArchivedUnderscoreDoesNotBleed(t *testing.T) {
 	// "my_proj/%" with an unescaped underscore matches "myXproj/sub".
 	if groupArchived(t, st, "myXproj/sub") || sessionArchived(t, st, "b") {
 		t.Fatal("myXproj/sub must not be caught by the my_proj archive (LIKE _ wildcard bleed)")
+	}
+}
+
+func TestPruneArchivedGroupsRemovesOnlyEmptyArchivedOnes(t *testing.T) {
+	st := newTestStore(t)
+	st.CreateGroup("proj", "")
+	st.CreateGroup("proj/gone", "")
+	st.CreateGroup("proj/live", "")
+	st.CreateSession(sample("a", "proj/live"))
+	if err := st.SetGroupArchived("proj/gone", true); err != nil {
+		t.Fatalf("archive group: %v", err)
+	}
+
+	removed, err := st.PruneArchivedGroups("proj")
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "proj/gone" {
+		t.Fatalf("removed = %v want [proj/gone]", removed)
+	}
+	paths := groupPaths(t, st)
+	if len(paths) != 2 || paths[0] != "proj" || paths[1] != "proj/live" {
+		t.Fatalf("remaining groups = %v want [proj proj/live]", paths)
+	}
+}
+
+func TestPruneArchivedGroupsKeepsArchivedGroupHoldingASession(t *testing.T) {
+	st := newTestStore(t)
+	st.CreateGroup("proj", "")
+	st.CreateGroup("proj/sub", "")
+	if err := st.SetGroupArchived("proj", true); err != nil {
+		t.Fatalf("archive group: %v", err)
+	}
+	// A session launched into an archived group starts out live, so neither
+	// its group nor that group's ancestors may be pruned away under it.
+	st.CreateSession(sample("a", "proj/sub"))
+
+	removed, err := st.PruneArchivedGroups("proj")
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v want none", removed)
+	}
+	if paths := groupPaths(t, st); len(paths) != 2 {
+		t.Fatalf("remaining groups = %v want both kept", paths)
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -474,16 +474,52 @@ func (m *Model) prepareDelete() {
 		m.err = err.Error()
 		return
 	}
+	if m.showArchived {
+		m.confirm = archivedGroupDelete(entry.group, subtree)
+	} else {
+		m.confirm = m.wholeGroupDelete(entry.group, subtree)
+	}
+	m.mode = modeConfirmDelete
+}
+
+// wholeGroupDelete targets the group as the active view shows it: the
+// group ceases to exist, so its subtree goes with it, archived sessions
+// included, leaving nothing stranded under a group that is gone.
+func (m *Model) wholeGroupDelete(path string, subtree []store.Session) confirmTarget {
 	subgroups := 0
 	for _, g := range m.groups {
-		if strings.HasPrefix(g, entry.group+"/") {
+		if strings.HasPrefix(g, path+"/") {
 			subgroups++
 		}
 	}
-	label := fmt.Sprintf("delete group %s (%d subgroups, %d sessions incl. archived)? kills their tmux sessions.",
-		entry.group, subgroups, len(subtree))
-	m.confirm = confirmTarget{isGroup: true, path: entry.group, label: label, sessions: subtree}
-	m.mode = modeConfirmDelete
+	return confirmTarget{
+		isGroup:  true,
+		path:     path,
+		sessions: subtree,
+		label: fmt.Sprintf("delete group %s (%d subgroups, %d sessions incl. archived)? kills their tmux sessions.",
+			path, subgroups, len(subtree)),
+	}
+}
+
+// archivedGroupDelete targets only what the archived view shows: the
+// archived sessions under the group. The live sessions and the group
+// itself belong to the active view and survive; the group row goes only
+// once nothing is left beneath it.
+func archivedGroupDelete(path string, subtree []store.Session) confirmTarget {
+	var archived []store.Session
+	for _, sess := range subtree {
+		if sess.Archived {
+			archived = append(archived, sess)
+		}
+	}
+	return confirmTarget{
+		isGroup:      true,
+		archivedOnly: true,
+		path:         path,
+		sessions:     archived,
+		label: fmt.Sprintf("delete %s from the archive (%d archived sessions)? kills their tmux sessions, live ones stay.",
+			path, len(archived)),
+	}
 }
 
 func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -509,14 +545,13 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if m.confirm.isGroup {
-			if err := m.store.DeleteGroup(m.confirm.path); err != nil {
+			removed, err := m.deleteConfirmedGroups()
+			if err != nil {
 				m.err = err.Error()
 				return m, nil
 			}
-			for path := range m.collapsed {
-				if path == m.confirm.path || strings.HasPrefix(path, m.confirm.path+"/") {
-					delete(m.collapsed, path)
-				}
+			for _, path := range removed {
+				delete(m.collapsed, path)
 			}
 			m.persistCollapsed()
 		}
@@ -526,6 +561,15 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	m.confirm = confirmTarget{}
 	return m, nil
+}
+
+// deleteConfirmedGroups removes the group rows the confirmed delete
+// covers, reporting the paths that went so their fold state can go too.
+func (m *Model) deleteConfirmedGroups() ([]string, error) {
+	if m.confirm.archivedOnly {
+		return m.store.PruneArchivedGroups(m.confirm.path)
+	}
+	return m.store.DeleteGroup(m.confirm.path)
 }
 
 func (m *Model) openRename() {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -97,10 +97,13 @@ type Model struct {
 }
 
 type confirmTarget struct {
-	isGroup  bool
-	path     string
-	label    string
-	sessions []store.Session
+	isGroup bool
+	// archivedOnly marks a group delete issued from the archived view,
+	// which clears the group's archive instead of the group itself.
+	archivedOnly bool
+	path         string
+	label        string
+	sessions     []store.Session
 }
 
 type renameTarget struct {
@@ -624,20 +627,8 @@ func groupClosure(groups []string, sessions []store.Session) map[string]bool {
 	return paths
 }
 
-// groupEffectivelyArchived reports whether a group path was archived, either
-// directly or by an ancestor group being archived as a whole.
 func (m *Model) groupEffectivelyArchived(path string) bool {
-	for path != "" {
-		if m.archivedGroups[path] {
-			return true
-		}
-		idx := strings.LastIndex(path, "/")
-		if idx < 0 {
-			break
-		}
-		path = path[:idx]
-	}
-	return false
+	return store.EffectivelyArchived(m.archivedGroups, path)
 }
 
 func addWithAncestors(set map[string]bool, path string) {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -397,6 +397,72 @@ func TestDeleteGroupSubtree(t *testing.T) {
 	}
 }
 
+func TestDeleteGroupInArchivedViewSparesLiveSessions(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+
+	if err := m.store.CreateGroup("bugs", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "old", dir, "bugs")
+	createSession(t, m, "live", dir, "bugs")
+
+	m.selectSessionRow(t, "old")
+	_, cmd := m.archiveSelected()
+	m.applyCmd(t, cmd)
+
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "bugs")
+	m.prepareDelete()
+	if len(m.confirm.sessions) != 1 || m.confirm.sessions[0].Name != "old" {
+		t.Fatalf("confirm should target only the archived session, got %+v", m.confirm.sessions)
+	}
+	archivedID := m.confirm.sessions[0].ID
+	_, cmd = m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m.applyCmd(t, cmd)
+
+	m.showArchived = false
+	m.applyCmd(t, m.refreshCmd())
+	if names := sessionNames(m); len(names) != 1 || names[0] != "live" {
+		t.Fatalf("active view sessions = %v want [live]", names)
+	}
+	if paths := m.groupRowPaths(); len(paths) != 1 || paths[0] != "bugs" {
+		t.Fatalf("group holding a live session should survive, got %v", paths)
+	}
+	for _, sess := range m.sessionRows() {
+		if !m.tmux.Exists(sess.ID) {
+			t.Fatalf("live session %s lost its tmux window", sess.Name)
+		}
+	}
+	if m.tmux.Exists(archivedID) {
+		t.Fatalf("archived session %s should be killed", archivedID)
+	}
+}
+
+func TestDeleteArchivedGroupInArchivedViewRemovesIt(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("empty", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "empty")
+	_, cmd := m.archiveSelected()
+	m.applyCmd(t, cmd)
+
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "empty")
+	m.prepareDelete()
+	_, cmd = m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m.applyCmd(t, cmd)
+
+	if paths := m.groupRowPaths(); len(paths) != 0 {
+		t.Fatalf("archived empty group should be gone, got %v", paths)
+	}
+}
+
 func TestRenameGroupCascades(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## What

Deleting a group row from the archived view deleted the group and every session under it, live ones included. The archived view lists a group whenever archived sessions live beneath it, so clearing a group's archive took its active sessions with it.

Delete now acts on what the view shows:

- **Archived view**: deletes the archived sessions under the group. Live sessions and the group itself stay. The group row is removed only once nothing is left beneath it, so an archived empty group is still deletable from the one view that shows it.
- **Active view**: unchanged. The group ceases to exist, so the whole subtree goes with it, archived sessions included, and the confirm prompt keeps saying so.

The confirm prompt names which of the two is about to happen.

## How

`store.PruneArchivedGroups` removes the groups in a subtree that are archived, directly or through an archived ancestor, and hold no session anywhere beneath them, and reports what it removed so the fold state follows. `deleteGroups` backs both it and `DeleteGroup`, which now returns the removed paths too.

`EffectivelyArchived` and the group-path ancestor walk move into the store and are shared with the UI, replacing the copy in `model.go` and the two hand-rolled loops.

## Verification

- `go test ./...` green, `go vet` and `gofmt` clean.
- New tests: archived-view delete spares the live session and its group, archived empty group still deletes, and the store prune keeps any group holding a session along with its ancestors.
- Ran the built binary against a throwaway state dir: archived-view delete left `bugs` and `live-one` standing in the active view; a follow-up active-view delete emptied both tables.