### PR TITLE
fix(tmux): run agents on a private -L socket

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -13,28 +13,54 @@ import (
 
 const prefix = "am_"
 
+// defaultSocket is the private tmux server name the manager runs every agent
+// on. A dedicated -L socket keeps agent sessions off the user's default
+// socket, where a shell tmux, a `go test`, or a stray kill-server would
+// otherwise share a server with the live agents and take them all down at once.
+const defaultSocket = "agentmgr"
+
 // reviewOption is the global tmux user option the in-session Ctrl+R binding
 // sets to signal the manager to open review for the session it just detached.
 const reviewOption = "@am_review"
 
 type Driver struct {
-	bin string
+	bin    string
+	socket string
 }
 
 func New() (*Driver, error) {
+	return NewWithSocket(defaultSocket)
+}
+
+// NewWithSocket builds a driver bound to a named tmux server. Tests pass an
+// isolated socket so their sessions never collide with the default socket or
+// with live agents on the production socket.
+func NewWithSocket(socket string) (*Driver, error) {
 	bin, err := exec.LookPath("tmux")
 	if err != nil {
 		return nil, fmt.Errorf("tmux not found on PATH: %w", err)
 	}
-	return &Driver{bin: bin}, nil
+	return &Driver{bin: bin, socket: socket}, nil
+}
+
+// SocketName is the tmux server name this driver targets. Tests use it to aim
+// raw tmux commands at the same private socket the driver runs on.
+func (d *Driver) SocketName() string {
+	return d.socket
 }
 
 func sessionName(id string) string {
 	return prefix + id
 }
 
+// args prefixes -L <socket> so every tmux invocation targets the driver's
+// private server. tmux requires the flag before the command word.
+func (d *Driver) args(a ...string) []string {
+	return append([]string{"-L", d.socket}, a...)
+}
+
 func (d *Driver) run(args ...string) (string, error) {
-	out, err := exec.Command(d.bin, args...).CombinedOutput()
+	out, err := exec.Command(d.bin, d.args(args...)...).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("tmux %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 	}
@@ -240,7 +266,7 @@ func sanitizeFormat(s string) string {
 // ReviewRequested reports whether the in-session Ctrl+R binding set the
 // review marker before detaching. A missing tmux server means no request.
 func (d *Driver) ReviewRequested() (bool, error) {
-	out, err := exec.Command(d.bin, "show-option", "-gqv", reviewOption).CombinedOutput()
+	out, err := exec.Command(d.bin, d.args("show-option", "-gqv", reviewOption)...).CombinedOutput()
 	if err != nil {
 		if noServer(string(out)) {
 			return false, nil
@@ -257,7 +283,7 @@ func (d *Driver) ClearReviewRequest() error {
 }
 
 func (d *Driver) AttachCommand(id string) *exec.Cmd {
-	return exec.Command(d.bin, "attach-session", "-t", sessionName(id))
+	return exec.Command(d.bin, d.args("attach-session", "-t", sessionName(id))...)
 }
 
 func (d *Driver) Kill(id string) error {
@@ -271,7 +297,7 @@ func (d *Driver) Kill(id string) error {
 }
 
 func (d *Driver) Exists(id string) bool {
-	err := exec.Command(d.bin, "has-session", "-t", sessionName(id)).Run()
+	err := exec.Command(d.bin, d.args("has-session", "-t", sessionName(id))...).Run()
 	return err == nil
 }
 
@@ -327,7 +353,7 @@ func noServer(out string) bool {
 // Panes returns every managed session's pane pid in a single tmux call,
 // which doubles as a liveness check: a session absent from the map is gone.
 func (d *Driver) Panes() (map[string]int, error) {
-	out, err := exec.Command(d.bin, "list-panes", "-a", "-F", "#{session_name} #{pane_pid}").CombinedOutput()
+	out, err := exec.Command(d.bin, d.args("list-panes", "-a", "-F", "#{session_name} #{pane_pid}")...).CombinedOutput()
 	if err != nil {
 		if noServer(string(out)) {
 			return map[string]int{}, nil

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -8,12 +8,30 @@ import (
 	"time"
 )
 
+// testSocket is an isolated tmux server for this package's tests, so they
+// never touch the default socket where the user's shell tmux and live agents
+// live. TestMain tears it down before and after the run.
+const testSocket = "amtmuxtest"
+
+// TestMain kills any leftover test server so each run starts and ends clean.
+func TestMain(m *testing.M) {
+	tmuxCmd("kill-server").Run()
+	code := m.Run()
+	tmuxCmd("kill-server").Run()
+	os.Exit(code)
+}
+
+// tmuxCmd builds a raw tmux command aimed at the test socket.
+func tmuxCmd(args ...string) *exec.Cmd {
+	return exec.Command("tmux", append([]string{"-L", testSocket}, args...)...)
+}
+
 func requireTmux(t *testing.T) *Driver {
 	t.Helper()
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux not installed")
 	}
-	driver, err := New()
+	driver, err := NewWithSocket(testSocket)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -22,7 +40,7 @@ func requireTmux(t *testing.T) *Driver {
 
 func windowSizeOption(t *testing.T, id string) string {
 	t.Helper()
-	out, err := exec.Command("tmux", "show-window-options", "-v", "-t", "am_"+id, "window-size").CombinedOutput()
+	out, err := tmuxCmd("show-window-options", "-v", "-t", "am_"+id, "window-size").CombinedOutput()
 	if err != nil {
 		t.Fatalf("show-window-options: %v: %s", err, out)
 	}
@@ -67,7 +85,7 @@ func TestSetLabelNeutralizesFormatStrings(t *testing.T) {
 	if err := driver.SetLabel(id, "evil #(touch "+marker+") name"); err != nil {
 		t.Fatalf("SetLabel: %v", err)
 	}
-	rendered, err := exec.Command("tmux", "display-message", "-p", "-t", "am_"+id, "#{T:status-left}").CombinedOutput()
+	rendered, err := tmuxCmd("display-message", "-p", "-t", "am_"+id, "#{T:status-left}").CombinedOutput()
 	if err != nil {
 		t.Fatalf("display-message: %v", err)
 	}
@@ -164,7 +182,7 @@ func TestReviewRequestRoundTrip(t *testing.T) {
 		t.Fatal("no request expected on a clean marker")
 	}
 
-	if _, err := exec.Command("tmux", "set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
 	requested, err = driver.ReviewRequested()
@@ -202,21 +220,21 @@ func TestRefreshChromeKeepsLabelAndAddsReviewHint(t *testing.T) {
 		t.Fatalf("RefreshChrome: %v", err)
 	}
 
-	right, err := exec.Command("tmux", "display-message", "-p", "-t", "am_"+id, "#{T:status-right}").CombinedOutput()
+	right, err := tmuxCmd("display-message", "-p", "-t", "am_"+id, "#{T:status-right}").CombinedOutput()
 	if err != nil {
 		t.Fatalf("status-right: %v", err)
 	}
 	if !strings.Contains(string(right), "Ctrl+r = review") {
 		t.Fatalf("footer should advertise review, got %q", right)
 	}
-	length, err := exec.Command("tmux", "show-option", "-t", "am_"+id, "-v", "status-right-length").CombinedOutput()
+	length, err := tmuxCmd("show-option", "-t", "am_"+id, "-v", "status-right-length").CombinedOutput()
 	if err != nil {
 		t.Fatalf("status-right-length: %v", err)
 	}
 	if strings.TrimSpace(string(length)) != "80" {
 		t.Fatalf("status-right-length should fit the footer, got %q", length)
 	}
-	left, err := exec.Command("tmux", "display-message", "-p", "-t", "am_"+id, "#{T:status-left}").CombinedOutput()
+	left, err := tmuxCmd("display-message", "-p", "-t", "am_"+id, "#{T:status-left}").CombinedOutput()
 	if err != nil {
 		t.Fatalf("status-left: %v", err)
 	}

--- a/internal/ui/resize_guard_test.go
+++ b/internal/ui/resize_guard_test.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
@@ -11,7 +10,7 @@ import (
 
 func windowSize(t *testing.T, id string) (int, int) {
 	t.Helper()
-	out, err := exec.Command("tmux", "display-message", "-p", "-t", "am_"+id,
+	out, err := tmuxCmd("display-message", "-p", "-t", "am_"+id,
 		"#{window_width} #{window_height}").CombinedOutput()
 	if err != nil {
 		t.Fatalf("display-message: %v: %s", err, out)
@@ -34,7 +33,7 @@ func TestFirstRefreshResizesExistingSessions(t *testing.T) {
 	id := m.sessionRows()[0].ID
 
 	// Drift the window as if an older manager had sized it to the terminal.
-	if _, err := exec.Command("tmux", "resize-window", "-t", "am_"+id, "-x", "191", "-y", "55").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("resize-window", "-t", "am_"+id, "-x", "191", "-y", "55").CombinedOutput(); err != nil {
 		t.Fatalf("resize-window: %v", err)
 	}
 
@@ -45,7 +44,7 @@ func TestFirstRefreshResizesExistingSessions(t *testing.T) {
 	}
 
 	// Later refreshes leave sizes alone (attach keeps its own resync path).
-	if _, err := exec.Command("tmux", "resize-window", "-t", "am_"+id, "-x", "100", "-y", "30").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("resize-window", "-t", "am_"+id, "-x", "100", "-y", "30").CombinedOutput(); err != nil {
 		t.Fatalf("resize-window: %v", err)
 	}
 	m.applyCmd(t, m.refreshCmd())
@@ -62,7 +61,7 @@ func TestUnchangedWindowSizeSkipsResize(t *testing.T) {
 	id := m.sessionRows()[0].ID
 
 	// Drift the session window away from the manager size behind its back.
-	if _, err := exec.Command("tmux", "resize-window", "-t", "am_"+id, "-x", "100", "-y", "30").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("resize-window", "-t", "am_"+id, "-x", "100", "-y", "30").CombinedOutput(); err != nil {
 		t.Fatalf("resize-window: %v", err)
 	}
 

--- a/internal/ui/review_reattach_test.go
+++ b/internal/ui/review_reattach_test.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"os/exec"
 	"testing"
 
 	"github.com/YoanWai/agent-manager/internal/status"
@@ -23,7 +22,7 @@ func TestInSessionReviewRemembersOriginAndReattaches(t *testing.T) {
 	}
 	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
 
-	if _, err := exec.Command("tmux", "set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
 	updated, _ := m.Update(attachDoneMsg{})
@@ -96,7 +95,7 @@ func TestReattachAcknowledgesFinished(t *testing.T) {
 	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
 		t.Fatalf("set finished: %v", err)
 	}
-	if _, err := exec.Command("tmux", "set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
 	updated, _ := m.Update(attachDoneMsg{})

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -252,7 +251,7 @@ func TestDragResizesTmuxOnlyOnRelease(t *testing.T) {
 	}
 
 	// Drift the session away so a real resize is observable.
-	if _, err := exec.Command("tmux", "resize-window", "-t", "am_"+id, "-x", "100", "-y", "30").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("resize-window", "-t", "am_"+id, "-x", "100", "-y", "30").CombinedOutput(); err != nil {
 		t.Fatalf("resize-window: %v", err)
 	}
 	if w := windowWidth(t, id); w != 100 {

--- a/internal/ui/tmux_socket_test.go
+++ b/internal/ui/tmux_socket_test.go
@@ -1,0 +1,26 @@
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// testSocket is an isolated tmux server for this package's tests, so they
+// never touch the default socket where the user's shell tmux and live agents
+// live. TestMain tears it down before and after the run.
+const testSocket = "amuitest"
+
+// TestMain kills any leftover test server so each run starts and ends clean.
+func TestMain(m *testing.M) {
+	tmuxCmd("kill-server").Run()
+	code := m.Run()
+	tmuxCmd("kill-server").Run()
+	os.Exit(code)
+}
+
+// tmuxCmd builds a raw tmux command aimed at the test socket, matching the
+// socket buildModel's driver runs on.
+func tmuxCmd(args ...string) *exec.Cmd {
+	return exec.Command("tmux", append([]string{"-L", testSocket}, args...)...)
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -57,7 +57,7 @@ func buildModel(t *testing.T) *Model {
 	}
 	t.Cleanup(func() { st.Close() })
 
-	driver, err := tmux.New()
+	driver, err := tmux.NewWithSocket(testSocket)
 	if err != nil {
 		t.Fatalf("tmux: %v", err)
 	}
@@ -161,7 +161,7 @@ func createSession(t *testing.T, m *Model, name, dir, group string) {
 
 func windowWidth(t *testing.T, id string) int {
 	t.Helper()
-	out, err := exec.Command("tmux", "display-message", "-p", "-t", "am_"+id, "#{window_width}").CombinedOutput()
+	out, err := tmuxCmd("display-message", "-p", "-t", "am_"+id, "#{window_width}").CombinedOutput()
 	if err != nil {
 		t.Fatalf("display-message: %v: %s", err, out)
 	}
@@ -1010,7 +1010,7 @@ func TestAttachDoneOpensReviewWhenMarkerSet(t *testing.T) {
 	m.selectSessionRow(t, "reviewme")
 	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
 
-	if _, err := exec.Command("tmux", "set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
 	updated, _ := m.Update(attachDoneMsg{})
@@ -2135,7 +2135,7 @@ func TestDiffAnnotateAndSend(t *testing.T) {
 	sess := m.sessionRows()[0]
 	// Join wrapped lines so the delivery check does not depend on where the
 	// pane's width breaks the prompt; the session sizes to the model width.
-	out, err := exec.Command("tmux", "capture-pane", "-p", "-J", "-t", "am_"+sess.ID).CombinedOutput()
+	out, err := tmuxCmd("capture-pane", "-p", "-J", "-t", "am_"+sess.ID).CombinedOutput()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Problem

Every agent session ran on the ambient **default** tmux socket, shared with the user's own shell tmux and with `go test` (which spawns real `am_*` sessions through the same driver). Nothing isolated them. So a single event on that shared server, a stray `tmux kill-server`, a shell-agent debugging tmux, a test teardown, took **every live agent down at once**.

Observed: all 14 sessions flipped to `dead` within ~1ms of each other (`last_status_at` clustered at the same instant), right after a `go build` completed, i.e. a run on the default socket wiped the shared server.

## Fix

Bind the tmux driver to a dedicated server via `-L agentmgr`, applied on every invocation site (`run()` plus the four direct `exec.Command` calls). Agents now live on their own server, untouchable by the default socket.

Tests get their own isolated sockets (`amtmuxtest`, `amuitest`) with a `TestMain` that tears them down before and after the run, so a test run can never reach the production socket or the user's default socket again. Three separate servers: production, tests, user shell.

## Verification

- `go vet ./...` + `go build ./...` clean
- Full suite green, including the real-tmux packages: `internal/tmux` and `internal/ui`
- Ran under `env -u TMUX TMUX_TMPDIR=/tmp/amt`; a live default-socket session survived the whole run with zero leaks

## Cutover

Relaunch the TUI to pick up the new socket. Reach agents from a shell with `tmux -L agentmgr ls` / `attach`.