### PR TITLE
fix(clipboard): speed up macOS image paste

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -6,10 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
-
-	"os/exec"
 )
 
 // ErrNoImage means the clipboard held no image when it was read.
@@ -25,6 +24,11 @@ var (
 	}
 )
 
+// pastesDir is the shared temp directory for clipboard image files.
+func pastesDir() string {
+	return filepath.Join(os.TempDir(), "agent-manager-pastes")
+}
+
 // ReadImage returns the clipboard image as raw bytes plus its file
 // extension. It errors when the clipboard holds no image, the platform
 // tooling is missing, or the OS is unsupported.
@@ -39,29 +43,99 @@ func ReadImage() ([]byte, string, error) {
 	}
 }
 
-// readDarwin coerces the clipboard to PNG through osascript, which writes
-// the bytes to a temp file we read back. A clipboard without image data
-// makes the coercion fail, which we report as ErrNoImage.
+// SaveImage writes a clipboard image into the pastes directory and returns
+// its absolute path. On Darwin this is a single write (no intermediate
+// buffer file). Linux still reads bytes then writes them once.
+func SaveImage() (string, error) {
+	switch goos {
+	case "darwin":
+		return saveDarwinImage()
+	case "linux":
+		data, ext, err := readLinux()
+		if err != nil {
+			return "", err
+		}
+		return SaveToTemp(data, ext)
+	default:
+		return "", fmt.Errorf("clipboard image paste is not supported on %s", goos)
+	}
+}
+
+// jxaReadPNG writes the clipboard image as PNG to the path in argv[0].
+// Prefers NSPasteboardTypePNG (fast, no conversion). Falls back to TIFF
+// only when needed. AppleScript "clipboard as PNGf" is several times
+// slower because it re-encodes through the Scripting Bridge.
+const jxaReadPNG = `
+ObjC.import("AppKit");
+ObjC.import("Foundation");
+function run(argv) {
+  var out = argv[0];
+  var pb = $.NSPasteboard.generalPasteboard;
+  var data = pb.dataForType($.NSPasteboardTypePNG);
+  if (!data || data.length === 0) {
+    var tiff = pb.dataForType($.NSPasteboardTypeTIFF);
+    if (tiff && tiff.length > 0) {
+      var img = $.NSBitmapImageRep.imageRepWithData(tiff);
+      if (img) {
+        data = img.representationUsingTypeProperties($.NSBitmapImageFileTypePNG, $());
+      }
+    }
+  }
+  if (!data || data.length === 0) {
+    throw new Error("no image");
+  }
+  if (!data.writeToFileAtomically($(out), true)) {
+    throw new Error("write failed");
+  }
+  return String(data.length);
+}
+`
+
+// writeDarwinPNG dumps the clipboard image as PNG to path using JXA
+// AppKit. Any failure (empty clipboard, no image type) is ErrNoImage.
+func writeDarwinPNG(path string) error {
+	if _, err := runCmd("osascript", "-l", "JavaScript", "-e", jxaReadPNG, path); err != nil {
+		return ErrNoImage
+	}
+	return nil
+}
+
+// saveDarwinImage writes the clipboard PNG straight into the pastes dir.
+func saveDarwinImage() (string, error) {
+	if err := os.MkdirAll(pastesDir(), 0o755); err != nil {
+		return "", err
+	}
+	file, err := os.CreateTemp(pastesDir(), "paste-*.png")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := writeDarwinPNG(path); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Size() == 0 {
+		_ = os.Remove(path)
+		return "", ErrNoImage
+	}
+	return path, nil
+}
+
+// readDarwin pulls PNG bytes for callers that still want the raw payload.
+// It writes once into a temp file under pastesDir and reads it back.
 func readDarwin() ([]byte, string, error) {
-	dst, err := os.CreateTemp("", "clip-*.png")
+	path, err := saveDarwinImage()
 	if err != nil {
 		return nil, "", err
 	}
-	path := dst.Name()
-	dst.Close()
+	// Caller owns only the bytes; drop the file so we do not leak pastes
+	// from ReadImage-only use. SaveImage is the path-returning API.
 	defer os.Remove(path)
-
-	script := `on run argv
-	set outFile to (item 1 of argv)
-	set pngData to (the clipboard as «class PNGf»)
-	set fh to open for access (POSIX file outFile) with write permission
-	set eof fh to 0
-	write pngData to fh
-	close access fh
-end run`
-	if _, err := runCmd("osascript", "-e", script, path); err != nil {
-		return nil, "", ErrNoImage
-	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, "", err
@@ -95,11 +169,10 @@ func readLinux() ([]byte, string, error) {
 // SaveToTemp writes image bytes to a uniquely named file under a shared
 // pastes directory and returns its absolute path.
 func SaveToTemp(data []byte, ext string) (string, error) {
-	dir := filepath.Join(os.TempDir(), "agent-manager-pastes")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(pastesDir(), 0o755); err != nil {
 		return "", err
 	}
-	file, err := os.CreateTemp(dir, "paste-*."+ext)
+	file, err := os.CreateTemp(pastesDir(), "paste-*."+ext)
 	if err != nil {
 		return "", err
 	}

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -19,24 +19,28 @@ func TestReadImageDarwinWritesAndReadsBytes(t *testing.T) {
 	defer restore()()
 	goos = "darwin"
 	want := []byte("fake-png-bytes")
-	var sawScript bool
+	var sawJXA bool
 	runCmd = func(name string, args ...string) ([]byte, error) {
 		if name != "osascript" {
 			t.Fatalf("expected osascript, got %q", name)
 		}
-		sawScript = true
+		// Prefer JXA AppKit path: osascript -l JavaScript -e <script> <path>
+		if len(args) < 4 || args[0] != "-l" || args[1] != "JavaScript" {
+			t.Fatalf("want JXA invocation, got %v", args)
+		}
+		sawJXA = true
 		path := args[len(args)-1]
 		if err := os.WriteFile(path, want, 0o644); err != nil {
 			t.Fatal(err)
 		}
-		return nil, nil
+		return []byte("12"), nil
 	}
 	data, ext, err := ReadImage()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !sawScript {
-		t.Fatal("osascript was not invoked")
+	if !sawJXA {
+		t.Fatal("JXA osascript was not invoked")
 	}
 	if string(data) != string(want) || ext != "png" {
 		t.Fatalf("got %q/%q", data, ext)
@@ -47,9 +51,52 @@ func TestReadImageDarwinNoImage(t *testing.T) {
 	defer restore()()
 	goos = "darwin"
 	runCmd = func(name string, args ...string) ([]byte, error) {
-		return nil, errors.New("coercion failed")
+		return nil, errors.New("no image")
 	}
 	if _, _, err := ReadImage(); !errors.Is(err, ErrNoImage) {
+		t.Fatalf("want ErrNoImage, got %v", err)
+	}
+}
+
+func TestSaveImageDarwinWritesOnce(t *testing.T) {
+	defer restore()()
+	goos = "darwin"
+	want := []byte("single-write-png")
+	var writePath string
+	runCmd = func(name string, args ...string) ([]byte, error) {
+		writePath = args[len(args)-1]
+		if err := os.WriteFile(writePath, want, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return []byte("16"), nil
+	}
+	path, err := SaveImage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+	if !strings.Contains(path, "agent-manager-pastes") {
+		t.Fatalf("want path under pastes dir, got %q", path)
+	}
+	if writePath != path {
+		t.Fatalf("JXA should write the final path directly; wrote %q, returned %q", writePath, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(want) {
+		t.Fatalf("got %q", data)
+	}
+}
+
+func TestSaveImageDarwinNoImage(t *testing.T) {
+	defer restore()()
+	goos = "darwin"
+	runCmd = func(name string, args ...string) ([]byte, error) {
+		return nil, errors.New("no image")
+	}
+	if _, err := SaveImage(); !errors.Is(err, ErrNoImage) {
 		t.Fatalf("want ErrNoImage, got %v", err)
 	}
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -818,24 +818,20 @@ func (m *Model) renameGroupLocally(old, newPath, dir string) {
 	m.persistCollapsed()
 }
 
-// captureClipboardImage is the seam the quick bar uses to read a pasted
-// image; tests swap it for a fake.
-var captureClipboardImage = clipboard.ReadImage
+// captureClipboardImage is the seam the quick bar uses to save a pasted
+// image to a temp file; tests swap it for a fake.
+var captureClipboardImage = clipboard.SaveImage
 
-// attachQuickImageCmd reads the clipboard image off the UI thread. macOS
-// osascript conversion can take a second or more on a large screenshot;
-// returning a Cmd keeps the TUI responsive and shows a pasting chip.
+// attachQuickImageCmd reads the clipboard image off the UI thread and
+// writes it once into the pastes directory. Returning a Cmd keeps the TUI
+// responsive and shows a pasting chip while the OS clipboard is read.
 func (m *Model) attachQuickImageCmd() tea.Cmd {
 	return func() tea.Msg {
-		data, ext, err := captureClipboardImage()
+		path, err := captureClipboardImage()
 		if err != nil {
 			if errors.Is(err, clipboard.ErrNoImage) {
 				return quickImageMsg{noImage: true}
 			}
-			return quickImageMsg{err: err}
-		}
-		path, err := clipboard.SaveToTemp(data, ext)
-		if err != nil {
 			return quickImageMsg{err: err}
 		}
 		return quickImageMsg{path: path}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1106,10 +1106,14 @@ func TestQuickAttachImageRecordsAttachmentNotInput(t *testing.T) {
 	m.selectSessionRow(t, "answer-me")
 	m.openQuickMode()
 
+	fakePath := filepath.Join(t.TempDir(), "paste-test.png")
+	if err := os.WriteFile(fakePath, []byte("png-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	orig := captureClipboardImage
 	defer func() { captureClipboardImage = orig }()
-	captureClipboardImage = func() ([]byte, string, error) {
-		return []byte("png-bytes"), "png", nil
+	captureClipboardImage = func() (string, error) {
+		return fakePath, nil
 	}
 
 	msg := m.attachQuickImageCmd()().(quickImageMsg)
@@ -1128,6 +1132,9 @@ func TestQuickAttachImageRecordsAttachmentNotInput(t *testing.T) {
 		t.Fatalf("want 1 attachment, got %d", len(m.quick.attachments))
 	}
 	path := m.quick.attachments[0]
+	if path != fakePath {
+		t.Fatalf("attachment path = %q, want %q", path, fakePath)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("attachment path is not a readable file: %v", err)
@@ -1271,8 +1278,8 @@ func TestQuickAttachImageRealErrorSurfaces(t *testing.T) {
 
 	orig := captureClipboardImage
 	defer func() { captureClipboardImage = orig }()
-	captureClipboardImage = func() ([]byte, string, error) {
-		return nil, "", errors.New("install wl-clipboard or xclip to paste images")
+	captureClipboardImage = func() (string, error) {
+		return "", errors.New("install wl-clipboard or xclip to paste images")
 	}
 
 	msg := m.attachQuickImageCmd()().(quickImageMsg)


### PR DESCRIPTION
## Summary
- macOS clipboard image read now uses **JXA + AppKit** (`NSPasteboardTypePNG`, TIFF fallback) instead of AppleScript PNGf coercion.
- Measured on this machine with a ~900KB screenshot: **~1.3s → ~60–100ms**.
- New `SaveImage()` writes the PNG **once** into `agent-manager-pastes/`; quick prompt uses it instead of ReadImage + SaveToTemp.

## Test plan
- [x] `go test ./internal/clipboard/ ./internal/ui/ -run 'TestReadImage|TestSaveImage|TestQuick'`
- [x] Live `SaveImage` ~100ms / ~60ms
- [ ] Ctrl+V image in quick prompt feels snappy; chip still appears