### PR TITLE
fix(ui): selected row background now spans full row

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -994,7 +994,7 @@ func (m *Model) renderDiffRow(fd *diff.FileDiff, hl *fileHL, index, width int, c
 		}
 		row := padRight(prefix+text, width)
 		if cursor {
-			row = selectedRowStyle.Render(row)
+			row = renderSelectedRow(row)
 		}
 		out[i] = row
 	}
@@ -1173,7 +1173,7 @@ func (m *Model) viewDiffFileList(width, height int) string {
 		}
 		row := left + strings.Repeat(" ", gap) + counts
 		if i == m.diff.fileIdx {
-			row = selectedRowStyle.Render(padRight(row, width))
+			row = renderSelectedRow(padRight(row, width))
 		}
 		b.WriteString(row + "\n")
 	}
@@ -1257,7 +1257,7 @@ func (m *Model) renderSideBySide(b *strings.Builder, fd *diff.FileDiff, hl *file
 			}
 			line := leftCell + sep + rightCell
 			if i == m.diff.cursorLine {
-				line = selectedRowStyle.Render(padRight(line, width))
+				line = renderSelectedRow(padRight(line, width))
 			}
 			out = append(out, line)
 		}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -35,6 +35,14 @@ var (
 
 	selectedRowStyle = lipgloss.NewStyle().Background(colorSelBg).Foreground(colorBright)
 
+	// selectedRowReapply is the SGR sequence re-applied after every inner
+	// SGR reset inside a selected row. lipgloss's .Render emits one reset
+	// per call, so wrapping pre-styled content with selectedRowStyle leaves
+	// the background set only on the first segment. renderSelectedRow
+	// substitutes each inner reset with reset+reapply so the selected bg
+	// holds across the whole row.
+	selectedRowReapply = "\x1b[0m\x1b[48;5;" + string(colorSelBg) + "m\x1b[38;5;" + string(colorBright) + "m"
+
 	mutedStyle  = lipgloss.NewStyle().Foreground(colorDim)
 	subtleStyle = lipgloss.NewStyle().Foreground(colorSubtle)
 	valueStyle  = lipgloss.NewStyle().Foreground(colorText)
@@ -42,6 +50,16 @@ var (
 	errStyle    = lipgloss.NewStyle().Foreground(colorErrored).Bold(true)
 	keyStyle    = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 )
+
+// renderSelectedRow wraps a pre-styled line with the selected row's
+// background and foreground. Internal SGR resets emitted by per-segment
+// lipgloss.Render calls (and padRight) would otherwise clear the outer
+// background after the first segment, leaving only the bar glyph tinted.
+// Re-applying the selected bg+fg after every reset keeps the row tinted
+// end-to-end.
+func renderSelectedRow(s string) string {
+	return selectedRowStyle.Render(strings.ReplaceAll(s, "\x1b[0m", selectedRowReapply))
+}
 
 func statusColor(s string) lipgloss.Color {
 	switch s {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -285,7 +285,7 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 
 	if m.renamingRow(entry) {
 		line := bar + " " + guides + m.renameRowInput(entry, width-2-ansi.StringWidth(guides))
-		return selectedRowStyle.Render(padRight(line, width))
+		return renderSelectedRow(padRight(line, width))
 	}
 
 	var content string
@@ -316,7 +316,7 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 	}
 	line = padRight(line, width)
 	if selected {
-		return selectedRowStyle.Render(line)
+		return renderSelectedRow(line)
 	}
 	return line
 }


### PR DESCRIPTION
## What

Selected row's grey background now paints across the entire row width. Previously it only tinted the first segment (the accent left-bar), so the rest of the row appeared with the terminal's default background and the row-highlight feature was effectively invisible.

## Root cause

`selectedRowStyle.Render(line)` wraps `line` with the selected bg+fg SGR codes. But `line` is assembled from many per-segment `lipgloss.Render` calls, each of which appends its own `\x1b[0m` reset. That reset clears **all** SGR attributes, including the outer bg. After the first segment, every subsequent character lost the bg.

The same bug affected all 5 call sites: tree rows (`view.go`), diff view entries, and the rename editor row (`diffview.go`).

## Fix

`renderSelectedRow` replaces every inner `\x1b[0m` with `\x1b[0m` + a re-application of the selected bg+fg sequence before wrapping. The tint now holds end-to-end, including the padding that fills the row to full width.

## Verification

- `go build ./...` clean
- `go test ./internal/ui/` — all pass

## Files

- `internal/ui/styles.go` — `selectedRowReapply` var + `renderSelectedRow` helper
- `internal/ui/view.go` — 2 call sites switched
- `internal/ui/diffview.go` — 3 call sites switched

## Follow-up

Will cut v0.6.2 after merge so `brew upgrade` picks up the fix.