### PR TITLE
feat(ui): edit session tool from rename (r)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 | `ctrl+q` | Inside a session: back to the manager |
 | `shift+↑` / `shift+↓` | Reorder session or group among its siblings |
 | `m` | Move session to another group |
-| `r` | Rename session / edit group (name and default path) |
+| `r` | Rename session / edit tool; edit group name and default path |
 | `v` | Revive a dead session (`revive_command`, e.g. `claude --continue`, resumes the conversation) |
 | `a` / `u` | Archive / restore a session, or a group and its entire subtree |
 | `d` | Delete session, or a group + its entire subtree |
@@ -102,7 +102,7 @@ Press `c` on a line to write a comment; `C` flattens every comment into one revi
 
 ### Groups
 
-Groups are paths (`backend/api/auth`) forming a tree of unlimited depth. Sessions can live at any node, including the root. Create subgroups inline with `g`, reorder both groups and sessions with `shift+↑↓` (the order persists), fold a subtree with `f`, and edit a group's name and default path with `r`.
+Groups are paths (`backend/api/auth`) forming a tree of unlimited depth. Sessions can live at any node, including the root. Create subgroups inline with `g`, reorder both groups and sessions with `shift+↑↓` (the order persists), fold a subtree with `f`, and edit a group's name and default path with `r`. On a session, `r` renames it and `tab` cycles the tool (status rules and revive follow the new tool; useful when you quit one agent in the pane and start another).
 
 ### Status
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -471,17 +471,33 @@ func (s *Store) RenameSession(id, name string) error {
 // UpdateTool changes which tool status rules and revive use for a session.
 // Clears the captured agent conversation id: that id only makes sense for
 // the tool that minted it, and a manual tool swap means the user swapped
-// the process in the pane (e.g. quit opencode, ran grok).
+// the process in the pane (e.g. quit opencode, ran grok). A no-op when the
+// tool column already matches leaves the conversation id alone.
 func (s *Store) UpdateTool(id, tool string) error {
 	if strings.TrimSpace(tool) == "" {
 		return fmt.Errorf("session tool cannot be empty")
 	}
 	res, err := s.db.Exec(
-		`UPDATE sessions SET tool = ?, agent_session_id = '' WHERE id = ?`, tool, id)
+		`UPDATE sessions SET tool = ?, agent_session_id = '' WHERE id = ? AND tool != ?`,
+		tool, id, tool)
 	if err != nil {
 		return err
 	}
-	return requireRow(res, id)
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n > 0 {
+		return nil
+	}
+	// Zero rows: either the tool already matched (success no-op) or the
+	// session is gone. Distinguish so callers still see ErrSessionGone.
+	var exists int
+	err = s.db.QueryRow(`SELECT 1 FROM sessions WHERE id = ?`, id).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("session %s: %w", id, ErrSessionGone)
+	}
+	return err
 }
 
 // DeleteGroup removes a group and all its descendant groups, reporting

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -468,6 +468,22 @@ func (s *Store) RenameSession(id, name string) error {
 	return requireRow(res, id)
 }
 
+// UpdateTool changes which tool status rules and revive use for a session.
+// Clears the captured agent conversation id: that id only makes sense for
+// the tool that minted it, and a manual tool swap means the user swapped
+// the process in the pane (e.g. quit opencode, ran grok).
+func (s *Store) UpdateTool(id, tool string) error {
+	if strings.TrimSpace(tool) == "" {
+		return fmt.Errorf("session tool cannot be empty")
+	}
+	res, err := s.db.Exec(
+		`UPDATE sessions SET tool = ?, agent_session_id = '' WHERE id = ?`, tool, id)
+	if err != nil {
+		return err
+	}
+	return requireRow(res, id)
+}
+
 // DeleteGroup removes a group and all its descendant groups, reporting
 // the paths it removed.
 func (s *Store) DeleteGroup(path string) ([]string, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -84,6 +84,37 @@ func TestUpdateStatus(t *testing.T) {
 	}
 }
 
