### PR TITLE
feat(update): daily release check with in-app update badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Download from [Releases](https://github.com/YoanWai/agent-manager/releases) (mac
 
 Run inside [WSL2](https://learn.microsoft.com/windows/wsl/install): agent-manager lives on tmux, which is a Linux/macOS tool. In a WSL shell, install with Homebrew or grab the Linux binary from Releases.
 
+### Updating
+
+The manager checks GitHub Releases once a day and shows a `↑ vX.Y.Z available` badge in the header when a newer version is out. Pull it in the way you installed:
+
+```bash
+brew upgrade yoanwai/tap/agent-manager   # Homebrew
+go install github.com/YoanWai/agent-manager@latest   # Go
+```
+
 ## Usage
 
 ```bash

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -16,6 +17,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/sysstat"
 	"github.com/YoanWai/agent-manager/internal/tmux"
+	"github.com/YoanWai/agent-manager/internal/update"
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -119,6 +121,12 @@ type Model struct {
 	// settle timers with an older gen are dropped so key-repeat cannot
 	// queue a second of tmux work after the user stops.
 	previewGen uint64
+
+	// version is this build's release tag; updateLatest/updateURL hold a
+	// newer release found on GitHub so the header can badge it.
+	version      string
+	updateLatest string
+	updateURL    string
 }
 
 // confirmTarget.action values; the zero value means delete.
@@ -232,7 +240,7 @@ type attachDoneMsg struct {
 	err    error
 }
 
-func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status.Engine, hookManager *hooks.Manager) *Model {
+func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status.Engine, hookManager *hooks.Manager, version string) *Model {
 	statusSources := make(map[string]string, len(cfg.Tools))
 	sessionStores := make(map[string]string, len(cfg.Tools))
 	for name, tool := range cfg.Tools {
@@ -253,6 +261,7 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 		collapsed:   loadCollapsed(st),
 		splitRatio:  loadSplitRatio(st),
 		mode:        modeList,
+		version:     version,
 	}
 }
 
@@ -321,7 +330,28 @@ func (m *Model) requestRefresh() {
 
 func (m *Model) Init() tea.Cmd {
 	m.syncPollInput()
-	return m.refreshExistingSessionUX
+	return tea.Batch(m.refreshExistingSessionUX, m.checkForUpdate)
+}
+
+// updateMsg carries the result of the background GitHub release check.
+type updateMsg struct {
+	latest string
+	url    string
+}
+
+// checkForUpdate hits GitHub Releases (throttled to once a day via an
+// on-disk cache) off the event loop and reports a newer release. Any
+// failure resolves to an empty message so the TUI simply shows no badge.
+func (m *Model) checkForUpdate() tea.Msg {
+	dir, err := config.Dir()
+	if err != nil {
+		return updateMsg{}
+	}
+	result, err := update.Check(context.Background(), dir, m.version)
+	if err != nil {
+		return updateMsg{}
+	}
+	return updateMsg{latest: result.Latest, url: result.URL}
 }
 
 // refreshExistingSessionUX re-applies the tmux bindings and status bar to
@@ -512,6 +542,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.procFor = msg.procFor
 		m.preview = msg.preview
 		return m, m.diffRefreshCmd()
+
+	case updateMsg:
+		m.updateLatest = msg.latest
+		m.updateURL = msg.url
+		return m, nil
 
 	case previewSettleMsg:
 		if msg.gen != m.previewGen {

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -405,7 +405,7 @@ func TestNewLoadsPersistedSplitRatio(t *testing.T) {
 	if err := m.store.SetSetting(splitRatioSetting, "0.45"); err != nil {
 		t.Fatalf("set setting: %v", err)
 	}
-	loaded := New(m.cfg, m.store, m.tmux, m.poller.engine, m.hooks)
+	loaded := New(m.cfg, m.store, m.tmux, m.poller.engine, m.hooks, "dev")
 	if loaded.splitRatio != 0.45 {
 		t.Fatalf("New splitRatio = %v want 0.45", loaded.splitRatio)
 	}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -66,7 +66,7 @@ func buildModel(t *testing.T) *Model {
 		t.Fatalf("engine: %v", err)
 	}
 
-	m := New(cfg, st, driver, engine, hooks.NewManager(t.TempDir()))
+	m := New(cfg, st, driver, engine, hooks.NewManager(t.TempDir()), "dev")
 	m.width = 120
 	m.height = 40
 	t.Cleanup(func() {

--- a/internal/ui/update_badge_test.go
+++ b/internal/ui/update_badge_test.go
@@ -1,0 +1,17 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHeaderShowsUpdateBadge(t *testing.T) {
+	m := &Model{width: 120, updateLatest: "v0.9.0"}
+	if got := m.viewHeader(); !strings.Contains(got, "v0.9.0") || !strings.Contains(got, "available") {
+		t.Errorf("header missing update badge: %q", got)
+	}
+	m.updateLatest = ""
+	if got := m.viewHeader(); strings.Contains(got, "available") {
+		t.Errorf("header should have no badge when up to date: %q", got)
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -194,6 +194,11 @@ func (m *Model) viewHeader() string {
 	meta := mutedStyle.Render(fmt.Sprintf("%d sessions", sessionCount)) +
 		subtleStyle.Render(" · ") +
 		lipgloss.NewStyle().Foreground(colorAccent2).Render(scope)
+	if m.updateLatest != "" {
+		meta += subtleStyle.Render(" · ") +
+			lipgloss.NewStyle().Foreground(colorAccent).Bold(true).
+				Render("↑ "+m.updateLatest+" available")
+	}
 	left := brand + "  " + meta
 
 	right := m.viewStatusCounts()

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,149 @@
+// Package update checks GitHub Releases for a newer agent-manager and
+// caches the result so the TUI can show an unobtrusive "vX available"
+// badge. It never self-replaces the binary: Homebrew and go install own
+// the actual upgrade, so the badge just points users at them.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	releasesURL   = "https://api.github.com/repos/YoanWai/agent-manager/releases/latest"
+	cacheFile     = "update-check.json"
+	checkInterval = 24 * time.Hour
+	requestBudget = 4 * time.Second
+)
+
+// Result is the newest release found. Latest is empty when the current
+// build is already up to date (or the version is a dev build).
+type Result struct {
+	Latest string `json:"latest"`
+	URL    string `json:"url"`
+}
+
+type cache struct {
+	CheckedAt time.Time `json:"checked_at"`
+	Latest    string    `json:"latest"`
+	URL       string    `json:"url"`
+}
+
+// Check returns the newest release when it is strictly newer than current.
+// It throttles to one network call per checkInterval by caching in configDir,
+// and returns an empty Result (no error) for dev builds or when up to date.
+// Network and parse failures are returned so the caller can log them, but the
+// TUI treats any error as "no badge" and moves on.
+func Check(ctx context.Context, configDir, current string) (Result, error) {
+	currentParts, ok := parseVersion(current)
+	if !ok {
+		return Result{}, nil
+	}
+
+	cachePath := filepath.Join(configDir, cacheFile)
+	if cached, ok := readCache(cachePath); ok && time.Since(cached.CheckedAt) < checkInterval {
+		return newerThan(currentParts, cached.Latest, cached.URL), nil
+	}
+
+	latest, url, err := fetchLatest(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	writeCache(cachePath, cache{CheckedAt: time.Now(), Latest: latest, URL: url})
+	return newerThan(currentParts, latest, url), nil
+}
+
+func newerThan(current [3]int, latest, url string) Result {
+	latestParts, ok := parseVersion(latest)
+	if !ok || !greater(latestParts, current) {
+		return Result{}
+	}
+	return Result{Latest: latest, URL: url}
+}
+
+func fetchLatest(ctx context.Context) (string, string, error) {
+	ctx, cancel := context.WithTimeout(ctx, requestBudget)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesURL, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("update: github returned %s", resp.Status)
+	}
+	var release struct {
+		TagName string `json:"tag_name"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", "", err
+	}
+	return release.TagName, release.HTMLURL, nil
+}
+
+func readCache(path string) (cache, bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return cache{}, false
+	}
+	var c cache
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return cache{}, false
+	}
+	return c, true
+}
+
+func writeCache(path string, c cache) {
+	raw, err := json.Marshal(c)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, raw, 0o644)
+}
+
+// parseVersion turns "v0.8.2" or "0.8.2" into its three numeric parts.
+// A dev build or any tag without three numeric components returns ok=false
+// so it is treated as un-comparable and never triggers a badge.
+func parseVersion(v string) ([3]int, bool) {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	if idx := strings.IndexAny(v, "-+"); idx >= 0 {
+		v = v[:idx]
+	}
+	fields := strings.Split(v, ".")
+	if len(fields) != 3 {
+		return [3]int{}, false
+	}
+	var parts [3]int
+	for i, field := range fields {
+		n, err := strconv.Atoi(field)
+		if err != nil {
+			return [3]int{}, false
+		}
+		parts[i] = n
+	}
+	return parts, true
+}
+
+func greater(a, b [3]int) bool {
+	for i := range a {
+		if a[i] != b[i] {
+			return a[i] > b[i]
+		}
+	}
+	return false
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,98 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseVersion(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  [3]int
+		valid bool
+	}{
+		{"v0.8.2", [3]int{0, 8, 2}, true},
+		{"0.8.2", [3]int{0, 8, 2}, true},
+		{"v1.20.30", [3]int{1, 20, 30}, true},
+		{"v0.9.0-12-gabc", [3]int{0, 9, 0}, true},
+		{"dev", [3]int{}, false},
+		{"v0.8", [3]int{}, false},
+		{"v0.8.x", [3]int{}, false},
+		{"", [3]int{}, false},
+	}
+	for _, c := range cases {
+		got, ok := parseVersion(c.in)
+		if ok != c.valid || got != c.want {
+			t.Errorf("parseVersion(%q) = %v,%v want %v,%v", c.in, got, ok, c.want, c.valid)
+		}
+	}
+}
+
+func TestGreater(t *testing.T) {
+	cases := []struct {
+		a, b [3]int
+		want bool
+	}{
+		{[3]int{0, 9, 0}, [3]int{0, 8, 2}, true},
+		{[3]int{1, 0, 0}, [3]int{0, 99, 99}, true},
+		{[3]int{0, 8, 3}, [3]int{0, 8, 2}, true},
+		{[3]int{0, 8, 2}, [3]int{0, 8, 2}, false},
+		{[3]int{0, 8, 1}, [3]int{0, 8, 2}, false},
+	}
+	for _, c := range cases {
+		if got := greater(c.a, c.b); got != c.want {
+			t.Errorf("greater(%v,%v) = %v want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestNewerThan(t *testing.T) {
+	if r := newerThan([3]int{0, 8, 2}, "v0.9.0", "url"); r.Latest != "v0.9.0" {
+		t.Errorf("expected newer release, got %+v", r)
+	}
+	if r := newerThan([3]int{0, 8, 2}, "v0.8.2", "url"); r.Latest != "" {
+		t.Errorf("equal version should not badge, got %+v", r)
+	}
+	if r := newerThan([3]int{0, 8, 2}, "garbage", "url"); r.Latest != "" {
+		t.Errorf("unparseable latest should not badge, got %+v", r)
+	}
+}
+
+func TestCheckDevBuildSkips(t *testing.T) {
+	if r, err := Check(context.Background(), t.TempDir(), "dev"); err != nil || r.Latest != "" {
+		t.Errorf("dev build should skip: got %+v err %v", r, err)
+	}
+}
+
+// A fresh cache short-circuits the network entirely; seeding one lets us
+// exercise Check's decision path without hitting GitHub.
+func TestCheckUsesFreshCache(t *testing.T) {
+	dir := t.TempDir()
+	seed := cache{CheckedAt: time.Now(), Latest: "v0.9.0", URL: "https://example/rel"}
+	raw, _ := json.Marshal(seed)
+	if err := os.WriteFile(filepath.Join(dir, cacheFile), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r, err := Check(context.Background(), dir, "v0.8.2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Latest != "v0.9.0" || r.URL != "https://example/rel" {
+		t.Errorf("expected cached newer release, got %+v", r)
+	}
+}
+
+func TestCheckFreshCacheNoUpdate(t *testing.T) {
+	dir := t.TempDir()
+	seed := cache{CheckedAt: time.Now(), Latest: "v0.8.2", URL: "u"}
+	raw, _ := json.Marshal(seed)
+	os.WriteFile(filepath.Join(dir, cacheFile), raw, 0o644)
+	r, err := Check(context.Background(), dir, "v0.8.2")
+	if err != nil || r.Latest != "" {
+		t.Errorf("same version should not badge: got %+v err %v", r, err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func run() error {
 	}
 	defer st.Close()
 
-	model := ui.New(cfg, st, driver, engine, hooks.NewManager(dir))
+	model := ui.New(cfg, st, driver, engine, hooks.NewManager(dir), version)
 	// Mouse cell motion is always on so the terminal (and nested tmux)
 	// cannot scroll the manager out of view. Shift+drag still selects text.
 	program := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())


### PR DESCRIPTION
## What

Adds a lightweight update notifier. On launch the manager checks GitHub Releases once a day and shows a `↑ vX.Y.Z available` badge in the header when a newer tag than the running build is out.

## How

- `internal/update`: fetches the latest release tag, compares semver, caches the result to `update-check.json` in the config dir so the network is hit at most once per 24h. 4s timeout, failures resolve to no badge.
- Never self-replaces the binary. Homebrew and `go install` own the upgrade; the badge points users at them.
- `ui.New` now takes the build `version`; `Init` fires the check off the event loop; the header renders the badge when a newer release is found.
- README gains an "Updating" section.

## Tests

- `internal/update`: semver parse/compare, dev-build skip, fresh-cache short-circuit (no network), no-badge-when-equal.
- `internal/ui`: header renders the badge when set, hides it when up to date.
- Full suite green, `go vet` clean, live GitHub call verified to return the real tag + URL.