### PR TITLE
fix(ui): keep selected-row stats readable on highlight bg

### DIFF
--- a/internal/ui/row_contrast_test.go
+++ b/internal/ui/row_contrast_test.go
@@ -1,0 +1,52 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+func forceANSI256(t *testing.T) {
+	t.Helper()
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+}
+
+func TestSelectedRowMetaUsesBrightNotSubtle(t *testing.T) {
+	forceANSI256(t)
+
+	m := &Model{}
+	entry := treeRow{
+		sess: store.Session{
+			ID:        "s1",
+			Name:      "demo-session",
+			Tool:      "grok",
+			Status:    status.Finished,
+			CreatedAt: time.Now().Add(-3 * time.Hour),
+		},
+	}
+	selected := m.renderTreeRow(entry, true, 80)
+	unselected := m.renderTreeRow(entry, false, 80)
+
+	if !strings.Contains(selected, "\x1b[") {
+		t.Fatal("selected row has no SGR; color profile not active")
+	}
+	if strings.Contains(selected, "38;5;240") {
+		t.Fatalf("selected row still uses subtle fg 240:\n%q", selected)
+	}
+	if !strings.Contains(unselected, "38;5;240") {
+		t.Fatalf("unselected row should use subtle fg 240:\n%q", unselected)
+	}
+	if !strings.Contains(selected, "38;5;231") {
+		t.Fatalf("selected row missing bright reapply fg 231:\n%q", selected)
+	}
+	if !strings.Contains(selected, " · grok · ") {
+		t.Fatalf("selected missing meta text:\n%q", selected)
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -319,12 +319,15 @@ func (m *Model) viewList(width, height int) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// treeGuides draws the dim vertical guides for a row's ancestor levels.
-func treeGuides(depth int) string {
+func treeGuides(depth int, selected bool) string {
 	if depth <= 0 {
 		return ""
 	}
-	return subtleStyle.Render(strings.Repeat("│ ", depth))
+	guides := strings.Repeat("│ ", depth)
+	if selected {
+		return guides
+	}
+	return subtleStyle.Render(guides)
 }
 
 // inGroupSubtree reports whether a session's group sits at or below the
@@ -368,11 +371,18 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 	if selected {
 		bar = lipgloss.NewStyle().Foreground(colorAccent).Render("▎")
 	}
-	guides := treeGuides(entry.depth)
+	guides := treeGuides(entry.depth, selected)
 
 	if m.renamingRow(entry) {
 		line := bar + " " + guides + m.renameRowInput(entry, width-2-ansi.StringWidth(guides))
 		return renderSelectedRow(padRight(line, width))
+	}
+
+	secondary := func(s string) string {
+		if selected {
+			return s
+		}
+		return subtleStyle.Render(s)
 	}
 
 	var content string
@@ -381,9 +391,9 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 		if m.collapsed[entry.group] {
 			marker = "▸"
 		}
-		count := subtleStyle.Render(fmt.Sprintf(" (%d)", m.groupSessionCount(entry.group)))
+		count := secondary(fmt.Sprintf(" (%d)", m.groupSessionCount(entry.group)))
 		name := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true).Render(baseName(entry.group))
-		content = subtleStyle.Render(marker) + " " + name + count + m.groupStatusGlyphs(entry.group)
+		content = secondary(marker) + " " + name + count + m.groupStatusGlyphs(entry.group)
 	} else {
 		sess := entry.sess
 		glyph := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
@@ -393,7 +403,7 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 		}
 		name := nameStyle.Render(sess.Name)
 		state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(sess.Status)
-		meta := state + subtleStyle.Render(" · "+sess.Tool+" · "+relTime(sess.CreatedAt))
+		meta := state + secondary(" · "+sess.Tool+" · "+relTime(sess.CreatedAt))
 		content = glyph + " " + name + "  " + meta
 	}
 


### PR DESCRIPTION
## Summary
- Selected row bg is 239; secondary text used subtleStyle fg 240, so tool/age, group counts, and tree guides nearly vanished when highlighted.
- Leave secondary text unstyled when selected so `renderSelectedRow`'s bright reapply (231) carries it.
- Unit test forces ANSI256 and asserts selected rows drop fg 240 while unselected keep it.

## Test plan
- [x] `go test ./internal/ui/ -run TestSelectedRowMetaUsesBrightNotSubtle`
- [x] `go test -race ./internal/ui/`
- [ ] Quit and relaunch manager; selected row shows bright `status · tool · age`