### PR TITLE
fix(review): dim diff tints, brighten comments

### DIFF
--- a/internal/ui/diffrender.go
+++ b/internal/ui/diffrender.go
@@ -18,16 +18,26 @@ const (
 	maxHighlightBytes = 256 << 10
 	highlightCacheCap = 8
 
-	bgAdd     = "\x1b[48;5;22m"
-	bgDel     = "\x1b[48;5;52m"
-	bgAddSpan = "\x1b[48;5;28m"
-	bgDelSpan = "\x1b[48;5;88m"
+	bgAdd     = "\x1b[48;2;22;42;22m"
+	bgDel     = "\x1b[48;2;48;24;24m"
+	bgAddSpan = "\x1b[48;2;38;74;38m"
+	bgDelSpan = "\x1b[48;2;82;36;36m"
 )
 
 var (
-	chromaStyle     = styles.Get("monokai")
+	chromaStyle     = brightCommentStyle()
 	chromaFormatter = formatters.Get("terminal256")
 )
+
+// brightCommentStyle lifts monokai's dim comment color so source comments
+// stay legible over the diff background tints.
+func brightCommentStyle() *chroma.Style {
+	style, err := styles.Get("monokai").Builder().Add(chroma.Comment, "#b0af99").Build()
+	if err != nil {
+		return styles.Get("monokai")
+	}
+	return style
+}
 
 // fileHL holds one file's syntax-highlighted lines per side, indexed by
 // OldNum/NewNum minus one.

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -746,8 +746,8 @@ func (m *Model) annotationRows(fd *diff.FileDiff, lineIdx, width int) []string {
 	if note == nil {
 		return nil
 	}
-	comment := mutedStyle.Italic(true).Render("  ¶ " + note.text)
-	return wrapTinted(comment, nil, "", "", width)
+	comment := annotationStyle.Render("  ¶ " + note.text)
+	return wrapTinted(comment, nil, annotationBg, annotationBg, width)
 }
 
 func (m *Model) annotationAt(path string, line diff.Line) *annotation {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -49,6 +49,9 @@ var (
 	labelStyle  = lipgloss.NewStyle().Foreground(colorDim)
 	errStyle    = lipgloss.NewStyle().Foreground(colorErrored).Bold(true)
 	keyStyle    = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+
+	annotationStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+	annotationBg    = "\x1b[48;2;28;32;46m"
 )
 
 // renderSelectedRow wraps a pre-styled line with the selected row's


### PR DESCRIPTION
## What

Review menu colors reworked so source code comments stay legible.

- **Diff tints**: add/del backgrounds dropped to dim truecolor (`48;2;`) tints. They no longer overwhelm the code.
- **Source comments**: monokai's comment token lifted `#75715e` to `#b0af99`, legible over the tint. Covers all comment subtypes.
- **Reviewer annotations**: moved off muted gray onto a bright accent band.

## Notes

Backgrounds now emit truecolor SGR instead of 256-color, for finer dim control. Renders as intended on truecolor terminals.

## Test

`go build ./...` clean. `internal/ui` tests pass.