### PR TITLE
fix(ui): unblock refresh from id capture + show launch state instantly

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -14,6 +14,10 @@ const (
 	Errored  = "errored"
 	Idle     = "idle"
 	Dead     = "dead"
+	// Starting is the transient state a session shows from launch until its
+	// agent first draws to the pane, so a new row appears immediately instead
+	// of after the next poll.
+	Starting = "starting"
 )
 
 type rule struct {

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -9,6 +9,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/mcpreg"
+	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -417,7 +418,9 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		Tool:           toolName,
 		Cwd:            dir,
 		Group:          group,
-		Status:         tool.DefaultStatus,
+		// Starting until the agent first draws to its pane, so the row shows
+		// a launch state immediately; the poller flips it to the real status.
+		Status:         status.Starting,
 		AgentSessionID: agentSessionID,
 	}
 	if err := m.store.CreateSession(sess); err != nil {
@@ -428,7 +431,14 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 	if deferDirective {
 		m.poller.markDirectivePending(id)
 	}
-	return m.tmux.SetLabel(id, sessionLabel(group, name))
+	if err := m.tmux.SetLabel(id, sessionLabel(group, name)); err != nil {
+		return err
+	}
+	// Show the new session at once instead of waiting for the next poll to
+	// reload it from the store.
+	m.sessions = append(m.sessions, sess)
+	m.rebuildRows()
+	return nil
 }
 
 // withPrompt embeds an optional starting prompt into a tool's launch

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -3,7 +3,9 @@ package ui
 import (
 	"errors"
 	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/YoanWai/agent-manager/internal/agentsession"
@@ -33,9 +35,15 @@ type poller struct {
 	mu              sync.Mutex
 	includeArchived bool
 	selectedID      string
+	// captureErr holds a background id-capture failure to surface on the
+	// next poll, since that work no longer runs inline.
+	captureErr error
 	// sessions whose rename directive could not ride the first prompt;
 	// sent as a message once the tool's input box appears
 	pendingDirective map[string]struct{}
+
+	// captureBusy guards the single in-flight id-capture goroutine.
+	captureBusy atomic.Bool
 
 	// guarded by runMu: refresh state shared between the polling loop
 	// and one-off refresh commands
@@ -52,6 +60,17 @@ type poller struct {
 // One poll is not enough: agents pause between tools (and a fast poll
 // interval would flap working/finished every few ticks).
 var quietEndGrace = time.Second
+
+// startingGrace caps how long a session may show the launch state before the
+// poll derives its real status regardless, so a tool that never paints its
+// pane does not sit on "starting" forever.
+const startingGrace = 30 * time.Second
+
+// paneBooted reports whether the agent has painted anything to its pane yet,
+// which marks the end of the launch state.
+func paneBooted(pane string) bool {
+	return strings.TrimSpace(ansi.Strip(pane)) != ""
+}
 
 func newPoller(st *store.Store, driver *tmux.Driver, engine *status.Engine, hookManager *hooks.Manager, statusSources, sessionStores map[string]string, interval time.Duration) *poller {
 	return &poller{
@@ -198,7 +217,12 @@ func (p *poller) refreshOnce() tea.Msg {
 	p.mu.Lock()
 	includeArchived := p.includeArchived
 	selectedID := p.selectedID
+	captureErr := p.captureErr
+	p.captureErr = nil
 	p.mu.Unlock()
+	if captureErr != nil {
+		return errMsg{captureErr}
+	}
 	// Machine gauges change slowly; sample them every other poll.
 	sampleStats := p.tick%2 == 0
 	p.tick++
@@ -224,14 +248,6 @@ func (p *poller) refreshOnce() tea.Msg {
 	var proc sysstat.ProcStat
 	var agents agentStats
 	paneHashes := make(map[string]uint64, len(sessions))
-	// Conversation ids already bound to a session, so a tool that mints its
-	// own id (codex, opencode) never has two sessions capture the same one.
-	claimed := make(map[string]bool, len(sessions))
-	for _, sess := range sessions {
-		if sess.AgentSessionID != "" {
-			claimed[sess.AgentSessionID] = true
-		}
-	}
 	for i, sess := range sessions {
 		if sess.Archived {
 			continue
@@ -267,6 +283,14 @@ func (p *poller) refreshOnce() tea.Msg {
 					return errMsg{err}
 				}
 				newStatus = derived
+				// Hold the launch state until the agent first paints its pane,
+				// so a just-created session reads "starting up" rather than
+				// flashing idle before it has booted. A grace cap keeps a tool
+				// that never paints from sticking on starting forever.
+				if sess.Status == status.Starting && !paneBooted(pane) &&
+					time.Since(sess.CreatedAt) < startingGrace {
+					newStatus = status.Starting
+				}
 				// Any real transition re-arms the finished alert.
 				if sess.Acked && newStatus != status.Idle && newStatus != status.Finished {
 					if err := ignoreDeletedSession(p.store.SetAcked(sess.ID, false)); err != nil {
@@ -298,9 +322,7 @@ func (p *poller) refreshOnce() tea.Msg {
 			}
 		}
 	}
-	if err := p.captureAgentSessionIDs(sessions, panes, claimed); err != nil {
-		return errMsg{err}
-	}
+	p.startCaptureIfIdle(sessions, panes)
 	p.paneHashes = paneHashes
 	p.sweepDirectives(sessions)
 
@@ -336,27 +358,69 @@ func (p *poller) refreshOnce() tea.Msg {
 	return msg
 }
 
+// idMinting reports whether a live, not-yet-captured session belongs to a
+// tool that mints its own conversation id (codex, opencode).
+func (p *poller) idMinting(sess store.Session, panes map[string]int) bool {
+	return !sess.Archived && panes[sess.ID] != 0 && sess.AgentSessionID == "" &&
+		p.sessionStores[sess.Tool] != ""
+}
+
+// startCaptureIfIdle runs id capture off the poll lock. Capturing an
+// opencode/codex id shells out to the tool's CLI, which can take seconds;
+// doing it inside refreshOnce would hold runMu and stall every refresh,
+// including a freshly submitted session's first appearance. One pass runs at
+// a time, on a snapshot, and a pass that captures anything pokes a refresh so
+// the UI and store pick up the new ids.
+func (p *poller) startCaptureIfIdle(sessions []store.Session, panes map[string]int) {
+	hasWork := false
+	for _, sess := range sessions {
+		if p.idMinting(sess, panes) {
+			hasWork = true
+			break
+		}
+	}
+	if !hasWork || !p.captureBusy.CompareAndSwap(false, true) {
+		return
+	}
+	snapshot := append([]store.Session(nil), sessions...)
+	go func() {
+		defer p.captureBusy.Store(false)
+		captured, err := p.captureAgentSessionIDs(snapshot, panes)
+		if err != nil {
+			p.mu.Lock()
+			p.captureErr = err
+			p.mu.Unlock()
+		}
+		if captured > 0 || err != nil {
+			p.requestRefresh()
+		}
+	}()
+}
+
 // captureAgentSessionIDs binds each not-yet-captured id-minting session
-// (codex, opencode) to the conversation its CLI wrote. Sessions are
-// processed in launch order so the earliest one claims the earliest
-// unclaimed rollout in its directory; a later session started in the same
-// directory then skips that rollout via claimed and captures its own.
-// Capturing out of launch order would let a later session claim an earlier
-// one's conversation. CreatedAt carries nanosecond precision, so sessions
-// launched a moment apart in the same directory still order deterministically.
-func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[string]int, claimed map[string]bool) error {
+// (codex, opencode) to the conversation its CLI wrote, returning how many it
+// bound. Sessions are processed in launch order so the earliest one claims
+// the earliest unclaimed conversation in its directory; a later session
+// started in the same directory then skips that one via claimed and captures
+// its own. CreatedAt carries nanosecond precision, so sessions launched a
+// moment apart in the same directory still order deterministically.
+func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[string]int) (int, error) {
+	claimed := make(map[string]bool, len(sessions))
+	for _, sess := range sessions {
+		if sess.AgentSessionID != "" {
+			claimed[sess.AgentSessionID] = true
+		}
+	}
 	pending := make([]int, 0, len(sessions))
 	for i, sess := range sessions {
-		if sess.Archived || panes[sess.ID] == 0 || sess.AgentSessionID != "" {
-			continue
-		}
-		if p.sessionStores[sess.Tool] != "" {
+		if p.idMinting(sess, panes) {
 			pending = append(pending, i)
 		}
 	}
 	sort.SliceStable(pending, func(a, b int) bool {
 		return sessions[pending[a]].CreatedAt.Before(sessions[pending[b]].CreatedAt)
 	})
+	captured := 0
 	for _, i := range pending {
 		sess := sessions[i]
 		agentID, ok := agentsession.Capture(p.sessionStores[sess.Tool], sess.Cwd, sess.CreatedAt, claimed)
@@ -364,12 +428,12 @@ func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[stri
 			continue
 		}
 		if err := ignoreDeletedSession(p.store.SetAgentSessionID(sess.ID, agentID)); err != nil {
-			return err
+			return captured, err
 		}
-		sessions[i].AgentSessionID = agentID
 		claimed[agentID] = true
+		captured++
 	}
-	return nil
+	return captured, nil
 }
 
 // maybeSendDirective delivers the deferred rename directive once the

--- a/internal/ui/poller_capture_test.go
+++ b/internal/ui/poller_capture_test.go
@@ -64,14 +64,26 @@ func TestCaptureAgentSessionIDsAssignsInLaunchOrder(t *testing.T) {
 	sessions := []store.Session{sessB, sessA} // store order, not launch order
 	p := &poller{store: st, sessionStores: map[string]string{"codex": "codex"}}
 	panes := map[string]int{"sess-A": 123, "sess-B": 456}
-	if err := p.captureAgentSessionIDs(sessions, panes, map[string]bool{}); err != nil {
+	captured, err := p.captureAgentSessionIDs(sessions, panes)
+	if err != nil {
 		t.Fatal(err)
 	}
-
-	if got := sessions[1].AgentSessionID; got != "A-id" {
-		t.Fatalf("session A captured %q, want A-id", got)
+	if captured != 2 {
+		t.Fatalf("captured %d, want 2", captured)
 	}
-	if got := sessions[0].AgentSessionID; got != "B-id" {
-		t.Fatalf("session B captured %q, want B-id", got)
+
+	gotA, err := st.Get("sess-A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotA.AgentSessionID != "A-id" {
+		t.Fatalf("session A captured %q, want A-id", gotA.AgentSessionID)
+	}
+	gotB, err := st.Get("sess-B")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotB.AgentSessionID != "B-id" {
+		t.Fatalf("session B captured %q, want B-id", gotB.AgentSessionID)
 	}
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -63,7 +63,7 @@ func renderSelectedRow(s string) string {
 
 func statusColor(s string) lipgloss.Color {
 	switch s {
-	case status.Working:
+	case status.Working, status.Starting:
 		return colorWorking
 	case status.Waiting:
 		return colorWaiting
@@ -80,6 +80,8 @@ func statusGlyph(s string) string {
 	switch s {
 	case status.Working:
 		return "◐"
+	case status.Starting:
+		return "◌"
 	case status.Waiting:
 		return "?"
 	case status.Finished:
@@ -89,6 +91,15 @@ func statusGlyph(s string) string {
 	default:
 		return "○"
 	}
+}
+
+// statusLabel is the human text for a status; most match the raw value, but
+// the transient launch state reads better spelled out.
+func statusLabel(s string) string {
+	if s == status.Starting {
+		return "starting up"
+	}
+	return s
 }
 
 // titledPanel draws a rounded box with the title embedded in the top

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1129,6 +1129,28 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	}
 }
 
+func TestNewSessionShowsStartingImmediately(t *testing.T) {
+	m := buildModel(t)
+	m.openForm()
+	m.form.name.SetValue("boot")
+	m.form.dir.SetValue(t.TempDir())
+	m.form.toolIndex = 0
+	pickGroup(t, m, "")
+	// submitForm without the follow-up refresh: the row must already show the
+	// launch state from the optimistic insert alone.
+	if _, _ = m.submitForm(); m.err != "" {
+		t.Fatalf("submit: %q", m.err)
+	}
+	rows := m.sessionRows()
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	if rows[0].Status != status.Starting {
+		t.Fatalf("new row status = %q, want %q", rows[0].Status, status.Starting)
+	}
+	t.Cleanup(func() { m.tmux.Kill(rows[0].ID) })
+}
+
 func TestReviveAllRecreatesEveryDeadSession(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -402,7 +402,7 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 			nameStyle = lipgloss.NewStyle().Foreground(colorBright).Bold(true)
 		}
 		name := nameStyle.Render(sess.Name)
-		state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(sess.Status)
+		state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusLabel(sess.Status))
 		meta := state + secondary(" · "+sess.Tool+" · "+relTime(sess.CreatedAt))
 		content = glyph + " " + name + "  " + meta
 	}


### PR DESCRIPTION
## Problem

The quick prompt felt broken: a new session appeared with a long delay after Enter. Two causes stacked:

1. A new session only surfaced on the **next poll** that reloaded the list from the store.
2. That poll had started shelling out to opencode's CLI (`session list` + `export`) to capture conversation ids, holding the refresh lock (`runMu`) for **seconds**. One-off refreshes issued right after submit block on that same lock, so the new row waited behind it.

## Fix

**Unblock the refresh (regression fix):** id capture now runs in a single background goroutine on a snapshot, off `runMu`. It pokes a refresh once it binds anything, so the UI and store pick up the new ids without the poll ever stalling. A rare store failure there is surfaced on the next poll instead of being swallowed. Single-flight via an atomic guard; the store uses one connection so the extra concurrent writer is safe.

**Instant launch state (the requested loader):** a submitted session is inserted into the list immediately with a new transient `starting` status rendered as "starting up" (`◌`). The poll holds that state until the agent first paints its pane, then flips to the real status. A 30s grace cap prevents a tool that never paints from sticking on it.

## Verification

- `go vet ./...` clean; full suite green (real-tmux `internal/ui` and `internal/tmux` included).
- New tests: `TestNewSessionShowsStartingImmediately` (optimistic row is `starting` before any refresh); launch-order capture test updated to read ids from the store (capture no longer mutates the passed slice).