### PR TITLE
fix(review): reset reviewed mark when file content changes

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -42,7 +42,7 @@ type diffState struct {
 	sideBySide bool
 
 	scrollByFile map[string]int
-	reviewed     map[string]map[string]bool
+	reviewed     map[string]map[string]uint64
 	annotations  map[string][]annotation
 
 	annotating  bool
@@ -323,6 +323,7 @@ func (m *Model) handleDiffLoaded(msg diffLoadedMsg) tea.Cmd {
 		previousPath = fd.File.Path
 	}
 	m.diff.set = msg.set
+	clearStaleReviewedMarks(m)
 	// Re-anchor only on a silent same-scope refresh. A scope cycle or session
 	// switch loads a different file set, where matching a comment by excerpt
 	// would rewrite its line against content it was never made against.
@@ -679,19 +680,20 @@ func (m *Model) toggleReviewed() tea.Cmd {
 	}
 	marks := m.diff.reviewed[m.reviewKey()]
 	if marks == nil {
-		marks = map[string]bool{}
+		marks = map[string]uint64{}
 		m.diff.reviewed[m.reviewKey()] = marks
 	}
-	marks[fd.File.Path] = !marks[fd.File.Path]
-	if !marks[fd.File.Path] {
+	if marks[fd.File.Path] != 0 {
+		marks[fd.File.Path] = 0
 		return nil
 	}
+	marks[fd.File.Path] = contentHash(fd)
 	// Advance to the next unreviewed file, review-queue style. The switch
 	// returns the highlight command for the newly shown file; dropping it
 	// would leave that file unhighlighted.
 	for step := 1; step < len(m.diff.set.Files); step++ {
 		next := (m.diff.fileIdx + step) % len(m.diff.set.Files)
-		if !marks[m.diff.set.Files[next].File.Path] {
+		if marks[m.diff.set.Files[next].File.Path] == 0 {
 			return m.switchDiffFile(next - m.diff.fileIdx)
 		}
 	}
@@ -699,7 +701,23 @@ func (m *Model) toggleReviewed() tea.Cmd {
 }
 
 func (m *Model) fileReviewed(path string) bool {
-	return m.diff.reviewed[m.reviewKey()][path]
+	return m.diff.reviewed[m.reviewKey()][path] != 0
+}
+
+func clearStaleReviewedMarks(m *Model) {
+	marks := m.diff.reviewed[m.reviewKey()]
+	if len(marks) == 0 {
+		return
+	}
+	for path, stored := range marks {
+		if stored == 0 {
+			continue
+		}
+		fd := m.fileDiffByPath(path)
+		if fd == nil || contentHash(fd) != stored {
+			delete(marks, path)
+		}
+	}
 }
 
 func (m *Model) openAnnotate() {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -142,7 +142,7 @@ func (m *Model) openDiff() tea.Cmd {
 	}
 	if m.diff.scrollByFile == nil {
 		m.diff.scrollByFile = map[string]int{}
-		m.diff.reviewed = map[string]map[string]bool{}
+		m.diff.reviewed = map[string]map[string]uint64{}
 		m.diff.annotations = map[string][]annotation{}
 		m.diff.hl = newHLCache()
 		m.diff.sideBySide = m.defaultSplitLayout()

--- a/internal/ui/review_regression_test.go
+++ b/internal/ui/review_regression_test.go
@@ -1520,3 +1520,35 @@ func TestReviewHeaderTargetLabelCleanAndKeyed(t *testing.T) {
 		t.Fatalf("header should show the cleaned target → branch, got %q", header)
 	}
 }
+
+func TestReviewedMarkClearsOnContentChange(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	dir := gitRepoWithTwoChangedFiles(t)
+	openReviewOn(t, m, "reset", dir)
+	if len(m.diff.set.Files) == 0 {
+		t.Fatal("want at least one changed file")
+	}
+	path := m.diff.set.Files[0].File.Path
+
+	m.drainCmds(t, m.toggleReviewed())
+	if !m.fileReviewed(path) {
+		t.Fatal("file should be reviewed after toggle")
+	}
+
+	original, err := os.ReadFile(filepath.Join(dir, path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := string(original) + "\nfunc Added() {}"
+	if err := os.WriteFile(filepath.Join(dir, path), []byte(changed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m.refreshDiff(t)
+	if m.fileReviewed(path) {
+		t.Fatal("reviewed mark should reset after content changes")
+	}
+}


### PR DESCRIPTION
Store content hash (FNV-1a over line Kind+Text) with each reviewed mark. On every diff load (silent refresh, scope cycle, reopen), marks whose content hash differs from the current file or whose file no longer exists are cleared.

Previously reviewed marks were a `map[string]bool` keyed only by path — they survived content changes indefinitely. Now `map[string]uint64` stores the content hash at marking time; `clearStaleReviewedMarks` runs after each `handleDiffLoaded` before the set is used.

Added `TestReviewedMarkClearsOnContentChange` that toggles review on a file, edits it on disk, refreshes, and verifies the mark cleared.