### PR TITLE
feat(review): repo, branch and base always visible in header

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -117,14 +117,15 @@ var skipDirs = map[string]bool{
 }
 
 // ResolveRepos returns the git repo roots reachable from cwd, most-active
-// first. When cwd is itself a repo, that is the only root. When cwd is an
+// first. When cwd is itself a repo, that repo plus its linked worktrees are
+// the roots. When cwd is an
 // umbrella folder holding several repos, each nested repo root is returned
 // ranked with dirty working trees before clean ones, then by most recent
 // commit, so review lands on the repo the agent is most likely editing.
 func (d *Driver) ResolveRepos(cwd string) ([]string, error) {
 	root, err := d.run(cwd, "rev-parse", "--show-toplevel")
 	if err == nil {
-		return []string{root}, nil
+		return d.expandWorktrees([]string{root}), nil
 	}
 	if !errors.Is(err, ErrNotARepo) {
 		return nil, err

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -557,3 +557,29 @@ func TestResolveReposIncludesOutsideWorktrees(t *testing.T) {
 		t.Fatalf("want repo + worktree once each, got %v", roots)
 	}
 }
+
+func TestResolveReposSingleIncludesWorktrees(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "a.go", "package a\n")
+	commit(t, dir, "init")
+
+	worktree := filepath.Join(t.TempDir(), "wt-feature")
+	cmd := exec.Command("git", "worktree", "add", "-b", "feature/x", worktree)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v: %s", err, out)
+	}
+
+	roots, err := driver.ResolveRepos(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 2 {
+		t.Fatalf("want repo + worktree, got %v", roots)
+	}
+	resolvedRepo, _ := filepath.EvalSymlinks(dir)
+	first, _ := filepath.EvalSymlinks(roots[0])
+	if first != resolvedRepo {
+		t.Fatalf("cwd repo should stay first, got %v", roots)
+	}
+}

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1086,12 +1086,21 @@ func (m *Model) viewDiffHeader(sessName string) string {
 	}
 	left := badgeStyle.Render("◆ Review · "+sessName) + "  " +
 		pill(m.diff.scope.String(), colorAccent2) + "  " + pill(layout, colorAccent)
-	if len(m.diff.repoRoots) > 1 {
+	if root := m.diff.set.Repo.Root; root != "" {
 		name := filepath.Base(m.diff.repoSel)
-		left += "  " + pill(fmt.Sprintf("%s · %d repos", name, len(m.diff.repoRoots)), colorAccent)
-	}
-	if m.diff.set.BaseDesc != "" && m.diff.scope == git.ScopeBranch {
-		left += "  " + subtleStyle.Render(m.diff.set.BaseDesc)
+		if name == "" || name == "." {
+			name = filepath.Base(root)
+		}
+		if len(m.diff.repoRoots) > 1 {
+			name = fmt.Sprintf("%s · %d repos", name, len(m.diff.repoRoots))
+		}
+		left += "  " + pill(name, colorAccent)
+		branch := m.diff.set.Repo.Branch
+		if m.diff.scope == git.ScopeBranch && m.diff.set.BaseDesc != "" {
+			left += "  " + subtleStyle.Render(m.diff.set.BaseDesc+" → "+branch)
+		} else if branch != "" {
+			left += "  " + subtleStyle.Render(branch)
+		}
 	}
 
 	adds, dels := 0, 0
@@ -1345,7 +1354,7 @@ func (m *Model) viewDiffFooter() string {
 		{"↑↓", "scroll"}, {"J/K", "file"}, {"n/N", "change"}, {"space", "reviewed"},
 		{"u", "layout"}, {"s", "scope: " + m.diff.scope.String()}, {"B", "base"}, {"c", "comment"},
 	}
-	if len(m.diff.repoRoots) > 1 {
+	if len(m.diff.repoRoots) > 0 {
 		pairs = append(pairs, [2]string{"r", "repo: " + filepath.Base(m.diff.repoSel)})
 	}
 	if len(m.diff.worktrees) > 1 {

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1096,7 +1096,7 @@ func (m *Model) viewDiffHeader(sessName string) string {
 		}
 		left += "  " + pill(name, colorAccent)
 		branch := m.diff.set.Repo.Branch
-		if m.diff.scope == git.ScopeBranch && m.diff.set.BaseDesc != "" {
+		if m.diff.scope == git.ScopeBranch && m.diff.set.BaseDesc != "" && branch != "" {
 			left += "  " + subtleStyle.Render(m.diff.set.BaseDesc+" → "+branch)
 		} else if branch != "" {
 			left += "  " + subtleStyle.Render(branch)

--- a/internal/ui/repopicker.go
+++ b/internal/ui/repopicker.go
@@ -37,7 +37,7 @@ type repoPickState struct {
 }
 
 func (m *Model) openRepoPick() {
-	if len(m.diff.repoRoots) < 2 {
+	if len(m.diff.repoRoots) == 0 {
 		return
 	}
 	rows := make([]pickRow, len(m.diff.repoRoots))

--- a/internal/ui/review_regression_test.go
+++ b/internal/ui/review_regression_test.go
@@ -1446,3 +1446,30 @@ func TestCLIReviewBaseReachesLoadAcrossSymlinkBoundary(t *testing.T) {
 		t.Fatal("the feature base should surface the diverging file in review")
 	}
 }
+
+// The review header always names the repo and its branch; in branch scope it
+// shows the base and the branch it diffs into.
+func TestReviewHeaderShowsRepoBranchAndBase(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	dir := gitRepoWithTwoChangedFiles(t)
+	openReviewOn(t, m, "hdr", dir)
+
+	header := m.viewDiffHeader("hdr")
+	if !strings.Contains(header, filepath.Base(dir)) {
+		t.Fatalf("header should name the repo, got %q", header)
+	}
+	if !strings.Contains(header, "main") {
+		t.Fatalf("header should show the branch, got %q", header)
+	}
+
+	for m.diff.scope != git.ScopeBranch {
+		m.drainCmds(t, m.cycleDiffScope())
+	}
+	header = m.viewDiffHeader("hdr")
+	if !strings.Contains(header, "→ main") {
+		t.Fatalf("branch scope header should show base → branch, got %q", header)
+	}
+}


### PR DESCRIPTION
Review header names the selected repo and branch in every scope, and shows base → branch when diffing vs base. The r repo picker is available in single-repo sessions too: a repo session's roots now include its linked worktrees.

- header pill: `<repo>` (plus `· N repos` under an umbrella), then `<branch>` or `<base> → <branch>`
- footer shows `r repo:` whenever a repo is resolved
- `ResolveRepos` single-repo fast path expands linked worktrees
- regression tests for both