### PR TITLE
fix(revive): capture opencode ids via CLI + revive-all on V

### DIFF
--- a/internal/agentsession/capture.go
+++ b/internal/agentsession/capture.go
@@ -7,9 +7,14 @@ package agentsession
 
 import (
 	"bufio"
+	"bytes"
+	"context"
 	"encoding/json"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -17,6 +22,22 @@ import (
 // clockSlack absorbs small differences between the manager's launch clock
 // and the filesystem timestamp on the store entry the CLI writes.
 const clockSlack = 10 * time.Second
+
+// opencodeScanLimit caps how many of the most-recent sessions we inspect per
+// capture. `opencode session list` is newest-first, so a just-launched
+// session sits near the top; scanning further only spends process spawns.
+const opencodeScanLimit = 40
+
+// opencodeCLITimeout bounds each opencode subprocess so a hung CLI cannot
+// stall the poll loop.
+const opencodeCLITimeout = 15 * time.Second
+
+// opencodeExportHeadBytes is how much of `opencode export` output to read.
+// The payload leads with the session's info block, then streams the entire
+// conversation, which for a long session takes far longer than the metadata
+// is worth waiting for. Reading a bounded prefix captures the info block and
+// lets us stop before the transcript.
+const opencodeExportHeadBytes = 64 * 1024
 
 // resolvePath canonicalizes a directory so a session launched via a
 // symlinked path (macOS /tmp -> /private/tmp) still matches the store
@@ -39,7 +60,7 @@ func Capture(sessionStore, cwd string, launchedAt time.Time, claimed map[string]
 	case "codex":
 		return captureCodex(codexRoot(), cwd, launchedAt, claimed)
 	case "opencode":
-		return captureOpencode(opencodeRoot(), cwd, launchedAt, claimed)
+		return captureOpencode(cwd, launchedAt, claimed)
 	default:
 		return "", false
 	}
@@ -56,15 +77,142 @@ func codexRoot() string {
 	return filepath.Join(home, ".codex", "sessions")
 }
 
-func opencodeRoot() string {
-	if data := os.Getenv("XDG_DATA_HOME"); data != "" {
-		return filepath.Join(data, "opencode", "storage", "session")
-	}
-	home, err := os.UserHomeDir()
+// runOpencode runs an opencode subcommand from cwd and returns its stdout.
+// Reading ids and metadata from opencode's own CLI keeps capture working
+// when opencode changes its private on-disk storage layout between releases,
+// which a hardcoded store path does not survive. The command runs in cwd
+// because `opencode session list` is scoped to the calling directory's
+// project, so a session's own conversations only surface from its cwd.
+func runOpencode(cwd string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), opencodeCLITimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "opencode", args...)
+	cmd.Dir = cwd
+	return cmd.Output()
+}
+
+// runOpencodeHead runs an opencode subcommand from cwd and returns at most
+// opencodeExportHeadBytes of stdout, killing the process once it has that
+// much. `opencode export` on a long session would otherwise stream the whole
+// transcript and blow past the timeout before the leading info block is even
+// consumed.
+func runOpencodeHead(cwd string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), opencodeCLITimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "opencode", args...)
+	cmd.Dir = cwd
+	pipe, err := cmd.StdoutPipe()
 	if err != nil {
-		return ""
+		return nil, err
 	}
