### PR TITLE
fix(ui): capture mouse so the host cannot scroll the TUI away

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -33,11 +33,9 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "esc":
 			return m.exitResizeMode(false)
 		case "q", "ctrl+c":
-			// Drop mouse reporting before quit so the terminal is not left
-			// in mouse mode if shutdown races the bubbletea teardown.
 			m.resizeMode = false
 			m.splitDragging = false
-			return m, tea.Sequence(tea.DisableMouse, tea.Quit)
+			return m, tea.Quit
 		default:
 			return m, nil
 		}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -106,8 +106,8 @@ type Model struct {
 	errAge        int
 
 	// Horizontal sessions/sidebar split. splitRatio is the left panel's
-	// share of the terminal width; resizeMode arms mouse reporting so the
-	// user can drag the divider without breaking normal text selection.
+	// share of the terminal width; resizeMode arms divider drag handling
+	// (mouse reporting itself is always on so the host cannot scroll us).
 	splitRatio       float64
 	splitRatioBefore float64
 	resizeMode       bool

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -85,9 +85,9 @@ func (m *Model) setSplitFromX(x int) {
 	m.splitRatio = float64(left) / float64(m.width)
 }
 
-// enterResizeMode turns mouse reporting on so the user can drag the
-// sessions/sidebar divider. Mouse stays off outside this mode so normal
-// terminal text selection still works.
+// enterResizeMode arms divider dragging. Mouse reporting is always on at
+// the program level (see main) so the terminal cannot scroll the TUI away;
+// this mode only changes how clicks/drags are interpreted.
 func (m *Model) enterResizeMode() (tea.Model, tea.Cmd) {
 	if m.mode != modeList || m.searching || m.quick.active {
 		return m, nil
@@ -96,12 +96,12 @@ func (m *Model) enterResizeMode() (tea.Model, tea.Cmd) {
 	m.splitDragging = false
 	m.splitRatioBefore = m.splitRatio
 	m.err = ""
-	return m, tea.EnableMouseCellMotion
+	return m, nil
 }
 
-// exitResizeMode turns mouse reporting back off. When commit is true the
-// current ratio is persisted; cancel restores the pre-mode ratio. Either
-// path ends with a pane resize so the preview stays 1:1 with the panel.
+// exitResizeMode leaves divider-drag mode. When commit is true the current
+// ratio is persisted; cancel restores the pre-mode ratio. Either path ends
+// with a pane resize so the preview stays 1:1 with the panel.
 func (m *Model) exitResizeMode(commit bool) (tea.Model, tea.Cmd) {
 	if !m.resizeMode && !m.splitDragging {
 		return m, nil
@@ -114,7 +114,7 @@ func (m *Model) exitResizeMode(commit bool) (tea.Model, tea.Cmd) {
 	m.splitDragging = false
 	m.resizeMode = false
 	m.resizeSessions()
-	return m, tea.DisableMouse
+	return m, nil
 }
 
 // nudgeSplit moves the divider by delta columns while resize mode is on.
@@ -164,10 +164,13 @@ func (m *Model) onDivider(x int) bool {
 }
 
 func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
-	if !m.resizeMode {
-		return m, nil
-	}
+	// Always consume mouse events so the host terminal / outer tmux never
+	// scrolls the manager off-screen. Wheel maps to in-app navigation;
+	// clicks only drive the divider while resize mode is armed.
 	if tea.MouseEvent(msg).IsWheel() {
+		return m.handleMouseWheel(msg)
+	}
+	if !m.resizeMode {
 		return m, nil
 	}
 
@@ -205,6 +208,38 @@ func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m.exitResizeMode(true)
 	}
 	return m, nil
+}
+
+// handleMouseWheel keeps the wheel inside the app: list cursor, diff
+// scroll, or a no-op swallow so the outer terminal cannot scroll away.
+func (m *Model) handleMouseWheel(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if m.resizeMode {
+		return m, nil
+	}
+	delta := 0
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		delta = -1
+	case tea.MouseButtonWheelDown:
+		delta = 1
+	default:
+		return m, nil
+	}
+	switch m.mode {
+	case modeDiff:
+		if m.diff.annotating || m.diff.sendConfirm {
+			return m, nil
+		}
+		m.moveDiffCursor(delta, m.diffCodeHeight())
+		return m, nil
+	case modeList, modeRename:
+		if m.searching {
+			return m, nil
+		}
+		return m, m.moveCursor(delta)
+	default:
+		return m, nil
+	}
 }
 
 // resizeGrip is the 1-column accent bar drawn between the panels while

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -85,18 +85,16 @@ func TestSetSplitFromXClampsAndUpdatesRatio(t *testing.T) {
 	}
 }
 
-func TestResizeModeKeyEnablesMouse(t *testing.T) {
+func TestResizeModeKeyArmsDrag(t *testing.T) {
 	m := &Model{mode: modeList, splitRatio: defaultSplitRatio, width: 120, height: 40}
 	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'|'}})
 	m = updated.(*Model)
 	if !m.resizeMode {
 		t.Fatal("| should enter resize mode")
 	}