+func TestUpdateTool(t *testing.T) {
+	st := newTestStore(t)
+	sess := sample("a", "g1")
+	sess.Tool = "opencode"
+	if err := st.CreateSession(sess); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := st.SetAgentSessionID("a", "ses_old"); err != nil {
+		t.Fatalf("set agent id: %v", err)
+	}
+	if err := st.UpdateTool("a", "grok"); err != nil {
+		t.Fatalf("update tool: %v", err)
+	}
+	got, err := st.Get("a")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Tool != "grok" {
+		t.Fatalf("tool = %q want grok", got.Tool)
+	}
+	if got.AgentSessionID != "" {
+		t.Fatalf("agent session id should clear on tool change, got %q", got.AgentSessionID)
+	}
+	if err := st.UpdateTool("a", ""); err == nil {
+		t.Fatal("empty tool should error")
+	}
+	if err := st.UpdateTool("missing", "claude"); err == nil {
+		t.Fatal("update tool on missing row should error")
+	}
+}
+
 func TestDelete(t *testing.T) {
 	st := newTestStore(t)
 	st.CreateSession(sample("a", "g1"))
@@ -263,6 +294,7 @@ func TestWritesToADeletedSessionReportGone(t *testing.T) {
 		"SetSnapshot":       st.SetSnapshot("a", "pane"),
 		"SetArchived":       st.SetArchived("a", true),
 		"RenameSession":     st.RenameSession("a", "renamed"),
+		"UpdateTool":        st.UpdateTool("a", "grok"),
 		"Delete":            st.Delete("a"),
 	}
 	for name, err := range writes {
@@ -285,6 +317,7 @@ func TestNoOpWriteDoesNotLookLikeADeletedSession(t *testing.T) {
 		"SetSnapshot":       st.SetSnapshot("a", ""),
 		"SetArchived":       st.SetArchived("a", false),
 		"RenameSession":     st.RenameSession("a", "n-a"),
+		"UpdateTool":        st.UpdateTool("a", "claude"),
 	}
 	for name, err := range writes {
 		if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -107,6 +107,19 @@ func TestUpdateTool(t *testing.T) {
 	if got.AgentSessionID != "" {
 		t.Fatalf("agent session id should clear on tool change, got %q", got.AgentSessionID)
 	}
+	if err := st.SetAgentSessionID("a", "ses_new"); err != nil {
+		t.Fatalf("reset agent id: %v", err)
+	}
+	if err := st.UpdateTool("a", "grok"); err != nil {
+		t.Fatalf("same-tool update: %v", err)
+	}
+	got, err = st.Get("a")
+	if err != nil {
+		t.Fatalf("get after same-tool: %v", err)
+	}
+	if got.AgentSessionID != "ses_new" {
+		t.Fatalf("same-tool update wiped agent id: %q", got.AgentSessionID)
+	}
 	if err := st.UpdateTool("a", ""); err == nil {
 		t.Fatal("empty tool should error")
 	}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -825,7 +825,15 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		tool := m.renameTool()
-		if tool != "" {
+		var prevTool string
+		for i := range m.sessions {
+			if m.sessions[i].ID == m.rename.sessID {
+				prevTool = m.sessions[i].Tool
+				break
+			}
+		}
+		toolChanged := tool != "" && tool != prevTool
+		if toolChanged {
 			if err := m.store.UpdateTool(m.rename.sessID, tool); err != nil {
 				m.err = err.Error()
 				return m, nil
@@ -834,7 +842,7 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 		for i := range m.sessions {
 			if m.sessions[i].ID == m.rename.sessID {
 				m.sessions[i].Name = name
-				if tool != "" {
+				if toolChanged {
 					m.sessions[i].Tool = tool
 					m.sessions[i].AgentSessionID = ""
 				}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -676,7 +676,26 @@ func (m *Model) openRename() {
 		m.rename = renameTarget{isGroup: true, path: entry.group, input: input, dir: dir}
 	} else {
 		input.SetValue(entry.sess.Name)
-		m.rename = renameTarget{sessID: entry.sess.ID, input: input}
+		tools := sortedToolNames(m.cfg)
+		toolIndex := 0
+		for i, name := range tools {
+			if name == entry.sess.Tool {
+				toolIndex = i
+				break
+			}
+		}
+		// Current tool missing from config (removed block): keep it selectable
+		// so save does not silently reassign to the first configured tool.
+		if len(tools) == 0 || tools[toolIndex] != entry.sess.Tool {
+			tools = append([]string{entry.sess.Tool}, tools...)
+			toolIndex = 0
+		}
+		m.rename = renameTarget{
+			sessID:    entry.sess.ID,
+			input:     input,
+			toolNames: tools,
+			toolIndex: toolIndex,
+		}
 	}
 	m.mode = modeRename
 	m.err = ""
@@ -704,17 +723,35 @@ func (m *Model) handleRenameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.mode = modeList
 		return m, nil
-	case "tab", "up", "down":
+	case "tab":
+		if !m.rename.isGroup {
+			m.cycleRenameTool(1)
+			return m, nil
+		}
+		if pathSuggesting {
+			m.applyPathSuggestion()
+			return m, nil
+		}
+		m.renameFocus(1)
+		return m, nil
+	case "shift+tab":
+		if !m.rename.isGroup {
+			m.cycleRenameTool(-1)
+			return m, nil
+		}
+		if pathSuggesting {
+			return m, nil
+		}
+		m.renameFocus(-1)
+		return m, nil
+	case "up", "down":
 		if !m.rename.isGroup {
 			break
 		}
 		if pathSuggesting {
-			switch msg.String() {
-			case "tab":
-				m.applyPathSuggestion()
-			case "up":
+			if msg.String() == "up" {
 				m.pathSugg.move(-1)
-			case "down":
+			} else {
 				m.pathSugg.move(1)
 			}
 			return m, nil
@@ -736,6 +773,21 @@ func (m *Model) handleRenameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.pathSugg.recompute(m.rename.dir.Value())
 	}
 	return m, cmd
+}
+
+func (m *Model) cycleRenameTool(delta int) {
+	if len(m.rename.toolNames) == 0 {
+		return
+	}
+	n := len(m.rename.toolNames)
+	m.rename.toolIndex = (m.rename.toolIndex + delta + n) % n
+}
+
+func (m *Model) renameTool() string {
+	if len(m.rename.toolNames) == 0 {
+		return ""
+	}
+	return m.rename.toolNames[m.rename.toolIndex]
 }
 
 func (m *Model) applyRename() (tea.Model, tea.Cmd) {
@@ -772,9 +824,20 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 			m.err = err.Error()
 			return m, nil
 		}
+		tool := m.renameTool()
+		if tool != "" {
+			if err := m.store.UpdateTool(m.rename.sessID, tool); err != nil {
+				m.err = err.Error()
+				return m, nil
+			}
+		}
 		for i := range m.sessions {
 			if m.sessions[i].ID == m.rename.sessID {
 				m.sessions[i].Name = name
+				if tool != "" {
+					m.sessions[i].Tool = tool
+					m.sessions[i].AgentSessionID = ""
+				}
 			}
 		}
 		m.relabelSession(m.rename.sessID)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -140,12 +140,14 @@ type confirmTarget struct {
 }
 
 type renameTarget struct {
-	isGroup bool
-	path    string
-	sessID  string
-	input   textinput.Model
-	dir     textinput.Model
-	focus   int
+	isGroup   bool
+	path      string
+	sessID    string
+	input     textinput.Model
+	dir       textinput.Model
+	focus     int
+	toolNames []string
+	toolIndex int
 }
 
 // quickState is the inline prompt bar docked under the preview: active

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -557,12 +557,27 @@ func TestRenameSession(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "before", t.TempDir(), "")
 	m.selectSessionRow(t, "before")
+	id := m.sessionRows()[0].ID
+	if err := m.store.SetAgentSessionID(id, "conv-keep"); err != nil {
+		t.Fatalf("set agent id: %v", err)
+	}
 	m.openRename()
 	m.rename.input.SetValue("after")
 	_, cmd := m.handleRenameKey(tea.KeyMsg{Type: tea.KeyEnter})
 	m.applyCmd(t, cmd)
-	if m.sessionRows()[0].Name != "after" {
-		t.Fatalf("rename failed: %+v", m.sessionRows()[0])
+	got := m.sessionRows()[0]
+	if got.Name != "after" {
+		t.Fatalf("rename failed: %+v", got)
+	}
+	stored, err := m.store.Get(id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if stored.AgentSessionID != "conv-keep" {
+		t.Fatalf("name-only rename wiped agent session id: %q", stored.AgentSessionID)
+	}
+	if stored.Tool != "claude" {
+		t.Fatalf("name-only rename changed tool: %q", stored.Tool)
 	}
 }
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -566,6 +566,47 @@ func TestRenameSession(t *testing.T) {
 	}
 }
 
+func TestRenameSessionChangesTool(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "swapped", t.TempDir(), "")
+	m.selectSessionRow(t, "swapped")
+	start := m.sessionRows()[0]
+	if start.Tool != "claude" {
+		t.Fatalf("setup tool = %q want claude", start.Tool)
+	}
+	if err := m.store.SetAgentSessionID(start.ID, "conv-1"); err != nil {
+		t.Fatalf("set agent id: %v", err)
+	}
+	m.openRename()
+	if m.renameTool() != "claude" {
+		t.Fatalf("rename tool start = %q want claude", m.renameTool())
+	}
+	if len(m.rename.toolNames) < 2 {
+		t.Fatalf("need at least 2 tools to cycle, got %v", m.rename.toolNames)
+	}
+	m.handleRenameKey(tea.KeyMsg{Type: tea.KeyTab})
+	wantTool := m.rename.toolNames[1]
+	if m.renameTool() != wantTool {
+		t.Fatalf("after tab tool = %q want %q", m.renameTool(), wantTool)
+	}
+	_, cmd := m.handleRenameKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m.applyCmd(t, cmd)
+	got := m.sessionRows()[0]
+	if got.Tool != wantTool {
+		t.Fatalf("tool after save = %q want %q", got.Tool, wantTool)
+	}
+	if got.AgentSessionID != "" {
+		t.Fatalf("agent session id should clear on tool change, got %q", got.AgentSessionID)
+	}
+	stored, err := m.store.Get(got.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if stored.Tool != wantTool || stored.AgentSessionID != "" {
+		t.Fatalf("store after save: tool=%q agent=%q", stored.Tool, stored.AgentSessionID)
+	}
+}
+
 func TestMoveSession(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -582,8 +582,14 @@ func (m *Model) viewDetail(width int) string {
 		return "\n" + mutedStyle.Render("Select a session to inspect it.")
 	}
 	var b strings.Builder
+	tool := sess.Tool
+	if m.mode == modeRename && !m.rename.isGroup && m.rename.sessID == sess.ID {
+		if picked := m.renameTool(); picked != "" {
+			tool = picked
+		}
+	}
 	b.WriteString(pill(sess.Status, statusColor(sess.Status)) + "  " +
-		pill(sess.Tool, colorAccent) + "\n")
+		pill(tool, colorAccent) + "\n")
 	b.WriteString(kv("group", displayGroup(sess.Group)))
 	b.WriteString(kv("dir", truncateTail(sess.Cwd, width-8)))
 	b.WriteString(kv("age", relTime(sess.CreatedAt)))
@@ -847,6 +853,8 @@ func (m *Model) viewFooter() string {
 		pairs = [][2]string{{"↵", "save"}, {"esc", "cancel"}}
 		if m.rename.isGroup {
 			pairs = [][2]string{{"⇥", "name / path"}, {"↵", "save"}, {"esc", "cancel"}}
+		} else if tool := m.renameTool(); tool != "" {
+			pairs = [][2]string{{"⇥", "tool: " + tool}, {"↵", "save"}, {"esc", "cancel"}}
 		}
 	}
 	return footerLine(pairs, m.width)


### PR DESCRIPTION
## Summary
- Session `r` keeps renaming the name and adds `tab` / `shift+tab` to cycle the configured agent tool.
- `store.UpdateTool` persists the tool and clears `agent_session_id` so revive does not resume a conversation id from the previous CLI.
- Details pill and footer show the live tool pick; status rules and revive follow the new tool on the next poll (pane is not relaunched).

## Test plan
- [x] `go test ./internal/store/ ./internal/ui/`
- [x] `TestUpdateTool`, `TestRenameSessionChangesTool`
- [ ] Manual: select a session, `r`, `tab` through tools, enter; sidebar tool label updates; status matches the running agent after a swap