-	return filepath.Join(home, ".local", "share", "opencode", "storage", "session")
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, opencodeExportHeadBytes)
+	n, _ := io.ReadFull(pipe, buf)
+	cancel()
+	_ = cmd.Wait()
+	return buf[:n], nil
+}
+
+var opencodeIDPattern = regexp.MustCompile(`ses_[A-Za-z0-9]+`)
+
+// opencodeListIDs returns session ids newest-first from `opencode session
+// list` run in cwd. A package variable so tests substitute canned output.
+var opencodeListIDs = func(cwd string) ([]string, bool) {
+	out, err := runOpencode(cwd, "session", "list")
+	if err != nil {
+		return nil, false
+	}
+	return dedupeOrdered(opencodeIDPattern.FindAllString(string(out), -1)), true
+}
+
+// opencodeSessionMeta returns a session's working directory and creation
+// time from `opencode export <id>` run in cwd. A package variable so tests
+// substitute canned output.
+var opencodeSessionMeta = func(cwd, id string) (directory string, created time.Time, ok bool) {
+	out, err := runOpencodeHead(cwd, "export", id)
+	if err != nil {
+		return "", time.Time{}, false
+	}
+	return parseOpencodeExport(out)
+}
+
+// dedupeOrdered removes duplicates while keeping first-seen order.
+func dedupeOrdered(items []string) []string {
+	seen := make(map[string]bool, len(items))
+	out := items[:0]
+	for _, item := range items {
+		if seen[item] {
+			continue
+		}
+		seen[item] = true
+		out = append(out, item)
+	}
+	return out
+}
+
+// parseOpencodeExport reads directory and creation time from the info block
+// of an `opencode export` payload. The output leads with a human preamble
+// and is read only as a prefix, so it extracts just the info object by brace
+// matching rather than decoding the whole (possibly truncated) document.
+func parseOpencodeExport(out []byte) (directory string, created time.Time, ok bool) {
+	obj, found := extractInfoObject(out)
+	if !found {
+		return "", time.Time{}, false
+	}
+	var info struct {
+		Directory string `json:"directory"`
+		Time      struct {
+			Created int64 `json:"created"`
+		} `json:"time"`
+	}
+	if err := json.Unmarshal(obj, &info); err != nil || info.Directory == "" {
+		return "", time.Time{}, false
+	}
+	return info.Directory, time.UnixMilli(info.Time.Created), true
+}
+
+// extractInfoObject returns the JSON object that follows the "info" key,
+// balancing braces so a truncated export prefix still yields a complete info
+// object as long as that block was fully read.
+func extractInfoObject(out []byte) ([]byte, bool) {
+	key := bytes.Index(out, []byte(`"info"`))
+	if key < 0 {
+		return nil, false
+	}
+	open := bytes.IndexByte(out[key:], '{')
+	if open < 0 {
+		return nil, false
+	}
+	start := key + open
+	depth, inString, escaped := 0, false, false
+	for i := start; i < len(out); i++ {
+		c := out[i]
+		if inString {
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return out[start : i+1], true
+			}
+		}
+	}
+	return nil, false
 }
 
 // candidate is a store entry that could be the session's conversation,
@@ -149,48 +297,31 @@ func codexMeta(path string) (id, cwd string, ok bool) {
 	return line.Payload.SessionID, line.Payload.Cwd, true
 }
 
-// captureOpencode scans ses_*.json files, each recording the session id
-// and the directory it ran in.
-func captureOpencode(root, cwd string, launchedAt time.Time, claimed map[string]bool) (string, bool) {
-	if root == "" {
+// captureOpencode finds the conversation opencode minted for a session
+// launched in cwd, reading ids and metadata from opencode's public CLI
+// rather than its private storage. It inspects the most-recent sessions,
+// keeps those whose directory matches and that were created at or after
+// launch, and returns the earliest such conversation not already claimed.
+func captureOpencode(cwd string, launchedAt time.Time, claimed map[string]bool) (string, bool) {
+	ids, ok := opencodeListIDs(cwd)
+	if !ok {
 		return "", false
 	}
 	cutoff := launchedAt.Add(-clockSlack)
 	wantCwd := resolvePath(cwd)
 	var cands []candidate
-	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			return nil
+	for i, id := range ids {
+		if i >= opencodeScanLimit {
+			break
 		}
-		name := d.Name()
-		if !strings.HasPrefix(name, "ses_") || !strings.HasSuffix(name, ".json") {
-			return nil
+		if claimed[id] {
+			continue
 		}
-		info, err := d.Info()
-		if err != nil || info.ModTime().Before(cutoff) {
-			return nil
+		dir, created, ok := opencodeSessionMeta(cwd, id)
+		if !ok || resolvePath(dir) != wantCwd || created.Before(cutoff) {
+			continue
 		}
-		id, dir, ok := opencodeMeta(path)
-		if !ok || resolvePath(dir) != wantCwd || claimed[id] {
-			return nil
-		}
-		cands = append(cands, candidate{id: id, modTime: info.ModTime()})
-		return nil
-	})
+		cands = append(cands, candidate{id: id, modTime: created})
+	}
 	return pickEarliest(cands)
-}
-
-func opencodeMeta(path string) (id, directory string, ok bool) {
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return "", "", false
-	}
-	var session struct {
-		ID        string `json:"id"`
-		Directory string `json:"directory"`
-	}
-	if err := json.Unmarshal(raw, &session); err != nil || session.ID == "" {
-		return "", "", false
-	}
-	return session.ID, session.Directory, true
 }

--- a/internal/agentsession/capture_test.go
+++ b/internal/agentsession/capture_test.go
@@ -71,37 +71,62 @@ func TestCaptureCodexNoMatch(t *testing.T) {
 	}
 }
 