-	if cmd == nil {
-		t.Fatal("enter should return EnableMouseCellMotion cmd")
-	}
-	if msg := cmd(); msg == nil {
-		t.Fatal("mouse enable cmd produced nil msg")
+	if cmd != nil {
+		// Mouse is always on at the program level; resize only flips a flag.
+		t.Fatal("enter should not toggle mouse reporting")
 	}
 
 	// Other keys are swallowed while armed.
@@ -114,8 +112,8 @@ func TestResizeModeKeyEnablesMouse(t *testing.T) {
 	if m.resizeMode {
 		t.Fatal("esc should leave resize mode")
 	}
-	if cmd == nil {
-		t.Fatal("exit should return DisableMouse cmd")
+	if cmd != nil {
+		t.Fatal("exit should not toggle mouse reporting")
 	}
 }
 
@@ -154,8 +152,8 @@ func TestArrowNudgeAndPipeCommits(t *testing.T) {
 	if m.resizeMode {
 		t.Fatal("| should commit and exit resize mode")
 	}
-	if cmd == nil {
-		t.Fatal("commit should disable mouse")
+	if cmd != nil {
+		t.Fatal("commit should not toggle mouse reporting")
 	}
 	raw, err := st.Setting(splitRatioSetting)
 	if err != nil || raw == "" {
@@ -224,8 +222,8 @@ func TestDragReleasePersistsAndExits(t *testing.T) {
 	if m.splitDragging || m.resizeMode {
 		t.Fatal("release should end drag and exit resize mode")
 	}
-	if cmd == nil {
-		t.Fatal("release should disable mouse")
+	if cmd != nil {
+		t.Fatal("release should not toggle mouse reporting")
 	}
 
 	raw, err := st.Setting(splitRatioSetting)
@@ -411,5 +409,49 @@ func TestNewLoadsPersistedSplitRatio(t *testing.T) {
 	loaded := New(m.cfg, m.store, m.tmux, m.poller.engine, m.hooks)
 	if loaded.splitRatio != 0.45 {
 		t.Fatalf("New splitRatio = %v want 0.45", loaded.splitRatio)
+	}
+}
+
+// Wheel events must be consumed by the app (so the host terminal cannot
+// scroll the TUI away) and advance the list cursor outside resize mode.
+func TestWheelScrollMovesListCursor(t *testing.T) {
+	m := &Model{
+		mode:   modeList,
+		cursor: 0,
+		rows:   []treeRow{{}, {}},
+		width:  80,
+		height: 24,
+	}
+	updated, _ := m.handleMouse(tea.MouseMsg{
+		Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress,
+	})
+	m = updated.(*Model)
+	if m.cursor != 1 {
+		t.Fatalf("wheel down cursor = %d want 1", m.cursor)
+	}
+	updated, _ = m.handleMouse(tea.MouseMsg{
+		Button: tea.MouseButtonWheelUp, Action: tea.MouseActionPress,
+	})
+	m = updated.(*Model)
+	if m.cursor != 0 {
+		t.Fatalf("wheel up cursor = %d want 0", m.cursor)
+	}
+}
+
+func TestWheelSwallowedInResizeMode(t *testing.T) {
+	m := &Model{
+		mode:       modeList,
+		resizeMode: true,
+		cursor:     0,
+		rows:       []treeRow{{}, {}},
+		width:      80,
+		height:     24,
+	}
+	updated, _ := m.handleMouse(tea.MouseMsg{
+		Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress,
+	})
+	m = updated.(*Model)
+	if m.cursor != 0 {
+		t.Fatalf("resize mode should swallow wheel, cursor = %d", m.cursor)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -153,7 +153,9 @@ func run() error {
 	defer st.Close()
 
 	model := ui.New(cfg, st, driver, engine, hooks.NewManager(dir))
-	program := tea.NewProgram(model, tea.WithAltScreen())
+	// Mouse cell motion is always on so the terminal (and nested tmux)
+	// cannot scroll the manager out of view. Shift+drag still selects text.
+	program := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	model.StartPoller(program.Send)
 	_, err = program.Run()
 	return err


### PR DESCRIPTION
## Summary
- Keep mouse cell-motion on for the whole run so the terminal/outer tmux cannot scroll the manager out of view.
- Map wheel to list cursor / diff scroll; swallow it in resize mode.
- Resize mode only arms divider drag (no more enable/disable mouse toggle). Shift+drag still selects text.

## Test plan
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...`
- [x] Wheel unit tests for list cursor + resize swallow
- [ ] Restart `agent-manager`, wheel no longer scrolls host scrollback; wheel moves list; `|` drag still works; Shift+drag selects text