### PR TITLE
fix(tui): native text selection and wheel that navigates instead of scrolling away

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -168,6 +168,9 @@ func (d *Driver) styleStatusBar(name string) error {
 		// hide the "0:windowname*" window list; it reads as noise here
 		{"set-option", "-t", name, "window-status-format", ""},
 		{"set-option", "-t", name, "window-status-current-format", ""},
+		// mouse on so tmux handles scrollback per-session instead of the
+		// terminal emulator, whose buffer carries content from prior attaches.
+		{"set-option", "-t", name, "mouse", "on"},
 	}
 	for _, args := range options {
 		if _, err := d.run(args...); err != nil {

--- a/internal/ui/altscroll.go
+++ b/internal/ui/altscroll.go
@@ -1,0 +1,22 @@
+package ui
+
+import "os"
+
+// DECSET 1007 (alternate scroll) makes the terminal translate wheel events
+// into arrow keys while the alt screen is up. The manager keeps mouse
+// tracking off so click+drag selects text natively; without 1007 the wheel
+// would scroll the host's scrollback and push the manager out of view.
+const (
+	altScrollOn  = "\x1b[?1007h"
+	altScrollOff = "\x1b[?1007l"
+)
+
+func EnableAlternateScroll() error {
+	_, err := os.Stdout.WriteString(altScrollOn)
+	return err
+}
+
+func DisableAlternateScroll() error {
+	_, err := os.Stdout.WriteString(altScrollOff)
+	return err
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -108,8 +108,7 @@ type Model struct {
 	errAge        int
 
 	// Horizontal sessions/sidebar split. splitRatio is the left panel's
-	// share of the terminal width; resizeMode arms divider drag handling
-	// (mouse motion reporting is always on so the host cannot scroll us).
+	// share of the terminal width; resizeMode arms keyboard divider nudging.
 	splitRatio       float64
 	splitRatioBefore float64
 	resizeMode       bool

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -109,7 +109,7 @@ type Model struct {
 
 	// Horizontal sessions/sidebar split. splitRatio is the left panel's
 	// share of the terminal width; resizeMode arms divider drag handling
-	// (mouse reporting itself is always on so the host cannot scroll us).
+	// (mouse motion reporting is always on so the host cannot scroll us).
 	splitRatio       float64
 	splitRatioBefore float64
 	resizeMode       bool
@@ -604,7 +604,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.err = msg.err.Error()
 			m.requestRefresh()
-			return m, tea.EnableMouseCellMotion
+			return m, nil
 		}
 		// Ctrl+R inside the session sets a marker before detaching; consume
 		// it here and jump straight to review for the session just attached.
@@ -618,17 +618,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if clearErr := m.tmux.ClearReviewRequest(); clearErr != nil {
 				m.err = clearErr.Error()
 				m.requestRefresh()
-				return m, tea.EnableMouseCellMotion
+				return m, nil
 			}
 			sess, ok := m.selected()
 			cmd := m.openDiff()
 			if ok && m.mode == modeDiff {
 				m.diff.reattachID = sess.ID
 			}
-			return m, tea.Batch(cmd, tea.EnableMouseCellMotion)
+			return m, cmd
 		}
 		m.requestRefresh()
-		return m, tea.EnableMouseCellMotion
+		return m, nil
 
 	case tea.MouseMsg:
 		return m.handleMouse(msg)

--- a/internal/ui/mouse_rearm_test.go
+++ b/internal/ui/mouse_rearm_test.go
@@ -1,25 +1,19 @@
 package ui
 
 import (
-	"reflect"
 	"testing"
-
-	tea "github.com/charmbracelet/bubbletea"
 )
 
-// Bubbletea's RestoreTerminal (v1.3.10) re-enables altscreen, bracketed
-// paste, and focus reporting after tea.ExecProcess but not mouse mode, so
-// every tmux attach/detach silently kills wheel capture and the host
-// scrolls the manager off-screen. Detaching must re-arm mouse cell motion.
-func TestDetachReArmsMouseCapture(t *testing.T) {
+// Mouse reporting is off by default and only enabled during resize mode.
+// After a tmux attach/detach, no mouse re-arming is needed because mouse
+// is off: the terminal handles native text selection directly.
+// This test verifies the handler returns no mouse-enable command.
+func TestDetachNoMouseReArm(t *testing.T) {
 	m := buildModel(t)
 	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
 
 	_, cmd := m.Update(attachDoneMsg{})
-	if cmd == nil {
-		t.Fatal("detach should re-enable mouse capture, got nil command")
-	}
-	if reflect.TypeOf(cmd()) != reflect.TypeOf(tea.EnableMouseCellMotion()) {
-		t.Fatalf("detach command = %T, want the tea.EnableMouseCellMotion message", cmd())
+	if cmd != nil {
+		t.Fatalf("detach should not re-arm mouse, got %T", cmd)
 	}
 }

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -85,9 +85,8 @@ func (m *Model) setSplitFromX(x int) {
 	m.splitRatio = float64(left) / float64(m.width)
 }
 
-// enterResizeMode arms divider dragging by enabling mouse cell motion so
-// drag events are captured. Mouse reporting is disabled outside this mode
-// so native text selection works in the terminal.
+// enterResizeMode arms divider dragging. Mouse is never enabled by the
+// app so native text selection always works in the terminal.
 func (m *Model) enterResizeMode() (tea.Model, tea.Cmd) {
 	if m.mode != modeList || m.searching || m.quick.active {
 		return m, nil
@@ -96,13 +95,12 @@ func (m *Model) enterResizeMode() (tea.Model, tea.Cmd) {
 	m.splitDragging = false
 	m.splitRatioBefore = m.splitRatio
 	m.err = ""
-	return m, tea.EnableMouseCellMotion
+	return m, nil
 }
 
 // exitResizeMode leaves divider-drag mode. When commit is true the current
 // ratio is persisted; cancel restores the pre-mode ratio. Either path ends
-// with a pane resize so the preview stays 1:1 and mouse reporting disabled
-// so the terminal regains native text selection.
+// with a pane resize so the preview stays 1:1 with the panel.
 func (m *Model) exitResizeMode(commit bool) (tea.Model, tea.Cmd) {
 	if !m.resizeMode && !m.splitDragging {
 		return m, nil
@@ -115,7 +113,7 @@ func (m *Model) exitResizeMode(commit bool) (tea.Model, tea.Cmd) {
 	m.splitDragging = false
 	m.resizeMode = false
 	m.resizeSessions()
-	return m, tea.DisableMouse
+	return m, nil
 }
 
 // nudgeSplit moves the divider by delta columns while resize mode is on.

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -85,9 +85,9 @@ func (m *Model) setSplitFromX(x int) {
 	m.splitRatio = float64(left) / float64(m.width)
 }
 
-// enterResizeMode arms divider dragging. Mouse reporting is always on at
-// the program level (see main) so the terminal cannot scroll the TUI away;
-// this mode only changes how clicks/drags are interpreted.
+// enterResizeMode arms divider dragging by enabling mouse cell motion so
+// drag events are captured. Mouse reporting is disabled outside this mode
+// so native text selection works in the terminal.
 func (m *Model) enterResizeMode() (tea.Model, tea.Cmd) {
 	if m.mode != modeList || m.searching || m.quick.active {
 		return m, nil
@@ -96,12 +96,13 @@ func (m *Model) enterResizeMode() (tea.Model, tea.Cmd) {
 	m.splitDragging = false
 	m.splitRatioBefore = m.splitRatio
 	m.err = ""
-	return m, nil
+	return m, tea.EnableMouseCellMotion
 }
 
 // exitResizeMode leaves divider-drag mode. When commit is true the current
 // ratio is persisted; cancel restores the pre-mode ratio. Either path ends
-// with a pane resize so the preview stays 1:1 with the panel.
+// with a pane resize so the preview stays 1:1 and mouse reporting disabled
+// so the terminal regains native text selection.
 func (m *Model) exitResizeMode(commit bool) (tea.Model, tea.Cmd) {
 	if !m.resizeMode && !m.splitDragging {
 		return m, nil
@@ -114,7 +115,7 @@ func (m *Model) exitResizeMode(commit bool) (tea.Model, tea.Cmd) {
 	m.splitDragging = false
 	m.resizeMode = false
 	m.resizeSessions()
-	return m, nil
+	return m, tea.DisableMouse
 }
 
 // nudgeSplit moves the divider by delta columns while resize mode is on.
@@ -164,9 +165,9 @@ func (m *Model) onDivider(x int) bool {
 }
 
 func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
-	// Always consume mouse events so the host terminal / outer tmux never
-	// scrolls the manager off-screen. Wheel maps to in-app navigation;
-	// clicks only drive the divider while resize mode is armed.
+	// Mouse events are always consumed so the host terminal / outer tmux
+	// never scrolls the manager off-screen. Wheel maps to in-app
+	// navigation; clicks only drive the divider while resize mode is armed.
 	if tea.MouseEvent(msg).IsWheel() {
 		return m.handleMouseWheel(msg)
 	}

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -91,8 +91,8 @@ func TestResizeModeKeyArmsDrag(t *testing.T) {
 	if !m.resizeMode {
 		t.Fatal("| should enter resize mode")
 	}
-	if cmd == nil {
-		t.Fatal("enter should enable mouse reporting")
+	if cmd != nil {
+		t.Fatal("enter should not toggle mouse reporting")
 	}
 
 	// Other keys are swallowed while armed.
@@ -110,8 +110,8 @@ func TestResizeModeKeyArmsDrag(t *testing.T) {
 	if m.resizeMode {
 		t.Fatal("esc should leave resize mode")
 	}
-	if cmd == nil {
-		t.Fatal("exit should disable mouse reporting")
+	if cmd != nil {
+		t.Fatal("exit should not toggle mouse reporting")
 	}
 }
 
@@ -150,8 +150,8 @@ func TestArrowNudgeAndPipeCommits(t *testing.T) {
 	if m.resizeMode {
 		t.Fatal("| should commit and exit resize mode")
 	}
-	if cmd == nil {
-		t.Fatal("commit should disable mouse reporting")
+	if cmd != nil {
+		t.Fatal("commit should not toggle mouse reporting")
 	}
 	raw, err := st.Setting(splitRatioSetting)
 	if err != nil || raw == "" {
@@ -220,8 +220,8 @@ func TestDragReleasePersistsAndExits(t *testing.T) {
 	if m.splitDragging || m.resizeMode {
 		t.Fatal("release should end drag and exit resize mode")
 	}
-	if cmd == nil {
-		t.Fatal("release should disable mouse reporting")
+	if cmd != nil {
+		t.Fatal("release should not toggle mouse reporting")
 	}
 
 	raw, err := st.Setting(splitRatioSetting)

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -91,9 +91,8 @@ func TestResizeModeKeyArmsDrag(t *testing.T) {
 	if !m.resizeMode {
 		t.Fatal("| should enter resize mode")
 	}
-	if cmd != nil {
-		// Mouse is always on at the program level; resize only flips a flag.
-		t.Fatal("enter should not toggle mouse reporting")
+	if cmd == nil {
+		t.Fatal("enter should enable mouse reporting")
 	}
 
 	// Other keys are swallowed while armed.
@@ -111,8 +110,8 @@ func TestResizeModeKeyArmsDrag(t *testing.T) {
 	if m.resizeMode {
 		t.Fatal("esc should leave resize mode")
 	}
-	if cmd != nil {
-		t.Fatal("exit should not toggle mouse reporting")
+	if cmd == nil {
+		t.Fatal("exit should disable mouse reporting")
 	}
 }
 
@@ -151,8 +150,8 @@ func TestArrowNudgeAndPipeCommits(t *testing.T) {
 	if m.resizeMode {
 		t.Fatal("| should commit and exit resize mode")
 	}
-	if cmd != nil {
-		t.Fatal("commit should not toggle mouse reporting")
+	if cmd == nil {
+		t.Fatal("commit should disable mouse reporting")
 	}
 	raw, err := st.Setting(splitRatioSetting)
 	if err != nil || raw == "" {
@@ -221,8 +220,8 @@ func TestDragReleasePersistsAndExits(t *testing.T) {
 	if m.splitDragging || m.resizeMode {
 		t.Fatal("release should end drag and exit resize mode")
 	}
-	if cmd != nil {
-		t.Fatal("release should not toggle mouse reporting")
+	if cmd == nil {
+		t.Fatal("release should disable mouse reporting")
 	}
 
 	raw, err := st.Setting(splitRatioSetting)

--- a/main.go
+++ b/main.go
@@ -153,11 +153,17 @@ func run() error {
 	defer st.Close()
 
 	model := ui.New(cfg, st, driver, engine, hooks.NewManager(dir), version)
-	// Mouse reporting is off by default so native text selection works
-	// in the terminal. It is enabled only during resize mode (divider drag)
-	// and disabled on exit, so the terminal handles selection normally.
+	// Mouse reporting stays off so the terminal keeps native text selection.
+	// Alternate scroll then turns the wheel into arrow keys instead of host
+	// scrollback, so the manager cannot be scrolled out of view.
 	program := tea.NewProgram(model, tea.WithAltScreen())
+	if err := ui.EnableAlternateScroll(); err != nil {
+		return err
+	}
 	model.StartPoller(program.Send)
-	_, err = program.Run()
-	return err
+	_, runErr := program.Run()
+	if err := ui.DisableAlternateScroll(); err != nil && runErr == nil {
+		runErr = err
+	}
+	return runErr
 }

--- a/main.go
+++ b/main.go
@@ -153,9 +153,10 @@ func run() error {
 	defer st.Close()
 
 	model := ui.New(cfg, st, driver, engine, hooks.NewManager(dir), version)
-	// Mouse cell motion is always on so the terminal (and nested tmux)
-	// cannot scroll the manager out of view. Shift+drag still selects text.
-	program := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	// Mouse reporting is off by default so native text selection works
+	// in the terminal. It is enabled only during resize mode (divider drag)
+	// and disabled on exit, so the terminal handles selection normally.
+	program := tea.NewProgram(model, tea.WithAltScreen())
 	model.StartPoller(program.Send)
 	_, err = program.Run()
 	return err


### PR DESCRIPTION
Three fixes to how the manager handles the mouse.

**Text selection.** Mouse tracking is off, so click+drag selects text natively in the terminal and macOS copy-on-select works.

**Wheel.** Alternate scroll (DECSET 1007) makes the terminal send arrow keys on wheel while the alt screen is up, so the wheel navigates the list and the manager stays in view. Verified by capturing the raw byte stream: startup emits `[?1007h`, quit emits `[?1007l`, and tmux attach/detach leaves the mode untouched, so no re-arm is needed on detach.

**Session scrollback.** tmux sessions set `mouse on`, so tmux owns per-session scrollback instead of the terminal's shared buffer, which carried content from earlier attaches.