-func opencodeSession(id, dir string) string {
-	return `{"id":"` + id + `","directory":"` + dir + `","time":{"created":1784385368000}}`
+type ocMeta struct {
+	dir     string
+	created time.Time
+}
+
+// stubOpencode replaces the opencode CLI seams with in-memory data for the
+// duration of a test and returns a restore function.
+func stubOpencode(t *testing.T, ids []string, metas map[string]ocMeta) {
+	t.Helper()
+	listSaved, metaSaved := opencodeListIDs, opencodeSessionMeta
+	opencodeListIDs = func(string) ([]string, bool) { return ids, true }
+	opencodeSessionMeta = func(_, id string) (string, time.Time, bool) {
+		m, ok := metas[id]
+		return m.dir, m.created, ok
+	}
+	t.Cleanup(func() { opencodeListIDs, opencodeSessionMeta = listSaved, metaSaved })
 }
 
 func TestCaptureOpencodePicksSessionAfterLaunchInCwd(t *testing.T) {
-	root := t.TempDir()
 	launch := time.Now()
-	writeFile(t, filepath.Join(root, "projhash/ses_old.json"),
-		opencodeSession("ses_old", "/repo"), launch.Add(-time.Hour))
-	writeFile(t, filepath.Join(root, "projhash/ses_other.json"),
-		opencodeSession("ses_other", "/elsewhere"), launch.Add(time.Second))
-	writeFile(t, filepath.Join(root, "projhash/ses_ours.json"),
-		opencodeSession("ses_ours", "/repo"), launch.Add(2*time.Second))
+	stubOpencode(t, []string{"ses_ours", "ses_other", "ses_old"}, map[string]ocMeta{
+		// An older conversation in the same cwd predates the launch: not ours.
+		"ses_old": {"/repo", launch.Add(-time.Hour)},
+		// A conversation in a different cwd started after launch: not ours.
+		"ses_other": {"/elsewhere", launch.Add(time.Second)},
+		// Ours: same cwd, created just after launch.
+		"ses_ours": {"/repo", launch.Add(2 * time.Second)},
+	})
 
-	id, ok := captureOpencode(root, "/repo", launch, map[string]bool{})
+	id, ok := captureOpencode("/repo", launch, map[string]bool{})
 	if !ok || id != "ses_ours" {
 		t.Fatalf("got id=%q ok=%v, want ses_ours true", id, ok)
 	}
 }
 
 func TestCaptureOpencodeSkipsClaimed(t *testing.T) {
-	root := t.TempDir()
 	launch := time.Now()
-	writeFile(t, filepath.Join(root, "p/ses_1.json"),
-		opencodeSession("ses_1", "/repo"), launch.Add(time.Second))
-	writeFile(t, filepath.Join(root, "p/ses_2.json"),
-		opencodeSession("ses_2", "/repo"), launch.Add(2*time.Second))
+	stubOpencode(t, []string{"ses_1", "ses_2"}, map[string]ocMeta{
+		"ses_1": {"/repo", launch.Add(time.Second)},
+		"ses_2": {"/repo", launch.Add(2 * time.Second)},
+	})
 
-	id, ok := captureOpencode(root, "/repo", launch, map[string]bool{"ses_1": true})
+	// ses_1 already belongs to another session, so the earliest unclaimed
+	// match wins instead.
+	id, ok := captureOpencode("/repo", launch, map[string]bool{"ses_1": true})
 	if !ok || id != "ses_2" {
 		t.Fatalf("got id=%q ok=%v, want ses_2 true", id, ok)
+	}
+}
+
+func TestParseOpencodeExportReadsDirectoryAndTime(t *testing.T) {
+	out := []byte("Exporting session: ses_x\n" +
+		`{"info":{"id":"ses_x","directory":"/repo","time":{"created":1784385368000}}}`)
+	dir, created, ok := parseOpencodeExport(out)
+	if !ok || dir != "/repo" || created.UnixMilli() != 1784385368000 {
+		t.Fatalf("got dir=%q created=%v ok=%v", dir, created, ok)
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -93,6 +93,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openGroupForm()
 	case "v":
 		return m.reviveSelected()
+	case "V":
+		return m.reviveAllDead()
 	case "a":
 		return m.archiveSelected()
 	case "u":
@@ -370,55 +372,102 @@ func (m *Model) reviveSelected() (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	if m.tmux.Exists(sess.ID) {
-		m.err = "session is still running; revive only applies to dead sessions"
+	if err := m.reviveSession(sess); err != nil {
+		m.err = err.Error()
 		return m, nil
+	}
+	m.err = m.degradedResumeNotice(sess)
+	m.requestRefresh()
+	return m, nil
+}
+
+// reviveAllDead relaunches every dead session in the current view, resuming
+// each by its captured id where one exists. It revives what it can and names
+// the first failure rather than stopping, so one broken session does not
+// block the rest.
+func (m *Model) reviveAllDead() (tea.Model, tea.Cmd) {
+	revived, degraded := 0, 0
+	var firstErr string
+	for _, sess := range m.visibleSessions() {
+		if sess.Status != status.Dead {
+			continue
+		}
+		if err := m.reviveSession(sess); err != nil {
+			if firstErr == "" {
+				firstErr = err.Error()
+			}
+			continue
+		}
+		revived++
+		if m.degradedResumeNotice(sess) != "" {
+			degraded++
+		}
+	}
+	switch {
+	case revived == 0 && firstErr == "":
+		m.err = "no dead sessions to revive"
+	case firstErr != "":
+		m.err = fmt.Sprintf("revived %d, first error: %s", revived, firstErr)
+	case degraded > 0:
+		m.err = fmt.Sprintf("revived %d, %d without a captured id (used --continue)", revived, degraded)
+	default:
+		m.err = ""
+	}
+	m.requestRefresh()
+	return m, nil
+}
+
+// degradedResumeNotice warns when a revived session had to fall back to the
+// working directory's most recent conversation because its own conversation
+// id was never captured, which resumes the wrong conversation whenever
+// sessions share a directory.
+func (m *Model) degradedResumeNotice(sess store.Session) string {
+	tool, ok := m.cfg.Tools[sess.Tool]
+	if !ok || sess.AgentSessionID != "" || tool.ResumeByIDCommand == "" {
+		return ""
+	}
+	return fmt.Sprintf("revived %s with --continue: no conversation id captured, may resume the wrong conversation", sess.Name)
+}
+
+// reviveSession relaunches one dead session under its old id, keeping its
+// name, group, and history. When the session's own conversation id was
+// captured, it resumes that exact conversation via the tool's
+// resume_by_id_command instead of the working directory's most recent one,
+// which would be the wrong conversation whenever sessions share a cwd.
+func (m *Model) reviveSession(sess store.Session) error {
+	if m.tmux.Exists(sess.ID) {
+		return fmt.Errorf("session %s is still running; revive only applies to dead sessions", sess.Name)
 	}
 	tool, ok := m.cfg.Tools[sess.Tool]
 	if !ok {
-		m.err = "tool " + sess.Tool + " is no longer configured"
-		return m, nil
+		return fmt.Errorf("tool %s is no longer configured", sess.Tool)
 	}
 	if info, err := os.Stat(sess.Cwd); err != nil || !info.IsDir() {
-		m.err = "working directory no longer exists: " + sess.Cwd
-		return m, nil
+		return fmt.Errorf("working directory no longer exists: %s", sess.Cwd)
 	}
 	baseCommand := tool.ReviveCommand
 	if baseCommand == "" {
 		baseCommand = tool.Command
 	}
-	// When the session's own conversation id is known, resume that exact
-	// conversation instead of the working directory's most recent one,
-	// which would be the wrong conversation whenever sessions share a cwd.
 	if sess.AgentSessionID != "" && tool.ResumeByIDCommand != "" {
 		baseCommand = strings.ReplaceAll(tool.ResumeByIDCommand, "{id}", sess.AgentSessionID)
 	}
 	command, env, err := m.buildLaunch(sess.Tool, tool, baseCommand, sess.ID)
 	if err != nil {
-		m.err = err.Error()
-		return m, nil
+		return err
 	}
 	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
-		m.err = err.Error()
-		return m, nil
+		return err
 	}
 	if err := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name)); err != nil {
-		m.err = err.Error()
-		return m, nil
+		return err
 	}
 	if err := m.store.UpdateStatus(sess.ID, tool.DefaultStatus); err != nil {
-		m.err = err.Error()
-		return m, nil
+		return err
 	}
 	// A leftover ack from the previous life must not swallow the revived
 	// agent's first finished alert.
-	if err := m.store.SetAcked(sess.ID, false); err != nil {
-		m.err = err.Error()
-		return m, nil
-	}
-	m.err = ""
-	m.requestRefresh()
-	return m, nil
+	return m.store.SetAcked(sess.ID, false)
 }
 
 func (m *Model) archiveSelected() (tea.Model, tea.Cmd) {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1129,6 +1129,30 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	}
 }
 
