### PR TITLE
perf(ui): parallelize git ops and skip repo discovery on scope cycle

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -5,6 +5,7 @@ package diff
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/YoanWai/agent-manager/internal/git"
 	udiff "github.com/aymanbagabas/go-udiff"
@@ -51,6 +52,7 @@ type Set struct {
 	Repo         git.Repo
 	Scope        git.Scope
 	BaseDesc     string
+	BaseRef      string
 	BaseOverride string
 	Files        []FileDiff
 }
@@ -82,6 +84,7 @@ func BuildSet(driver *git.Driver, cwd string, scope git.Scope, baseOverride stri
 			return Set{}, err
 		}
 		set.BaseDesc = describe
+		set.BaseRef = baseRef
 	case git.ScopeStaged, git.ScopeUncommitted:
 		set.BaseDesc = "HEAD"
 	case git.ScopeLastCommit:
@@ -91,13 +94,25 @@ func BuildSet(driver *git.Driver, cwd string, scope git.Scope, baseOverride stri
 		return set, nil
 	}
 
-	files, err := driver.ChangedFiles(repo.Root, scope, baseRef)
-	if err != nil {
-		return Set{}, err
+	var files []git.ChangedFile
+	var stats map[string]git.FileStat
+	var filesErr, statsErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		files, filesErr = driver.ChangedFiles(repo.Root, scope, baseRef)
+	}()
+	go func() {
+		defer wg.Done()
+		stats, statsErr = driver.NumStat(repo.Root, scope, baseRef)
+	}()
+	wg.Wait()
+	if filesErr != nil {
+		return Set{}, filesErr
 	}
