### PR TITLE
feat(ui): subtle grey row highlight for selected session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /agent-manager
 /am
+.worktrees/
 *.db
 *.db-*
 .DS_Store

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -14,7 +14,7 @@ var (
 	colorSubtle  = lipgloss.Color("240")
 	colorBorder  = lipgloss.Color("238")
 	colorBg      = lipgloss.Color("236")
-	colorSelBg   = lipgloss.Color("238")
+	colorSelBg   = lipgloss.Color("239")
 	colorBright  = lipgloss.Color("231")
 	colorAccent  = lipgloss.Color("111")
 	colorAccent2 = lipgloss.Color("79")


### PR DESCRIPTION
## What

Selected session row now shows a subtle greyish background across the full row width, in addition to the existing accent left-bar.

## Why

Previously `selectedRowStyle` used `colorSelBg = 238`, which is indistinguishable from the terminal background on most terminals. The cursor was effectively marked only by the thin accent bar (`▎`) on the left, so focus was easy to lose on a glance.

## Change

Bump `colorSelBg` from `238` to `239` (`~#4e4e4e`). Visible enough to read as a row highlight, subtle enough that content (status glyph, name, meta) stays readable.

The left-bar (`colorAccent = 111`) is untouched, so the bar-plus-bg combo reads as a deliberate two-part focus indicator.

## Verification

- `go build ./...` clean
- Manual TUI run: row bg clearly visible against terminal bg, status colors and name still readable

## Files

- `internal/ui/styles.go` — one-line color bump (line 17)

## Risk

Cosmetic only. Affects every place `selectedRowStyle` is used: tree rows, diff view selected entries, rename rows.