+func TestReviveAllRecreatesEveryDeadSession(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	createSession(t, m, "alpha", dir, "")
+	createSession(t, m, "beta", dir, "")
+
+	for _, sess := range m.visibleSessions() {
+		if err := m.tmux.Kill(sess.ID); err != nil {
+			t.Fatalf("kill %s: %v", sess.Name, err)
+		}
+	}
+	// A refresh marks the pane-less sessions dead so revive-all picks them up.
+	m.applyCmd(t, m.refreshCmd())
+
+	if _, _ = m.reviveAllDead(); m.err != "" {
+		t.Fatalf("revive all: %q", m.err)
+	}
+	for _, sess := range m.visibleSessions() {
+		if !m.tmux.Exists(sess.ID) {
+			t.Fatalf("revive all should recreate %s", sess.Name)
+		}
+	}
+}
+
 func TestReviveRefusesLiveSession(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "alive", t.TempDir(), "")


### PR DESCRIPTION
## Problem

Conversation-id capture read opencode's **private on-disk store** at a path opencode 1.18 no longer writes to. Every capture silently failed, leaving `agent_session_id` empty, so revive fell back to `opencode --continue`, which resumes the working directory's **most recent** conversation. Whenever sessions share a repo (5 of ours share `/monorepo`, 2 share `/MySpaze`), that resumes the wrong conversation.

