### PR TITLE
feat(ui): mouse-resizable sessions/sidebar split

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -24,7 +24,11 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "|", "esc":
 			return m.exitResizeMode(false)
 		case "q", "ctrl+c":
-			return m, tea.Quit
+			// Drop mouse reporting before quit so the terminal is not left
+			// in mouse mode if shutdown races the bubbletea teardown.
+			m.resizeMode = false
+			m.splitDragging = false
+			return m, tea.Sequence(tea.DisableMouse, tea.Quit)
 		default:
 			return m, nil
 		}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -17,6 +17,19 @@ import (
 )
 
 func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Resize mode owns the keyboard until the drag commits or the user
+	// cancels: other bindings would fight the mouse-gated session.
+	if m.resizeMode {
+		switch msg.String() {
+		case "|", "esc":
+			return m.exitResizeMode(false)
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		default:
+			return m, nil
+		}
+	}
+
 	switch m.mode {
 	case modeForm:
 		return m.handleFormKey(msg)
@@ -81,6 +94,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.toggleCollapseAll()
 	case "s":
 		m.openSettings()
+	case "|":
+		return m.enterResizeMode()
 	case "t":
 		m.showArchived = !m.showArchived
 		m.requestRefresh()

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -182,6 +182,7 @@ func (m *Model) viewHelp() string {
 		{"B", "in review: pick the base the branch diff compares against"},
 		{"F", "fold / unfold all groups"},
 		{"s", "settings (quick spawn tool, review layout)"},
+		{"|", "resize sessions/sidebar split (drag divider)"},
 		{"t", "toggle archived view"},
 		{"/", "search"},
 		{"↑↓ / jk", "move cursor"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -104,6 +104,14 @@ type Model struct {
 	err           string
 	errShown      string
 	errAge        int
+
+	// Horizontal sessions/sidebar split. splitRatio is the left panel's
+	// share of the terminal width; resizeMode arms mouse reporting so the
+	// user can drag the divider without breaking normal text selection.
+	splitRatio       float64
+	splitRatioBefore float64
+	resizeMode       bool
+	splitDragging    bool
 }
 
 // confirmTarget.action values; the zero value means delete.
@@ -209,6 +217,7 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 		setSnapshot: st.SetSnapshot,
 		poller:      newPoller(st, driver, engine, hookManager, statusSources, sessionStores, cfg.PollInterval.Duration),
 		collapsed:   loadCollapsed(st),
+		splitRatio:  loadSplitRatio(st),
 		mode:        modeList,
 	}
 }
@@ -476,6 +485,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.requestRefresh()
 		return m, nil
+
+	case tea.MouseMsg:
+		return m.handleMouse(msg)
 
 	case tea.KeyMsg:
 		model, cmd := m.handleKey(msg)

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -118,16 +118,25 @@ func (m *Model) exitResizeMode(commit bool) (tea.Model, tea.Cmd) {
 	return m, tea.DisableMouse
 }
 
-// bodyYRange is the inclusive-start exclusive-end row range of the main
-// sessions/sidebar body, matching the layout in View.
-func (m *Model) bodyYRange() (start, end int) {
-	footer := m.viewFooter()
-	bodyHeight := m.height - 4 - lipgloss.Height(footer)
+// listChromeRows is the number of rows above the sessions/sidebar body
+// in list mode: header + blank separator. Shared by View and bodyYRange
+// so hit-testing cannot drift from paint.
+const listChromeRows = 2
+
+// listBodyHeight is the vertical budget for the sessions/sidebar panels.
+// Matches View: height - (header, blank, status, footer baseline).
+func (m *Model) listBodyHeight() int {
+	bodyHeight := m.height - 4 - lipgloss.Height(m.viewFooter())
 	if bodyHeight < 3 {
 		bodyHeight = 3
 	}
-	// header, blank line, then body.
-	return 2, 2 + bodyHeight
+	return bodyHeight
+}
+
+// bodyYRange is the inclusive-start exclusive-end row range of the main
+// sessions/sidebar body, matching the layout in View.
+func (m *Model) bodyYRange() (start, end int) {
+	return listChromeRows, listChromeRows + m.listBodyHeight()
 }
 
 // dividerX is the column index of the sessions/sidebar junction (first
@@ -183,11 +192,7 @@ func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.setSplitFromX(msg.X)
-		m.splitDragging = false
-		m.persistSplitRatio()
-		m.resizeSessions()
-		m.resizeMode = false
-		return m, tea.DisableMouse
+		return m.exitResizeMode(true)
 	}
 	return m, nil
 }

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -1,0 +1,210 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	splitRatioSetting = "split_ratio"
+	defaultSplitRatio = 0.34
+	minSplitSide      = 30
+	// How many columns on either side of the panel junction count as the
+	// divider hit target. Wide enough to grab without hunting.
+	splitHitSlop = 1
+)
+
+// settingReader is the store surface loadSplitRatio needs; tests stub it.
+type settingReader interface {
+	Setting(key string) (string, error)
+}
+
+// loadSplitRatio restores the sessions/sidebar ratio, or the 34% default
+// when nothing is stored or the value is unusable.
+func loadSplitRatio(st settingReader) float64 {
+	raw, err := st.Setting(splitRatioSetting)
+	if err != nil || raw == "" {
+		return defaultSplitRatio
+	}
+	ratio, err := strconv.ParseFloat(raw, 64)
+	if err != nil || ratio <= 0 || ratio >= 1 {
+		return defaultSplitRatio
+	}
+	return ratio
+}
+
+// persistSplitRatio writes the current ratio so the next launch reopens
+// at the same split.
+func (m *Model) persistSplitRatio() {
+	if m.store == nil {
+		return
+	}
+	if err := m.store.SetSetting(splitRatioSetting, strconv.FormatFloat(m.splitRatio, 'f', 4, 64)); err != nil {
+		m.err = err.Error()
+	}
+}
+
+// clampSplitLeft keeps both panels above minSplitSide when the terminal
+// is wide enough; on a narrow terminal it just keeps both sides visible.
+func clampSplitLeft(left, width int) int {
+	if width < 2 {
+		if width < 1 {
+			return 0
+		}
+		return 1
+	}
+	if width < minSplitSide*2 {
+		if left < 1 {
+			left = 1
+		}
+		if left >= width {
+			left = width - 1
+		}
+		return left
+	}
+	if left < minSplitSide {
+		left = minSplitSide
+	}
+	if width-left < minSplitSide {
+		left = width - minSplitSide
+	}
+	return left
+}
+
+// setSplitFromX pins the left panel's right edge to terminal column x and
+// updates the stored ratio. Live during a drag; consumers re-read via
+// splitWidths on the next View.
+func (m *Model) setSplitFromX(x int) {
+	if m.width <= 0 {
+		return
+	}
+	left := clampSplitLeft(x, m.width)
+	m.splitRatio = float64(left) / float64(m.width)
+}
+
+// enterResizeMode turns mouse reporting on so the user can drag the
+// sessions/sidebar divider. Mouse stays off outside this mode so normal
+// terminal text selection still works.
+func (m *Model) enterResizeMode() (tea.Model, tea.Cmd) {
+	if m.mode != modeList || m.searching || m.quick.active {
+		return m, nil
+	}
+	m.resizeMode = true
+	m.splitDragging = false
+	m.splitRatioBefore = m.splitRatio
+	m.err = ""
+	return m, tea.EnableMouseCellMotion
+}
+
+// exitResizeMode turns mouse reporting back off. When commit is true the
+// current ratio is persisted and live sessions are resized once; otherwise
+// a mid-drag cancel restores the pre-drag ratio.
+func (m *Model) exitResizeMode(commit bool) (tea.Model, tea.Cmd) {
+	if !m.resizeMode && !m.splitDragging {
+		return m, nil
+	}
+	if m.splitDragging && !commit {
+		m.splitRatio = m.splitRatioBefore
+	}
+	if commit {
+		m.persistSplitRatio()
+		m.resizeSessions()
+	}
+	m.splitDragging = false
+	m.resizeMode = false
+	return m, tea.DisableMouse
+}
+
+// bodyYRange is the inclusive-start exclusive-end row range of the main
+// sessions/sidebar body, matching the layout in View.
+func (m *Model) bodyYRange() (start, end int) {
+	footer := m.viewFooter()
+	bodyHeight := m.height - 4 - lipgloss.Height(footer)
+	if bodyHeight < 3 {
+		bodyHeight = 3
+	}
+	// header, blank line, then body.
+	return 2, 2 + bodyHeight
+}
+
+// dividerX is the column index of the sessions/sidebar junction (first
+// column of the right panel, or the grip column when resize mode is on).
+func (m *Model) dividerX() int {
+	left, _ := m.splitWidths()
+	return left
+}
+
+// onDivider reports whether terminal column x is close enough to the
+// split junction to start a drag.
+func (m *Model) onDivider(x int) bool {
+	div := m.dividerX()
+	return x >= div-splitHitSlop && x <= div+splitHitSlop
+}
+
+func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if !m.resizeMode {
+		return m, nil
+	}
+	if tea.MouseEvent(msg).IsWheel() {
+		return m, nil
+	}
+
+	switch msg.Action {
+	case tea.MouseActionPress:
+		if msg.Button != tea.MouseButtonLeft {
+			return m, nil
+		}
+		y0, y1 := m.bodyYRange()
+		if msg.Y < y0 || msg.Y >= y1 {
+			return m, nil
+		}
+		if !m.onDivider(msg.X) {
+			return m, nil
+		}
+		m.splitDragging = true
+		m.splitRatioBefore = m.splitRatio
+		m.setSplitFromX(msg.X)
+		return m, nil
+
+	case tea.MouseActionMotion:
+		if !m.splitDragging {
+			return m, nil
+		}
+		// Button may be reported as left or none depending on terminal;
+		// once a drag has started, any motion updates the live ratio.
+		m.setSplitFromX(msg.X)
+		return m, nil
+
+	case tea.MouseActionRelease:
+		if !m.splitDragging {
+			return m, nil
+		}
+		m.setSplitFromX(msg.X)
+		m.splitDragging = false
+		m.persistSplitRatio()
+		m.resizeSessions()
+		m.resizeMode = false
+		return m, tea.DisableMouse
+	}
+	return m, nil
+}
+
+// resizeGrip is the 1-column accent bar drawn between the panels while
+// resize mode is active so the drag target is obvious.
+func (m *Model) resizeGrip(height int) string {
+	style := lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+	if m.splitDragging {
+		style = lipgloss.NewStyle().Foreground(colorAccent2).Bold(true)
+	}
+	if height < 1 {
+		height = 1
+	}
+	lines := make([]string, height)
+	for i := range lines {
+		lines[i] = style.Render("║")
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -1,0 +1,237 @@
+package ui
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/store"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type memSettings map[string]string
+
+func (m memSettings) Setting(key string) (string, error) {
+	return m[key], nil
+}
+
+func TestLoadSplitRatio(t *testing.T) {
+	if got := loadSplitRatio(memSettings{}); got != defaultSplitRatio {
+		t.Fatalf("empty setting: got %v want %v", got, defaultSplitRatio)
+	}
+	if got := loadSplitRatio(memSettings{splitRatioSetting: "0.5"}); got != 0.5 {
+		t.Fatalf("stored 0.5: got %v", got)
+	}
+	if got := loadSplitRatio(memSettings{splitRatioSetting: "nope"}); got != defaultSplitRatio {
+		t.Fatalf("garbage should fall back, got %v", got)
+	}
+	if got := loadSplitRatio(memSettings{splitRatioSetting: "1.5"}); got != defaultSplitRatio {
+		t.Fatalf("out of range should fall back, got %v", got)
+	}
+	if got := loadSplitRatio(memSettings{splitRatioSetting: "0"}); got != defaultSplitRatio {
+		t.Fatalf("zero should fall back, got %v", got)
+	}
+}
+
+func TestClampSplitLeft(t *testing.T) {
+	if got := clampSplitLeft(10, 100); got != minSplitSide {
+		t.Fatalf("below min left: got %d want %d", got, minSplitSide)
+	}
+	if got := clampSplitLeft(90, 100); got != 100-minSplitSide {
+		t.Fatalf("below min right: got %d want %d", got, 100-minSplitSide)
+	}
+	if got := clampSplitLeft(40, 100); got != 40 {
+		t.Fatalf("in range: got %d want 40", got)
+	}
+	// Narrow terminal cannot honor both floors; keep both sides visible.
+	if got := clampSplitLeft(0, 50); got != 1 {
+		t.Fatalf("narrow zero: got %d want 1", got)
+	}
+	if got := clampSplitLeft(50, 50); got != 49 {
+		t.Fatalf("narrow full: got %d want 49", got)
+	}
+}
+
+func TestSplitWidthsUsesRatio(t *testing.T) {
+	m := &Model{width: 100, splitRatio: 0.4}
+	left, right := m.splitWidths()
+	if left != 40 || right != 60 {
+		t.Fatalf("splitWidths = %d,%d want 40,60", left, right)
+	}
+	// Default ratio when unset.
+	m.splitRatio = 0
+	left, right = m.splitWidths()
+	if left != 34 || right != 66 {
+		t.Fatalf("default split = %d,%d want 34,66", left, right)
+	}
+}
+
+func TestSetSplitFromXClampsAndUpdatesRatio(t *testing.T) {
+	m := &Model{width: 100, splitRatio: defaultSplitRatio}
+	m.setSplitFromX(50)
+	if m.splitRatio != 0.5 {
+		t.Fatalf("ratio = %v want 0.5", m.splitRatio)
+	}
+	left, _ := m.splitWidths()
+	if left != 50 {
+		t.Fatalf("left = %d want 50", left)
+	}
+	m.setSplitFromX(5)
+	left, right := m.splitWidths()
+	if left != minSplitSide || right != 100-minSplitSide {
+		t.Fatalf("clamped left split = %d,%d", left, right)
+	}
+}
+
+func TestResizeModeKeyEnablesMouse(t *testing.T) {
+	m := &Model{mode: modeList, splitRatio: defaultSplitRatio, width: 120, height: 40}
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'|'}})
+	m = updated.(*Model)
+	if !m.resizeMode {
+		t.Fatal("| should enter resize mode")
+	}
+	if cmd == nil {
+		t.Fatal("enter should return EnableMouseCellMotion cmd")
+	}
+	if msg := cmd(); msg == nil {
+		t.Fatal("mouse enable cmd produced nil msg")
+	}
+
+	// Other keys are swallowed while armed.
+	updated, cmd = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m = updated.(*Model)
+	if m.mode != modeList || !m.resizeMode {
+		t.Fatal("resize mode should swallow n")
+	}
+	if cmd != nil {
+		t.Fatal("swallowed key should return no cmd")
+	}
+
+	updated, cmd = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(*Model)
+	if m.resizeMode {
+		t.Fatal("esc should leave resize mode")
+	}
+	if cmd == nil {
+		t.Fatal("exit should return DisableMouse cmd")
+	}
+}
+
+func TestDragReleasePersistsAndExits(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	m := &Model{
+		store:      st,
+		mode:       modeList,
+		width:      100,
+		height:     40,
+		splitRatio: defaultSplitRatio,
+	}
+	updated, _ := m.enterResizeMode()
+	m = updated.(*Model)
+
+	div := m.dividerX()
+	// Body starts at y=2; any y inside the body range works.
+	updated, _ = m.handleMouse(tea.MouseMsg{
+		X: div, Y: 5, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	if !m.splitDragging {
+		t.Fatal("press on divider should start drag")
+	}
+
+	updated, _ = m.handleMouse(tea.MouseMsg{
+		X: 50, Y: 5, Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	if left, _ := m.splitWidths(); left != 50 {
+		t.Fatalf("motion should set left=50, got %d", left)
+	}
+
+	updated, cmd := m.handleMouse(tea.MouseMsg{
+		X: 50, Y: 5, Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	if m.splitDragging || m.resizeMode {
+		t.Fatal("release should end drag and exit resize mode")
+	}
+	if cmd == nil {
+		t.Fatal("release should disable mouse")
+	}
+
+	raw, err := st.Setting(splitRatioSetting)
+	if err != nil {
+		t.Fatalf("read setting: %v", err)
+	}
+	got, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		t.Fatalf("parse setting %q: %v", raw, err)
+	}
+	if got != 0.5 {
+		t.Fatalf("persisted ratio = %v want 0.5", got)
+	}
+}
+
+func TestDragCancelRestoresRatio(t *testing.T) {
+	m := &Model{
+		mode:       modeList,
+		width:      100,
+		height:     40,
+		splitRatio: 0.34,
+	}
+	updated, _ := m.enterResizeMode()
+	m = updated.(*Model)
+	div := m.dividerX()
+	updated, _ = m.handleMouse(tea.MouseMsg{
+		X: div, Y: 5, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	updated, _ = m.handleMouse(tea.MouseMsg{
+		X: 55, Y: 5, Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	if left, _ := m.splitWidths(); left != 55 {
+		t.Fatalf("pre-cancel left = %d want 55", left)
+	}
+
+	updated, _ = m.exitResizeMode(false)
+	m = updated.(*Model)
+	if m.resizeMode || m.splitDragging {
+		t.Fatal("cancel should clear resize state")
+	}
+	if left, _ := m.splitWidths(); left != 34 {
+		t.Fatalf("cancel should restore left=34, got %d", left)
+	}
+}
+
+func TestPressOffDividerDoesNotDrag(t *testing.T) {
+	m := &Model{
+		mode:       modeList,
+		width:      100,
+		height:     40,
+		splitRatio: 0.34,
+		resizeMode: true,
+	}
+	updated, _ := m.handleMouse(tea.MouseMsg{
+		X: 5, Y: 5, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	if m.splitDragging {
+		t.Fatal("press far from divider should not start drag")
+	}
+}
+
+func TestNewLoadsPersistedSplitRatio(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.SetSetting(splitRatioSetting, "0.45"); err != nil {
+		t.Fatalf("set setting: %v", err)
+	}
+	loaded := New(m.cfg, m.store, m.tmux, m.poller.engine, m.hooks)
+	if loaded.splitRatio != 0.45 {
+		t.Fatalf("New splitRatio = %v want 0.45", loaded.splitRatio)
+	}
+}

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -1,12 +1,14 @@
 package ui
 
 import (
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/YoanWai/agent-manager/internal/store"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 type memSettings map[string]string
@@ -135,7 +137,7 @@ func TestDragReleasePersistsAndExits(t *testing.T) {
 	m = updated.(*Model)
 
 	div := m.dividerX()
-	// Body starts at y=2; any y inside the body range works.
+	// Body starts at listChromeRows; any y inside the body range works.
 	updated, _ = m.handleMouse(tea.MouseMsg{
 		X: div, Y: 5, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
 	})
@@ -173,6 +175,118 @@ func TestDragReleasePersistsAndExits(t *testing.T) {
 	}
 	if got != 0.5 {
 		t.Fatalf("persisted ratio = %v want 0.5", got)
+	}
+}
+
+// Motion updates the live ratio only; tmux resize happens once on release.
+func TestDragResizesTmuxOnlyOnRelease(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "split-drag", t.TempDir(), "")
+	id := m.sessionRows()[0].ID
+	m.splitRatio = defaultSplitRatio
+	m.resizeSessions()
+	before := windowWidth(t, id)
+	if before != m.previewPaneWidth() {
+		t.Fatalf("setup width = %d want %d", before, m.previewPaneWidth())
+	}
+
+	// Drift the session away so a real resize is observable.
+	if _, err := exec.Command("tmux", "resize-window", "-t", "am_"+id, "-x", "100", "-y", "30").CombinedOutput(); err != nil {
+		t.Fatalf("resize-window: %v", err)
+	}
+	if w := windowWidth(t, id); w != 100 {
+		t.Fatalf("drifted width = %d want 100", w)
+	}
+
+	updated, _ := m.enterResizeMode()
+	m = updated.(*Model)
+	div := m.dividerX()
+	y0, _ := m.bodyYRange()
+	updated, _ = m.handleMouse(tea.MouseMsg{
+		X: div, Y: y0, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	updated, _ = m.handleMouse(tea.MouseMsg{
+		X: 50, Y: y0, Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	if w := windowWidth(t, id); w != 100 {
+		t.Fatalf("motion must not resize tmux, width = %d want 100", w)
+	}
+	wantPreview := m.previewPaneWidth()
+	if wantPreview == 100 {
+		t.Fatal("test setup: preview width should differ from drifted 100")
+	}
+
+	updated, _ = m.handleMouse(tea.MouseMsg{
+		X: 50, Y: y0, Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	if w := windowWidth(t, id); w != wantPreview {
+		t.Fatalf("release should resize once to preview width, got %d want %d", w, wantPreview)
+	}
+}
+
+func TestPressOutsideBodyDoesNotDrag(t *testing.T) {
+	m := &Model{
+		mode:       modeList,
+		width:      100,
+		height:     40,
+		splitRatio: 0.34,
+		resizeMode: true,
+	}
+	div := m.dividerX()
+	updated, _ := m.handleMouse(tea.MouseMsg{
+		X: div, Y: 0, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	if m.splitDragging {
+		t.Fatal("press on header row must not start drag")
+	}
+	y0, y1 := m.bodyYRange()
+	if y0 != listChromeRows {
+		t.Fatalf("body start = %d want %d", y0, listChromeRows)
+	}
+	updated, _ = m.handleMouse(tea.MouseMsg{
+		X: div, Y: y1, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	m = updated.(*Model)
+	if m.splitDragging {
+		t.Fatal("press on exclusive body end must not start drag")
+	}
+}
+
+func TestEnterResizeBlockedWhenSearchingOrQuick(t *testing.T) {
+	m := &Model{mode: modeList, width: 100, height: 40, splitRatio: defaultSplitRatio, searching: true}
+	updated, cmd := m.enterResizeMode()
+	m = updated.(*Model)
+	if m.resizeMode || cmd != nil {
+		t.Fatal("searching should block resize mode")
+	}
+	m.searching = false
+	m.quick.active = true
+	updated, cmd = m.enterResizeMode()
+	m = updated.(*Model)
+	if m.resizeMode || cmd != nil {
+		t.Fatal("quick prompt should block resize mode")
+	}
+}
+
+func TestBodyYRangeMatchesListChrome(t *testing.T) {
+	m := &Model{width: 120, height: 40, splitRatio: defaultSplitRatio, mode: modeList}
+	start, end := m.bodyYRange()
+	if start != listChromeRows {
+		t.Fatalf("start = %d want listChromeRows=%d", start, listChromeRows)
+	}
+	wantH := m.height - 4 - lipgloss.Height(m.viewFooter())
+	if wantH < 3 {
+		wantH = 3
+	}
+	if m.listBodyHeight() != wantH {
+		t.Fatalf("listBodyHeight = %d want %d", m.listBodyHeight(), wantH)
+	}
+	if end != listChromeRows+wantH {
+		t.Fatalf("end = %d want %d", end, listChromeRows+wantH)
 	}
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -40,6 +40,14 @@ func (m *Model) View() string {
 		bodyHeight = 3
 	}
 
+	// Grip column sits between the panels in resize mode so the drag
+	// target is visible; steal it from the right panel to keep total width.
+	gripWidth := 0
+	if m.resizeMode && rightWidth > 1 {
+		gripWidth = 1
+		rightWidth--
+	}
+
 	listInner := leftWidth - 4
 	leftBody := m.viewList(listInner, bodyHeight-2)
 	stats := m.viewComputer(listInner)
@@ -49,18 +57,29 @@ func (m *Model) View() string {
 	}
 	left := titledPanel("Sessions", leftBody, leftWidth, bodyHeight)
 	right := titledPanel(m.sidebarTitle(), m.viewSidebar(rightWidth-4, bodyHeight-2), rightWidth, bodyHeight)
-	body := lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+	var body string
+	if gripWidth > 0 {
+		body = lipgloss.JoinHorizontal(lipgloss.Top, left, m.resizeGrip(bodyHeight), right)
+	} else {
+		body = lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+	}
 
 	return strings.Join([]string{m.viewHeader(), "", body, m.viewStatus(), footer}, "\n")
 }
 
-// splitWidths is the body's horizontal split: the sessions panel takes 34%
-// of the terminal (30 columns minimum) and the sidebar the rest.
+// splitWidths is the body's horizontal split: the sessions panel takes
+// splitRatio of the terminal (default 34%), floored so both sides stay
+// usable when the window is wide enough.
 func (m *Model) splitWidths() (int, int) {
-	leftWidth := m.width * 34 / 100
-	if leftWidth < 30 {
-		leftWidth = 30
+	if m.width <= 0 {
+		return 0, 0
 	}
+	ratio := m.splitRatio
+	if ratio <= 0 || ratio >= 1 {
+		ratio = defaultSplitRatio
+	}
+	leftWidth := int(float64(m.width)*ratio + 0.5)
+	leftWidth = clampSplitLeft(leftWidth, m.width)
 	return leftWidth, m.width - leftWidth
 }
 
@@ -78,6 +97,12 @@ func (m *Model) viewStatus() string {
 	switch {
 	case m.mode == modeConfirmDelete:
 		return padRight(errStyle.Render(" ⚠ "+m.confirm.label)+subtleStyle.Render("  y/n"), m.width)
+	case m.resizeMode:
+		hint := "drag the divider · release to set · esc cancels"
+		if m.splitDragging {
+			hint = "release to set · esc cancels"
+		}
+		return padRight(keyStyle.Render(" resize ")+subtleStyle.Render(hint), m.width)
 	case m.searching:
 		cursor := lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
 		line := keyStyle.Render(" search ") + valueStyle.Render(m.search) + cursor +
@@ -683,12 +708,17 @@ func (m *Model) viewFooter() string {
 		{"↑↓", "navigate"}, {"↵", "attach"}, {"n", "new"}, {"g", "group"},
 		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"ctrl+r", "review"}, {"F", "fold all"}, {"m", "move"}, {"r", "rename/edit"},
 		{"v", "revive"}, {"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
-		{"t", "archived"}, {"s", "settings"}, {"?", "help"}, {"q", "quit"},
+		{"t", "archived"}, {"s", "settings"}, {"|", "resize"}, {"?", "help"}, {"q", "quit"},
 	}
 	if m.quick.active {
 		pairs = [][2]string{
 			{"↵", "send"}, {"↑↓", "switch target"}, {"⇥", "tool: " + m.quickTool()},
 			{"esc", "close"},
+		}
+	}
+	if m.resizeMode {
+		pairs = [][2]string{
+			{"drag", "divider"}, {"release", "commit"}, {"esc / |", "cancel"},
 		}
 	}
 	if m.mode == modeRename {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -35,10 +35,7 @@ func (m *Model) View() string {
 
 	leftWidth, rightWidth := m.splitWidths()
 	footer := m.viewFooter()
-	bodyHeight := m.height - 4 - lipgloss.Height(footer)
-	if bodyHeight < 3 {
-		bodyHeight = 3
-	}
+	bodyHeight := m.listBodyHeight()
 
 	// Grip column sits between the panels in resize mode so the drag
 	// target is visible; steal it from the right panel to keep total width.
@@ -64,6 +61,7 @@ func (m *Model) View() string {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, left, right)
 	}
 
+	// listChromeRows (header + blank) must stay aligned with bodyYRange.
 	return strings.Join([]string{m.viewHeader(), "", body, m.viewStatus(), footer}, "\n")
 }
 


### PR DESCRIPTION
## Summary
- Gate mouse reporting behind `|` so normal terminal text selection stays intact.
- Drag the sessions/sidebar divider; redraw live; on release persist `split_ratio` and resize tmux panes once.
- Esc/`|` cancels mid-drag and restores the previous ratio.

`|` is a **toggle** (not a held modifier): bubbletea cannot arm mouse on a held key alone. Toggle-in / release-or-esc-out is the intentional terminal-safe design for #42.

Closes #42.

## Test plan
- [x] Unit: `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./internal/ui/ -run 'Split|Clamp|ResizeMode|Drag|PressOff|NewLoads|BodyY|EnterResize' -count=1`
- [ ] Full: `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./... -count=1`
- [ ] Manual: press `|`, drag divider, release; confirm split persists across restart
- [ ] Manual: confirm text selection still works when not in resize mode
- [ ] Manual: Esc mid-drag restores prior split; no stray mouse capture after exit