### PR TITLE
fix(ui): debounce preview on key-repeat

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -156,9 +156,9 @@ func (m *Model) openDiff() tea.Cmd {
 	return m.retargetDiff(sess)
 }
 
-// moveCursor shifts the selection and kicks off an immediate preview
-// fetch for the newly selected session, so the sidebar follows the
-// cursor without waiting for the next poll tick.
+// moveCursor shifts the selection and schedules a debounced preview
+// fetch. Key-repeat only bumps the gen; a single capture runs after the
+// cursor settles so holding j/k cannot pile up tmux work.
 func (m *Model) moveCursor(delta int) tea.Cmd {
 	if len(m.rows) == 0 {
 		return nil
@@ -174,15 +174,14 @@ func (m *Model) moveCursor(delta int) tea.Cmd {
 	if m.cursor == previous {
 		return nil
 	}
-	sess, ok := m.selected()
-	if !ok {
-		m.preview = ""
-		m.proc = sysstat.ProcStat{}
-		m.procFor = ""
+	m.preview = ""
+	m.proc = sysstat.ProcStat{}
+	m.procFor = ""
+	if _, ok := m.selected(); !ok {
 		return nil
 	}
-	m.preview = ""
-	return m.previewCmd(sess)
+	m.previewGen++
+	return m.schedulePreview()
 }
 
 // reorderSelected moves the selected session among its group siblings,

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -115,6 +115,10 @@ type Model struct {
 	// paneGeom is the last width×height we told tmux for each session id.
 	// Skips no-op resize-window calls that otherwise stall the UI.
 	paneGeom map[string][2]int
+	// previewGen increments on every cursor move. In-flight captures and
+	// settle timers with an older gen are dropped so key-repeat cannot
+	// queue a second of tmux work after the user stops.
+	previewGen uint64
 }
 
 // confirmTarget.action values; the zero value means delete.
@@ -203,9 +207,21 @@ type previewMsg struct {
 	sessID  string
 	preview string
 	proc    sysstat.ProcStat
-	// sized is the width×height applied before capture (0,0 if skipped).
-	sized [2]int
+	// gen is the previewGen the capture was scheduled for; mismatched
+	// gens are discarded so a hold-j burst cannot paint a stale session.
+	gen uint64
 }
+
+// previewSettleMsg fires after the cursor has stopped moving so one
+// capture runs instead of one per key-repeat tick.
+type previewSettleMsg struct {
+	gen uint64
+}
+
+// previewSettle is how long we wait after the last cursor move before
+// talking to tmux. Short enough to feel instant, long enough to collapse
+// a held j/k burst into a single capture.
+const previewSettle = 50 * time.Millisecond
 
 type errMsg struct{ err error }
 
@@ -359,20 +375,22 @@ func (m *Model) selectedRow() (treeRow, bool) {
 	return m.rows[m.cursor], true
 }
 
-// previewCmd captures one session's pane and process stats right away,
-// off the render loop, for instant sidebar updates on cursor moves.
-// A size pin runs in this same background cmd only when the target box
-// changed, so j/k never blocks on tmux and never re-resizes no-ops.
-func (m *Model) previewCmd(sess store.Session) tea.Cmd {
-	width, height := m.previewPaneWidth(), m.previewPaneHeight()
-	needResize := true
-	if m.paneGeom != nil {
-		if last, ok := m.paneGeom[sess.ID]; ok && last[0] == width && last[1] == height {
-			needResize = false
-		}
-	}
+// schedulePreview arms a single capture after previewSettle. Call after
+// bumping previewGen so earlier timers and in-flight captures go stale.
+func (m *Model) schedulePreview() tea.Cmd {
+	gen := m.previewGen
+	return tea.Tick(previewSettle, func(time.Time) tea.Msg {
+		return previewSettleMsg{gen: gen}
+	})
+}
+
+// previewCmd captures one session's pane and process stats off the
+// render loop. gen tags the result so a newer cursor move can discard it.
+// Size pins stay on resizeSessions / create / attach — not on every look —
+// so a settle capture is one capture-pane, not resize+capture+pid storms.
+func (m *Model) previewCmd(sess store.Session, gen uint64) tea.Cmd {
 	return func() tea.Msg {
-		msg := previewMsg{sessID: sess.ID}
+		msg := previewMsg{sessID: sess.ID, gen: gen}
 		if sess.Archived {
 			snapshot, err := archivedPreview(m.store, m.tmux, sess.ID)
 			if err != nil {
@@ -382,11 +400,6 @@ func (m *Model) previewCmd(sess store.Session) tea.Cmd {
 			return msg
 		}
 		if m.tmux.Exists(sess.ID) {
-			if needResize && width > 0 && height > 0 {
-				if err := m.tmux.Resize(sess.ID, width, height); err == nil {
-					msg.sized = [2]int{width, height}
-				}
-			}
 			if pane, err := m.tmux.CapturePane(sess.ID); err == nil {
 				msg.preview = pane
 			}
@@ -486,19 +499,27 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// tick) carries the wrong preview; resync and fetch it directly.
 		if sess, ok := m.selected(); ok && sess.ID != msg.procFor {
 			m.syncPollInput()
-			return m, tea.Batch(m.previewCmd(sess), m.diffRefreshCmd())
+			m.previewGen++
+			return m, tea.Batch(m.previewCmd(sess, m.previewGen), m.diffRefreshCmd())
 		}
 		m.proc = msg.proc
 		m.procFor = msg.procFor
 		m.preview = msg.preview
 		return m, m.diffRefreshCmd()
 
+	case previewSettleMsg:
+		if msg.gen != m.previewGen {
+			return m, nil
+		}
+		sess, ok := m.selected()
+		if !ok {
+			return m, nil
+		}
+		return m, m.previewCmd(sess, msg.gen)
+
 	case previewMsg:
-		if msg.sized[0] > 0 && msg.sized[1] > 0 {
-			if m.paneGeom == nil {
-				m.paneGeom = map[string][2]int{}
-			}
-			m.paneGeom[msg.sessID] = msg.sized
+		if msg.gen != 0 && msg.gen != m.previewGen {
+			return m, nil
 		}
 		if sess, ok := m.selected(); ok && sess.ID == msg.sessID {
 			m.preview = msg.preview

--- a/internal/ui/model_preview_test.go
+++ b/internal/ui/model_preview_test.go
@@ -1,0 +1,62 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/store"
+)
+
+func TestPreviewSettleDropsStaleGen(t *testing.T) {
+	m := &Model{mode: modeList, width: 120, height: 40, previewGen: 3}
+	updated, cmd := m.Update(previewSettleMsg{gen: 2})
+	m = updated.(*Model)
+	if cmd != nil {
+		t.Fatal("stale settle should not schedule previewCmd")
+	}
+	updated, cmd = m.Update(previewSettleMsg{gen: 3})
+	m = updated.(*Model)
+	if cmd != nil {
+		t.Fatal("settle without a session row should not capture")
+	}
+}
+
+func TestMoveCursorDebouncesPreview(t *testing.T) {
+	m := &Model{
+		mode:   modeList,
+		width:  120,
+		height: 40,
+		rows: []treeRow{
+			{sess: store.Session{ID: "a", Name: "a"}},
+			{sess: store.Session{ID: "b", Name: "b"}},
+		},
+		cursor: 0,
+	}
+	cmd := m.moveCursor(1)
+	if m.cursor != 1 {
+		t.Fatalf("cursor = %d want 1", m.cursor)
+	}
+	if m.previewGen != 1 {
+		t.Fatalf("previewGen = %d want 1", m.previewGen)
+	}
+	if cmd == nil {
+		t.Fatal("move should schedule a settle tick")
+	}
+	// tea.Tick cmds sleep; invoke the settle path directly for the gen check.
+	msg := previewSettleMsg{gen: 1}
+	// A second move bumps gen; the first settle is now stale.
+	m.moveCursor(-1)
+	if m.previewGen != 2 {
+		t.Fatalf("previewGen = %d want 2", m.previewGen)
+	}
+	updated, next := m.Update(msg)
+	m = updated.(*Model)
+	if next != nil {
+		t.Fatal("stale settle after second move must not capture")
+	}
+	// Fresh settle for the current gen with a session should schedule previewCmd.
+	updated, next = m.Update(previewSettleMsg{gen: m.previewGen})
+	m = updated.(*Model)
+	if next == nil {
+		t.Fatal("current settle should schedule a capture")
+	}
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2185,7 +2185,8 @@ func TestArchivedSessionKeepsPaneSnapshot(t *testing.T) {
 	}
 
 	m.preview = ""
-	m.applyCmd(t, m.previewCmd(m.rows[m.cursor].sess))
+	m.previewGen++
+	m.applyCmd(t, m.previewCmd(m.rows[m.cursor].sess, m.previewGen))
 	if !strings.Contains(m.preview, "snapshot-marker") {
 		t.Fatalf("previewCmd should serve the snapshot for an archived session, preview = %q", m.preview)
 	}


### PR DESCRIPTION
## Summary
- Cursor moves only schedule a 50ms settle timer (bumped gen each move).
- One `capture-pane` runs after the cursor stops; older timers/captures are discarded.
- Removed per-look `resize-window` from the preview path (size pins stay on create/window/split/attach).

## Test plan
- [x] `go test ./internal/ui/`
- [ ] Manual: hold j, release — list stops with the selection, no second of catch-up