### PR TITLE
fix(clipboard): Linux/WSL image paste parity

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // ErrNoImage means the clipboard held no image when it was read.
@@ -22,6 +23,20 @@ var (
 	runCmd   = func(name string, args ...string) ([]byte, error) {
 		return exec.Command(name, args...).Output()
 	}
+	// runCmdToFile runs a command with stdout directed at outPath.
+	runCmdToFile = func(outPath string, name string, args ...string) error {
+		file, err := os.OpenFile(outPath, os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		cmd := exec.Command(name, args...)
+		cmd.Stdout = file
+		return cmd.Run()
+	}
+	// wslProbe reports whether we are running under WSL (Windows clipboard
+	// bridge needed when Linux tools cannot see the host clipboard).
+	wslProbe = detectWSL
 )
 
 // pastesDir is the shared temp directory for clipboard image files.
@@ -44,18 +59,14 @@ func ReadImage() ([]byte, string, error) {
 }
 
 // SaveImage writes a clipboard image into the pastes directory and returns
-// its absolute path. On Darwin this is a single write (no intermediate
-// buffer file). Linux still reads bytes then writes them once.
+// its absolute path. Each platform writes the PNG once (no intermediate
+// buffer file when tools can stream to a path).
 func SaveImage() (string, error) {
 	switch goos {
 	case "darwin":
 		return saveDarwinImage()
 	case "linux":
-		data, ext, err := readLinux()
-		if err != nil {
-			return "", err
-		}
-		return SaveToTemp(data, ext)
+		return saveLinuxImage()
 	default:
 		return "", fmt.Errorf("clipboard image paste is not supported on %s", goos)
 	}
@@ -102,24 +113,15 @@ func writeDarwinPNG(path string) error {
 
 // saveDarwinImage writes the clipboard PNG straight into the pastes dir.
 func saveDarwinImage() (string, error) {
-	if err := os.MkdirAll(pastesDir(), 0o755); err != nil {
-		return "", err
-	}
-	file, err := os.CreateTemp(pastesDir(), "paste-*.png")
+	path, err := newPasteFile("png")
 	if err != nil {
-		return "", err
-	}
-	path := file.Name()
-	if err := file.Close(); err != nil {
-		_ = os.Remove(path)
 		return "", err
 	}
 	if err := writeDarwinPNG(path); err != nil {
 		_ = os.Remove(path)
 		return "", err
 	}
-	info, err := os.Stat(path)
-	if err != nil || info.Size() == 0 {
+	if !fileNonEmpty(path) {
 		_ = os.Remove(path)
 		return "", ErrNoImage
 	}
@@ -146,24 +148,157 @@ func readDarwin() ([]byte, string, error) {
 	return data, "png", nil
 }
 
-// readLinux pulls PNG bytes from whichever clipboard tool is installed,
-// preferring the Wayland one.
-func readLinux() ([]byte, string, error) {
+// saveLinuxImage writes a clipboard PNG in one shot. Order:
+//  1. wl-paste (Wayland)
+//  2. xclip (X11 / WSLg)
+//  3. On WSL: Windows clipboard via powershell.exe (host paste)
+//
+// Native tools are tried first so a real Linux desktop stays local and
+// fast; WSL falls through to Windows when those cannot see the image.
+func saveLinuxImage() (string, error) {
+	var triedTool bool
 	if _, err := lookPath("wl-paste"); err == nil {
-		data, err := runCmd("wl-paste", "--type", "image/png")
-		if err != nil || len(data) == 0 {
-			return nil, "", ErrNoImage
+		triedTool = true
+		path, err := writePasteFromCmd("png", "wl-paste", "--type", "image/png")
+		if err == nil {
+			return path, nil
 		}
-		return data, "png", nil
 	}
 	if _, err := lookPath("xclip"); err == nil {
-		data, err := runCmd("xclip", "-selection", "clipboard", "-t", "image/png", "-o")
-		if err != nil || len(data) == 0 {
-			return nil, "", ErrNoImage
+		triedTool = true
+		path, err := writePasteFromCmd("png", "xclip", "-selection", "clipboard", "-t", "image/png", "-o")
+		if err == nil {
+			return path, nil
 		}
-		return data, "png", nil
 	}
-	return nil, "", errors.New("install wl-clipboard or xclip to paste images")
+	if wslProbe() {
+		path, err := saveWSLWindowsImage()
+		if err == nil {
+			return path, nil
+		}
+		// WSL with no image on either clipboard is still "no image".
+		if errors.Is(err, ErrNoImage) {
+			return "", ErrNoImage
+		}
+		// Missing powershell is a real config problem on WSL when native
+		// tools also cannot deliver an image.
+		if !triedTool {
+			return "", err
+		}
+		return "", ErrNoImage
+	}
+	if !triedTool {
+		return "", errors.New("install wl-clipboard or xclip to paste images")
+	}
+	return "", ErrNoImage
+}
+
+// readLinux pulls PNG bytes for the ReadImage API (in-memory).
+func readLinux() ([]byte, string, error) {
+	path, err := saveLinuxImage()
+	if err != nil {
+		return nil, "", err
+	}
+	defer os.Remove(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(data) == 0 {
+		return nil, "", ErrNoImage
+	}
+	return data, "png", nil
+}
+
+// writePasteFromCmd creates a paste file and streams the command's stdout
+// into it. Empty output or a failed command is ErrNoImage.
+func writePasteFromCmd(ext string, name string, args ...string) (string, error) {
+	path, err := newPasteFile(ext)
+	if err != nil {
+		return "", err
+	}
+	if err := runCmdToFile(path, name, args...); err != nil {
+		_ = os.Remove(path)
+		return "", ErrNoImage
+	}
+	if !fileNonEmpty(path) {
+		_ = os.Remove(path)
+		return "", ErrNoImage
+	}
+	return path, nil
+}
+
+// saveWSLWindowsImage reads an image from the Windows host clipboard via
+// PowerShell and saves it to a WSL pastes path (converted with wslpath).
+func saveWSLWindowsImage() (string, error) {
+	ps, err := lookPath("powershell.exe")
+	if err != nil {
+		ps, err = lookPath("pwsh.exe")
+		if err != nil {
+			return "", errors.New("WSL image paste needs powershell.exe (Windows clipboard) or wl-clipboard/xclip")
+		}
+	}
+	path, err := newPasteFile("png")
+	if err != nil {
+		return "", err
+	}
+	winOut, err := runCmd("wslpath", "-w", path)
+	if err != nil {
+		_ = os.Remove(path)
+		return "", fmt.Errorf("wslpath: %w", err)
+	}
+	winPath := strings.TrimSpace(string(winOut))
+	// Single-quoted PowerShell string: double any embedded quotes.
+	winPath = strings.ReplaceAll(winPath, "'", "''")
+	script := "Add-Type -AssemblyName System.Windows.Forms,System.Drawing; " +
+		"$img = [System.Windows.Forms.Clipboard]::GetImage(); " +
+		"if ($null -eq $img) { exit 1 }; " +
+		"$img.Save('" + winPath + "', [System.Drawing.Imaging.ImageFormat]::Png)"
+	if _, err := runCmd(ps, "-NoProfile", "-NonInteractive", "-Command", script); err != nil {
+		_ = os.Remove(path)
+		return "", ErrNoImage
+	}
+	if !fileNonEmpty(path) {
+		_ = os.Remove(path)
+		return "", ErrNoImage
+	}
+	return path, nil
+}
+
+// detectWSL reports WSL via env or the kernel release string.
+func detectWSL() bool {
+	if os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSL_INTEROP") != "" {
+		return true
+	}
+	data, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		return false
+	}
+	release := strings.ToLower(string(data))
+	return strings.Contains(release, "microsoft") || strings.Contains(release, "wsl")
+}
+
+// newPasteFile creates an empty paste-* file under pastesDir and returns
+// its absolute path (caller fills it or removes it).
+func newPasteFile(ext string) (string, error) {
+	if err := os.MkdirAll(pastesDir(), 0o755); err != nil {
+		return "", err
+	}
+	file, err := os.CreateTemp(pastesDir(), "paste-*."+ext)
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
+}
+
+func fileNonEmpty(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Size() > 0
 }
 
 // SaveToTemp writes image bytes to a uniquely named file under a shared

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func restore() func() {
-	origGOOS, origLook, origRun := goos, lookPath, runCmd
+	origGOOS, origLook, origRun, origToFile, origWSL := goos, lookPath, runCmd, runCmdToFile, wslProbe
 	return func() {
-		goos, lookPath, runCmd = origGOOS, origLook, origRun
+		goos, lookPath, runCmd, runCmdToFile, wslProbe = origGOOS, origLook, origRun, origToFile, origWSL
 	}
 }
 
@@ -101,9 +101,10 @@ func TestSaveImageDarwinNoImage(t *testing.T) {
 	}
 }
 
-func TestReadImageLinuxWayland(t *testing.T) {
+func TestSaveImageLinuxWlPasteStreamsToFile(t *testing.T) {
 	defer restore()()
 	goos = "linux"
+	wslProbe = func() bool { return false }
 	want := []byte("wayland-png")
 	lookPath = func(name string) (string, error) {
 		if name == "wl-paste" {
@@ -111,11 +112,198 @@ func TestReadImageLinuxWayland(t *testing.T) {
 		}
 		return "", errors.New("not found")
 	}
-	runCmd = func(name string, args ...string) ([]byte, error) {
+	var wrote string
+	runCmdToFile = func(outPath string, name string, args ...string) error {
 		if name != "wl-paste" {
 			t.Fatalf("expected wl-paste, got %q", name)
 		}
-		return want, nil
+		wrote = outPath
+		return os.WriteFile(outPath, want, 0o644)
+	}
+	path, err := SaveImage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+	if wrote != path {
+		t.Fatalf("tool should stream to final path; wrote %q returned %q", wrote, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(want) {
+		t.Fatalf("got %q", data)
+	}
+}
+
+func TestSaveImageLinuxXclipFallback(t *testing.T) {
+	defer restore()()
+	goos = "linux"
+	wslProbe = func() bool { return false }
+	lookPath = func(name string) (string, error) {
+		if name == "xclip" {
+			return "/usr/bin/xclip", nil
+		}
+		return "", errors.New("not found")
+	}
+	var used string
+	runCmdToFile = func(outPath string, name string, args ...string) error {
+		used = name
+		return os.WriteFile(outPath, []byte("x11-png"), 0o644)
+	}
+	path, err := SaveImage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+	if used != "xclip" {
+		t.Fatalf("expected xclip, used %q", used)
+	}
+}
+
+func TestSaveImageLinuxNoTool(t *testing.T) {
+	defer restore()()
+	goos = "linux"
+	wslProbe = func() bool { return false }
+	lookPath = func(name string) (string, error) { return "", errors.New("not found") }
+	_, err := SaveImage()
+	if err == nil || errors.Is(err, ErrNoImage) {
+		t.Fatalf("want a missing-tool error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "wl-clipboard") {
+		t.Fatalf("error should name the tools to install, got %v", err)
+	}
+}
+
+func TestSaveImageWSLUsesWindowsClipboard(t *testing.T) {
+	defer restore()()
+	goos = "linux"
+	wslProbe = func() bool { return true }
+	// No native Linux clipboard tools: WSL should go to PowerShell.
+	lookPath = func(name string) (string, error) {
+		switch name {
+		case "powershell.exe":
+			return "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe", nil
+		case "wslpath":
+			return "/usr/bin/wslpath", nil
+		default:
+			return "", errors.New("not found")
+		}
+	}
+	var sawPS, sawWslpath bool
+	var psScript string
+	runCmd = func(name string, args ...string) ([]byte, error) {
+		base := filepath.Base(name)
+		if base == "wslpath" || name == "wslpath" {
+			sawWslpath = true
+			return []byte(`C:\Users\me\paste.png`), nil
+		}
+		if strings.Contains(base, "powershell") || strings.Contains(name, "powershell") {
+			sawPS = true
+			// last arg is -Command script
+			psScript = args[len(args)-1]
+			// The path powershell saves is a Windows path; the WSL file is
+			// the paste file already created. Simulate a successful save by
+			// writing through the wslpath reverse: tests write the WSL file
+			// from the script's target. We re-find the empty paste file.
+			// Easier: write to every paste-*.png created under pastesDir.
+			dir := pastesDir()
+			entries, _ := os.ReadDir(dir)
+			for _, entry := range entries {
+				if strings.HasPrefix(entry.Name(), "paste-") {
+					_ = os.WriteFile(filepath.Join(dir, entry.Name()), []byte("win-png"), 0o644)
+				}
+			}
+			return nil, nil
+		}
+		t.Fatalf("unexpected command %q %v", name, args)
+		return nil, nil
+	}
+	path, err := SaveImage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+	if !sawPS || !sawWslpath {
+		t.Fatalf("want powershell + wslpath, sawPS=%v sawWslpath=%v", sawPS, sawWslpath)
+	}
+	if !strings.Contains(psScript, "Clipboard]::GetImage") {
+		t.Fatalf("script should read Windows clipboard image, got %q", psScript)
+	}
+	if !strings.Contains(psScript, `C:\Users\me\paste.png`) {
+		t.Fatalf("script should save to wslpath result, got %q", psScript)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "win-png" {
+		t.Fatalf("got %q", data)
+	}
+}
+
+func TestSaveImageWSLFallsBackWhenNativeMisses(t *testing.T) {
+	defer restore()()
+	goos = "linux"
+	wslProbe = func() bool { return true }
+	lookPath = func(name string) (string, error) {
+		switch name {
+		case "wl-paste":
+			return "/usr/bin/wl-paste", nil
+		case "powershell.exe":
+			return "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe", nil
+		case "wslpath":
+			return "/usr/bin/wslpath", nil
+		default:
+			return "", errors.New("not found")
+		}
+	}
+	// wl-paste sees no image; Windows clipboard has one.
+	runCmdToFile = func(outPath string, name string, args ...string) error {
+		return errors.New("no image on wayland")
+	}
+	runCmd = func(name string, args ...string) ([]byte, error) {
+		base := filepath.Base(name)
+		if base == "wslpath" || name == "wslpath" {
+			return []byte(`C:\tmp\out.png`), nil
+		}
+		if strings.Contains(base, "powershell") || strings.Contains(name, "powershell") {
+			dir := pastesDir()
+			entries, _ := os.ReadDir(dir)
+			for _, entry := range entries {
+				if strings.HasPrefix(entry.Name(), "paste-") {
+					_ = os.WriteFile(filepath.Join(dir, entry.Name()), []byte("from-windows"), 0o644)
+				}
+			}
+			return nil, nil
+		}
+		return nil, errors.New("unexpected")
+	}
+	path, err := SaveImage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+	data, _ := os.ReadFile(path)
+	if string(data) != "from-windows" {
+		t.Fatalf("want Windows clipboard fallback, got %q", data)
+	}
+}
+
+func TestReadImageLinuxWayland(t *testing.T) {
+	defer restore()()
+	goos = "linux"
+	wslProbe = func() bool { return false }
+	want := []byte("wayland-png")
+	lookPath = func(name string) (string, error) {
+		if name == "wl-paste" {
+			return "/usr/bin/wl-paste", nil
+		}
+		return "", errors.New("not found")
+	}
+	runCmdToFile = func(outPath string, name string, args ...string) error {
+		return os.WriteFile(outPath, want, 0o644)
 	}
 	data, ext, err := ReadImage()
 	if err != nil {
@@ -129,6 +317,7 @@ func TestReadImageLinuxWayland(t *testing.T) {
 func TestReadImageLinuxXclipFallback(t *testing.T) {
 	defer restore()()
 	goos = "linux"
+	wslProbe = func() bool { return false }
 	lookPath = func(name string) (string, error) {
 		if name == "xclip" {
 			return "/usr/bin/xclip", nil
@@ -136,9 +325,9 @@ func TestReadImageLinuxXclipFallback(t *testing.T) {
 		return "", errors.New("not found")
 	}
 	var used string
-	runCmd = func(name string, args ...string) ([]byte, error) {
+	runCmdToFile = func(outPath string, name string, args ...string) error {
 		used = name
-		return []byte("x11-png"), nil
+		return os.WriteFile(outPath, []byte("x11-png"), 0o644)
 	}
 	if _, _, err := ReadImage(); err != nil {
 		t.Fatal(err)
@@ -151,6 +340,7 @@ func TestReadImageLinuxXclipFallback(t *testing.T) {
 func TestReadImageLinuxNoTool(t *testing.T) {
 	defer restore()()
 	goos = "linux"
+	wslProbe = func() bool { return false }
 	lookPath = func(name string) (string, error) { return "", errors.New("not found") }
 	_, _, err := ReadImage()
 	if err == nil || errors.Is(err, ErrNoImage) {
@@ -184,5 +374,17 @@ func TestSaveToTempWritesBytes(t *testing.T) {
 	}
 	if string(data) != "payload" {
 		t.Fatalf("got %q", data)
+	}
+}
+
+func TestDetectWSLEnv(t *testing.T) {
+	t.Setenv("WSL_DISTRO_NAME", "Ubuntu")
+	if !detectWSL() {
+		t.Fatal("WSL_DISTRO_NAME should mark WSL")
+	}
+	t.Setenv("WSL_DISTRO_NAME", "")
+	t.Setenv("WSL_INTEROP", "/run/WSL/1_interop")
+	if !detectWSL() {
+		t.Fatal("WSL_INTEROP should mark WSL")
 	}
 }


### PR DESCRIPTION
## Summary
macOS paste was sped up in #55; this brings Linux and WSL up to the same bar.

- **Linux**: stream `wl-paste` / `xclip` stdout into the paste file (one write, no full buffer then rewrite).
- **WSL**: if native tools miss or are missing, fall back to the **Windows** clipboard via `powershell.exe` + `wslpath` so images copied in Windows apps paste into agent-manager.
- Order: Wayland → X11 → (WSL only) Windows host.

## Test plan
- [x] `go test ./internal/clipboard/ -run 'TestSaveImage|TestReadImage|TestDetect'`
- [x] UI quick-paste tests still pass
- [ ] Linux desktop: Ctrl+V image with wl-clipboard or xclip
- [ ] WSL: copy image in Windows, Ctrl+V in agent-manager quick prompt