### PR TITLE
fix(ui): insert pasted image paths into the quick prompt

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -845,7 +845,24 @@ func (m *Model) attachQuickImage() bool {
 		return true
 	}
 	// Space-pad so the path is a standalone, backspace-deletable token.
-	m.quick.input.InsertString(" " + path + " ")
+	token := " " + path + " "
+	// bubbles InsertString silently truncates at CharLimit; refuse when the
+	// full path would not fit so we never submit a broken partial path.
+	if limit := m.quick.input.CharLimit; limit > 0 {
+		if m.quick.input.Length()+len([]rune(token)) > limit {
+			_ = os.Remove(path)
+			m.err = "prompt is full"
+			return true
+		}
+	}
+	before := m.quick.input.Value()
+	m.quick.input.InsertString(token)
+	if !strings.Contains(m.quick.input.Value(), path) {
+		m.quick.input.SetValue(before)
+		_ = os.Remove(path)
+		m.err = "prompt is full"
+		return true
+	}
 	m.err = ""
 	return true
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -825,11 +825,11 @@ func (m *Model) renameGroupLocally(old, newPath, dir string) {
 // image; tests swap it for a fake.
 var captureClipboardImage = clipboard.ReadImage
 
-// attachQuickImage saves a clipboard image to a temp file and records it as
-// an attachment shown beside the prompt; its path is appended to the message
-// on submit so the agent can open it. It reports whether it handled the
-// keypress: an empty clipboard returns false so the caller can fall back to a
-// plain text paste, while a real failure is surfaced through m.err.
+// attachQuickImage saves a clipboard image to a temp file and inserts that
+// path into the prompt at the cursor so the user can edit or delete it like
+// any other text. It reports whether it handled the keypress: an empty
+// clipboard returns false so the caller can fall back to a plain text paste,
+// while a real failure is surfaced through m.err.
 func (m *Model) attachQuickImage() bool {
 	data, ext, err := captureClipboardImage()
 	if err != nil {
@@ -844,23 +844,15 @@ func (m *Model) attachQuickImage() bool {
 		m.err = err.Error()
 		return true
 	}
-	m.quick.attachments = append(m.quick.attachments, path)
+	// Space-pad so the path is a standalone, backspace-deletable token.
+	m.quick.input.InsertString(" " + path + " ")
 	m.err = ""
 	return true
 }
 
-// quickMessage is the text delivered on submit: the typed prompt with any
-// attachment paths appended so the target agent can open them.
+// quickMessage is the text delivered on submit.
 func (m *Model) quickMessage() string {
-	text := strings.TrimSpace(m.quick.input.Value())
-	if len(m.quick.attachments) == 0 {
-		return text
-	}
-	paths := strings.Join(m.quick.attachments, " ")
-	if text == "" {
-		return paths
-	}
-	return text + " " + paths
+	return strings.TrimSpace(m.quick.input.Value())
 }
 
 func (m *Model) openQuickMode() {
@@ -960,7 +952,6 @@ func (m *Model) submitQuick() (tea.Model, tea.Cmd) {
 	// The prompt is delivered: clear the input before anything else can
 	// fail, so a retry cannot send it twice.
 	m.quick.input.SetValue("")
-	m.quick.attachments = nil
 	m.err = ""
 	// A queued answer means the user expects a fresh finished alert.
 	if err := m.store.SetAcked(entry.sess.ID, false); err != nil {
@@ -991,7 +982,6 @@ func (m *Model) quickSpawn(group, prompt string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.quick.input.SetValue("")
-	m.quick.attachments = nil
 	m.err = ""
 	return m, m.refreshCmd()
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -145,11 +145,10 @@ type renameTarget struct {
 // across cursor moves, so the target follows the selection. The tool is
 // the spawn CLI for group targets, cycled with tab.
 type quickState struct {
-	active      bool
-	input       textarea.Model
-	toolNames   []string
-	toolIndex   int
-	attachments []string
+	active    bool
+	input     textarea.Model
+	toolNames []string
+	toolIndex int
 }
 
 type settingsState struct {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1172,7 +1172,45 @@ func TestQuickAttachImagePadsBesideExistingText(t *testing.T) {
 		t.Fatalf("want text tokens plus path, got %q", msg)
 	}
 	path := fields[len(fields)-1]
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("padded path is not a readable file: %v", err)
+	}
+	if string(data) != "png-bytes" {
+		t.Fatalf("temp file holds %q", data)
+	}
 	os.Remove(path)
+}
+
+func TestQuickAttachImageFullPromptSurfacesError(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "answer-me", t.TempDir(), "")
+	m.selectSessionRow(t, "answer-me")
+	m.openQuickMode()
+	// Fill the textarea to CharLimit so the padded path cannot fit.
+	limit := m.quick.input.CharLimit
+	if limit <= 0 {
+		t.Fatal("quick input needs a positive CharLimit for this test")
+	}
+	m.quick.input.SetValue(strings.Repeat("x", limit))
+	m.quick.input.CursorEnd()
+	before := m.quick.input.Value()
+
+	orig := captureClipboardImage
+	defer func() { captureClipboardImage = orig }()
+	captureClipboardImage = func() ([]byte, string, error) {
+		return []byte("png-bytes"), "png", nil
+	}
+
+	if !m.attachQuickImage() {
+		t.Fatal("full-prompt attach should still handle the keypress")
+	}
+	if m.err == "" {
+		t.Fatal("full prompt should surface an error")
+	}
+	if m.quick.input.Value() != before {
+		t.Fatalf("input should stay unchanged when the path cannot fit, got %q", m.quick.input.Value())
+	}
 }
 
 func TestQuickAttachImageNoImageFallsThrough(t *testing.T) {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1101,7 +1101,7 @@ func TestQuickPromptSendClearsAcked(t *testing.T) {
 	}
 }
 
-func TestQuickAttachImageRecordsAttachmentNotInput(t *testing.T) {
+func TestQuickAttachImageInsertsPathIntoInput(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "answer-me", t.TempDir(), "")
 	m.selectSessionRow(t, "answer-me")
@@ -1119,54 +1119,60 @@ func TestQuickAttachImageRecordsAttachmentNotInput(t *testing.T) {
 	if m.err != "" {
 		t.Fatalf("attach: %q", m.err)
 	}
-	if m.quick.input.Value() != "" {
-		t.Fatal("the path should stay out of the typed input")
+	value := strings.TrimSpace(m.quick.input.Value())
+	if value == "" {
+		t.Fatal("the path should be inserted into the typed input")
 	}
-	if len(m.quick.attachments) != 1 {
-		t.Fatalf("want 1 attachment, got %d", len(m.quick.attachments))
+	if !strings.HasSuffix(value, ".png") {
+		t.Fatalf("input should hold a .png path, got %q", value)
 	}
-	path := m.quick.attachments[0]
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(value)
 	if err != nil {
-		t.Fatalf("attachment path is not a readable file: %v", err)
+		t.Fatalf("inserted path is not a readable file: %v", err)
 	}
 	if string(data) != "png-bytes" {
 		t.Fatalf("temp file holds %q", data)
 	}
-	os.Remove(path)
+	if got := m.quickMessage(); got != value {
+		t.Fatalf("quickMessage = %q, want %q", got, value)
+	}
+	os.Remove(value)
 }
 
-func TestQuickAttachmentChipShowsBasename(t *testing.T) {
-	m := buildModel(t)
-	if got := m.quickAttachmentChip(80); got != "" {
-		t.Fatalf("no attachments should render nothing, got %q", got)
-	}
-	m.quick.attachments = []string{"/tmp/agent-manager-pastes/paste-123.png"}
-	chip := m.quickAttachmentChip(80)
-	if !strings.Contains(chip, "paste-123.png") {
-		t.Fatalf("chip should show the file name, got %q", chip)
-	}
-	if strings.Contains(chip, "/tmp/") {
-		t.Fatalf("chip should not show the full path, got %q", chip)
-	}
-}
-
-func TestQuickMessageAppendsAttachmentPaths(t *testing.T) {
+func TestQuickAttachImagePadsBesideExistingText(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "answer-me", t.TempDir(), "")
 	m.selectSessionRow(t, "answer-me")
 	m.openQuickMode()
-
 	m.quick.input.SetValue("look at this")
-	m.quick.attachments = []string{"/tmp/a.png", "/tmp/b.png"}
-	if got := m.quickMessage(); got != "look at this /tmp/a.png /tmp/b.png" {
-		t.Fatalf("compose = %q", got)
+	m.quick.input.CursorEnd()
+
+	orig := captureClipboardImage
+	defer func() { captureClipboardImage = orig }()
+	captureClipboardImage = func() ([]byte, string, error) {
+		return []byte("png-bytes"), "png", nil
 	}
 
-	m.quick.input.SetValue("")
-	if got := m.quickMessage(); got != "/tmp/a.png /tmp/b.png" {
-		t.Fatalf("image-only compose = %q", got)
+	if !m.attachQuickImage() {
+		t.Fatal("attachQuickImage should report it handled the image")
 	}
+	value := m.quick.input.Value()
+	if !strings.HasPrefix(value, "look at this ") {
+		t.Fatalf("existing text should stay put, got %q", value)
+	}
+	if !strings.Contains(value, "agent-manager-pastes") {
+		t.Fatalf("path should land in the input, got %q", value)
+	}
+	msg := m.quickMessage()
+	if !strings.HasPrefix(msg, "look at this ") {
+		t.Fatalf("compose should space-separate path, got %q", msg)
+	}
+	fields := strings.Fields(msg)
+	if len(fields) < 4 {
+		t.Fatalf("want text tokens plus path, got %q", msg)
+	}
+	path := fields[len(fields)-1]
+	os.Remove(path)
 }
 
 func TestQuickAttachImageNoImageFallsThrough(t *testing.T) {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -483,25 +482,7 @@ func (m *Model) viewQuickBar(width int) string {
 	}
 	m.quick.input.SetWidth(width)
 	m.quick.input.SetHeight(m.quickBarRows(width - 2))
-	bar := divider("Quick Prompt · "+target, width) + "\n" + m.quick.input.View()
-	if chip := m.quickAttachmentChip(width); chip != "" {
-		bar += "\n" + chip
-	}
-	return bar
-}
-
-// quickAttachmentChip renders the pasted images docked under the prompt as
-// a muted line of file names, so the raw temp paths stay out of the input.
-func (m *Model) quickAttachmentChip(width int) string {
-	if len(m.quick.attachments) == 0 {
-		return ""
-	}
-	names := make([]string, len(m.quick.attachments))
-	for i, path := range m.quick.attachments {
-		names[i] = filepath.Base(path)
-	}
-	line := "📎 " + strings.Join(names, "  ")
-	return mutedStyle.Render(ansi.Truncate(line, max(width, 1), "…"))
+	return divider("Quick Prompt · "+target, width) + "\n" + m.quick.input.View()
 }
 
 const quickBarMaxRows = 5


### PR DESCRIPTION
## Summary
- Paste (`Ctrl+V`) now inserts the temp image path into the quick-prompt textarea as normal, editable text.
- Removes the attachment chip / `attachments` state that blocked deleting a pasted image.
- Submit still sends the path as part of the prompt so the agent can open the file.

## Test plan
- [x] `go test ./internal/ui/ -run 'TestQuickAttach|TestQuickCtrlV'`
- [ ] Open quick prompt, paste an image, confirm path appears inline
- [ ] Backspace / delete the path, confirm it is gone before submit
- [ ] Paste beside existing text, confirm space separation
- [ ] Submit with path still present, confirm agent receives the path