### PR TITLE
chore(ci): coverage upload + status badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ jobs:
       - name: Vet
         run: go vet ./...
       - name: Test
-        run: go test -race ./...
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Build
         run: go build ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Agent Manager
 
+[![CI](https://github.com/YoanWai/agent-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/YoanWai/agent-manager/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/YoanWai/agent-manager.svg)](https://pkg.go.dev/github.com/YoanWai/agent-manager)
+[![Go Report Card](https://goreportcard.com/badge/github.com/YoanWai/agent-manager)](https://goreportcard.com/report/github.com/YoanWai/agent-manager)
+[![codecov](https://codecov.io/gh/YoanWai/agent-manager/branch/main/graph/badge.svg)](https://codecov.io/gh/YoanWai/agent-manager)
+
 ![agent-manager demo](docs/demo.gif)
 
 Run every AI coding agent from one terminal. Claude Code, Codex, OpenCode, and Grok run side by side, each in its own tmux session, so they keep working after you quit the manager.


### PR DESCRIPTION
Adds a code coverage report (Codecov) plus pkg.go.dev, Go Report Card, CI, and Codecov badges in the README. These are the prerequisites for listing on avelino/awesome-go.

- CI now runs `go test` with `-coverprofile` and uploads to Codecov (non-blocking: `fail_ci_if_error: false`).
- README shows CI / Go Reference / Go Report Card / Codecov badges.

Manual step to activate coverage: sign in to codecov.io with GitHub (auto-detects this public repo), then optionally add a `CODECOV_TOKEN` repo secret for reliable uploads. Until then the Codecov badge shows 'unknown' and the upload step is a no-op.