## Fix

Capture ids from opencode's **public CLI** instead of its private storage:
- `opencode session list`, run in the session's own cwd (the list is project-scoped), enumerates candidate ids.
- `opencode export <id>` yields `info.directory` and `info.time.created` to match on, same logic as before (directory equals cwd, created at/after launch, earliest unclaimed wins).
- Export streams the entire transcript, so we read only the leading info block and stop, extracting that object by brace-matching.

Why this holds up: it uses opencode's stable public interface, so it survives storage-layout changes between releases. It needs no setup: the `opencode` binary is already on PATH (it's the tool being launched), no config, no plugins. Capture runs automatically in the existing poll loop.

## Also

- **`V` (shift+v) revives every dead session** in the current view at once, resuming each by its captured id where one exists.
- Revive now **surfaces when it fell back to `--continue`** for a session with no captured id, instead of silently resuming the wrong conversation.

## Verification

- `go vet ./...` clean; full suite green (real-tmux `internal/ui` and `internal/tmux` included).
- New unit tests: opencode capture via the CLI seam, `export` info-block parsing, revive-all recreates every dead session.
- Exercised the real path against installed opencode 1.18.4: `captureOpencode` correctly assigned each of two shared-cwd sessions its own conversation id (titles matched names).

Note: the two already-dead opencode sessions missed automatic capture while it was broken; their ids were backfilled into the local DB directly so revive-all resumes them correctly.
