### PR TITLE
fix: a session deleted mid-poll no longer errors the poll pass

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,12 +2,18 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	_ "modernc.org/sqlite"
 )
+
+// ErrSessionGone reports a write against a session row that is no longer
+// there. Deleting a session is normal, so a caller holding a session
+// listed a moment earlier can tell that race apart from a real failure.
+var ErrSessionGone = errors.New("session no longer exists")
 
 type Session struct {
 	ID           string
@@ -689,7 +695,7 @@ func requireRow(res sql.Result, id string) error {
 		return err
 	}
 	if affected == 0 {
-		return fmt.Errorf("session %s not found", id)
+		return fmt.Errorf("session %s: %w", id, ErrSessionGone)
 	}
 	return nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -272,6 +272,27 @@ func TestWritesToADeletedSessionReportGone(t *testing.T) {
 	}
 }
 
+func TestNoOpWriteDoesNotLookLikeADeletedSession(t *testing.T) {
+	st := newTestStore(t)
+	st.CreateSession(sample("a", "proj"))
+
+	// Rewriting a column with the value it already holds still counts as a
+	// row affected, so ErrSessionGone only ever means the row is absent.
+	writes := map[string]error{
+		"UpdateStatus":      st.UpdateStatus("a", "idle"),
+		"SetAcked":          st.SetAcked("a", false),
+		"SetAgentSessionID": st.SetAgentSessionID("a", ""),
+		"SetSnapshot":       st.SetSnapshot("a", ""),
+		"SetArchived":       st.SetArchived("a", false),
+		"RenameSession":     st.RenameSession("a", "n-a"),
+	}
+	for name, err := range writes {
+		if err != nil {
+			t.Errorf("%s writing an unchanged value = %v, want nil", name, err)
+		}
+	}
+}
+
 func TestSetGroupArchivedEmptyPathErrors(t *testing.T) {
 	st := newTestStore(t)
 	if err := st.SetGroupArchived("", true); err == nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -245,6 +246,29 @@ func TestPruneArchivedGroupsKeepsArchivedGroupHoldingASession(t *testing.T) {
 	}
 	if paths := groupPaths(t, st); len(paths) != 2 {
 		t.Fatalf("remaining groups = %v want both kept", paths)
+	}
+}
+
+func TestWritesToADeletedSessionReportGone(t *testing.T) {
+	st := newTestStore(t)
+	st.CreateSession(sample("a", "proj"))
+	if err := st.Delete("a"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	writes := map[string]error{
+		"UpdateStatus":      st.UpdateStatus("a", "idle"),
+		"SetAcked":          st.SetAcked("a", true),
+		"SetAgentSessionID": st.SetAgentSessionID("a", "conv"),
+		"SetSnapshot":       st.SetSnapshot("a", "pane"),
+		"SetArchived":       st.SetArchived("a", true),
+		"RenameSession":     st.RenameSession("a", "renamed"),
+		"Delete":            st.Delete("a"),
+	}
+	for name, err := range writes {
+		if !errors.Is(err, ErrSessionGone) {
+			t.Errorf("%s on a deleted session = %v, want ErrSessionGone", name, err)
+		}
 	}
 }
 

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"sort"
 	"sync"
 	"time"
@@ -144,6 +145,17 @@ func (p *poller) run(send func(tea.Msg)) {
 	}
 }
 
+// ignoreDeletedSession drops the error a store write returns when the
+// session was deleted between this pass listing it and writing to it.
+// The row is gone on purpose, so there is nothing left to write and
+// nothing for the user to act on; any other failure still surfaces.
+func ignoreDeletedSession(err error) error {
+	if errors.Is(err, store.ErrSessionGone) {
+		return nil
+	}
+	return err
+}
+
 // archivedPreview serves an archived session's stored pane snapshot,
 // backfilling it from a still-live tmux window for sessions archived
 // before snapshots existed.