-	stats, err := driver.NumStat(repo.Root, scope, baseRef)
-	if err != nil {
-		return Set{}, err
+	if statsErr != nil {
+		return Set{}, statsErr
 	}
 
 	for i, file := range files {
@@ -127,10 +142,7 @@ func EnsureFile(driver *git.Driver, set *Set, index int) {
 	if fd.Lines != nil || fd.Binary || fd.Err != nil {
 		return
 	}
-	baseRef := ""
-	if set.Scope == git.ScopeBranch {
-		baseRef, _, _ = driver.BranchBase(set.Repo.Root, set.BaseOverride)
-	}
+	baseRef := set.BaseRef
 	loadFile(driver, set.Repo.Root, set.Scope, baseRef, fd)
 }
 

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/YoanWai/agent-manager/internal/diff"
 	"github.com/YoanWai/agent-manager/internal/git"
@@ -106,15 +107,23 @@ type diffProbeMsg struct {
 // repoWant is matched by path so the selection survives ResolveRepos re-ranking between loads.
 func (m *Model) diffLoadCmd(sess store.Session, scope git.Scope, gen int, repoWant string, refresh bool) tea.Cmd {
 	driver := m.gitDrv
-	// The store handle is goroutine-safe sqlite; capture it so the closure
-	// never touches the Model.
 	stor := m.store
+	var cachedRoots []string
+	var cachedCWD string
 	return func() tea.Msg {
 		msg := diffLoadedMsg{sessID: sess.ID, scope: scope, gen: gen, refresh: refresh}
-		roots, err := driver.ResolveRepos(sess.Cwd)
-		if err != nil {
-			msg.err = err
-			return msg
+		var roots []string
+		var err error
+		if sess.Cwd == cachedCWD && cachedRoots != nil {
+			roots = cachedRoots
+		} else {
+			roots, err = driver.ResolveRepos(sess.Cwd)
+			if err != nil {
+				msg.err = err
+				return msg
+			}
+			cachedCWD = sess.Cwd
+			cachedRoots = roots
 		}
 		repoIdx, found := 0, false
 		for i, root := range roots {
@@ -133,23 +142,44 @@ func (m *Model) diffLoadCmd(sess store.Session, scope git.Scope, gen int, repoWa
 		}
 		msg.repoRoots = roots
 		msg.repoRoot = roots[repoIdx]
-		// Read the declared base only once the final root is known, since the
-		// base is keyed per repo. Resolve symlinks so the key matches the CLI,
-		// which stores under git's symlink-expanded toplevel.
 		override, err := stor.ReviewBase(sess.ID, resolveSymlinksOrSelf(roots[repoIdx]))
 		if err != nil {
 			msg.err = err
 			return msg
 		}
-		msg.set, msg.err = diff.BuildSet(driver, roots[repoIdx], scope, override)
-		if msg.err == nil {
-			baseRef := ""
-			if scope == git.ScopeBranch {
-				baseRef, _, _ = driver.BranchBase(msg.set.Repo.Root, override)
-			}
-			msg.fp, _ = driver.Fingerprint(msg.set.Repo.Root, scope, baseRef)
-			msg.worktrees, _ = driver.Worktrees(msg.set.Repo.Root)
+		finishDiffMsg(driver, scope, gen, roots[repoIdx], override, roots, &msg)
+		return msg
+	}
+}
+
+func finishDiffMsg(driver *git.Driver, scope git.Scope, gen int, gitRoot, override string, repoRoots []string, msg *diffLoadedMsg) {
+	msg.repoRoots = repoRoots
+	msg.repoRoot = gitRoot
+	msg.set, msg.err = diff.BuildSet(driver, gitRoot, scope, override)
+	if msg.err == nil {
+		baseRef := msg.set.BaseRef
+		if scope == git.ScopeBranch && baseRef == "" {
+			baseRef, _, _ = driver.BranchBase(msg.set.Repo.Root, override)
 		}
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			msg.fp, _ = driver.Fingerprint(msg.set.Repo.Root, scope, baseRef)
+		}()
+		go func() {
+			defer wg.Done()
+			msg.worktrees, _ = driver.Worktrees(msg.set.Repo.Root)
+		}()
+		wg.Wait()
+	}
+}
+
+func (m *Model) diffReloadCmd(sess store.Session, scope git.Scope, gen int, gitRoot, override string, repoRoots []string) tea.Cmd {
+	driver := m.gitDrv
+	return func() tea.Msg {
+		msg := diffLoadedMsg{sessID: sess.ID, scope: scope, gen: gen}
+		finishDiffMsg(driver, scope, gen, gitRoot, override, repoRoots, &msg)
 		return msg
 	}
 }
@@ -223,9 +253,19 @@ func (m *Model) cycleDiffScope() tea.Cmd {
 	m.diff.gen++
 	m.diff.loading = true
 	m.diff.errText = ""
+	m.diff.set = diff.Set{}
 	m.diff.fileIdx = 0
 	m.diff.scroll = 0
 	m.diff.cursorLine = 0
+	if m.diff.repoSel != "" && len(m.diff.repoRoots) > 0 {
+		override, err := m.store.ReviewBase(sess.ID, resolveSymlinksOrSelf(m.diff.repoSel))
+		if err != nil {
+			m.diff.loading = false
+			m.err = err.Error()
+			return nil
+		}
+		return m.diffReloadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, override, m.diff.repoRoots)
+	}
 	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, false)
 }
 

--- a/internal/ui/repopicker.go
+++ b/internal/ui/repopicker.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/YoanWai/agent-manager/internal/diff"
 	"github.com/YoanWai/agent-manager/internal/git"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -202,6 +203,7 @@ func (m *Model) selectRepo(root string) tea.Cmd {
 	m.diff.gen++
 	m.diff.loading = true
 	m.diff.errText = ""
+	m.diff.set = diff.Set{}
 	m.diff.fileIdx = 0
 	m.diff.scroll = 0
 	m.diff.cursorLine = 0
@@ -226,9 +228,13 @@ func (m *Model) selectBase(ref string) tea.Cmd {
 	m.diff.gen++
 	m.diff.loading = true
 	m.diff.errText = ""
+	m.diff.set = diff.Set{}
 	m.diff.fileIdx = 0
 	m.diff.scroll = 0
 	m.diff.cursorLine = 0
+	if m.diff.repoSel != "" && len(m.diff.repoRoots) > 0 {
+		return m.diffReloadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, ref, m.diff.repoRoots)
+	}
 	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, false)
 }
 


### PR DESCRIPTION
## What

Parallelizes independent git operations in the diff/review load path and adds a fast-reload path for scope cycling that skips redundant repo discovery.

## Changes

### Speed
- `diff.BuildSet`: `ChangedFiles` + `NumStat` run concurrently (2 git calls parallel instead of sequential)
- `diffLoadCmd`: `Fingerprint` + `Worktrees` run concurrently after BuildSet
- `cycleDiffScope` + `selectBase`: skip `ResolveRepos` entirely via `diffReloadCmd` fast path (saves directory walk + worktree expansion + ranking per scope switch, ~4-8 git calls)
- `EnsureFile`: reuses `set.BaseRef` instead of recomputing `BranchBase` per lazy-loaded file
- `diffLoadCmd` closure: caches `ResolveRepos` result per CWD

### UX
- `cycleDiffScope`, `selectRepo`, `selectBase`: clear `diff.set` immediately, view shows "(loading diff...)" instead of stale previous-scope data
- `SelectBase` also uses the fast `diffReloadCmd` path since repo roots don't change

## Files
- `internal/diff/diff.go` — parallelized ChangedFiles+NumStat, added BaseRef to Set, reused BaseRef in EnsureFile
- `internal/ui/diffview.go` — extracted finishDiffMsg, added diffReloadCmd, ResolveRepos cache, clear set on scope cycle
- `internal/ui/repopicker.go` — clear set on repo/base switch, use fast path for selectBase