### PR TITLE
feat(settings): show build version and update status

### DIFF
--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -151,8 +151,20 @@ func (m *Model) viewSettings() string {
 		return marker + labelStyle.Render(name) + "  " + picker
 	}
 	body := row(settingsFieldTool, "quick spawn tool", m.settings.toolNames[m.settings.toolIndex]) + "\n" +
-		row(settingsFieldLayout, "review layout", layout)
+		row(settingsFieldLayout, "review layout", layout) + "\n\n" +
+		subtleStyle.Render("  version ") + valueStyle.Render(m.version) + m.versionStatus()
 	return m.card("⚙ Settings", body, "↑↓ field · ←→ change · ↵/esc save")
+}
+
+// versionStatus reports whether a newer release is known, as a suffix for
+// the settings version line. Empty when the daily check has not found one.
+func (m *Model) versionStatus() string {
+	if m.updateLatest == "" {
+		return ""
+	}
+	return subtleStyle.Render(" · ") +
+		lipgloss.NewStyle().Foreground(colorAccent).Bold(true).
+			Render("↑ "+m.updateLatest+" available")
 }
 
 func (m *Model) viewMove() string {

--- a/internal/ui/settings_version_test.go
+++ b/internal/ui/settings_version_test.go
@@ -1,0 +1,24 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSettingsShowsVersion(t *testing.T) {
+	m := &Model{
+		version:  "v0.9.0",
+		settings: settingsState{toolNames: []string{"claude"}},
+	}
+	out := m.viewSettings()
+	if !strings.Contains(out, "version") || !strings.Contains(out, "v0.9.0") {
+		t.Errorf("settings missing version: %q", out)
+	}
+	if strings.Contains(out, "available") {
+		t.Errorf("no badge expected when up to date: %q", out)
+	}
+	m.updateLatest = "v0.9.1"
+	if out := m.viewSettings(); !strings.Contains(out, "v0.9.1") || !strings.Contains(out, "available") {
+		t.Errorf("settings missing update badge: %q", out)
+	}
+}


### PR DESCRIPTION
Adds a `version <tag>` line to the settings card, with a `↑ vX.Y.Z available` suffix when a newer release is known (same signal as the header badge). Test covers both states.