### PR TITLE
fix(ui): re-arm mouse capture after tmux attach/detach

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -569,7 +569,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.err = msg.err.Error()
 			m.requestRefresh()
-			return m, nil
+			return m, tea.EnableMouseCellMotion
 		}
 		// Ctrl+R inside the session sets a marker before detaching; consume
 		// it here and jump straight to review for the session just attached.
@@ -583,17 +583,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if clearErr := m.tmux.ClearReviewRequest(); clearErr != nil {
 				m.err = clearErr.Error()
 				m.requestRefresh()
-				return m, nil
+				return m, tea.EnableMouseCellMotion
 			}
 			sess, ok := m.selected()
 			cmd := m.openDiff()
 			if ok && m.mode == modeDiff {
 				m.diff.reattachID = sess.ID
 			}
-			return m, cmd
+			return m, tea.Batch(cmd, tea.EnableMouseCellMotion)
 		}
 		m.requestRefresh()
-		return m, nil
+		return m, tea.EnableMouseCellMotion
 
 	case tea.MouseMsg:
 		return m.handleMouse(msg)

--- a/internal/ui/mouse_rearm_test.go
+++ b/internal/ui/mouse_rearm_test.go
@@ -1,0 +1,25 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Bubbletea's RestoreTerminal (v1.3.10) re-enables altscreen, bracketed
+// paste, and focus reporting after tea.ExecProcess but not mouse mode, so
+// every tmux attach/detach silently kills wheel capture and the host
+// scrolls the manager off-screen. Detaching must re-arm mouse cell motion.
+func TestDetachReArmsMouseCapture(t *testing.T) {
+	m := buildModel(t)
+	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+
+	_, cmd := m.Update(attachDoneMsg{})
+	if cmd == nil {
+		t.Fatal("detach should re-enable mouse capture, got nil command")
+	}
+	if reflect.TypeOf(cmd()) != reflect.TypeOf(tea.EnableMouseCellMotion()) {
+		t.Fatalf("detach command = %T, want the tea.EnableMouseCellMotion message", cmd())
+	}
+}


### PR DESCRIPTION
## Why

The TUI scroll regression has returned four times. Root cause is in bubbletea, not our earlier fixes.

Bubbletea v1.3.10 `RestoreTerminal()` runs after every `tea.ExecProcess` (each tmux attach). It re-enables altscreen, bracketed paste, and focus reporting, but **not mouse mode**. So the first session attach/detach silently kills wheel capture, the wheel goes to the host terminal or outer tmux, and the manager scrolls off-screen. Startup `WithMouseCellMotion()` arms mouse once at boot, which is exactly why every prior fix worked until the first attach and then regressed.

## What

Re-issue `tea.EnableMouseCellMotion` on all four `attachDoneMsg` return paths: normal detach, attach error, review jump, and review-clear error. Wheel capture now survives every attach/detach.

`internal/ui/mouse_rearm_test.go` asserts detach emits the mouse-enable command, guarding against a fifth regression.

## Verification

- `go build ./...` clean
- new regression test passes
- full `internal/ui` suite passes