@@ -159,7 +171,7 @@ func archivedPreview(st *store.Store, driver *tmux.Driver, sessID string) (strin
 	if err != nil || pane == "" {
 		return "", nil
 	}
-	if err := st.SetSnapshot(sessID, pane); err != nil {
+	if err := ignoreDeletedSession(st.SetSnapshot(sessID, pane)); err != nil {
 		return "", err
 	}
 	return pane, nil
@@ -241,7 +253,7 @@ func (p *poller) refreshOnce() tea.Msg {
 				newStatus = derived
 				// Any real transition re-arms the finished alert.
 				if sess.Acked && newStatus != status.Idle && newStatus != status.Finished {
-					if err := p.store.SetAcked(sess.ID, false); err != nil {
+					if err := ignoreDeletedSession(p.store.SetAcked(sess.ID, false)); err != nil {
 						return errMsg{err}
 					}
 					sessions[i].Acked = false
@@ -252,7 +264,7 @@ func (p *poller) refreshOnce() tea.Msg {
 			}
 		}
 		if newStatus != sess.Status {
-			if err := p.store.UpdateStatus(sess.ID, newStatus); err != nil {
+			if err := ignoreDeletedSession(p.store.UpdateStatus(sess.ID, newStatus)); err != nil {
 				return errMsg{err}
 			}
 			sessions[i].Status = newStatus
@@ -335,7 +347,7 @@ func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[stri
 		if !ok {
 			continue
 		}
-		if err := p.store.SetAgentSessionID(sess.ID, agentID); err != nil {
+		if err := ignoreDeletedSession(p.store.SetAgentSessionID(sess.ID, agentID)); err != nil {
 			return err
 		}
 		sessions[i].AgentSessionID = agentID
@@ -374,7 +386,7 @@ func (p *poller) applyPendingRename(sess *store.Session) error {
 		return nil
 	}
 	if name != "" && name != sess.Name {
-		if err := p.store.RenameSession(sess.ID, name); err != nil {
+		if err := ignoreDeletedSession(p.store.RenameSession(sess.ID, name)); err != nil {
 			return err
 		}
 		sess.Name = name

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -460,6 +461,40 @@ func TestDeleteArchivedGroupInArchivedViewRemovesIt(t *testing.T) {
 
 	if paths := m.groupRowPaths(); len(paths) != 0 {
 		t.Fatalf("archived empty group should be gone, got %v", paths)
+	}
+}
+
+func TestIgnoreDeletedSessionDropsOnlyTheDeleteRace(t *testing.T) {
+	if err := ignoreDeletedSession(fmt.Errorf("abc: %w", store.ErrSessionGone)); err != nil {
+		t.Fatalf("a session deleted mid-poll should not fail the pass: %v", err)
+	}
+	if err := ignoreDeletedSession(errors.New("database is locked")); err == nil {
+		t.Fatal("a real store failure must still surface")
+	}
+}
+
+func TestPendingRenameForADeletedSessionDoesNotFailThePoll(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "doomed", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+
+	// The manager deleted the row while this poll pass still held it.
+	if err := m.store.Delete(sess.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	nameFile := m.hooks.NameFile(sess.ID)
+	if err := os.MkdirAll(filepath.Dir(nameFile), 0o755); err != nil {
+		t.Fatalf("hooks dir: %v", err)
+	}
+	if err := os.WriteFile(nameFile, []byte("renamed"), 0o644); err != nil {
+		t.Fatalf("write name file: %v", err)
+	}
+
+	if err := m.poller.applyPendingRename(&sess); err != nil {
+		t.Fatalf("rename of a deleted session should not fail the pass: %v", err)
+	}
+	if _, found := m.hooks.ReadName(sess.ID); found {
+		t.Fatal("the name file should be consumed instead of retried every poll")
 	}
 }
 


### PR DESCRIPTION
## What

Deleting a session flashed `session <id> not found` in red at the bottom left.

A poll pass lists the sessions, then walks them writing status, pane snapshots and captured conversation ids. Delete a session in between and the pass writes to a row that is already gone, so `requireRow` reports zero rows affected and the whole pass fails into an `errMsg`. The delete itself always succeeded; only the report was wrong.

## How

`store.ErrSessionGone` names the case, and `requireRow` wraps it so a caller holding a session listed a moment earlier can tell the race apart from a real failure.

The poller runs each session write through `ignoreDeletedSession`, which drops that one error and passes everything else through: the row went away on purpose, so there is nothing left to write and nothing for the user to act on. Covered sites are the status update, the acked reset, the captured conversation id, the archived pane snapshot, and the pending rename.

## Verification

- `go test ./...` green, `go vet` and `gofmt` clean.
- New tests: every session write reports `ErrSessionGone` once the row is deleted, `ignoreDeletedSession` drops only that error, and a pending rename for a deleted session leaves the poll pass clean while still consuming its name file.
- Reproduced the original failure with a throwaway race probe (kill a session's window so the pass writes a new status, start the pass, delete the row 30ms in): 3/3 passes failed on `main` with `session ded1d8d2 not found`, 5/5 clean on this branch. The probe is timing-based, so it stays out of the suite.