### PR TITLE
fix: one review key, ctrl+r everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 | `a` / `u` | Archive / restore a session, or a group and its entire subtree |
 | `d` | Delete session, or a group + its entire subtree |
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
-| `D` | Review the selected session's changes: full-screen whole-file diffs, line comments sent to the agent |
+| `ctrl+r` | Review the selected session's changes: full-screen whole-file diffs, line comments sent to the agent |
 | `f` | Fold / unfold group |
 | `s` | Settings (default tool for quick spawn) |
 | `t` | Toggle archived view |
@@ -88,7 +88,7 @@ Agents usually work in git worktrees, one branch per worktree, and those worktre
 
 ### Diff review
 
-Press `D` or `ctrl+r` on a session to open a full-screen review of its repo: changed files with +/− counts on the left, the whole file on the right with syntax highlighting and changed lines tinted, so every edit reads in full context. Arrow keys and `ctrl+d`/`ctrl+u` scroll the file, `J`/`K` switch files, `n`/`N` jump between changes, `u` toggles unified and side-by-side, `s` cycles the scope (uncommitted, vs base, last commit, staged), and `space` marks a file reviewed. When the working directory holds several repos, `r` opens a picker you type to filter, and `b` lists the current repo's worktrees by branch name so you can review another branch with one keypress. `B` picks the base the "vs base" scope compares against. The diff refreshes as the agent keeps editing.
+Press `ctrl+r` on a session to open a full-screen review of its repo: changed files with +/− counts on the left, the whole file on the right with syntax highlighting and changed lines tinted, so every edit reads in full context. Arrow keys and `ctrl+d`/`ctrl+u` scroll the file, `J`/`K` switch files, `n`/`N` jump between changes, `u` toggles unified and side-by-side, `s` cycles the scope (uncommitted, vs base, last commit, staged), and `space` marks a file reviewed. When the working directory holds several repos, `r` opens a picker you type to filter, and `b` lists the current repo's worktrees by branch name so you can review another branch with one keypress. `B` picks the base the "vs base" scope compares against. The diff refreshes as the agent keeps editing.
 
 Press `c` on a line to write a comment; `C` flattens every comment into one review prompt and sends it straight into the agent's pane, so the agent starts addressing your notes while you watch the diff update. `esc` closes the review.
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -93,8 +93,6 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openMove()
 	case "?":
 		m.mode = modeHelp
-	case "D", "x":
-		return m, m.openDiff()
 	case "ctrl+r":
 		return m, m.openDiff()
 	}

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -175,7 +175,7 @@ func (m *Model) viewHelp() string {
 		{"space", "quick prompt: answer session / spawn agent in group"},
 		{"⇥", "in quick prompt: switch spawn tool"},
 		{"^v", "in quick prompt: attach a clipboard image"},
-		{"D / x / ctrl+r", "review changes: whole-file diffs, comment lines, send to agent"},
+		{"ctrl+r", "review changes: whole-file diffs, comment lines, send to agent"},
 		{"s", "in review: cycle scope (uncommitted / vs base / last commit / staged)"},
 		{"r", "in review: pick the repo when the session dir holds several"},
 		{"b", "in review: pick the branch from the repo's worktrees"},

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -681,7 +681,7 @@ func padToHeight(s string, height int) string {
 func (m *Model) viewFooter() string {
 	pairs := [][2]string{
 		{"↑↓", "navigate"}, {"↵", "attach"}, {"n", "new"}, {"g", "group"},
-		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"D", "review"}, {"F", "fold all"}, {"m", "move"}, {"r", "rename/edit"},
+		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"ctrl+r", "review"}, {"F", "fold all"}, {"m", "move"}, {"r", "rename/edit"},
 		{"v", "revive"}, {"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
 		{"t", "archived"}, {"s", "settings"}, {"?", "help"}, {"q", "quit"},
 	}


### PR DESCRIPTION
Review had three keys from the list (D, x, ctrl+r) and one inside a session (ctrl+r). Now ctrl+r is the single review key in both places; help, footer, and README updated to match.