### PR TITLE
feat(ui): arrow resize, 1:1 preview fit, lock frame scroll

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -398,7 +398,7 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 	if err != nil {
 		return err
 	}
-	if err := m.tmux.Create(id, dir, command, env, m.previewPaneWidth(), m.height); err != nil {
+	if err := m.tmux.Create(id, dir, command, env, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
 		return err
 	}
 	sess := store.Session{

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -21,7 +21,16 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// cancels: other bindings would fight the mouse-gated session.
 	if m.resizeMode {
 		switch msg.String() {
-		case "|", "esc":
+		case "left", "h":
+			m.nudgeSplit(-1)
+			return m, nil
+		case "right", "l":
+			m.nudgeSplit(1)
+			return m, nil
+		case "|":
+			// Second | commits the working ratio (arrows or an unfinished drag).
+			return m.exitResizeMode(true)
+		case "esc":
 			return m.exitResizeMode(false)
 		case "q", "ctrl+c":
 			// Drop mouse reporting before quit so the terminal is not left
@@ -173,6 +182,9 @@ func (m *Model) moveCursor(delta int) tea.Cmd {
 		return nil
 	}
 	m.preview = ""
+	// Detail block height can change per session; pin the pane to the
+	// preview box before capturing so the frame matches 1:1.
+	_ = m.tmux.Resize(sess.ID, m.previewPaneWidth(), m.previewPaneHeight())
 	return m.previewCmd(sess)
 }
 
@@ -392,7 +404,7 @@ func (m *Model) reviveSelected() (tea.Model, tea.Cmd) {
 		m.err = err.Error()
 		return m, nil
 	}
-	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.previewPaneWidth(), m.height); err != nil {
+	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
 		m.err = err.Error()
 		return m, nil
 	}

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -182,7 +182,7 @@ func (m *Model) viewHelp() string {
 		{"B", "in review: pick the base the branch diff compares against"},
 		{"F", "fold / unfold all groups"},
 		{"s", "settings (quick spawn tool, review layout)"},
-		{"|", "resize sessions/sidebar split (drag divider)"},
+		{"|", "resize split (←→ / drag, | commits, esc cancels)"},
 		{"t", "toggle archived view"},
 		{"/", "search"},
 		{"↑↓ / jk", "move cursor"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -378,14 +378,15 @@ func (m *Model) refreshCmd() tea.Cmd {
 }
 
 // resizeSessions syncs every live session's tmux window to the preview
-// panel's width, so a detached session's capture fits the panel instead of
-// getting clipped on the right. Dead sessions error harmlessly and skip.
+// panel's pixel box so a capture fills the preview 1:1. Dead sessions
+// error harmlessly and skip.
 func (m *Model) resizeSessions() {
+	width, height := m.previewPaneWidth(), m.previewPaneHeight()
 	for _, sess := range m.sessions {
 		if sess.Archived {
 			continue
 		}
-		_ = m.tmux.Resize(sess.ID, m.previewPaneWidth(), m.height)
+		_ = m.tmux.Resize(sess.ID, width, height)
 	}
 }
 
@@ -456,7 +457,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// The attach client sized the window to the full terminal and tmux
 		// keeps that size on detach; shrink it back to the preview panel so
 		// the capture is not clipped on the right.
-		_ = m.tmux.Resize(msg.sessID, m.previewPaneWidth(), m.height)
+		_ = m.tmux.Resize(msg.sessID, m.previewPaneWidth(), m.previewPaneHeight())
 		if msg.err != nil {
 			m.err = msg.err.Error()
 			m.requestRefresh()

--- a/internal/ui/resize_guard_test.go
+++ b/internal/ui/resize_guard_test.go
@@ -73,10 +73,11 @@ func TestUnchangedWindowSizeSkipsResize(t *testing.T) {
 		t.Fatalf("unchanged size should skip resize, session is %dx%d, want 100x30", w, h)
 	}
 
-	// A real resize propagates the preview panel width to the session.
+	// A real resize propagates the preview panel box to the session.
 	updated, _ = m.Update(tea.WindowSizeMsg{Width: 150, Height: 45})
 	*m = *updated.(*Model)
-	if w, h := windowSize(t, id); w != m.previewPaneWidth() || h != 45 {
-		t.Fatalf("changed size should resize session, got %dx%d, want %dx45", w, h, m.previewPaneWidth())
+	wantW, wantH := m.previewPaneWidth(), m.previewPaneHeight()
+	if w, h := windowSize(t, id); w != wantW || h != wantH {
+		t.Fatalf("changed size should resize session, got %dx%d, want %dx%d", w, h, wantW, wantH)
 	}
 }

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -100,22 +100,32 @@ func (m *Model) enterResizeMode() (tea.Model, tea.Cmd) {
 }
 
 // exitResizeMode turns mouse reporting back off. When commit is true the
-// current ratio is persisted and live sessions are resized once; otherwise
-// a mid-drag cancel restores the pre-drag ratio.
+// current ratio is persisted; cancel restores the pre-mode ratio. Either
+// path ends with a pane resize so the preview stays 1:1 with the panel.
 func (m *Model) exitResizeMode(commit bool) (tea.Model, tea.Cmd) {
 	if !m.resizeMode && !m.splitDragging {
 		return m, nil
 	}
-	if m.splitDragging && !commit {
+	if !commit {
 		m.splitRatio = m.splitRatioBefore
-	}
-	if commit {
+	} else {
 		m.persistSplitRatio()
-		m.resizeSessions()
 	}
 	m.splitDragging = false
 	m.resizeMode = false
+	m.resizeSessions()
 	return m, tea.DisableMouse
+}
+
+// nudgeSplit moves the divider by delta columns while resize mode is on.
+// Panes reflow live so the preview keeps fitting; persist waits for |.
+func (m *Model) nudgeSplit(delta int) {
+	if m.width <= 0 || delta == 0 {
+		return
+	}
+	left, _ := m.splitWidths()
+	m.setSplitFromX(left + delta)
+	m.resizeSessions()
 }
 
 // listChromeRows is the number of rows above the sessions/sidebar body

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -119,6 +119,69 @@ func TestResizeModeKeyEnablesMouse(t *testing.T) {
 	}
 }
 
+func TestArrowNudgeAndPipeCommits(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	m := &Model{
+		store:      st,
+		mode:       modeList,
+		width:      100,
+		height:     40,
+		splitRatio: 0.34,
+	}
+	updated, _ := m.enterResizeMode()
+	m = updated.(*Model)
+	before, _ := m.splitWidths()
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated.(*Model)
+	after, _ := m.splitWidths()
+	if after != before+1 {
+		t.Fatalf("right arrow left width = %d want %d", after, before+1)
+	}
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
+	m = updated.(*Model)
+	if left, _ := m.splitWidths(); left != before {
+		t.Fatalf("left arrow should undo nudge, left=%d want %d", left, before)
+	}
+	// Nudge once more, then | commits.
+	m.handleKey(tea.KeyMsg{Type: tea.KeyRight})
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'|'}})
+	m = updated.(*Model)
+	if m.resizeMode {
+		t.Fatal("| should commit and exit resize mode")
+	}
+	if cmd == nil {
+		t.Fatal("commit should disable mouse")
+	}
+	raw, err := st.Setting(splitRatioSetting)
+	if err != nil || raw == "" {
+		t.Fatalf("committed ratio missing: %v %q", err, raw)
+	}
+	if left, _ := m.splitWidths(); left != before+1 {
+		t.Fatalf("committed left = %d want %d", left, before+1)
+	}
+}
+
+func TestArrowCancelRestoresRatio(t *testing.T) {
+	m := &Model{mode: modeList, width: 100, height: 40, splitRatio: 0.34}
+	updated, _ := m.enterResizeMode()
+	m = updated.(*Model)
+	m.handleKey(tea.KeyMsg{Type: tea.KeyRight})
+	m.handleKey(tea.KeyMsg{Type: tea.KeyRight})
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(*Model)
+	if m.resizeMode {
+		t.Fatal("esc should exit")
+	}
+	if left, _ := m.splitWidths(); left != 34 {
+		t.Fatalf("esc should restore left=34, got %d", left)
+	}
+}
+
 func TestDragReleasePersistsAndExits(t *testing.T) {
 	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
 	if err != nil {
@@ -213,15 +276,16 @@ func TestDragResizesTmuxOnlyOnRelease(t *testing.T) {
 	if w := windowWidth(t, id); w != 100 {
 		t.Fatalf("motion must not resize tmux, width = %d want 100", w)
 	}
-	wantPreview := m.previewPaneWidth()
-	if wantPreview == 100 {
-		t.Fatal("test setup: preview width should differ from drifted 100")
-	}
 
 	updated, _ = m.handleMouse(tea.MouseMsg{
 		X: 50, Y: y0, Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft,
 	})
 	m = updated.(*Model)
+	// After exit, grip is gone; measure the committed preview width.
+	wantPreview := m.previewPaneWidth()
+	if wantPreview == 100 {
+		t.Fatal("test setup: preview width should differ from drifted 100")
+	}
 	if w := windowWidth(t, id); w != wantPreview {
 		t.Fatalf("release should resize once to preview width, got %d want %d", w, wantPreview)
 	}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -173,21 +173,25 @@ func windowWidth(t *testing.T, id string) int {
 	return w
 }
 
-// A detached session must boot at the preview panel's width so its pane
-// preview fills without cropping on the right, and follow later terminal
-// resizes, rather than staying at tmux's 80-column default until attach.
+// A detached session must boot at the preview panel's width×height so its
+// pane preview fills 1:1, and follow later terminal resizes, rather than
+// staying at tmux's 80×24 default until attach.
 func TestSessionSizesToPreviewPane(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "sized", t.TempDir(), "")
 	id := m.sessionRows()[0].ID
+	// Create sizes from pre-selection geometry; re-pin to the live preview box.
+	m.resizeSessions()
 
-	if w := windowWidth(t, id); w != m.previewPaneWidth() {
-		t.Fatalf("new session window width = %d, want %d", w, m.previewPaneWidth())
+	wantW, wantH := m.previewPaneWidth(), m.previewPaneHeight()
+	if w, h := windowSize(t, id); w != wantW || h != wantH {
+		t.Fatalf("new session window = %dx%d, want %dx%d", w, h, wantW, wantH)
 	}
 
 	m.Update(tea.WindowSizeMsg{Width: 150, Height: 45})
-	if w := windowWidth(t, id); w != m.previewPaneWidth() {
-		t.Fatalf("after resize, window width = %d, want %d", w, m.previewPaneWidth())
+	wantW, wantH = m.previewPaneWidth(), m.previewPaneHeight()
+	if w, h := windowSize(t, id); w != wantW || h != wantH {
+		t.Fatalf("after resize, window = %dx%d, want %dx%d", w, h, wantW, wantH)
 	}
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -16,23 +16,30 @@ func (m *Model) View() string {
 	if m.width == 0 {
 		return "loading..."
 	}
+	var frame string
 	switch m.mode {
 	case modeForm:
-		return m.viewForm()
+		frame = m.viewForm()
 	case modeHelp:
-		return m.viewHelp()
+		frame = m.viewHelp()
 	case modeSettings:
-		return m.viewSettings()
+		frame = m.viewSettings()
 	case modeMove:
-		return m.viewMove()
+		frame = m.viewMove()
 	case modeRepoPick:
-		return m.viewRepoPick()
+		frame = m.viewRepoPick()
 	case modeGroupForm:
-		return m.viewGroupForm()
+		frame = m.viewGroupForm()
 	case modeDiff:
-		return m.viewDiffFull()
+		frame = m.viewDiffFull()
+	default:
+		frame = m.viewListFrame()
 	}
+	return clampFrame(frame, m.height)
+}
 
+// viewListFrame is the sessions/sidebar layout used in list mode.
+func (m *Model) viewListFrame() string {
 	leftWidth, rightWidth := m.splitWidths()
 	footer := m.viewFooter()
 	bodyHeight := m.listBodyHeight()
@@ -65,6 +72,22 @@ func (m *Model) View() string {
 	return strings.Join([]string{m.viewHeader(), "", body, m.viewStatus(), footer}, "\n")
 }
 
+// clampFrame pins a rendered frame to exactly height rows so the outer
+// terminal cannot scroll the TUI away when a layout overshoots.
+func clampFrame(frame string, height int) string {
+	if height <= 0 {
+		return frame
+	}
+	lines := strings.Split(frame, "\n")
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	for len(lines) < height {
+		lines = append(lines, "")
+	}
+	return strings.Join(lines, "\n")
+}
+
 // splitWidths is the body's horizontal split: the sessions panel takes
 // splitRatio of the terminal (default 34%), floored so both sides stay
 // usable when the window is wide enough.
@@ -86,7 +109,49 @@ func (m *Model) splitWidths() (int, int) {
 // fit the panel instead of getting clipped on the right.
 func (m *Model) previewPaneWidth() int {
 	_, rightWidth := m.splitWidths()
-	return rightWidth - 4
+	if m.resizeMode && rightWidth > 1 {
+		// Grip steals one column from the right panel while resize is on.
+		rightWidth--
+	}
+	w := rightWidth - 4
+	if w < 1 {
+		return 1
+	}
+	return w
+}
+
+// previewPaneHeight is the rows of session pane content the Preview
+// section can show. Mirrors viewSidebar + viewPreview so tmux is pinned
+// to the same box the UI paints into.
+func (m *Model) previewPaneHeight() int {
+	width := m.previewPaneWidth()
+	if m.height < 1 {
+		return 1
+	}
+	sidebarInner := m.listBodyHeight() - 2
+	if sidebarInner < 1 {
+		return 1
+	}
+	avail := sidebarInner
+	if m.quick.active {
+		barH := lipgloss.Height(m.viewQuickBar(width)) + 1
+		avail -= barH
+		if avail < 3 {
+			avail = 3
+		}
+	}
+	detailH := lipgloss.Height(divider("Details", width) + "\n" + m.viewDetail(width))
+	rest := avail - detailH - 1
+	if rest < 3 {
+		// Preview section is hidden; keep a tiny pane for create/attach paths.
+		return 3
+	}
+	// viewPreview spends one row on its "Preview" divider.
+	h := rest - 1
+	if h < 1 {
+		return 1
+	}
+	return h
 }
 
 // viewStatus is the transient message line: prompts, search, and
@@ -96,7 +161,7 @@ func (m *Model) viewStatus() string {
 	case m.mode == modeConfirmDelete:
 		return padRight(errStyle.Render(" ⚠ "+m.confirm.label)+subtleStyle.Render("  y/n"), m.width)
 	case m.resizeMode:
-		hint := "drag the divider · release to set · esc cancels"
+		hint := "←→ resize · drag divider · | set · esc cancel"
 		if m.splitDragging {
 			hint = "release to set · esc cancels"
 		}
@@ -625,13 +690,18 @@ func (m *Model) viewGroupAgents(group string, width, height int) string {
 	return padToHeight(strings.TrimRight(b.String(), "\n"), height)
 }
 
-// viewPreview renders the tail of the selected session's tmux pane with
-// its original ANSI colors, clipped to the panel. Each line is sanitized
-// and closed with an SGR reset so pane colors never leak into the layout.
+// viewPreview renders the selected session's tmux pane 1:1 with its
+// original ANSI colors. The pane is sized to this box, so the capture is
+// painted top-to-bottom without tail/collapse transforms that would make
+// it look unlike being inside the session.
 func (m *Model) viewPreview(width, height int) string {
 	var b strings.Builder
 	b.WriteString(divider("Preview", width) + "\n")
-	lines := paneTail(m.preview, height-1)
+	contentRows := height - 1
+	if contentRows < 1 {
+		return padToHeight(b.String(), height)
+	}
+	lines := paneExact(m.preview, contentRows)
 	if len(lines) == 0 {
 		b.WriteString(mutedStyle.Render("(no output yet)"))
 		return padToHeight(b.String(), height)
@@ -642,13 +712,16 @@ func (m *Model) viewPreview(width, height int) string {
 	return padToHeight(strings.TrimRight(b.String(), "\n"), height)
 }
 
-// eraseSeqs matches CSI K (erase in line) and CSI J (erase in display).
-// Captured panes carry them, and passed through they make the outer
-// terminal paint the current background past the clip point.
-var eraseSeqs = regexp.MustCompile(`\x1b\[[0-9]*[KJ]`)
+// previewDangerSeqs strips capture sequences that would scroll or clear the
+// outer manager terminal when embedded in View output: erase (K/J), scroll
+// (S/T), insert/delete lines (L/M), set scroll region (r), and the 7-bit
+// index / reverse-index / next-line controls (D/M/E).
+var previewDangerSeqs = regexp.MustCompile(
+	`\x1b\[[0-9;]*[KJLMSTr]|\x1b[DEM]`,
+)
 
 func previewLine(line string, width int) string {
-	line = eraseSeqs.ReplaceAllString(line, "")
+	line = previewDangerSeqs.ReplaceAllString(line, "")
 	line = strings.Map(func(r rune) rune {
 		if r < 0x20 && r != 0x1b && r != '\t' {
 			return -1
@@ -656,7 +729,7 @@ func previewLine(line string, width int) string {
 		return r
 	}, line)
 	if ansi.StringWidth(line) > width {
-		line = ansi.Truncate(line, width-1, "…")
+		line = ansi.Truncate(line, width, "")
 	}
 	if strings.ContainsRune(line, 0x1b) {
 		line += "\x1b[0m"
@@ -664,10 +737,26 @@ func previewLine(line string, width int) string {
 	return line
 }
 
-// paneTail returns the last n lines of pane text. Trailing blanks are
-// dropped and interior runs of blank lines collapse to one, so sparse
-// TUI panes (claude leaves most rows empty) show their real content
-// instead of a window of whitespace. ANSI-only lines count as blank.
+// paneExact returns up to n lines of pane text as captured, preserving
+// blank rows so a full-screen agent TUI looks the same in the preview.
+// When the capture is taller than the panel (stale size), the bottom n
+// lines are kept — the visible end of the pane.
+func paneExact(pane string, n int) []string {
+	if n <= 0 || pane == "" {
+		return nil
+	}
+	// capture-pane often ends with a trailing newline; drop only that.
+	pane = strings.TrimSuffix(pane, "\n")
+	lines := strings.Split(pane, "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return lines
+}
+
+// paneTail returns the last n content-bearing lines of pane text with
+// blank runs collapsed. Used by tests and any caller that wants a dense
+// log-style excerpt rather than a 1:1 TUI frame.
 func paneTail(pane string, n int) []string {
 	if n <= 0 || pane == "" {
 		return nil
@@ -716,7 +805,7 @@ func (m *Model) viewFooter() string {
 	}
 	if m.resizeMode {
 		pairs = [][2]string{
-			{"drag", "divider"}, {"release", "commit"}, {"esc / |", "cancel"},
+			{"←→", "nudge"}, {"drag", "divider"}, {"| / release", "commit"}, {"esc", "cancel"},
 		}
 	}
 	if m.mode == modeRename {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -34,6 +34,31 @@ func TestScrollWindow(t *testing.T) {
 	}
 }
 
+func TestPaneExactPreservesBlanks(t *testing.T) {
+	pane := "one\n\n\ntwo\n"
+	got := paneExact(pane, 10)
+	if len(got) != 4 || got[1] != "" || got[2] != "" {
+		t.Fatalf("paneExact should keep blank rows: %q", got)
+	}
+	got = paneExact("a\nb\nc\nd", 2)
+	if len(got) != 2 || got[0] != "c" || got[1] != "d" {
+		t.Fatalf("paneExact oversize should take bottom lines: %q", got)
+	}
+}
+
+func TestClampFrame(t *testing.T) {
+	tall := "a\nb\nc\nd\ne"
+	got := clampFrame(tall, 3)
+	if got != "a\nb\nc" {
+		t.Fatalf("clampFrame trim = %q", got)
+	}
+	short := "x"
+	got = clampFrame(short, 3)
+	if got != "x\n\n" {
+		t.Fatalf("clampFrame pad = %q", got)
+	}
+}
+
 func TestPaneTail(t *testing.T) {
 	pane := "one\ntwo\nthree\n\n\n"
 	got := paneTail(pane, 2)
@@ -77,6 +102,10 @@ func TestPreviewLine(t *testing.T) {
 	erased := "abc\x1b[K\x1b[2Jdef"
 	if got := previewLine(erased, 80); got != "abcdef" {
 		t.Fatalf("erase sequences should be stripped: %q", got)
+	}
+	scrolled := "a\x1b[1Sb\x1bMc\x1b[2Td"
+	if got := previewLine(scrolled, 80); got != "abcd" {
+		t.Fatalf("scroll sequences should be stripped: %q", got)
 	}
 
 	control := "a\rb\bc"


### PR DESCRIPTION
## Summary
- Resize mode: `←`/`→` (and `h`/`l`) nudge the split; `|` commits; `esc` cancels.
- Detached tmux panes size to the Preview box (width and height) so the capture paints 1:1 like being inside the session.
- Preview keeps blank rows and strips scroll/clear ANSI that could shove the outer TUI.
- Every frame is clamped to the terminal height so the manager cannot scroll away.

## Test plan
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./... -count=1`
- [ ] Manual: `|` then arrows, `|` commits; esc restores
- [ ] Manual: preview matches attached session layout density
- [ ] Manual: trackpad/scroll no longer runs the TUI off-screen