### PR TITLE
fix(ui): stop fleet-wide working flash after pane reflow

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -449,18 +449,22 @@ func (m *Model) resizeSessions() {
 		id  string
 		err error
 	}
-	results := make(chan result, len(todo))
-	for _, id := range todo {
-		go func(id string) {
-			results <- result{id: id, err: m.tmux.Resize(id, width, height)}
-		}(id)
-	}
-	for range todo {
-		r := <-results
-		if r.err == nil {
-			m.paneGeom[r.id] = [2]int{width, height}
+	// Pause polling for the whole clear+resize window so a mid-reflow
+	// capture cannot compare against a pre-resize hash.
+	m.poller.reflowSessions(todo, func() {
+		results := make(chan result, len(todo))
+		for _, id := range todo {
+			go func(id string) {
+				results <- result{id: id, err: m.tmux.Resize(id, width, height)}
+			}(id)
 		}
-	}
+		for range todo {
+			r := <-results
+			if r.err == nil {
+				m.paneGeom[r.id] = [2]int{width, height}
+			}
+		}
+	})
 }
 
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -552,11 +556,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.paneGeom != nil {
 			delete(m.paneGeom, msg.sessID)
 		}
-		_ = m.tmux.Resize(msg.sessID, m.previewPaneWidth(), m.previewPaneHeight())
+		width, height := m.previewPaneWidth(), m.previewPaneHeight()
+		m.poller.reflowSessions([]string{msg.sessID}, func() {
+			_ = m.tmux.Resize(msg.sessID, width, height)
+		})
 		if m.paneGeom == nil {
 			m.paneGeom = map[string][2]int{}
 		}
-		m.paneGeom[msg.sessID] = [2]int{m.previewPaneWidth(), m.previewPaneHeight()}
+		m.paneGeom[msg.sessID] = [2]int{width, height}
 		if msg.err != nil {
 			m.err = msg.err.Error()
 			m.requestRefresh()

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -427,6 +427,22 @@ func (p *poller) applyPendingReviewBase(sess *store.Session) error {
 	return p.hooks.RemoveReviewBase(sess.ID)
 }
 
+// reflowSessions drops activity-region hashes for ids and runs reflow
+// while the poller is paused (runMu held). A poll must not capture mid-
+// resize against a pre-resize hash: that comparison treats reflow as
+// streaming and flashes every session as working for one tick.
+func (p *poller) reflowSessions(ids []string, reflow func()) {
+	if len(ids) == 0 {
+		return
+	}
+	p.runMu.Lock()
+	defer p.runMu.Unlock()
+	for _, id := range ids {
+		delete(p.paneHashes, id)
+	}
+	reflow()
+}
+
 // derivePaneStatus turns one captured pane into a session status. The
 // capture carries ANSI escapes for the preview; rules match against the
 // stripped text. Streaming output often renders without any spinner, so
@@ -438,6 +454,10 @@ func (p *poller) applyPendingReviewBase(sess *store.Session) error {
 // versus waiting. Finished is an alert: entering the session acknowledges
 // it (acked), and the pane keeps deriving finished until the next turn,
 // so acked maps it back to idle.
+//
+// A missing prior hash (first observation, or post-resize rebaseline)
+// never invents working and never collapses finished/waiting to the tool
+// default: the stored status holds until the next poll has a baseline.
 func (p *poller) derivePaneStatus(sess store.Session, pane string, agentAlive bool, paneHashes map[string]uint64) (string, error) {
 	text := ansi.Strip(pane)
 	region, hasRegion := p.engine.ActivityRegion(sess.Tool, text)
@@ -465,6 +485,8 @@ func (p *poller) derivePaneStatus(sess store.Session, pane string, agentAlive bo
 			} else if turnInFlight(sess.Status) {
 				newStatus = p.engine.TurnEndedState(sess.Tool, region)
 			}
+		} else if turnInFlight(sess.Status) {
+			newStatus = sess.Status
 		}
 	}
 	if newStatus == status.Finished && sess.Acked {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -831,6 +831,45 @@ func TestChangedRegionStillDerivesWorking(t *testing.T) {
 	}
 }
 
+// A post-resize rebaseline (no prior hash) must keep finished instead of
+// inventing working from reflowed content or collapsing to idle.
+func TestRebaselineKeepsFinishedWithoutFlashingWorking(t *testing.T) {
+	m := buildModel(t)
+	sess := store.Session{ID: "reflow01", Tool: "claude-hooked", Status: status.Finished}
+	before := "final answer line that wraps differently after resize\n❯ \n"
+	after := "final answer line that wraps\ndifferently after resize\n❯ \n"
+	seedRegionHash(t, m, sess, before)
+	// Without clearing, a reflow looks like streaming work.
+	if got := deriveStatus(t, m, sess, after, true); got != status.Working {
+		t.Fatalf("reflow with a prior hash should look like working (precondition), got %q", got)
+	}
+	seedRegionHash(t, m, sess, before)
+	m.poller.reflowSessions([]string{sess.ID}, func() {})
+	if got := deriveStatus(t, m, sess, after, true); got != status.Finished {
+		t.Fatalf("rebaseline after resize must keep finished, got %q", got)
+	}
+}
+
+func TestRebaselineKeepsWaitingAndWorking(t *testing.T) {
+	m := buildModel(t)
+	pane := "Which option do you prefer?\n❯ \n"
+	for _, st := range []string{status.Waiting, status.Working} {
+		sess := store.Session{ID: "reflow-" + st, Tool: "claude-hooked", Status: st}
+		if got := deriveStatus(t, m, sess, pane, true); got != st {
+			t.Fatalf("unseen baseline with status %q: got %q", st, got)
+		}
+	}
+}
+
+func TestRebaselineIdleStaysIdle(t *testing.T) {
+	m := buildModel(t)
+	sess := store.Session{ID: "reflow-idle", Tool: "claude-hooked", Status: status.Idle}
+	pane := "old transcript text\n❯ \n"
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Idle {
+		t.Fatalf("unseen baseline idle should stay idle, got %q", got)
+	}
+}
+
 func TestLiveQuietTurnResolvesFinished(t *testing.T) {
 	m := buildModel(t)
 	m.openForm()


### PR DESCRIPTION
## Summary
- Terminal and layout resizes reflow every session pane at once. Activity-region hash changes were treated as streaming work, so finished sessions all flashed `working` for one poll (~2s).
- Pause the poller, clear those hashes during resize, and rebaseline: keep finished/waiting/working when there is no prior hash instead of inventing `working` or collapsing to idle.

## Test plan
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./internal/ui/ -count=1`
- [x] Unit tests for reflow rebaseline (finished stays finished, idle stays idle, real hash change still working)
- [ ] Manual: open several finished sessions, resize the terminal, confirm no fleet-wide working flash