### PR TITLE
Redesign the TUI on painted surfaces

### DIFF
--- a/internal/ui/banner.go
+++ b/internal/ui/banner.go
@@ -1,0 +1,122 @@
+package ui
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The wordmark is drawn from half-block glyphs, three rows tall. Only the
+// seven letters in "agent manager" exist, which is the whole point: a
+// wordmark, not a font.
+var bannerGlyphs = map[rune][3]string{
+	'a': {"▄▀▄", "█▀█", "▀ ▀"},
+	'g': {"█▀▀", "█▄█", "▀▀▀"},
+	'e': {"█▀▀", "█▀▀", "▀▀▀"},
+	'n': {"█▄ █", "█ ▀█", "▀  ▀"},
+	't': {"▀█▀", " █ ", " ▀ "},
+	'm': {"█▀▄▀█", "█ ▀ █", "▀   ▀"},
+	'r': {"█▀█", "█▀▄", "▀ ▀"},
+	' ': {"  ", "  ", "  "},
+}
+
+const (
+	bannerWord = "agent manager"
+	bannerRows = 3
+
+	// bannerFrames is how long the intro sweep runs. The wordmark animates
+	// on launch and then holds still: a permanently animating header would
+	// repaint the frame forever, and a repainting frame cannot be selected
+	// with the mouse.
+	bannerFrames   = 22
+	bannerInterval = 110 * time.Millisecond
+)
+
+type bannerTickMsg struct{}
+
+// bannerTick drives the intro sweep, and stops scheduling itself once the
+// wordmark has settled.
+func (m *Model) bannerTick() tea.Cmd {
+	if m.bannerPhase >= bannerFrames {
+		return nil
+	}
+	return tea.Tick(bannerInterval, func(time.Time) tea.Msg { return bannerTickMsg{} })
+}
+
+// bannerWidth is the columns the wordmark needs, letters plus the single
+// column between them.
+func bannerWidth() int {
+	width := 0
+	for i, r := range bannerWord {
+		if i > 0 {
+			width++
+		}
+		width += ansi.StringWidth(bannerGlyphs[r][0])
+	}
+	return width
+}
+
+// showBanner reports whether the terminal is wide enough for the wordmark
+// to sit beside the fleet rollup without crowding it.
+func (m *Model) showBanner() bool {
+	return m.width >= bannerWidth()+34
+}
+
+// headerRows is how many rows the header occupies, which the body height
+// and every mouse hit-test are measured against.
+func (m *Model) headerRows() int {
+	if m.showBanner() {
+		return bannerRows
+	}
+	return 1
+}
+
+// viewBanner draws the wordmark, lit by a highlight that sweeps left to
+// right during the intro and then rests just past the end of the word.
+func (m *Model) viewBanner() []string {
+	sweep := float64(m.bannerPhase) / float64(bannerFrames)
+	// The resting position keeps the tail of the word brightest, so a
+	// settled header still has a direction to it.
+	head := sweep * float64(bannerWidth()) * 1.25
+
+	rows := make([]string, bannerRows)
+	for row := 0; row < bannerRows; row++ {
+		var b strings.Builder
+		column := 0
+		for i, letter := range bannerWord {
+			if i > 0 {
+				b.WriteString(" ")
+				column++
+			}
+			glyph := bannerGlyphs[letter][row]
+			for _, cell := range glyph {
+				b.WriteString(lipgloss.NewStyle().
+					Foreground(lipgloss.Color(bannerTint(float64(column), head))).
+					Render(string(cell)))
+				column++
+			}
+		}
+		rows[row] = strings.Repeat(" ", railGutter) + b.String()
+	}
+	return rows
+}
+
+// bannerTint colors one column of the wordmark by its distance from the
+// sweep's head: lit at the head, accent behind it, and the quieter
+// secondary accent ahead of it.
+func bannerTint(column, head float64) string {
+	distance := head - column
+	switch {
+	case distance < 0:
+		return mix(current.Accent2, current.Subtle, 0.55)
+	case distance < 4:
+		return mix(current.Accent, current.Bright, 1-distance/4)
+	case distance < 12:
+		return mix(current.Accent, current.Accent2, (distance-4)/8)
+	default:
+		return current.Accent2
+	}
+}

--- a/internal/ui/banner.go
+++ b/internal/ui/banner.go
@@ -39,11 +39,10 @@ func bannerWidth() int {
 	return len(bannerWord)*2 - 1
 }
 
-// showBanner reports whether the rail is wide enough for the tracked-out
-// wordmark; a narrow rail gets the name set plainly instead.
+// showBanner reports whether the terminal leaves the tracked-out wordmark
+// room beside the fleet readings; a narrow one gets the name set plainly.
 func (m *Model) showBanner() bool {
-	left, _ := m.splitWidths()
-	return left >= bannerWidth()+railGutter+1
+	return m.width >= bannerWidth()+railGutter+40
 }
 
 // headerRows is how many rows the header occupies, which the body height

--- a/internal/ui/banner.go
+++ b/internal/ui/banner.go
@@ -6,26 +6,14 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/x/ansi"
 )
 
-// The wordmark is drawn from half-block glyphs, three rows tall. Only the
-// seven letters in "agent manager" exist, which is the whole point: a
-// wordmark, not a font.
-var bannerGlyphs = map[rune][bannerRows]string{
-	'a': {"▄▀▄", "█▀█"},
-	'g': {"█▀▀", "█▄█"},
-	'e': {"█▀▀", "██▄"},
-	'n': {"█▄█", "█ █"},
-	't': {"▀█▀", " █ "},
-	'm': {"█▄▀▄█", "█ ▀ █"},
-	'r': {"█▀▄", "█▀▄"},
-	' ': {"  ", "  "},
-}
-
+// The wordmark is the product name set in tracked-out capitals, lit by a
+// highlight that sweeps across it once on launch. One row: a header, not a
+// splash screen.
 const (
 	bannerWord = "agent manager"
-	bannerRows = 2
+	bannerRows = 1
 
 	// bannerFrames is how long the intro sweep runs. The wordmark animates
 	// on launch and then holds still: a permanently animating header would
@@ -46,33 +34,21 @@ func (m *Model) bannerTick() tea.Cmd {
 	return tea.Tick(bannerInterval, func(time.Time) tea.Msg { return bannerTickMsg{} })
 }
 
-// bannerWidth is the columns the wordmark needs, letters plus the single
-// column between them.
+// bannerWidth is the columns the tracked-out wordmark needs.
 func bannerWidth() int {
-	width := 0
-	for i, r := range bannerWord {
-		if i > 0 {
-			width++
-		}
-		width += ansi.StringWidth(bannerGlyphs[r][0])
-	}
-	return width
+	return len(bannerWord)*2 - 1
 }
 
-// showBanner reports whether the terminal is wide enough for the wordmark
-// to sit beside the fleet rollup without crowding it.
+// showBanner reports whether the rail is wide enough for the tracked-out
+// wordmark; a narrow rail gets the name set plainly instead.
 func (m *Model) showBanner() bool {
-	return m.width >= bannerWidth()+34
+	left, _ := m.splitWidths()
+	return left >= bannerWidth()+railGutter+1
 }
 
 // headerRows is how many rows the header occupies, which the body height
 // and every mouse hit-test are measured against.
-func (m *Model) headerRows() int {
-	if m.showBanner() {
-		return bannerRows
-	}
-	return 1
-}
+func (m *Model) headerRows() int { return bannerRows }
 
 // viewBanner draws the wordmark, lit by a highlight that sweeps left to
 // right during the intro and then rests just past the end of the word.
@@ -82,26 +58,23 @@ func (m *Model) viewBanner() []string {
 	// settled header still has a direction to it.
 	head := sweep * float64(bannerWidth()) * 1.25
 
-	rows := make([]string, bannerRows)
-	for row := 0; row < bannerRows; row++ {
-		var b strings.Builder
-		column := 0
-		for i, letter := range bannerWord {
-			if i > 0 {
-				b.WriteString(" ")
-				column++
-			}
-			glyph := bannerGlyphs[letter][row]
-			for _, cell := range glyph {
-				b.WriteString(lipgloss.NewStyle().
-					Foreground(lipgloss.Color(bannerTint(float64(column), head))).
-					Render(string(cell)))
-				column++
-			}
-		}
-		rows[row] = strings.Repeat(" ", railGutter) + b.String()
+	var b strings.Builder
+	b.WriteString(strings.Repeat(" ", railGutter))
+	if !m.showBanner() {
+		// Too tight for tracking; the name still leads the rail.
+		b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(colorAccent).Render(bannerWord))
+		return []string{b.String()}
 	}
-	return rows
+	for i, letter := range bannerWord {
+		if i > 0 {
+			b.WriteString(" ")
+		}
+		b.WriteString(lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color(bannerTint(float64(i*2), head))).
+			Render(strings.ToUpper(string(letter))))
+	}
+	return []string{b.String()}
 }
 
 // bannerTint colors one column of the wordmark by its distance from the

--- a/internal/ui/banner.go
+++ b/internal/ui/banner.go
@@ -12,20 +12,20 @@ import (
 // The wordmark is drawn from half-block glyphs, three rows tall. Only the
 // seven letters in "agent manager" exist, which is the whole point: a
 // wordmark, not a font.
-var bannerGlyphs = map[rune][3]string{
-	'a': {"▄▀▄", "█▀█", "▀ ▀"},
-	'g': {"█▀▀", "█▄█", "▀▀▀"},
-	'e': {"█▀▀", "█▀▀", "▀▀▀"},
-	'n': {"█▄ █", "█ ▀█", "▀  ▀"},
-	't': {"▀█▀", " █ ", " ▀ "},
-	'm': {"█▀▄▀█", "█ ▀ █", "▀   ▀"},
-	'r': {"█▀█", "█▀▄", "▀ ▀"},
-	' ': {"  ", "  ", "  "},
+var bannerGlyphs = map[rune][bannerRows]string{
+	'a': {"▄▀▄", "█▀█"},
+	'g': {"█▀▀", "█▄█"},
+	'e': {"█▀▀", "██▄"},
+	'n': {"█▄█", "█ █"},
+	't': {"▀█▀", " █ "},
+	'm': {"█▄▀▄█", "█ ▀ █"},
+	'r': {"█▀▄", "█▀▄"},
+	' ': {"  ", "  "},
 }
 
 const (
 	bannerWord = "agent manager"
-	bannerRows = 3
+	bannerRows = 2
 
 	// bannerFrames is how long the intro sweep runs. The wordmark animates
 	// on launch and then holds still: a permanently animating header would

--- a/internal/ui/cursor_visible_test.go
+++ b/internal/ui/cursor_visible_test.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Whatever the cursor is on has to be on screen. A window that reserves
+// room for one overflow indicator but paints two loses a row at the bottom,
+// and the row it loses is the one the cursor just moved to.
+func TestRailCursorAlwaysPainted(t *testing.T) {
+	now := time.Now()
+	sessions := make([]store.Session, 40)
+	rows := make([]treeRow, len(sessions))
+	for i := range sessions {
+		name := fmt.Sprintf("session-%02d", i)
+		sessions[i] = store.Session{
+			ID: name, Name: name, Tool: "claude", Status: status.Idle,
+			CreatedAt: now, LastStatusAt: now,
+		}
+		rows[i] = treeRow{sess: sessions[i]}
+	}
+
+	for _, size := range []struct{ w, h int }{{80, 16}, {100, 24}, {120, 30}, {160, 44}} {
+		for _, cursor := range []int{0, 1, len(rows) / 2, len(rows) - 2, len(rows) - 1} {
+			m := &Model{
+				width: size.w, height: size.h, mode: modeList,
+				sessions: sessions, rows: rows, cursor: cursor,
+				collapsed: map[string]bool{}, splitRatio: defaultSplitRatio,
+			}
+			view := ansi.Strip(m.View())
+			if !strings.Contains(view, sessions[cursor].Name) {
+				t.Errorf("%dx%d cursor=%d: %q is selected but never painted:\n%s",
+					size.w, size.h, cursor, sessions[cursor].Name, view)
+			}
+		}
+	}
+}
+
+// The same rule for review's file list: tabbing to the last file has to
+// bring it on screen, not just select it.
+func TestDiffFileListCursorAlwaysPainted(t *testing.T) {
+	m := buildModel(t)
+	dir := gitRepoWithManyFiles(t, 40)
+	createSession(t, m, "coder", dir, "")
+	m.selectSessionRow(t, "coder")
+	m.applyCmd(t, m.openDiff())
+	if m.diff.loading || len(m.diff.set.Files) < 2 {
+		t.Fatalf("diff did not load: %q", m.diff.errText)
+	}
+
+	last := len(m.diff.set.Files) - 1
+	for _, size := range []struct{ w, h int }{{80, 20}, {100, 30}, {140, 44}} {
+		m.width, m.height = size.w, size.h
+		m.diff.fileIdx = last
+		view := ansi.Strip(m.viewDiffFull())
+		name := m.diff.set.Files[last].File.Path
+		if !strings.Contains(view, name) {
+			t.Errorf("%dx%d: file %q is selected but never painted:\n%s", size.w, size.h, name, view)
+		}
+	}
+}
+
+// gitRepoWithManyFiles is a repo with n changed files, enough to overflow
+// review's file list.
+func gitRepoWithManyFiles(t *testing.T, n int) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	run("config", "user.email", "t@t")
+	run("config", "user.name", "t")
+	for i := 0; i < n; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("file-%02d.txt", i))
+		if err := os.WriteFile(path, []byte("seed\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	run("add", "-A")
+	run("commit", "-m", "init")
+	for i := 0; i < n; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("file-%02d.txt", i))
+		if err := os.WriteFile(path, []byte("seed\nchanged\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}

--- a/internal/ui/diff_frame_test.go
+++ b/internal/ui/diff_frame_test.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Review has to paint exactly the terminal it was given. A frame with more
+// rows than the terminal scrolls the top away; a line wider than the
+// terminal wraps and pushes every row below it off the bottom, which is how
+// the end of a file ends up selected but off screen.
+func TestDiffFrameFitsTerminal(t *testing.T) {
+	m := buildModel(t)
+	dir := gitRepoWithLongFile(t, 400)
+	createSession(t, m, "coder", dir, "")
+	m.selectSessionRow(t, "coder")
+	m.applyCmd(t, m.openDiff())
+	if m.diff.loading || len(m.diff.set.Files) == 0 {
+		t.Fatalf("diff did not load: %q", m.diff.errText)
+	}
+
+	// Narrow widths matter as much as short ones: the footer wraps onto
+	// extra lines there, and every row the footer takes is a row the body
+	// must give back.
+	sizes := []struct{ w, h int }{
+		{60, 16}, {60, 20}, {70, 18}, {80, 24}, {90, 22}, {96, 28}, {100, 30},
+		{110, 26}, {120, 40}, {132, 34}, {160, 50}, {200, 60}, {240, 70},
+	}
+	for _, split := range []bool{false, true} {
+		for _, annotating := range []bool{false, true} {
+			for _, size := range sizes {
+				m.width, m.height = size.w, size.h
+				m.diff.sideBySide = split
+				m.diff.annotating = false
+				if annotating {
+					m.openAnnotate()
+					m.diff.annInput.SetValue("note")
+				}
+
+				raw := strings.Split(m.viewDiffFull(), "\n")
+				if len(raw) != size.h {
+					t.Errorf("split=%v annotating=%v %dx%d: frame paints %d rows",
+						split, annotating, size.w, size.h, len(raw))
+				}
+				for i, line := range raw {
+					if got := ansi.StringWidth(line); got > size.w {
+						t.Errorf("split=%v annotating=%v %dx%d: line %d is %d wide: %q",
+							split, annotating, size.w, size.h, i, got, ansi.Strip(line))
+					}
+				}
+			}
+		}
+	}
+}
+
+// The cursor's line has to be inside the rows review actually paints. A
+// viewport taller than its painted area lets the cursor walk past the last
+// visible row: the selection is at the end of the file, the screen is not.
+func TestDiffCursorStaysOnScreen(t *testing.T) {
+	const lines = 400
+	m := buildModel(t)
+	dir := gitRepoWithLongFile(t, lines)
+	createSession(t, m, "coder", dir, "")
+	m.selectSessionRow(t, "coder")
+	m.applyCmd(t, m.openDiff())
+	if m.diff.loading || len(m.diff.set.Files) == 0 {
+		t.Fatalf("diff did not load: %q", m.diff.errText)
+	}
+
+	for _, size := range []struct{ w, h int }{{80, 24}, {100, 30}, {120, 40}, {160, 50}} {
+		m.width, m.height = size.w, size.h
+		m.diff.scroll = 0
+		m.diff.cursorLine = 0
+		m.moveDiffCursor(lines*2, m.diffCodeHeight())
+
+		fd := m.currentFileDiff()
+		if fd == nil {
+			t.Fatal("no file diff")
+		}
+		want := fd.Lines[m.cursorDiffLine()]
+		if want.Text == "" {
+			continue
+		}
+		view := ansi.Strip(m.viewDiffFull())
+		if !strings.Contains(view, strings.TrimSpace(want.Text)) {
+			t.Errorf("%dx%d: cursor sits on %q, which the frame never paints",
+				size.w, size.h, strings.TrimSpace(want.Text))
+		}
+	}
+}

--- a/internal/ui/diff_reach_test.go
+++ b/internal/ui/diff_reach_test.go
@@ -81,8 +81,13 @@ func TestDiffReviewReachesLastLine(t *testing.T) {
 			if !strings.Contains(view, last) {
 				t.Fatalf("G should paint the last line %q, got:\n%s", last, view)
 			}
-			if !strings.Contains(view, fmt.Sprintf("line-%03d", lines-1)) {
-				t.Fatalf("the line before the end should be painted too, got:\n%s", view)
+			// The whole tail has to be on screen, not just the final line:
+			// a viewport that outruns its painted rows shows the last line
+			// and silently drops the ones just above it.
+			for n := lines; n > lines-6; n-- {
+				if !strings.Contains(view, fmt.Sprintf("line-%03d", n)) {
+					t.Fatalf("line %d missing from the end of the file, got:\n%s", n, view)
+				}
 			}
 		})
 	}

--- a/internal/ui/diff_reach_test.go
+++ b/internal/ui/diff_reach_test.go
@@ -1,0 +1,112 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// gitRepoWithLongFile is a repo whose single change is far taller than any
+// terminal, so the review viewport has to scroll to reach the end.
+func gitRepoWithLongFile(t *testing.T, lines int) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	run("config", "user.email", "t@t")
+	run("config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(dir, "long.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-m", "init")
+
+	var b strings.Builder
+	for i := 1; i <= lines; i++ {
+		fmt.Fprintf(&b, "line-%03d\n", i)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "long.txt"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The end of a file has to be reachable in review. A viewport sized larger
+// than the rows the frame actually paints leaves a tail of lines the cursor
+// can address but the screen never shows, which is how the last screenful
+// silently went missing once before.
+func TestDiffReviewReachesLastLine(t *testing.T) {
+	const lines = 400
+	for _, layout := range []struct {
+		name  string
+		split bool
+	}{{"unified", false}, {"side-by-side", true}} {
+		t.Run(layout.name, func(t *testing.T) {
+			m := buildModel(t)
+			dir := gitRepoWithLongFile(t, lines)
+			createSession(t, m, "coder", dir, "")
+			m.selectSessionRow(t, "coder")
+			m.applyCmd(t, m.openDiff())
+			if m.diff.loading || len(m.diff.set.Files) == 0 {
+				t.Fatalf("diff did not load: %q", m.diff.errText)
+			}
+			m.diff.sideBySide = layout.split
+
+			last := fmt.Sprintf("line-%03d", lines)
+			view := ansi.Strip(m.View())
+			if strings.Contains(view, last) {
+				t.Fatalf("the file's end should start off screen, got:\n%s", view)
+			}
+
+			// G jumps to the end; the final line must be painted, not merely
+			// selected, and the cursor must sit on it.
+			m.handleDiffKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+			view = ansi.Strip(m.View())
+			if !strings.Contains(view, last) {
+				t.Fatalf("G should paint the last line %q, got:\n%s", last, view)
+			}
+			if !strings.Contains(view, fmt.Sprintf("line-%03d", lines-1)) {
+				t.Fatalf("the line before the end should be painted too, got:\n%s", view)
+			}
+		})
+	}
+}
+
+// Stepping down one line at a time has to arrive at the same place G does:
+// if the viewport is taller than the painted rows, the walk stops short and
+// the tail of the file becomes unreachable by keyboard.
+func TestDiffReviewStepsDownToTheEnd(t *testing.T) {
+	const lines = 120
+	m := buildModel(t)
+	dir := gitRepoWithLongFile(t, lines)
+	createSession(t, m, "coder", dir, "")
+	m.selectSessionRow(t, "coder")
+	m.applyCmd(t, m.openDiff())
+	if m.diff.loading || len(m.diff.set.Files) == 0 {
+		t.Fatalf("diff did not load: %q", m.diff.errText)
+	}
+
+	for i := 0; i < lines*2; i++ {
+		m.handleDiffKey(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	last := fmt.Sprintf("line-%03d", lines)
+	if view := ansi.Strip(m.View()); !strings.Contains(view, last) {
+		t.Fatalf("stepping down should reach the last line %q, got:\n%s", last, view)
+	}
+}

--- a/internal/ui/diff_reach_test.go
+++ b/internal/ui/diff_reach_test.go
@@ -115,3 +115,84 @@ func TestDiffReviewStepsDownToTheEnd(t *testing.T) {
 		t.Fatalf("stepping down should reach the last line %q, got:\n%s", last, view)
 	}
 }
+
+// gitRepoWithWideFile is a repo whose changed lines are far wider than any
+// pane, so every line soft-wraps onto several painted rows.
+func gitRepoWithWideFile(t *testing.T, lines, lineWidth int) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	run("config", "user.email", "t@t")
+	run("config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(dir, "wide.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-m", "init")
+
+	var b strings.Builder
+	for i := 1; i <= lines; i++ {
+		fmt.Fprintf(&b, "wide-%03d %s\n", i, strings.Repeat("x", lineWidth))
+	}
+	if err := os.WriteFile(filepath.Join(dir, "wide.txt"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// Long lines wrap onto several painted rows, but the cursor and scroll
+// count logical lines. If the window math ignores the wraps, every wrapped
+// line on screen pushes one more line of the file's tail off the bottom:
+// the cursor lands on the last line and the screen never shows it.
+func TestDiffReviewReachesEndWithWrappedLines(t *testing.T) {
+	const lines = 80
+	for _, layout := range []struct {
+		name  string
+		split bool
+	}{{"unified", false}, {"side-by-side", true}} {
+		t.Run(layout.name, func(t *testing.T) {
+			m := buildModel(t)
+			dir := gitRepoWithWideFile(t, lines, 220)
+			createSession(t, m, "coder", dir, "")
+			m.selectSessionRow(t, "coder")
+			m.applyCmd(t, m.openDiff())
+			if m.diff.loading || len(m.diff.set.Files) == 0 {
+				t.Fatalf("diff did not load: %q", m.diff.errText)
+			}
+			m.width, m.height = 120, 34
+			m.diff.sideBySide = layout.split
+
+			m.handleDiffKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+			last := fmt.Sprintf("wide-%03d", lines)
+			if view := ansi.Strip(m.View()); !strings.Contains(view, last) {
+				t.Fatalf("G should paint the last line %q, got:\n%s", last, view)
+			}
+
+			// Stepping down must keep the cursor painted the whole way.
+			m.handleDiffKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+			for i := 0; i < lines+5; i++ {
+				m.handleDiffKey(tea.KeyMsg{Type: tea.KeyDown})
+				fd := m.currentFileDiff()
+				lineIdx := m.cursorDiffLine()
+				if fd == nil || lineIdx >= len(fd.Lines) {
+					t.Fatal("cursor out of range")
+				}
+				marker := strings.Fields(fd.Lines[lineIdx].Text)[0]
+				if view := ansi.Strip(m.View()); !strings.Contains(view, marker) {
+					t.Fatalf("step %d: cursor on %q but the frame never paints it:\n%s", i, marker, view)
+				}
+			}
+		})
+	}
+}

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1134,9 +1134,8 @@ func (m *Model) viewDiffFull() string {
 	// Files sit on the rail surface, the code on the backdrop: the same
 	// two-surface split the session list uses, so review reads as the same
 	// application rather than a second one.
-	cardWidth := fileWidth - 2
 	fileLines := append([]string{"", "  " + subtleStyle.Render("files")},
-		indentLines(splitLines(m.viewDiffFileList(cardWidth-2*railGutter, bodyHeight-4)), railGutter)...)
+		indentLines(splitLines(m.viewDiffFileList(fileWidth-2*railGutter, bodyHeight-2)), railGutter)...)
 	codeLines := append([]string{"", "  " + subtleStyle.Render(ansi.Strip(m.diffCodeTitle()))},
 		indentLines(splitLines(m.viewDiffCode(codeWidth-2*contentGutter, bodyHeight-2)), contentGutter)...)
 
@@ -1146,19 +1145,8 @@ func (m *Model) viewDiffFull() string {
 		paint(m.viewDiffHeader(sess.Name), m.width, backdropHex()),
 		paint(hruleJoined(m.width, fileWidth, "┬"), m.width, backdropHex()),
 	}
-	// The files card floats inside its column with the same four-sided
-	// margin the sessions rail wears.
-	card := paintRows(fileLines, cardWidth, bodyHeight-2, panelHex())
-	files := make([]string, bodyHeight)
-	for i := range files {
-		if i == 0 || i == bodyHeight-1 {
-			files[i] = paint("", fileWidth, backdropHex())
-		} else {
-			files[i] = paint("", 1, backdropHex()) + card[i-1] + paint("", 1, backdropHex())
-		}
-	}
 	frame = append(frame, joinColumns(
-		files,
+		paintRows(fileLines, fileWidth, bodyHeight, panelHex()),
 		m.vruleColumn(bodyHeight),
 		paintRows(codeLines, codeWidth, bodyHeight, backdropHex()),
 	)...)

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1135,7 +1135,7 @@ func (m *Model) viewDiffFull() string {
 	// two-surface split the session list uses, so review reads as the same
 	// application rather than a second one.
 	fileLines := append([]string{"", "  " + subtleStyle.Render("files")},
-		indentLines(splitLines(m.viewDiffFileList(fileWidth-2*railGutter, bodyHeight-2)), railGutter)...)
+		indentLines(splitLines(m.viewDiffFileList(fileWidth-1-2*railGutter, bodyHeight-2)), railGutter)...)
 	codeLines := append([]string{"", "  " + subtleStyle.Render(ansi.Strip(m.diffCodeTitle()))},
 		indentLines(splitLines(m.viewDiffCode(codeWidth-2*contentGutter, bodyHeight-2)), contentGutter)...)
 
@@ -1145,8 +1145,14 @@ func (m *Model) viewDiffFull() string {
 		paint(m.viewDiffHeader(sess.Name), m.width, backdropHex()),
 		paint(hruleJoined(m.width, fileWidth, "┬"), m.width, backdropHex()),
 	}
+	// The files card keeps the same unpainted margin column as the rail.
+	margin := make([]string, bodyHeight)
+	for i := range margin {
+		margin[i] = paint("", 1, backdropHex())
+	}
 	frame = append(frame, joinColumns(
-		paintRows(fileLines, fileWidth, bodyHeight, panelHex()),
+		margin,
+		paintRows(fileLines, fileWidth-1, bodyHeight, panelHex()),
 		m.vruleColumn(bodyHeight),
 		paintRows(codeLines, codeWidth, bodyHeight, backdropHex()),
 	)...)

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -765,7 +765,7 @@ func (m *Model) annotationRows(fd *diff.FileDiff, lineIdx, width int) []string {
 		return nil
 	}
 	comment := annotationStyle.Render("  ¶ " + note.text)
-	return wrapTinted(comment, nil, annotationBg, annotationBg, width)
+	return wrapTinted(comment, nil, annotationBg(), annotationBg(), width)
 }
 
 func (m *Model) annotationAt(path string, line diff.Line) *annotation {
@@ -1130,8 +1130,9 @@ func (m *Model) viewDiffFull() string {
 	}
 	codeWidth := m.width - fileWidth
 
-	files := titledPanel("Files", m.viewDiffFileList(fileWidth-4, bodyHeight-2), fileWidth, bodyHeight)
-	code := titledPanel(m.diffCodeTitle(), m.viewDiffCode(codeWidth-4, bodyHeight-2), codeWidth, bodyHeight)
+	// The cursor lives in the code panel, so it wears the focus border.
+	files := titledPanel("Files", m.viewDiffFileList(fileWidth-4, bodyHeight-2), fileWidth, bodyHeight, false)
+	code := titledPanel(m.diffCodeTitle(), m.viewDiffCode(codeWidth-4, bodyHeight-2), codeWidth, bodyHeight, true)
 	body := lipgloss.JoinHorizontal(lipgloss.Top, files, code)
 
 	header := m.viewDiffHeader(sess.Name)

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1144,7 +1144,7 @@ func (m *Model) viewDiffFull() string {
 	// same as the list view, so the two screens share one frame language.
 	frame := []string{
 		paint(m.viewDiffHeader(sess.Name), m.width, backdropHex()),
-		m.boundedRuleRow(fileWidth+1, m.width, "▄"),
+		m.boundedRuleRow(fileWidth+1, m.width, "▀"),
 	}
 	frame = append(frame, joinColumns(
 		paintRows(fileLines, fileWidth, bodyHeight, panelHex()),
@@ -1153,7 +1153,7 @@ func (m *Model) viewDiffFull() string {
 		paintRows(codeLines, codeWidth, bodyHeight, backdropHex()),
 	)...)
 	frame = append(frame,
-		m.boundedRuleRow(fileWidth+1, m.width, "▀"),
+		m.boundedRuleRow(fileWidth+1, m.width, "▄"),
 		paint(m.viewDiffStatus(), m.width, backdropHex()),
 	)
 	for _, line := range splitLines(footer) {

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1128,8 +1128,9 @@ func (m *Model) viewDiffFull() string {
 	if fileWidth < 28 {
 		fileWidth = 28
 	}
-	// One column goes to the seam between the two surfaces.
-	codeWidth := m.width - fileWidth - 1
+	// Two columns go to the seam and the fill's bleed edge between the
+	// two surfaces.
+	codeWidth := m.width - fileWidth - 2
 
 	// Files sit on the rail surface, the code on the backdrop: the same
 	// two-surface split the session list uses, so review reads as the same
@@ -1143,15 +1144,16 @@ func (m *Model) viewDiffFull() string {
 	// same as the list view, so the two screens share one frame language.
 	frame := []string{
 		paint(m.viewDiffHeader(sess.Name), m.width, backdropHex()),
-		m.boundedRuleRow(fileWidth, m.width, "┬"),
+		m.boundedRuleRow(fileWidth+1, m.width, "▄"),
 	}
 	frame = append(frame, joinColumns(
 		paintRows(fileLines, fileWidth, bodyHeight, panelHex()),
 		m.vruleColumn(bodyHeight),
+		m.bleedColumn(bodyHeight),
 		paintRows(codeLines, codeWidth, bodyHeight, backdropHex()),
 	)...)
 	frame = append(frame,
-		m.boundedRuleRow(fileWidth, m.width, "┴"),
+		m.boundedRuleRow(fileWidth+1, m.width, "▀"),
 		paint(m.viewDiffStatus(), m.width, backdropHex()),
 	)
 	for _, line := range splitLines(footer) {

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1128,7 +1128,8 @@ func (m *Model) viewDiffFull() string {
 	if fileWidth < 28 {
 		fileWidth = 28
 	}
-	codeWidth := m.width - fileWidth
+	// One column goes to the seam between the two surfaces.
+	codeWidth := m.width - fileWidth - 1
 
 	// Files sit on the rail surface, the code on the backdrop: the same
 	// two-surface split the session list uses, so review reads as the same
@@ -1140,13 +1141,17 @@ func (m *Model) viewDiffFull() string {
 
 	frame := []string{
 		paint(m.viewDiffHeader(sess.Name), m.width, backdropHex()),
-		paint("", m.width, backdropHex()),
+		paint(hrule(m.width), m.width, backdropHex()),
 	}
 	frame = append(frame, joinColumns(
 		paintRows(fileLines, fileWidth, bodyHeight, panelHex()),
+		m.vruleColumn(bodyHeight),
 		paintRows(codeLines, codeWidth, bodyHeight, backdropHex()),
 	)...)
-	frame = append(frame, paint(m.viewDiffStatus(), m.width, backdropHex()))
+	frame = append(frame,
+		paint(hrule(m.width), m.width, backdropHex()),
+		paint(m.viewDiffStatus(), m.width, backdropHex()),
+	)
 	for _, line := range splitLines(footer) {
 		frame = append(frame, paint(line, m.width, backdropHex()))
 	}
@@ -1169,7 +1174,7 @@ func (m *Model) viewDiffHeader(sessName string) string {
 	if m.diff.sideBySide {
 		layout = "split"
 	}
-	left := badgeStyle.Render("◆ Review · "+sessName) + "  " +
+	left := "  " + lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("review · "+sessName) + "  " +
 		keyPill("s", m.diff.scope.String(), colorAccent2) + "  " +
 		keyPill("u", layout, colorAccent)
 	if root := m.diff.set.Repo.Root; root != "" {

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1135,8 +1135,8 @@ func (m *Model) viewDiffFull() string {
 	// Files sit on the rail surface, the code on the backdrop: the same
 	// two-surface split the session list uses, so review reads as the same
 	// application rather than a second one.
-	fileLines := append([]string{"", "  " + subtleStyle.Render("files")},
-		indentLines(splitLines(m.viewDiffFileList(fileWidth-2*railGutter, bodyHeight-2)), railGutter)...)
+	fileLines := append([]string{"", strings.Repeat(" ", railInset) + subtleStyle.Render("files")},
+		indentLines(splitLines(m.viewDiffFileList(fileWidth-2*railGutter, bodyHeight-2)), railInset)...)
 	codeLines := append([]string{"", "  " + subtleStyle.Render(ansi.Strip(m.diffCodeTitle()))},
 		indentLines(splitLines(m.viewDiffCode(codeWidth-2*contentGutter, bodyHeight-2)), contentGutter)...)
 
@@ -1146,8 +1146,13 @@ func (m *Model) viewDiffFull() string {
 		paint(m.viewDiffHeader(sess.Name), m.width, backdropHex()),
 		m.boundedRuleRow(fileWidth+1, m.width, "▀"),
 	}
+	edge := make([]string, bodyHeight)
+	for i := range edge {
+		edge[i] = railEdgeCell(panelHex())
+	}
 	frame = append(frame, joinColumns(
-		paintRows(fileLines, fileWidth, bodyHeight, panelHex()),
+		edge,
+		paintRows(fileLines, fileWidth-1, bodyHeight, panelHex()),
 		m.vruleColumn(bodyHeight),
 		m.bleedColumn(bodyHeight),
 		paintRows(codeLines, codeWidth, bodyHeight, backdropHex()),

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1139,9 +1139,11 @@ func (m *Model) viewDiffFull() string {
 	codeLines := append([]string{"", "  " + subtleStyle.Render(ansi.Strip(m.diffCodeTitle()))},
 		indentLines(splitLines(m.viewDiffCode(codeWidth-2*contentGutter, bodyHeight-2)), contentGutter)...)
 
+	// The column seam tees into the rules that open and close the body,
+	// same as the list view, so the two screens share one frame language.
 	frame := []string{
 		paint(m.viewDiffHeader(sess.Name), m.width, backdropHex()),
-		paint(hrule(m.width), m.width, backdropHex()),
+		paint(hruleJoined(m.width, fileWidth, "┬"), m.width, backdropHex()),
 	}
 	frame = append(frame, joinColumns(
 		paintRows(fileLines, fileWidth, bodyHeight, panelHex()),
@@ -1149,7 +1151,7 @@ func (m *Model) viewDiffFull() string {
 		paintRows(codeLines, codeWidth, bodyHeight, backdropHex()),
 	)...)
 	frame = append(frame,
-		paint(hrule(m.width), m.width, backdropHex()),
+		paint(hruleJoined(m.width, fileWidth, "┴"), m.width, backdropHex()),
 		paint(m.viewDiffStatus(), m.width, backdropHex()),
 	)
 	for _, line := range splitLines(footer) {

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1143,7 +1143,7 @@ func (m *Model) viewDiffFull() string {
 	// same as the list view, so the two screens share one frame language.
 	frame := []string{
 		paint(m.viewDiffHeader(sess.Name), m.width, backdropHex()),
-		paint(hruleJoined(m.width, fileWidth, "┬"), m.width, backdropHex()),
+		m.boundedRuleRow(fileWidth, m.width, "┬"),
 	}
 	frame = append(frame, joinColumns(
 		paintRows(fileLines, fileWidth, bodyHeight, panelHex()),
@@ -1151,7 +1151,7 @@ func (m *Model) viewDiffFull() string {
 		paintRows(codeLines, codeWidth, bodyHeight, backdropHex()),
 	)...)
 	frame = append(frame,
-		paint(hruleJoined(m.width, fileWidth, "┴"), m.width, backdropHex()),
+		m.boundedRuleRow(fileWidth, m.width, "┴"),
 		paint(m.viewDiffStatus(), m.width, backdropHex()),
 	)
 	for _, line := range splitLines(footer) {

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1130,14 +1130,27 @@ func (m *Model) viewDiffFull() string {
 	}
 	codeWidth := m.width - fileWidth
 
-	// The cursor lives in the code panel, so it wears the focus border.
-	files := titledPanel("Files", m.viewDiffFileList(fileWidth-4, bodyHeight-2), fileWidth, bodyHeight, false)
-	code := titledPanel(m.diffCodeTitle(), m.viewDiffCode(codeWidth-4, bodyHeight-2), codeWidth, bodyHeight, true)
-	body := lipgloss.JoinHorizontal(lipgloss.Top, files, code)
+	// Files sit on the rail surface, the code on the backdrop: the same
+	// two-surface split the session list uses, so review reads as the same
+	// application rather than a second one.
+	fileLines := append([]string{"", "  " + subtleStyle.Render("files")},
+		indentLines(splitLines(m.viewDiffFileList(fileWidth-2*railGutter, bodyHeight-2)), railGutter)...)
+	codeLines := append([]string{"", "  " + subtleStyle.Render(ansi.Strip(m.diffCodeTitle()))},
+		indentLines(splitLines(m.viewDiffCode(codeWidth-2*contentGutter, bodyHeight-2)), contentGutter)...)
 
-	header := m.viewDiffHeader(sess.Name)
-	status := m.viewDiffStatus()
-	return strings.Join([]string{header, "", body, status, footer}, "\n")
+	frame := []string{
+		paint(m.viewDiffHeader(sess.Name), m.width, backdropHex()),
+		paint("", m.width, backdropHex()),
+	}
+	frame = append(frame, joinColumns(
+		paintRows(fileLines, fileWidth, bodyHeight, panelHex()),
+		paintRows(codeLines, codeWidth, bodyHeight, backdropHex()),
+	)...)
+	frame = append(frame, paint(m.viewDiffStatus(), m.width, backdropHex()))
+	for _, line := range splitLines(footer) {
+		frame = append(frame, paint(line, m.width, backdropHex()))
+	}
+	return strings.Join(frame, "\n")
 }
 
 // stripBaseHash drops the @<short-sha> suffix BaseDesc carries from

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1134,8 +1134,9 @@ func (m *Model) viewDiffFull() string {
 	// Files sit on the rail surface, the code on the backdrop: the same
 	// two-surface split the session list uses, so review reads as the same
 	// application rather than a second one.
+	cardWidth := fileWidth - 2
 	fileLines := append([]string{"", "  " + subtleStyle.Render("files")},
-		indentLines(splitLines(m.viewDiffFileList(fileWidth-1-2*railGutter, bodyHeight-2)), railGutter)...)
+		indentLines(splitLines(m.viewDiffFileList(cardWidth-2*railGutter, bodyHeight-4)), railGutter)...)
 	codeLines := append([]string{"", "  " + subtleStyle.Render(ansi.Strip(m.diffCodeTitle()))},
 		indentLines(splitLines(m.viewDiffCode(codeWidth-2*contentGutter, bodyHeight-2)), contentGutter)...)
 
@@ -1145,14 +1146,19 @@ func (m *Model) viewDiffFull() string {
 		paint(m.viewDiffHeader(sess.Name), m.width, backdropHex()),
 		paint(hruleJoined(m.width, fileWidth, "┬"), m.width, backdropHex()),
 	}
-	// The files card keeps the same unpainted margin column as the rail.
-	margin := make([]string, bodyHeight)
-	for i := range margin {
-		margin[i] = paint("", 1, backdropHex())
+	// The files card floats inside its column with the same four-sided
+	// margin the sessions rail wears.
+	card := paintRows(fileLines, cardWidth, bodyHeight-2, panelHex())
+	files := make([]string, bodyHeight)
+	for i := range files {
+		if i == 0 || i == bodyHeight-1 {
+			files[i] = paint("", fileWidth, backdropHex())
+		} else {
+			files[i] = paint("", 1, backdropHex()) + card[i-1] + paint("", 1, backdropHex())
+		}
 	}
 	frame = append(frame, joinColumns(
-		margin,
-		paintRows(fileLines, fileWidth-1, bodyHeight, panelHex()),
+		files,
 		m.vruleColumn(bodyHeight),
 		paintRows(codeLines, codeWidth, bodyHeight, backdropHex()),
 	)...)

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1311,6 +1311,7 @@ func (m *Model) viewDiffCode(width, height int) string {
 	}
 
 	hl := m.currentHL()
+	m.ensureDiffCursorVisible(fd, hl, width, height)
 	var b strings.Builder
 	if m.diff.sideBySide {
 		m.renderSideBySide(&b, fd, hl, width, height)
@@ -1323,6 +1324,74 @@ func (m *Model) viewDiffCode(width, height int) string {
 		return padToHeight(body, height) + "\n" + bar
 	}
 	return body
+}
+
+// ensureDiffCursorVisible raises the scroll until every painted row of the
+// window from the scroll through the cursor fits the viewport. The cursor
+// and scroll count logical lines, but a long line wraps onto several
+// painted rows, and a comment adds more below its line; sizing the window
+// by line count alone lets the cursor walk below the last painted row, so
+// the end of a wrapped file is selected but never on screen.
+func (m *Model) ensureDiffCursorVisible(fd *diff.FileDiff, hl *fileHL, width, height int) {
+	total := len(fd.Lines)
+	span := func(i int) int {
+		return len(m.renderDiffRow(fd, hl, i, width, false)) + len(m.annotationRows(fd, i, width))
+	}
+	if m.diff.sideBySide && m.mode == modeDiff {
+		rows := fd.SideBySideRows()
+		total = len(rows)
+		half := (width - 1) / 2
+		span = func(i int) int {
+			row := rows[i]
+			tallest := len(m.renderSideCell(fd, hl, row.Left, half, true))
+			if right := len(m.renderSideCell(fd, hl, row.Right, width-half-1, false)); right > tallest {
+				tallest = right
+			}
+			if row.Left >= 0 {
+				tallest += len(m.annotationRows(fd, row.Left, width))
+			}
+			if row.Right >= 0 && row.Right != row.Left {
+				tallest += len(m.annotationRows(fd, row.Right, width))
+			}
+			return tallest
+		}
+	}
+
+	cursor := m.diff.cursorLine
+	if cursor > total-1 {
+		cursor = total - 1
+	}
+	if cursor < 0 {
+		return
+	}
+	if m.diff.scroll > cursor {
+		m.diff.scroll = cursor
+	}
+	if m.diff.scroll < 0 {
+		m.diff.scroll = 0
+	}
+	for m.diff.scroll < cursor {
+		// Each overflow indicator takes a row of the same budget.
+		used := 0
+		if m.diff.scroll > 0 {
+			used++
+		}
+		if cursor < total-1 {
+			used++
+		}
+		fits := true
+		for i := m.diff.scroll; i <= cursor; i++ {
+			used += span(i)
+			if used > height {
+				fits = false
+				break
+			}
+		}
+		if fits {
+			break
+		}
+		m.diff.scroll++
+	}
 }
 
 func (m *Model) renderSideBySide(b *strings.Builder, fd *diff.FileDiff, hl *fileHL, width, height int) {

--- a/internal/ui/frame_bench_test.go
+++ b/internal/ui/frame_bench_test.go
@@ -1,0 +1,12 @@
+package ui
+
+import "testing"
+
+func BenchmarkListFrame(b *testing.B) {
+	m := shotModel()
+	m.width, m.height = 200, 50
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = m.View()
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -1258,6 +1258,7 @@ func (m *Model) cycleSetting(step int) {
 	case settingsFieldTheme:
 		m.settings.themeIndex = (m.settings.themeIndex + step + len(themes)) % len(themes)
 		applyTheme(themes[m.settings.themeIndex])
+		SyncTerminalBackground()
 	case settingsFieldLayout:
 		m.settings.layoutSplit = !m.settings.layoutSplit
 	}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -1213,6 +1213,7 @@ func (m *Model) openSettings() {
 	m.settings = settingsState{
 		toolNames:   names,
 		toolIndex:   index,
+		themeIndex:  themeIndex(current.Name),
 		layoutSplit: m.defaultSplitLayout(),
 	}
 	m.mode = modeSettings
@@ -1220,16 +1221,19 @@ func (m *Model) openSettings() {
 
 func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "up", "k", "down", "j":
+	case "up", "k":
+		m.settings.field = (m.settings.field + settingsFieldCount - 1) % settingsFieldCount
+	case "down", "j":
 		m.settings.field = (m.settings.field + 1) % settingsFieldCount
-	case "left", "h", "right", "l":
-		if m.settings.field == settingsFieldTool {
-			m.settings.toolIndex = (m.settings.toolIndex + 1) % len(m.settings.toolNames)
-		} else {
-			m.settings.layoutSplit = !m.settings.layoutSplit
-		}
+	case "left", "h":
+		m.cycleSetting(-1)
+	case "right", "l":
+		m.cycleSetting(1)
 	case "enter", "esc":
 		if err := m.store.SetSetting("default_tool", m.settings.toolNames[m.settings.toolIndex]); err != nil {
+			m.err = err.Error()
+		}
+		if err := m.store.SetSetting(themeSetting, themes[m.settings.themeIndex].Name); err != nil {
 			m.err = err.Error()
 		}
 		layout := "split"
@@ -1242,6 +1246,21 @@ func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.mode = modeList
 	}
 	return m, nil
+}
+
+// cycleSetting steps the focused setting by one. The theme applies as it
+// is stepped so the picker doubles as a live preview of the palette.
+func (m *Model) cycleSetting(step int) {
+	switch m.settings.field {
+	case settingsFieldTool:
+		count := len(m.settings.toolNames)
+		m.settings.toolIndex = (m.settings.toolIndex + step + count) % count
+	case settingsFieldTheme:
+		m.settings.themeIndex = (m.settings.themeIndex + step + len(themes)) % len(themes)
+		applyTheme(themes[m.settings.themeIndex])
+	case settingsFieldLayout:
+		m.settings.layoutSplit = !m.settings.layoutSplit
+	}
 }
 
 func (m *Model) openMove() {

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -49,7 +49,7 @@ func (m *Model) viewListFrame() string {
 		rightRule := i < len(contentRows) && contentRows[i].rule
 		seam[i] = m.seamCell(leftRule, rightRule)
 	}
-	frame = append(frame, m.boundedRuleRow(leftWidth+1, m.width, "▄"))
+	frame = append(frame, m.boundedRuleRow(leftWidth+1, m.width, "▀"))
 	frame = append(frame, joinColumns(
 		paintContent(railRows, leftWidth, bodyHeight, panelHex()),
 		seam,
@@ -57,7 +57,7 @@ func (m *Model) viewListFrame() string {
 		paintContent(contentRows, bleedWidth, bodyHeight, backdropHex()),
 	)...)
 	frame = append(frame,
-		m.boundedRuleRow(leftWidth+1, m.width, "▀"),
+		m.boundedRuleRow(leftWidth+1, m.width, "▄"),
 		paint(m.viewStatus(), m.width, backdropHex()),
 	)
 	for _, line := range splitLines(footer) {

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -26,21 +26,26 @@ func (m *Model) viewListFrame() string {
 	footer := m.viewFooter()
 	bodyHeight := m.listBodyHeight()
 
-	// One column goes to the seam between the rail and the content.
+	// One column goes to the seam between the rail and the content, and the
+	// rail carries the wordmark so the two surfaces run from the very top of
+	// the frame down to the footer's seam.
 	contentWidth := rightWidth - 1
+	headerRows := m.headerRows()
 
-	frame := []string{}
-	for _, line := range m.viewHeaderRows() {
-		frame = append(frame, paint(line, m.width, backdropHex()))
-	}
-	frame = append(frame, paint(hrule(m.width), m.width, backdropHex()))
-	frame = append(frame, joinColumns(
-		paintRows(m.railLines(leftWidth, bodyHeight), leftWidth, bodyHeight, panelHex()),
-		m.vruleColumn(bodyHeight),
-		paintContent(m.contentLines(contentWidth-2*contentGutter, bodyHeight), contentWidth, bodyHeight, backdropHex()),
-	)...)
+	railHead := m.viewBanner()
+	contentHead := m.viewHeaderRows()
+
+	rail := append(
+		paintRows(railHead, leftWidth, headerRows, panelHex()),
+		paintRows(m.railLines(leftWidth, bodyHeight), leftWidth, bodyHeight, panelHex())...)
+	seam := m.vruleColumn(headerRows + bodyHeight)
+	content := append(
+		paintRows(contentHead, contentWidth, headerRows, backdropHex()),
+		paintContent(m.contentLines(contentWidth-2*contentGutter, bodyHeight), contentWidth, bodyHeight, backdropHex())...)
+
+	frame := joinColumns(rail, seam, content)
 	frame = append(frame,
-		paint(hrule(m.width), m.width, backdropHex()),
+		paint(hruleJoined(m.width, leftWidth, "┴"), m.width, backdropHex()),
 		paint(m.viewStatus(), m.width, backdropHex()),
 	)
 	for _, line := range splitLines(footer) {
@@ -306,8 +311,11 @@ func (m *Model) contentLines(width, height int) []contentLine {
 // marked raw: painting our backdrop behind an agent's own CLI colors would
 // replace the background it drew itself, so those rows keep the terminal's.
 func (m *Model) previewLines(width, height int, gutter string) []contentLine {
-	lines := []contentLine{{text: gutter + subtleStyle.Render("preview")}}
-	rows := height - 1
+	lines := []contentLine{
+		{text: gutter + subtleStyle.Render("preview")},
+		{raw: true},
+	}
+	rows := height - len(lines)
 	if rows < 1 {
 		return lines
 	}
@@ -455,51 +463,43 @@ func (m *Model) viewQuickBar(width int) string {
 // it, with the scope line and the fleet rollup set against the right edge
 // on the wordmark's own rows.
 func (m *Model) viewHeaderRows() []string {
-	if !m.showBanner() {
-		return []string{m.viewHeader()}
-	}
-	// Each header row offers its readings richest-first and takes the
-	// widest one that still clears the wordmark.
-	right := [][]string{
-		{m.headerScope()},
-		{
-			joinHeaderRight(m.viewStatusCounts(false), m.headerAgents()),
-			joinHeaderRight(m.viewStatusCounts(true), m.headerAgents()),
-			m.viewStatusCounts(true),
-		},
-	}
-	rows := m.viewBanner()
-	for i := range rows {
-		if i >= len(right) {
+	_, rightWidth := m.splitWidths()
+	width := rightWidth - 1 - contentGutter
+	left := strings.Repeat(" ", contentGutter) + m.headerScope()
+
+	// The rollup offers its readings richest-first and takes the widest one
+	// that still clears the scope on its left.
+	for _, right := range []string{
+		joinHeaderRight(m.viewStatusCounts(false), m.headerAgents()),
+		joinHeaderRight(m.viewStatusCounts(true), m.headerAgents()),
+		m.viewStatusCounts(true),
+		"",
+	} {
+		gap := width - ansi.StringWidth(left) - ansi.StringWidth(right)
+		if right == "" || gap < 2 {
 			continue
 		}
-		for _, text := range right[i] {
-			if text == "" {
-				continue
-			}
-			gap := m.width - railGutter - ansi.StringWidth(rows[i]) - ansi.StringWidth(text)
-			if gap >= 2 {
-				rows[i] += strings.Repeat(" ", gap) + text
-				break
-			}
-		}
+		return []string{left + strings.Repeat(" ", gap) + right}
 	}
-	return rows
+	return []string{left}
 }
 
 // headerScope names what the list is showing and badges a newer release.
+// The count is of the same sessions the rollup beside it breaks down, so
+// the two lines always add up; counting painted rows instead would drop
+// everything folded inside a collapsed group.
 func (m *Model) headerScope() string {
 	scope := "active"
 	if m.showArchived {
 		scope = "archived"
 	}
-	sessionCount := 0
-	for _, entry := range m.rows {
-		if !entry.isGroup {
-			sessionCount++
-		}
+	count := len(m.visibleSessions())
+	label := " sessions"
+	if count == 1 {
+		label = " session"
 	}
-	line := valueStyle.Render(fmt.Sprintf("%d", sessionCount)) + subtleStyle.Render(" "+scope)
+	line := valueStyle.Render(fmt.Sprintf("%d", count)) + subtleStyle.Render(label) +
+		subtleStyle.Render(" · "+scope)
 	if m.updateLatest != "" {
 		line += subtleStyle.Render("   ") +
 			lipgloss.NewStyle().Foreground(colorAccent).Render("↑ "+m.updateLatest+" available")
@@ -514,32 +514,6 @@ func (m *Model) headerAgents() string {
 	}
 	return labelStyle.Render("cpu ") + valueStyle.Render(fmt.Sprintf("%.0f%%", m.agents.cpu)) +
 		subtleStyle.Render(" · ") + labelStyle.Render("ram ") + valueStyle.Render(humanBytes(m.agents.rss))
-}
-
-// viewHeader is the single-line header used when the terminal is too narrow
-// for the wordmark: the product mark, what is on screen, and the fleet
-// rollup pushed to the right edge.
-func (m *Model) viewHeader() string {
-	left := strings.Repeat(" ", railGutter) +
-		lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render(bannerWord) +
-		subtleStyle.Render("   ") + m.headerScope()
-
-	agents := m.headerAgents()
-	for _, right := range []string{
-		joinHeaderRight(m.viewStatusCounts(false), agents),
-		joinHeaderRight(m.viewStatusCounts(true), agents),
-		joinHeaderRight(m.viewStatusCounts(true), ""),
-		"",
-	} {
-		if right == "" {
-			break
-		}
-		gap := m.width - 2*railGutter - ansi.StringWidth(left) - ansi.StringWidth(right)
-		if gap >= 2 {
-			return left + strings.Repeat(" ", gap) + right
-		}
-	}
-	return left
 }
 
 func joinHeaderRight(counts, agents string) string {
@@ -557,10 +531,8 @@ func joinHeaderRight(counts, agents string) string {
 // per state present among the listed sessions.
 func (m *Model) viewStatusCounts(compact bool) string {
 	counts := map[string]int{}
-	for _, sess := range m.sessions {
-		if !sess.Archived {
-			counts[sess.Status]++
-		}
+	for _, sess := range m.visibleSessions() {
+		counts[sess.Status]++
 	}
 	var parts []string
 	for _, st := range []string{status.Waiting, status.Working, status.Finished, status.Idle, status.Errored, status.Dead} {

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -47,14 +47,14 @@ func (m *Model) viewListFrame() string {
 		rightRule := i < len(contentRows) && contentRows[i].rule
 		seam[i] = m.seamCell(leftRule, rightRule)
 	}
-	frame = append(frame, paint(hruleJoined(m.width, leftWidth, "┬"), m.width, backdropHex()))
+	frame = append(frame, m.boundedRuleRow(leftWidth, m.width, "┬"))
 	frame = append(frame, joinColumns(
 		paintContent(railRows, leftWidth, bodyHeight, panelHex()),
 		seam,
 		paintContent(contentRows, contentWidth, bodyHeight, backdropHex()),
 	)...)
 	frame = append(frame,
-		paint(hruleJoined(m.width, leftWidth, "┴"), m.width, backdropHex()),
+		m.boundedRuleRow(leftWidth, m.width, "┴"),
 		paint(m.viewStatus(), m.width, backdropHex()),
 	)
 	for _, line := range splitLines(footer) {

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -35,11 +35,19 @@ func (m *Model) viewListFrame() string {
 	for _, line := range m.viewHeaderRows() {
 		frame = append(frame, paint(line, m.width, backdropHex()))
 	}
+	railRows := m.railLines(leftWidth, bodyHeight)
+	contentRows := m.contentLines(contentWidth-2*contentGutter, bodyHeight)
+	seam := make([]string, bodyHeight)
+	for i := range seam {
+		leftRule := i < len(railRows) && railRows[i].rule
+		rightRule := i < len(contentRows) && contentRows[i].rule
+		seam[i] = m.seamCell(leftRule, rightRule)
+	}
 	frame = append(frame, paint(hruleJoined(m.width, leftWidth, "┬"), m.width, backdropHex()))
 	frame = append(frame, joinColumns(
-		paintRows(m.railLines(leftWidth, bodyHeight), leftWidth, bodyHeight, panelHex()),
-		m.vruleColumn(bodyHeight),
-		paintContent(m.contentLines(contentWidth-2*contentGutter, bodyHeight), contentWidth, bodyHeight, backdropHex()),
+		paintContent(railRows, leftWidth, bodyHeight, panelHex()),
+		seam,
+		paintContent(contentRows, contentWidth, bodyHeight, backdropHex()),
 	)...)
 	frame = append(frame,
 		paint(hruleJoined(m.width, leftWidth, "┴"), m.width, backdropHex()),
@@ -52,18 +60,28 @@ func (m *Model) viewListFrame() string {
 }
 
 // railLines is the sessions rail: the entry list on top, the machine
-// meters docked at the bottom.
-func (m *Model) railLines(width, height int) []string {
+// meters docked at the bottom behind their seam.
+func (m *Model) railLines(width, height int) []contentLine {
 	meters := m.computerLines(width)
-	listHeight := height - len(meters)
+	listHeight := height - len(meters) - 1
 	if listHeight < 3 {
 		listHeight, meters = height, nil
 	}
-	lines := append([]string{""}, m.entryLines(width, listHeight-1)...)
-	for len(lines) < listHeight {
-		lines = append(lines, "")
+	rows := []contentLine{{}}
+	for _, line := range m.entryLines(width, listHeight-1) {
+		rows = append(rows, contentLine{text: line})
 	}
-	return append(lines[:listHeight], meters...)
+	for len(rows) < listHeight {
+		rows = append(rows, contentLine{})
+	}
+	rows = rows[:listHeight]
+	if meters != nil {
+		rows = append(rows, contentLine{rule: true})
+		for _, line := range meters {
+			rows = append(rows, contentLine{text: line})
+		}
+	}
+	return rows
 }
 
 // entryLines renders the visible slice of the tree. Entries are two lines
@@ -254,7 +272,7 @@ func (m *Model) computerLines(width int) []string {
 		return line
 	}
 
-	lines := []string{hrule(width), pad + subtleStyle.Render("computer")}
+	lines := []string{pad + subtleStyle.Render("computer")}
 	lines = append(lines,
 		meter("cpu", snap.CPUPercent, snap.CPUOK, ""),
 		meter("mem", snap.MemPercent, snap.MemOK, humanBytes(snap.MemUsed)+"/"+humanBytes(snap.MemTotal)),

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -17,6 +17,9 @@ import (
 const (
 	railGutter    = 2
 	contentGutter = 2
+	// railInset is the pad inside the rail's own column, one short of
+	// railGutter because the edge column already occupies the first cell.
+	railInset = railGutter - 1
 )
 
 // viewListFrame is the sessions rail beside the session content, both
@@ -35,23 +38,32 @@ func (m *Model) viewListFrame() string {
 	for _, line := range m.viewHeaderRows() {
 		frame = append(frame, paint(line, m.width, backdropHex()))
 	}
-	// The rail's fill runs flush from the window edge through the seam
-	// column, then bleeds half a cell further right, and half a cell above
-	// and below its body rows — soft edges drawn with half blocks, the
-	// finest step a character cell allows. The window padding around the
-	// grid carries the backdrop tone via the terminal background sync.
+	// The rail's fill runs from the edge column through the seam column,
+	// then bleeds half a cell further right, and half a cell above and
+	// below its body rows — soft edges drawn with half blocks, the finest
+	// step a character cell allows. The first column is drawn as foreground
+	// blocks so the window margin beside it keeps the terminal's own
+	// background and the fill's corners land exactly on the cell grid.
 	bleedWidth := contentWidth - 1
-	railRows := m.railLines(leftWidth, bodyHeight)
+	railWidth := leftWidth - 1
+	railRows := m.railLines(railWidth, bodyHeight)
 	contentRows := m.contentLines(bleedWidth-2*contentGutter, bodyHeight)
 	seam := make([]string, bodyHeight)
+	edge := make([]string, bodyHeight)
 	for i := range seam {
 		leftRule := i < len(railRows) && railRows[i].rule
 		rightRule := i < len(contentRows) && contentRows[i].rule
 		seam[i] = m.seamCell(leftRule, rightRule)
+		tone := panelHex()
+		if i < len(railRows) && railRows[i].tone != "" {
+			tone = railRows[i].tone
+		}
+		edge[i] = railEdgeCell(tone)
 	}
 	frame = append(frame, m.boundedRuleRow(leftWidth+1, m.width, "▀"))
 	frame = append(frame, joinColumns(
-		paintContent(railRows, leftWidth, bodyHeight, panelHex()),
+		edge,
+		paintContent(railRows, railWidth, bodyHeight, panelHex()),
 		seam,
 		m.bleedColumn(bodyHeight),
 		paintContent(contentRows, bleedWidth, bodyHeight, backdropHex()),
@@ -75,9 +87,7 @@ func (m *Model) railLines(width, height int) []contentLine {
 		listHeight, meters = height, nil
 	}
 	rows := []contentLine{{}}
-	for _, line := range m.entryLines(width, listHeight-1) {
-		rows = append(rows, contentLine{text: line})
-	}
+	rows = append(rows, m.entryLines(width, listHeight-1)...)
 	for len(rows) < listHeight {
 		rows = append(rows, contentLine{})
 	}
@@ -92,10 +102,15 @@ func (m *Model) railLines(width, height int) []contentLine {
 }
 
 // entryLines renders the visible slice of the tree. Entries are two lines
-// tall, so the window is measured in lines rather than rows.
-func (m *Model) entryLines(width, height int) []string {
+// tall, so the window is measured in lines rather than rows. Each line
+// carries the tone its entry painted, which the edge column matches.
+func (m *Model) entryLines(width, height int) []contentLine {
 	if len(m.rows) == 0 {
-		return m.emptyRailLines(width)
+		var lines []contentLine
+		for _, line := range m.emptyRailLines(width) {
+			lines = append(lines, contentLine{text: line})
+		}
+		return lines
 	}
 	heights := make([]int, len(m.rows))
 	for i := range heights {
@@ -103,15 +118,22 @@ func (m *Model) entryLines(width, height int) []string {
 	}
 	start, end := lineWindow(heights, m.cursor, height)
 
-	var lines []string
+	var lines []contentLine
 	if start > 0 {
-		lines = append(lines, subtleStyle.Render(strings.Repeat(" ", railGutter)+fmt.Sprintf("↑ %d more", start)))
+		lines = append(lines, contentLine{text: subtleStyle.Render(strings.Repeat(" ", railInset) + fmt.Sprintf("↑ %d more", start))})
 	}
 	for i := start; i < end; i++ {
-		lines = append(lines, splitLines(m.renderTreeRow(m.rows[i], i == m.cursor, width))...)
+		selected := i == m.cursor
+		tone := panelHex()
+		if selected || m.renamingRow(m.rows[i]) {
+			tone = selectedHex()
+		}
+		for _, line := range splitLines(m.renderTreeRow(m.rows[i], selected, width)) {
+			lines = append(lines, contentLine{text: line, tone: tone})
+		}
 	}
 	if end < len(m.rows) {
-		lines = append(lines, subtleStyle.Render(strings.Repeat(" ", railGutter)+fmt.Sprintf("↓ %d more", len(m.rows)-end)))
+		lines = append(lines, contentLine{text: subtleStyle.Render(strings.Repeat(" ", railInset) + fmt.Sprintf("↓ %d more", len(m.rows)-end))})
 	}
 	if len(lines) > height {
 		lines = lines[:height]
@@ -176,7 +198,7 @@ func (m *Model) emptyRailLines(width int) []string {
 		title = "no matches"
 		hint = subtleStyle.Render("for \"" + m.search + "\"")
 	}
-	pad := strings.Repeat(" ", railGutter)
+	pad := strings.Repeat(" ", railInset)
 	return []string{"", pad + mutedStyle.Render(title), "", pad + hint}
 }
 
@@ -184,7 +206,7 @@ func (m *Model) emptyRailLines(width int) []string {
 // second line carrying the state and tool. The selected entry lifts onto
 // its own band instead of wearing a marker.
 func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
-	pad := strings.Repeat(" ", railGutter)
+	pad := strings.Repeat(" ", railInset)
 	indent := strings.Repeat("  ", entry.depth)
 
 	if m.renamingRow(entry) {
@@ -258,7 +280,7 @@ func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, i
 // and one thin meter per resource.
 func (m *Model) computerLines(width int) []string {
 	snap := m.snap
-	pad := strings.Repeat(" ", railGutter)
+	pad := strings.Repeat(" ", railInset)
 	barWidth := width - 22
 	if barWidth < 4 {
 		barWidth = 4

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -128,7 +128,7 @@ func (m *Model) entryLines(width, height int) []contentLine {
 		if selected || m.renamingRow(m.rows[i]) {
 			tone = selectedHex()
 		}
-		for _, line := range splitLines(m.renderTreeRow(m.rows[i], selected, width)) {
+		for _, line := range splitLines(m.renderTreeRow(m.rows[i], selected, width, i)) {
 			lines = append(lines, contentLine{text: line, tone: tone})
 		}
 	}
@@ -202,49 +202,82 @@ func (m *Model) emptyRailLines(width int) []string {
 	return []string{"", pad + mutedStyle.Render(title), "", pad + hint}
 }
 
-// treeGuides is the ancestry trail left of a nested entry: one quiet
-// guide line per level, drawn on both lines of an entry so the line runs
-// unbroken down a group's children.
-func treeGuides(depth int) string {
-	if depth <= 0 {
-		return ""
+// treeGuidesAt is the ancestry trail left of a nested entry: the head
+// line takes a branch connector — ├─ mid-list, ╰─ for the last child —
+// and the meta line under it continues the guide, so a group's children
+// hang off its branch the way the legacy tree drew them. A slot goes
+// quiet once its level has no further siblings below.
+func (m *Model) treeGuidesAt(index int) (string, string) {
+	if index < 0 || index >= len(m.rows) {
+		return "", ""
 	}
-	return subtleStyle.Render(strings.Repeat("│  ", depth))
+	depth := m.rows[index].depth
+	if depth <= 0 {
+		return "", ""
+	}
+	var head, meta strings.Builder
+	for slot := 1; slot <= depth; slot++ {
+		continues := false
+		for j := index + 1; j < len(m.rows); j++ {
+			if m.rows[j].depth < slot {
+				break
+			}
+			if m.rows[j].depth == slot {
+				continues = true
+				break
+			}
+		}
+		switch {
+		case slot < depth && continues:
+			head.WriteString("│  ")
+			meta.WriteString("│  ")
+		case slot < depth:
+			head.WriteString("   ")
+			meta.WriteString("   ")
+		case continues:
+			head.WriteString("├─ ")
+			meta.WriteString("│  ")
+		default:
+			head.WriteString("╰─ ")
+			meta.WriteString("   ")
+		}
+	}
+	return subtleStyle.Render(head.String()), subtleStyle.Render(meta.String())
 }
 
 // renderTreeRow paints one entry: a status dot, the name, and a quiet
 // second line carrying the state and tool. The selected entry lifts onto
 // its own band instead of wearing a marker.
-func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
+func (m *Model) renderTreeRow(entry treeRow, selected bool, width, index int) string {
 	pad := strings.Repeat(" ", railInset)
-	indent := treeGuides(entry.depth)
+	head, meta := m.treeGuidesAt(index)
 
 	if m.renamingRow(entry) {
-		line := pad + indent + m.renameRowInput(entry, width-railGutter-ansi.StringWidth(indent))
+		line := pad + head + m.renameRowInput(entry, width-railGutter-ansi.StringWidth(head))
 		return paint(line, width, selectedHex())
 	}
 
 	if entry.isGroup {
-		return m.renderGroupEntry(entry, selected, width, pad, indent)
+		return m.renderGroupEntry(entry, selected, width, pad, head, meta)
 	}
-	return m.renderSessionEntry(entry, selected, width, pad, indent)
+	return m.renderSessionEntry(entry, selected, width, pad, head, meta)
 }
 
-func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad, indent string) string {
+func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad, headGuides, metaGuides string) string {
 	sess := entry.sess
 	dot := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
 	nameStyle := valueStyle
 	if selected {
 		nameStyle = lipgloss.NewStyle().Foreground(colorBright).Bold(true)
 	}
-	head := pad + indent + dot + " " + nameStyle.Render(sess.Name)
+	head := pad + headGuides + dot + " " + nameStyle.Render(sess.Name)
 
 	metaStyle := subtleStyle
 	if selected {
 		metaStyle = mutedStyle
 	}
 	age := metaStyle.Render(relSince(lastActivity(sess)))
-	meta := pad + indent + "  " +
+	meta := pad + metaGuides + "  " +
 		lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusLabel(sess.Status)) +
 		metaStyle.Render(" · "+sess.Tool)
 
@@ -255,7 +288,7 @@ func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad,
 	return paint(rowColumns(head, age, width-railGutter), width, bg) + "\n" + paint(meta, width, bg)
 }
 
-func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, indent string) string {
+func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, headGuides, metaGuides string) string {
 	marker := "▾"
 	if m.collapsed[entry.group] {
 		marker = "▸"
@@ -269,7 +302,7 @@ func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, i
 	if count == 1 {
 		countLabel = "1 agent"
 	}
-	head := pad + indent + subtleStyle.Render(marker) + " " + nameStyle.Render(baseName(entry.group))
+	head := pad + headGuides + subtleStyle.Render(marker) + " " + nameStyle.Render(baseName(entry.group))
 
 	// The second line carries what the group is doing, so a folded group
 	// still reports its subtree without being opened.
@@ -283,7 +316,7 @@ func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, i
 		bg = selectedHex()
 	}
 	return paint(rowColumns(head, subtleStyle.Render(countLabel), width-railGutter), width, bg) + "\n" +
-		paint(pad+indent+"  "+meta, width, bg)
+		paint(pad+metaGuides+"  "+meta, width, bg)
 }
 
 // computerLines is the machine block docked at the rail's foot: a label

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -3,8 +3,10 @@ package ui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -13,7 +15,7 @@ import (
 // the content column's. Consistent insets are what make an unbordered
 // layout read as columns.
 const (
-	railGutter    = 2
+	railGutter    = 3
 	contentGutter = 2
 )
 
@@ -24,26 +26,20 @@ func (m *Model) viewListFrame() string {
 	footer := m.viewFooter()
 	bodyHeight := m.listBodyHeight()
 
-	gripWidth := 0
-	if m.resizeMode && rightWidth > 1 {
-		gripWidth = 1
-		rightWidth--
-	}
-
-	rail := paintRows(m.railLines(leftWidth, bodyHeight), leftWidth, bodyHeight, panelHex())
-	content := paintRows(m.contentLines(rightWidth-2*contentGutter, bodyHeight), rightWidth, bodyHeight, backdropHex())
-	columns := [][]string{rail}
-	if gripWidth > 0 {
-		columns = append(columns, paintRows(splitLines(m.resizeGrip(bodyHeight)), 1, bodyHeight, panelHex()))
-	}
-	columns = append(columns, content)
+	// One column goes to the seam between the rail and the content.
+	contentWidth := rightWidth - 1
 
 	frame := []string{
 		paint(m.viewHeader(), m.width, backdropHex()),
-		paint("", m.width, backdropHex()),
+		paint(hrule(m.width), m.width, backdropHex()),
 	}
-	frame = append(frame, joinColumns(columns...)...)
+	frame = append(frame, joinColumns(
+		paintRows(m.railLines(leftWidth, bodyHeight), leftWidth, bodyHeight, panelHex()),
+		m.vruleColumn(bodyHeight),
+		paintRows(m.contentLines(contentWidth-2*contentGutter, bodyHeight), contentWidth, bodyHeight, backdropHex()),
+	)...)
 	frame = append(frame,
+		paint(hrule(m.width), m.width, backdropHex()),
 		paint(m.viewStatus(), m.width, backdropHex()),
 	)
 	for _, line := range splitLines(footer) {
@@ -60,7 +56,7 @@ func (m *Model) railLines(width, height int) []string {
 	if listHeight < 3 {
 		listHeight, meters = height, nil
 	}
-	lines := m.entryLines(width, listHeight)
+	lines := append([]string{""}, m.entryLines(width, listHeight-1)...)
 	for len(lines) < listHeight {
 		lines = append(lines, "")
 	}
@@ -74,8 +70,8 @@ func (m *Model) entryLines(width, height int) []string {
 		return m.emptyRailLines(width)
 	}
 	heights := make([]int, len(m.rows))
-	for i, entry := range m.rows {
-		heights[i] = m.entryHeight(entry, i)
+	for i := range heights {
+		heights[i] = m.entryHeight()
 	}
 	start, end := lineWindow(heights, m.cursor, height)
 
@@ -95,18 +91,10 @@ func (m *Model) entryLines(width, height int) []string {
 	return lines
 }
 
-// entryHeight is how many lines an entry paints: sessions carry a second
-// meta line, group headers are a single line with a spacer above unless
-// they open the list.
-func (m *Model) entryHeight(entry treeRow, index int) int {
-	if !entry.isGroup {
-		return 2
-	}
-	if index == 0 {
-		return 1
-	}
-	return 2
-}
+// entryHeight is how many lines an entry paints. Every entry is the same
+// height, groups included: a ragged list of one- and two-line rows reads
+// as gaps rather than as rhythm.
+func (m *Model) entryHeight() int { return 2 }
 
 // lineWindow keeps the cursor's entry fully visible inside a line budget,
 // scrolling by whole entries so an entry is never cut in half.
@@ -195,7 +183,7 @@ func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad,
 	if selected {
 		metaStyle = mutedStyle
 	}
-	age := metaStyle.Render(relTime(sess.CreatedAt))
+	age := metaStyle.Render(relTime(lastActivity(sess)))
 	meta := pad + indent + "  " +
 		lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusLabel(sess.Status)) +
 		metaStyle.Render(" · "+sess.Tool)
@@ -212,22 +200,30 @@ func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, i
 	if m.collapsed[entry.group] {
 		marker = "▸"
 	}
-	nameStyle := lipgloss.NewStyle().Foreground(colorAccent2)
+	nameStyle := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true)
 	if selected {
-		nameStyle = nameStyle.Foreground(colorBright).Bold(true)
+		nameStyle = nameStyle.Foreground(colorBright)
+	}
+	count := m.groupSessionCount(entry.group)
+	countLabel := fmt.Sprintf("%d agents", count)
+	if count == 1 {
+		countLabel = "1 agent"
 	}
 	head := pad + indent + subtleStyle.Render(marker) + " " + nameStyle.Render(baseName(entry.group))
-	tail := subtleStyle.Render(fmt.Sprintf("%d", m.groupSessionCount(entry.group))) + m.groupStatusGlyphs(entry.group)
+
+	// The second line carries what the group is doing, so a folded group
+	// still reports its subtree without being opened.
+	meta := m.groupStatusBreakdown(entry.group)
+	if meta == "" {
+		meta = subtleStyle.Render("no agents yet")
+	}
 
 	bg := panelHex()
 	if selected {
 		bg = selectedHex()
 	}
-	line := paint(rowColumns(head, tail, width-railGutter), width, bg)
-	if entry == m.rows[0] {
-		return line
-	}
-	return paint("", width, panelHex()) + "\n" + line
+	return paint(rowColumns(head, subtleStyle.Render(countLabel), width-railGutter), width, bg) + "\n" +
+		paint(pad+indent+"  "+meta, width, bg)
 }
 
 // computerLines is the machine block docked at the rail's foot: a label
@@ -255,7 +251,7 @@ func (m *Model) computerLines(width int) []string {
 		return line
 	}
 
-	lines := []string{"", pad + subtleStyle.Render("computer")}
+	lines := []string{hrule(width), pad + subtleStyle.Render("computer")}
 	lines = append(lines,
 		meter("cpu", snap.CPUPercent, snap.CPUOK, ""),
 		meter("mem", snap.MemPercent, snap.MemOK, humanBytes(snap.MemUsed)+"/"+humanBytes(snap.MemTotal)),
@@ -298,7 +294,7 @@ func (m *Model) contentLines(width, height int) []string {
 		} else {
 			section = m.viewPreview(width, rest)
 		}
-		body = append(body, "")
+		body = append(body, hrule(width))
 		body = append(body, indent(splitLines(section))...)
 	}
 	for len(body)+len(bar) < height {
@@ -326,9 +322,10 @@ func (m *Model) viewDetail(width int) string {
 
 	title := lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(sess.Name)
 	state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).
-		Render(statusGlyph(sess.Status) + " " + statusLabel(sess.Status))
+		Render(statusGlyph(sess.Status)+" "+statusLabel(sess.Status)) +
+		subtleStyle.Render(" · "+relTime(lastActivity(sess)))
 
-	facts := []string{tool, displayGroup(sess.Group), relTime(sess.CreatedAt)}
+	facts := []string{tool, displayGroup(sess.Group), "started " + relTime(sess.CreatedAt) + " ago"}
 	if m.procFor == sess.ID && m.proc.OK {
 		facts = append(facts, fmt.Sprintf("%.1f%% · %s", m.proc.CPUPercent, humanBytes(m.proc.RSS)))
 	}
@@ -412,11 +409,22 @@ func (m *Model) viewGroupAgents(group string, width, height int) string {
 		}
 		dot := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
 		line := rowColumns(dot+" "+valueStyle.Render(sess.Name),
-			subtleStyle.Render(sess.Tool+" · "+relTime(sess.CreatedAt)), width)
+			subtleStyle.Render(sess.Tool+" · "+relTime(lastActivity(sess))), width)
 		lines = append(lines, line)
 		shown++
 	}
 	return strings.Join(lines, "\n")
+}
+
+// lastActivity is when a session last changed state: the agent answering,
+// finishing, erroring, or the moment a prompt set it working. It is what
+// "how long since anything happened here" means to someone scanning the
+// rail, where uptime says nothing about whether an agent is stuck.
+func lastActivity(sess store.Session) time.Time {
+	if sess.LastStatusAt.IsZero() {
+		return sess.CreatedAt
+	}
+	return sess.LastStatusAt
 }
 
 // viewQuickBar is the docked prompt: enter answers the selected session, or

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -202,12 +202,22 @@ func (m *Model) emptyRailLines(width int) []string {
 	return []string{"", pad + mutedStyle.Render(title), "", pad + hint}
 }
 
+// treeGuides is the ancestry trail left of a nested entry: one quiet
+// guide line per level, drawn on both lines of an entry so the line runs
+// unbroken down a group's children.
+func treeGuides(depth int) string {
+	if depth <= 0 {
+		return ""
+	}
+	return subtleStyle.Render(strings.Repeat("│  ", depth))
+}
+
 // renderTreeRow paints one entry: a status dot, the name, and a quiet
 // second line carrying the state and tool. The selected entry lifts onto
 // its own band instead of wearing a marker.
 func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 	pad := strings.Repeat(" ", railInset)
-	indent := strings.Repeat("  ", entry.depth)
+	indent := treeGuides(entry.depth)
 
 	if m.renamingRow(entry) {
 		line := pad + indent + m.renameRowInput(entry, width-railGutter-ansi.StringWidth(indent))

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -614,17 +614,6 @@ func (m *Model) headerAgents() string {
 		subtleStyle.Render(" · ") + labelStyle.Render("ram ") + valueStyle.Render(humanBytes(m.agents.rss))
 }
 
-func joinHeaderRight(counts, agents string) string {
-	switch {
-	case counts == "":
-		return agents
-	case agents == "":
-		return counts
-	default:
-		return counts + subtleStyle.Render("   ") + agents
-	}
-}
-
 // viewStatusCounts is the fleet-at-a-glance strip: a tinted dot and count
 // per state present among the listed sessions.
 func (m *Model) viewStatusCounts(compact bool) string {

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -35,22 +35,28 @@ func (m *Model) viewListFrame() string {
 	for _, line := range m.viewHeaderRows() {
 		frame = append(frame, paint(line, m.width, backdropHex()))
 	}
-	// The rail card leaves its first column unpainted so its fill never
-	// touches the window edge; see the surface rules in surface.go.
-	railRows := m.railLines(leftWidth-1, bodyHeight)
+	// The rail card floats: a margin of the terminal's own background on
+	// all four sides, so its fill never touches the window edge, the
+	// header's rule, the seam, or the footer's rule. Its own rules stop at
+	// the card's edge; see the surface rules in surface.go.
+	cardWidth := leftWidth - 2
+	railRows := m.railLines(cardWidth, bodyHeight-2)
+	card := paintContent(railRows, cardWidth, bodyHeight-2, panelHex())
 	contentRows := m.contentLines(contentWidth-2*contentGutter, bodyHeight)
+	rail := make([]string, bodyHeight)
 	seam := make([]string, bodyHeight)
-	margin := make([]string, bodyHeight)
-	for i := range seam {
-		leftRule := i < len(railRows) && railRows[i].rule
+	for i := range rail {
+		if i == 0 || i == bodyHeight-1 {
+			rail[i] = paint("", leftWidth, backdropHex())
+		} else {
+			rail[i] = paint("", 1, backdropHex()) + card[i-1] + paint("", 1, backdropHex())
+		}
 		rightRule := i < len(contentRows) && contentRows[i].rule
-		seam[i] = m.seamCell(leftRule, rightRule)
-		margin[i] = paint("", 1, backdropHex())
+		seam[i] = m.seamCell(false, rightRule)
 	}
 	frame = append(frame, paint(hruleJoined(m.width, leftWidth, "┬"), m.width, backdropHex()))
 	frame = append(frame, joinColumns(
-		margin,
-		paintContent(railRows, leftWidth-1, bodyHeight, panelHex()),
+		rail,
 		seam,
 		paintContent(contentRows, contentWidth, bodyHeight, backdropHex()),
 	)...)

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -37,7 +37,7 @@ func (m *Model) viewListFrame() string {
 	frame = append(frame, joinColumns(
 		paintRows(m.railLines(leftWidth, bodyHeight), leftWidth, bodyHeight, panelHex()),
 		m.vruleColumn(bodyHeight),
-		paintRows(m.contentLines(contentWidth-2*contentGutter, bodyHeight), contentWidth, bodyHeight, backdropHex()),
+		paintContent(m.contentLines(contentWidth-2*contentGutter, bodyHeight), contentWidth, bodyHeight, backdropHex()),
 	)...)
 	frame = append(frame,
 		paint(hrule(m.width), m.width, backdropHex()),
@@ -272,36 +272,58 @@ func (m *Model) computerLines(width int) []string {
 
 // contentLines is the right column: what the cursor is on, then its live
 // pane, with the quick prompt docked at the foot when it is open.
-func (m *Model) contentLines(width, height int) []string {
+func (m *Model) contentLines(width, height int) []contentLine {
 	gutter := strings.Repeat(" ", contentGutter)
-	indent := func(lines []string) []string {
-		out := make([]string, len(lines))
+	ours := func(lines []string) []contentLine {
+		out := make([]contentLine, len(lines))
 		for i, line := range lines {
-			out[i] = gutter + line
+			out[i] = contentLine{text: gutter + line}
 		}
 		return out
 	}
 
-	bar := []string{}
+	var bar []contentLine
 	if m.quick.active {
-		bar = append([]string{""}, indent(splitLines(m.viewQuickBar(width)))...)
+		bar = append([]contentLine{{}}, ours(splitLines(m.viewQuickBar(width)))...)
 	}
-	body := indent(splitLines(m.viewDetail(width)))
+	body := ours(splitLines(m.viewDetail(width)))
 	rest := height - len(body) - len(bar) - 1
 	if rest >= 3 {
-		var section string
+		body = append(body, contentLine{text: hrule(width)})
 		if group, ok := m.selectedGroup(); ok {
-			section = m.viewGroupAgents(group, width, rest)
+			body = append(body, ours(splitLines(m.viewGroupAgents(group, width, rest)))...)
 		} else {
-			section = m.viewPreview(width, rest)
+			body = append(body, m.previewLines(width, rest, gutter)...)
 		}
-		body = append(body, hrule(width))
-		body = append(body, indent(splitLines(section))...)
 	}
 	for len(body)+len(bar) < height {
-		body = append(body, "")
+		body = append(body, contentLine{})
 	}
 	return append(body[:max(height-len(bar), 0)], bar...)
+}
+
+// previewLines is the captured pane under its label. The captured rows are
+// marked raw: painting our backdrop behind an agent's own CLI colors would
+// replace the background it drew itself, so those rows keep the terminal's.
+func (m *Model) previewLines(width, height int, gutter string) []contentLine {
+	lines := []contentLine{{text: gutter + subtleStyle.Render("preview")}}
+	rows := height - 1
+	if rows < 1 {
+		return lines
+	}
+	pane := paneExact(m.preview, rows)
+	if len(pane) == 0 {
+		return append(lines, contentLine{text: gutter + mutedStyle.Render("(no output yet)")})
+	}
+	for _, line := range pane {
+		lines = append(lines, contentLine{text: gutter + previewLine(line, width), raw: true})
+	}
+	// Rows past the capture stay raw too: a painted tail under unpainted
+	// output would read as a box drawn around the agent's last line.
+	for len(lines) < height {
+		lines = append(lines, contentLine{raw: true})
+	}
+	return lines
 }
 
 // viewDetail heads the content column: the selected session's name, its
@@ -328,7 +350,7 @@ func (m *Model) viewDetail(width int) string {
 
 	facts := []string{tool, displayGroup(sess.Group), "started " + relSince(sess.CreatedAt)}
 	if m.procFor == sess.ID && m.proc.OK {
-		facts = append(facts, fmt.Sprintf("%.1f%% · %s", m.proc.CPUPercent, humanBytes(m.proc.RSS)))
+		facts = append(facts, fmt.Sprintf("cpu %.1f%% · ram %s", m.proc.CPUPercent, humanBytes(m.proc.RSS)))
 	}
 	meta := subtleStyle.Render(strings.Join(facts, " · "))
 	dir := subtleStyle.Render(truncateTail(sess.Cwd, width))
@@ -370,24 +392,6 @@ func (m *Model) viewGroupDetail(group string, width int) string {
 	lines := []string{head, subtleStyle.Render(truncateTail(path, width-len(source))) + source}
 	if breakdown := m.groupStatusBreakdown(group); breakdown != "" {
 		lines = append(lines, breakdown)
-	}
-	return strings.Join(lines, "\n")
-}
-
-// viewPreview shows the selected session's pane 1:1 with its own colors,
-// under a quiet label rather than inside a box.
-func (m *Model) viewPreview(width, height int) string {
-	lines := []string{subtleStyle.Render("preview")}
-	contentRows := height - 1
-	if contentRows < 1 {
-		return strings.Join(lines, "\n")
-	}
-	pane := paneExact(m.preview, contentRows)
-	if len(pane) == 0 {
-		return lines[0] + "\n" + mutedStyle.Render("(no output yet)")
-	}
-	for _, line := range pane {
-		lines = append(lines, previewLine(line, width))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -458,8 +462,11 @@ func (m *Model) viewHeaderRows() []string {
 	// widest one that still clears the wordmark.
 	right := [][]string{
 		{m.headerScope()},
-		{m.viewStatusCounts(false), m.viewStatusCounts(true)},
-		{m.headerAgents()},
+		{
+			joinHeaderRight(m.viewStatusCounts(false), m.headerAgents()),
+			joinHeaderRight(m.viewStatusCounts(true), m.headerAgents()),
+			m.viewStatusCounts(true),
+		},
 	}
 	rows := m.viewBanner()
 	for i := range rows {
@@ -505,7 +512,8 @@ func (m *Model) headerAgents() string {
 	if m.agents.count == 0 {
 		return ""
 	}
-	return subtleStyle.Render(fmt.Sprintf("%.0f%% · %s", m.agents.cpu, humanBytes(m.agents.rss)))
+	return labelStyle.Render("cpu ") + valueStyle.Render(fmt.Sprintf("%.0f%%", m.agents.cpu)) +
+		subtleStyle.Render(" · ") + labelStyle.Render("ram ") + valueStyle.Render(humanBytes(m.agents.rss))
 }
 
 // viewHeader is the single-line header used when the terminal is too narrow

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -1,0 +1,516 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// railGutter is the left inset every rail line shares, and contentGutter
+// the content column's. Consistent insets are what make an unbordered
+// layout read as columns.
+const (
+	railGutter    = 2
+	contentGutter = 2
+)
+
+// viewListFrame is the sessions rail beside the session content, both
+// painted surfaces rather than drawn panels.
+func (m *Model) viewListFrame() string {
+	leftWidth, rightWidth := m.splitWidths()
+	footer := m.viewFooter()
+	bodyHeight := m.listBodyHeight()
+
+	gripWidth := 0
+	if m.resizeMode && rightWidth > 1 {
+		gripWidth = 1
+		rightWidth--
+	}
+
+	rail := paintRows(m.railLines(leftWidth, bodyHeight), leftWidth, bodyHeight, panelHex())
+	content := paintRows(m.contentLines(rightWidth-2*contentGutter, bodyHeight), rightWidth, bodyHeight, backdropHex())
+	columns := [][]string{rail}
+	if gripWidth > 0 {
+		columns = append(columns, paintRows(splitLines(m.resizeGrip(bodyHeight)), 1, bodyHeight, panelHex()))
+	}
+	columns = append(columns, content)
+
+	frame := []string{
+		paint(m.viewHeader(), m.width, backdropHex()),
+		paint("", m.width, backdropHex()),
+	}
+	frame = append(frame, joinColumns(columns...)...)
+	frame = append(frame,
+		paint(m.viewStatus(), m.width, backdropHex()),
+	)
+	for _, line := range splitLines(footer) {
+		frame = append(frame, paint(line, m.width, backdropHex()))
+	}
+	return strings.Join(frame, "\n")
+}
+
+// railLines is the sessions rail: the entry list on top, the machine
+// meters docked at the bottom.
+func (m *Model) railLines(width, height int) []string {
+	meters := m.computerLines(width)
+	listHeight := height - len(meters)
+	if listHeight < 3 {
+		listHeight, meters = height, nil
+	}
+	lines := m.entryLines(width, listHeight)
+	for len(lines) < listHeight {
+		lines = append(lines, "")
+	}
+	return append(lines[:listHeight], meters...)
+}
+
+// entryLines renders the visible slice of the tree. Entries are two lines
+// tall, so the window is measured in lines rather than rows.
+func (m *Model) entryLines(width, height int) []string {
+	if len(m.rows) == 0 {
+		return m.emptyRailLines(width)
+	}
+	heights := make([]int, len(m.rows))
+	for i, entry := range m.rows {
+		heights[i] = m.entryHeight(entry, i)
+	}
+	start, end := lineWindow(heights, m.cursor, height)
+
+	var lines []string
+	if start > 0 {
+		lines = append(lines, subtleStyle.Render(strings.Repeat(" ", railGutter)+fmt.Sprintf("↑ %d more", start)))
+	}
+	for i := start; i < end; i++ {
+		lines = append(lines, splitLines(m.renderTreeRow(m.rows[i], i == m.cursor, width))...)
+	}
+	if end < len(m.rows) {
+		lines = append(lines, subtleStyle.Render(strings.Repeat(" ", railGutter)+fmt.Sprintf("↓ %d more", len(m.rows)-end)))
+	}
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	return lines
+}
+
+// entryHeight is how many lines an entry paints: sessions carry a second
+// meta line, group headers are a single line with a spacer above unless
+// they open the list.
+func (m *Model) entryHeight(entry treeRow, index int) int {
+	if !entry.isGroup {
+		return 2
+	}
+	if index == 0 {
+		return 1
+	}
+	return 2
+}
+
+// lineWindow keeps the cursor's entry fully visible inside a line budget,
+// scrolling by whole entries so an entry is never cut in half.
+func lineWindow(heights []int, cursor, budget int) (int, int) {
+	if len(heights) == 0 || budget <= 0 {
+		return 0, 0
+	}
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor >= len(heights) {
+		cursor = len(heights) - 1
+	}
+	total := 0
+	for _, h := range heights {
+		total += h
+	}
+	if total <= budget {
+		return 0, len(heights)
+	}
+	// Grow a window around the cursor, preferring to keep entries above it
+	// on screen so the list does not jump when stepping down.
+	start, end, used := cursor, cursor+1, heights[cursor]
+	for {
+		grew := false
+		if end < len(heights) && used+heights[end] <= budget-1 {
+			used += heights[end]
+			end++
+			grew = true
+		}
+		if start > 0 && used+heights[start-1] <= budget-1 {
+			start--
+			used += heights[start]
+			grew = true
+		}
+		if !grew {
+			break
+		}
+	}
+	return start, end
+}
+
+func (m *Model) emptyRailLines(width int) []string {
+	title := "no sessions yet"
+	hint := keyCap("n", "starts one")
+	if m.showArchived {
+		title = "nothing archived"
+		hint = keyCap("t", "back to active")
+	}
+	if strings.TrimSpace(m.search) != "" {
+		title = "no matches"
+		hint = subtleStyle.Render("for \"" + m.search + "\"")
+	}
+	pad := strings.Repeat(" ", railGutter)
+	return []string{"", pad + mutedStyle.Render(title), "", pad + hint}
+}
+
+// renderTreeRow paints one entry: a status dot, the name, and a quiet
+// second line carrying the state and tool. The selected entry lifts onto
+// its own band instead of wearing a marker.
+func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
+	pad := strings.Repeat(" ", railGutter)
+	indent := strings.Repeat("  ", entry.depth)
+
+	if m.renamingRow(entry) {
+		line := pad + indent + m.renameRowInput(entry, width-railGutter-ansi.StringWidth(indent))
+		return paint(line, width, selectedHex())
+	}
+
+	if entry.isGroup {
+		return m.renderGroupEntry(entry, selected, width, pad, indent)
+	}
+	return m.renderSessionEntry(entry, selected, width, pad, indent)
+}
+
+func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad, indent string) string {
+	sess := entry.sess
+	dot := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
+	nameStyle := valueStyle
+	if selected {
+		nameStyle = lipgloss.NewStyle().Foreground(colorBright).Bold(true)
+	}
+	head := pad + indent + dot + " " + nameStyle.Render(sess.Name)
+
+	metaStyle := subtleStyle
+	if selected {
+		metaStyle = mutedStyle
+	}
+	age := metaStyle.Render(relTime(sess.CreatedAt))
+	meta := pad + indent + "  " +
+		lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusLabel(sess.Status)) +
+		metaStyle.Render(" · "+sess.Tool)
+
+	bg := panelHex()
+	if selected {
+		bg = selectedHex()
+	}
+	return paint(rowColumns(head, age, width-railGutter), width, bg) + "\n" + paint(meta, width, bg)
+}
+
+func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, indent string) string {
+	marker := "▾"
+	if m.collapsed[entry.group] {
+		marker = "▸"
+	}
+	nameStyle := lipgloss.NewStyle().Foreground(colorAccent2)
+	if selected {
+		nameStyle = nameStyle.Foreground(colorBright).Bold(true)
+	}
+	head := pad + indent + subtleStyle.Render(marker) + " " + nameStyle.Render(baseName(entry.group))
+	tail := subtleStyle.Render(fmt.Sprintf("%d", m.groupSessionCount(entry.group))) + m.groupStatusGlyphs(entry.group)
+
+	bg := panelHex()
+	if selected {
+		bg = selectedHex()
+	}
+	line := paint(rowColumns(head, tail, width-railGutter), width, bg)
+	if entry == m.rows[0] {
+		return line
+	}
+	return paint("", width, panelHex()) + "\n" + line
+}
+
+// computerLines is the machine block docked at the rail's foot: a label
+// and one thin meter per resource.
+func (m *Model) computerLines(width int) []string {
+	snap := m.snap
+	pad := strings.Repeat(" ", railGutter)
+	barWidth := width - 22
+	if barWidth < 4 {
+		barWidth = 4
+	}
+	if barWidth > 10 {
+		barWidth = 10
+	}
+
+	meter := func(label string, percent float64, ok bool, extra string) string {
+		if !ok {
+			return pad + labelStyle.Width(5).Render(label) + subtleStyle.Render("n/a")
+		}
+		line := pad + labelStyle.Width(5).Render(label) + gauge(percent, barWidth) +
+			valueStyle.Render(fmt.Sprintf(" %3.0f%%", percent))
+		if extra != "" {
+			line += subtleStyle.Render(" " + extra)
+		}
+		return line
+	}
+
+	lines := []string{"", pad + subtleStyle.Render("computer")}
+	lines = append(lines,
+		meter("cpu", snap.CPUPercent, snap.CPUOK, ""),
+		meter("mem", snap.MemPercent, snap.MemOK, humanBytes(snap.MemUsed)+"/"+humanBytes(snap.MemTotal)),
+	)
+	if snap.SwapOK && snap.SwapTotal > 0 {
+		lines = append(lines, meter("swap", snap.SwapPercent, true, humanBytes(snap.SwapUsed)))
+	}
+	lines = append(lines, meter("disk", snap.DiskPercent, snap.DiskOK,
+		humanBytes(snap.DiskTotal-snap.DiskUsed)+" free"))
+	if m.netRates {
+		lines = append(lines, pad+labelStyle.Width(5).Render("net")+
+			valueStyle.Render("↓ "+humanBytes(m.netDown)+"/s")+
+			subtleStyle.Render("  ↑ "+humanBytes(m.netUp)+"/s"))
+	}
+	return append(lines, "")
+}
+
+// contentLines is the right column: what the cursor is on, then its live
+// pane, with the quick prompt docked at the foot when it is open.
+func (m *Model) contentLines(width, height int) []string {
+	gutter := strings.Repeat(" ", contentGutter)
+	indent := func(lines []string) []string {
+		out := make([]string, len(lines))
+		for i, line := range lines {
+			out[i] = gutter + line
+		}
+		return out
+	}
+
+	bar := []string{}
+	if m.quick.active {
+		bar = append([]string{""}, indent(splitLines(m.viewQuickBar(width)))...)
+	}
+	body := indent(splitLines(m.viewDetail(width)))
+	rest := height - len(body) - len(bar) - 1
+	if rest >= 3 {
+		var section string
+		if group, ok := m.selectedGroup(); ok {
+			section = m.viewGroupAgents(group, width, rest)
+		} else {
+			section = m.viewPreview(width, rest)
+		}
+		body = append(body, "")
+		body = append(body, indent(splitLines(section))...)
+	}
+	for len(body)+len(bar) < height {
+		body = append(body, "")
+	}
+	return append(body[:max(height-len(bar), 0)], bar...)
+}
+
+// viewDetail heads the content column: the selected session's name, its
+// state, and the facts that place it (group, directory, age, usage).
+func (m *Model) viewDetail(width int) string {
+	sess, ok := m.selected()
+	if !ok {
+		if group, isGroup := m.selectedGroup(); isGroup {
+			return m.viewGroupDetail(group, width)
+		}
+		return mutedStyle.Render("Select a session to inspect it.")
+	}
+	tool := sess.Tool
+	if m.mode == modeRename && !m.rename.isGroup && m.rename.sessID == sess.ID {
+		if picked := m.renameTool(); picked != "" {
+			tool = picked
+		}
+	}
+
+	title := lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(sess.Name)
+	state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).
+		Render(statusGlyph(sess.Status) + " " + statusLabel(sess.Status))
+
+	facts := []string{tool, displayGroup(sess.Group), relTime(sess.CreatedAt)}
+	if m.procFor == sess.ID && m.proc.OK {
+		facts = append(facts, fmt.Sprintf("%.1f%% · %s", m.proc.CPUPercent, humanBytes(m.proc.RSS)))
+	}
+	meta := subtleStyle.Render(strings.Join(facts, " · "))
+	dir := subtleStyle.Render(truncateTail(sess.Cwd, width))
+	return rowColumns(title, state, width) + "\n" + meta + "\n" + dir
+}
+
+// viewGroupDetail heads the content column for a group: its name, how many
+// agents sit under it, where they start, and what they are all doing.
+func (m *Model) viewGroupDetail(group string, width int) string {
+	count := m.groupSessionCount(group)
+	countLabel := fmt.Sprintf("%d agents", count)
+	if count == 1 {
+		countLabel = "1 agent"
+	}
+	title := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true).Render(displayGroup(group))
+	head := rowColumns(title, subtleStyle.Render(countLabel), width)
+
+	if m.renamingGroup(group) {
+		label := labelStyle
+		if m.rename.focus == 1 {
+			label = lipgloss.NewStyle().Foreground(colorAccent)
+		}
+		if fieldWidth := width - 8; fieldWidth >= 10 {
+			m.rename.dir.Width = fieldWidth
+		}
+		out := head + "\n" + label.Width(6).Render("path") + m.rename.dir.View()
+		if m.rename.focus == 1 && m.pathSugg.active() {
+			out += "\n" + m.viewPathSuggestions()
+		}
+		return out
+	}
+
+	path := m.groupPaths[group]
+	source := ""
+	if path == "" {
+		path = m.groupDefaultDir(group)
+		source = subtleStyle.Render(" · inherited")
+	}
+	lines := []string{head, subtleStyle.Render(truncateTail(path, width-len(source))) + source}
+	if breakdown := m.groupStatusBreakdown(group); breakdown != "" {
+		lines = append(lines, breakdown)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// viewPreview shows the selected session's pane 1:1 with its own colors,
+// under a quiet label rather than inside a box.
+func (m *Model) viewPreview(width, height int) string {
+	lines := []string{subtleStyle.Render("preview")}
+	contentRows := height - 1
+	if contentRows < 1 {
+		return strings.Join(lines, "\n")
+	}
+	pane := paneExact(m.preview, contentRows)
+	if len(pane) == 0 {
+		return lines[0] + "\n" + mutedStyle.Render("(no output yet)")
+	}
+	for _, line := range pane {
+		lines = append(lines, previewLine(line, width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// viewGroupAgents lists a group's sessions where a session's pane preview
+// would sit, so a group reads as a roster.
+func (m *Model) viewGroupAgents(group string, width, height int) string {
+	lines := []string{subtleStyle.Render("agents")}
+	shown, total := 0, m.groupSessionCount(group)
+	if total == 0 {
+		return lines[0] + "\n" + mutedStyle.Render("(none yet — press space to spawn one)")
+	}
+	for _, sess := range m.visibleSessions() {
+		if !inGroupSubtree(sess.Group, group) {
+			continue
+		}
+		if shown >= height-2 && total > shown+1 {
+			lines = append(lines, subtleStyle.Render(fmt.Sprintf("… %d more", total-shown)))
+			break
+		}
+		dot := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
+		line := rowColumns(dot+" "+valueStyle.Render(sess.Name),
+			subtleStyle.Render(sess.Tool+" · "+relTime(sess.CreatedAt)), width)
+		lines = append(lines, line)
+		shown++
+	}
+	return strings.Join(lines, "\n")
+}
+
+// viewQuickBar is the docked prompt: enter answers the selected session, or
+// spawns a fresh agent when a group is selected.
+func (m *Model) viewQuickBar(width int) string {
+	target := "no selection"
+	if entry, ok := m.selectedRow(); ok {
+		if entry.isGroup {
+			target = "new " + m.quickTool() + " agent in " + displayGroup(entry.group)
+		} else {
+			target = "answer " + entry.sess.Name
+		}
+	}
+	// Chips live in the textarea prompt so they sit on the same line as the
+	// typed text (Claude-style inline chips), not on a separate strip below.
+	m.syncQuickInlineChips()
+	m.quick.input.SetWidth(width)
+	m.quick.input.SetHeight(m.quickBarRows(width - 2))
+	return subtleStyle.Render(target) + "\n" + m.quick.input.View()
+}
+
+// viewHeader is the top line: the product mark, what is on screen, and the
+// fleet rollup pushed to the right edge.
+func (m *Model) viewHeader() string {
+	scope := "active"
+	if m.showArchived {
+		scope = "archived"
+	}
+	sessionCount := 0
+	for _, entry := range m.rows {
+		if !entry.isGroup {
+			sessionCount++
+		}
+	}
+	left := strings.Repeat(" ", railGutter) +
+		lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("agent manager") +
+		subtleStyle.Render(fmt.Sprintf("   %d %s", sessionCount, scope))
+	if m.updateLatest != "" {
+		left += subtleStyle.Render("   ") +
+			lipgloss.NewStyle().Foreground(colorAccent).Render("↑ "+m.updateLatest+" available")
+	}
+
+	agents := ""
+	if m.agents.count > 0 {
+		agents = subtleStyle.Render(fmt.Sprintf("%.0f%% · %s", m.agents.cpu, humanBytes(m.agents.rss)))
+	}
+	for _, right := range []string{
+		joinHeaderRight(m.viewStatusCounts(false), agents),
+		joinHeaderRight(m.viewStatusCounts(true), agents),
+		joinHeaderRight(m.viewStatusCounts(true), ""),
+		"",
+	} {
+		if right == "" {
+			break
+		}
+		gap := m.width - 2*railGutter - ansi.StringWidth(left) - ansi.StringWidth(right)
+		if gap >= 2 {
+			return left + strings.Repeat(" ", gap) + right
+		}
+	}
+	return left
+}
+
+func joinHeaderRight(counts, agents string) string {
+	switch {
+	case counts == "":
+		return agents
+	case agents == "":
+		return counts
+	default:
+		return counts + subtleStyle.Render("   ") + agents
+	}
+}
+
+// viewStatusCounts is the fleet-at-a-glance strip: a tinted dot and count
+// per state present among the listed sessions.
+func (m *Model) viewStatusCounts(compact bool) string {
+	counts := map[string]int{}
+	for _, sess := range m.sessions {
+		if !sess.Archived {
+			counts[sess.Status]++
+		}
+	}
+	var parts []string
+	for _, st := range []string{status.Waiting, status.Working, status.Finished, status.Idle, status.Errored, status.Dead} {
+		if counts[st] == 0 {
+			continue
+		}
+		dot := lipgloss.NewStyle().Foreground(statusColor(st)).Render(statusGlyph(st))
+		label := fmt.Sprintf(" %d %s", counts[st], st)
+		if compact {
+			label = fmt.Sprintf(" %d", counts[st])
+		}
+		parts = append(parts, dot+subtleStyle.Render(label))
+	}
+	return strings.Join(parts, subtleStyle.Render("  "))
+}

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -26,24 +26,21 @@ func (m *Model) viewListFrame() string {
 	footer := m.viewFooter()
 	bodyHeight := m.listBodyHeight()
 
-	// One column goes to the seam between the rail and the content, and the
-	// rail carries the wordmark so the two surfaces run from the very top of
-	// the frame down to the footer's seam.
+	// The header is one full-width band over both columns, closed by a
+	// rule; the seam between the rail and the content tees into that rule
+	// and runs down to meet the footer's.
 	contentWidth := rightWidth - 1
-	headerRows := m.headerRows()
 
-	railHead := m.viewBanner()
-	contentHead := m.viewHeaderRows()
-
-	rail := append(
-		paintRows(railHead, leftWidth, headerRows, panelHex()),
-		paintRows(m.railLines(leftWidth, bodyHeight), leftWidth, bodyHeight, panelHex())...)
-	seam := m.vruleColumn(headerRows + bodyHeight)
-	content := append(
-		paintRows(contentHead, contentWidth, headerRows, backdropHex()),
-		paintContent(m.contentLines(contentWidth-2*contentGutter, bodyHeight), contentWidth, bodyHeight, backdropHex())...)
-
-	frame := joinColumns(rail, seam, content)
+	frame := []string{}
+	for _, line := range m.viewHeaderRows() {
+		frame = append(frame, paint(line, m.width, backdropHex()))
+	}
+	frame = append(frame, paint(hruleJoined(m.width, leftWidth, "┬"), m.width, backdropHex()))
+	frame = append(frame, joinColumns(
+		paintRows(m.railLines(leftWidth, bodyHeight), leftWidth, bodyHeight, panelHex()),
+		m.vruleColumn(bodyHeight),
+		paintContent(m.contentLines(contentWidth-2*contentGutter, bodyHeight), contentWidth, bodyHeight, backdropHex()),
+	)...)
 	frame = append(frame,
 		paint(hruleJoined(m.width, leftWidth, "┴"), m.width, backdropHex()),
 		paint(m.viewStatus(), m.width, backdropHex()),
@@ -459,29 +456,40 @@ func (m *Model) viewQuickBar(width int) string {
 	return subtleStyle.Render(target) + "\n" + m.quick.input.View()
 }
 
-// viewHeaderRows is the header block: the wordmark when there is room for
-// it, with the scope line and the fleet rollup set against the right edge
-// on the wordmark's own rows.
+// viewHeaderRows is the full-width band over both columns: the wordmark
+// on the left, and the richest reading of the fleet that fits set against
+// the right edge (scope and rollup, then a compact rollup, then the scope
+// alone).
 func (m *Model) viewHeaderRows() []string {
-	_, rightWidth := m.splitWidths()
-	width := rightWidth - 1 - contentGutter
-	left := strings.Repeat(" ", contentGutter) + m.headerScope()
-
-	// The rollup offers its readings richest-first and takes the widest one
-	// that still clears the scope on its left.
+	left := m.viewBanner()[0]
+	sep := subtleStyle.Render("   ")
+	scope := m.headerScope()
+	agents := m.headerAgents()
 	for _, right := range []string{
-		joinHeaderRight(m.viewStatusCounts(false), m.headerAgents()),
-		joinHeaderRight(m.viewStatusCounts(true), m.headerAgents()),
-		m.viewStatusCounts(true),
+		joinHeaderPieces(sep, scope, m.viewStatusCounts(false), agents),
+		joinHeaderPieces(sep, scope, m.viewStatusCounts(true), agents),
+		joinHeaderPieces(sep, scope, m.viewStatusCounts(true), ""),
+		scope,
 		"",
 	} {
-		gap := width - ansi.StringWidth(left) - ansi.StringWidth(right)
+		gap := m.width - railGutter - ansi.StringWidth(left) - ansi.StringWidth(right)
 		if right == "" || gap < 2 {
 			continue
 		}
-		return []string{left + strings.Repeat(" ", gap) + right}
+		return []string{left + strings.Repeat(" ", gap) + right + strings.Repeat(" ", railGutter)}
 	}
 	return []string{left}
+}
+
+// joinHeaderPieces joins the header's non-empty readings with a separator.
+func joinHeaderPieces(sep string, pieces ...string) string {
+	kept := pieces[:0:0]
+	for _, piece := range pieces {
+		if piece != "" {
+			kept = append(kept, piece)
+		}
+	}
+	return strings.Join(kept, sep)
 }
 
 // headerScope names what the list is showing and badges a newer release.

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -35,28 +35,21 @@ func (m *Model) viewListFrame() string {
 	for _, line := range m.viewHeaderRows() {
 		frame = append(frame, paint(line, m.width, backdropHex()))
 	}
-	// The rail card floats: a margin of the terminal's own background on
-	// all four sides, so its fill never touches the window edge, the
-	// header's rule, the seam, or the footer's rule. Its own rules stop at
-	// the card's edge; see the surface rules in surface.go.
-	cardWidth := leftWidth - 2
-	railRows := m.railLines(cardWidth, bodyHeight-2)
-	card := paintContent(railRows, cardWidth, bodyHeight-2, panelHex())
+	// The rail's fill runs flush: from the header's rule to the footer's
+	// and from the window edge to the seam, one solid pane. The window
+	// padding around the grid carries the backdrop tone via the terminal
+	// background sync, so the pane reads as filling its box exactly.
+	railRows := m.railLines(leftWidth, bodyHeight)
 	contentRows := m.contentLines(contentWidth-2*contentGutter, bodyHeight)
-	rail := make([]string, bodyHeight)
 	seam := make([]string, bodyHeight)
-	for i := range rail {
-		if i == 0 || i == bodyHeight-1 {
-			rail[i] = paint("", leftWidth, backdropHex())
-		} else {
-			rail[i] = paint("", 1, backdropHex()) + card[i-1] + paint("", 1, backdropHex())
-		}
+	for i := range seam {
+		leftRule := i < len(railRows) && railRows[i].rule
 		rightRule := i < len(contentRows) && contentRows[i].rule
-		seam[i] = m.seamCell(false, rightRule)
+		seam[i] = m.seamCell(leftRule, rightRule)
 	}
 	frame = append(frame, paint(hruleJoined(m.width, leftWidth, "┬"), m.width, backdropHex()))
 	frame = append(frame, joinColumns(
-		rail,
+		paintContent(railRows, leftWidth, bodyHeight, panelHex()),
 		seam,
 		paintContent(contentRows, contentWidth, bodyHeight, backdropHex()),
 	)...)

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -35,26 +35,29 @@ func (m *Model) viewListFrame() string {
 	for _, line := range m.viewHeaderRows() {
 		frame = append(frame, paint(line, m.width, backdropHex()))
 	}
-	// The rail's fill runs flush: from the header's rule to the footer's
-	// and from the window edge to the seam, one solid pane. The window
-	// padding around the grid carries the backdrop tone via the terminal
-	// background sync, so the pane reads as filling its box exactly.
+	// The rail's fill runs flush from the window edge through the seam
+	// column, then bleeds half a cell further right, and half a cell above
+	// and below its body rows — soft edges drawn with half blocks, the
+	// finest step a character cell allows. The window padding around the
+	// grid carries the backdrop tone via the terminal background sync.
+	bleedWidth := contentWidth - 1
 	railRows := m.railLines(leftWidth, bodyHeight)
-	contentRows := m.contentLines(contentWidth-2*contentGutter, bodyHeight)
+	contentRows := m.contentLines(bleedWidth-2*contentGutter, bodyHeight)
 	seam := make([]string, bodyHeight)
 	for i := range seam {
 		leftRule := i < len(railRows) && railRows[i].rule
 		rightRule := i < len(contentRows) && contentRows[i].rule
 		seam[i] = m.seamCell(leftRule, rightRule)
 	}
-	frame = append(frame, m.boundedRuleRow(leftWidth, m.width, "┬"))
+	frame = append(frame, m.boundedRuleRow(leftWidth+1, m.width, "▄"))
 	frame = append(frame, joinColumns(
 		paintContent(railRows, leftWidth, bodyHeight, panelHex()),
 		seam,
-		paintContent(contentRows, contentWidth, bodyHeight, backdropHex()),
+		m.bleedColumn(bodyHeight),
+		paintContent(contentRows, bleedWidth, bodyHeight, backdropHex()),
 	)...)
 	frame = append(frame,
-		m.boundedRuleRow(leftWidth, m.width, "┴"),
+		m.boundedRuleRow(leftWidth+1, m.width, "▀"),
 		paint(m.viewStatus(), m.width, backdropHex()),
 	)
 	for _, line := range splitLines(footer) {

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -35,17 +35,22 @@ func (m *Model) viewListFrame() string {
 	for _, line := range m.viewHeaderRows() {
 		frame = append(frame, paint(line, m.width, backdropHex()))
 	}
-	railRows := m.railLines(leftWidth, bodyHeight)
+	// The rail card leaves its first column unpainted so its fill never
+	// touches the window edge; see the surface rules in surface.go.
+	railRows := m.railLines(leftWidth-1, bodyHeight)
 	contentRows := m.contentLines(contentWidth-2*contentGutter, bodyHeight)
 	seam := make([]string, bodyHeight)
+	margin := make([]string, bodyHeight)
 	for i := range seam {
 		leftRule := i < len(railRows) && railRows[i].rule
 		rightRule := i < len(contentRows) && contentRows[i].rule
 		seam[i] = m.seamCell(leftRule, rightRule)
+		margin[i] = paint("", 1, backdropHex())
 	}
 	frame = append(frame, paint(hruleJoined(m.width, leftWidth, "┬"), m.width, backdropHex()))
 	frame = append(frame, joinColumns(
-		paintContent(railRows, leftWidth, bodyHeight, panelHex()),
+		margin,
+		paintContent(railRows, leftWidth-1, bodyHeight, panelHex()),
 		seam,
 		paintContent(contentRows, contentWidth, bodyHeight, backdropHex()),
 	)...)

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -15,7 +15,7 @@ import (
 // the content column's. Consistent insets are what make an unbordered
 // layout read as columns.
 const (
-	railGutter    = 3
+	railGutter    = 2
 	contentGutter = 2
 )
 
@@ -29,10 +29,11 @@ func (m *Model) viewListFrame() string {
 	// One column goes to the seam between the rail and the content.
 	contentWidth := rightWidth - 1
 
-	frame := []string{
-		paint(m.viewHeader(), m.width, backdropHex()),
-		paint(hrule(m.width), m.width, backdropHex()),
+	frame := []string{}
+	for _, line := range m.viewHeaderRows() {
+		frame = append(frame, paint(line, m.width, backdropHex()))
 	}
+	frame = append(frame, paint(hrule(m.width), m.width, backdropHex()))
 	frame = append(frame, joinColumns(
 		paintRows(m.railLines(leftWidth, bodyHeight), leftWidth, bodyHeight, panelHex()),
 		m.vruleColumn(bodyHeight),
@@ -183,7 +184,7 @@ func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad,
 	if selected {
 		metaStyle = mutedStyle
 	}
-	age := metaStyle.Render(relTime(lastActivity(sess)))
+	age := metaStyle.Render(relSince(lastActivity(sess)))
 	meta := pad + indent + "  " +
 		lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusLabel(sess.Status)) +
 		metaStyle.Render(" · "+sess.Tool)
@@ -323,9 +324,9 @@ func (m *Model) viewDetail(width int) string {
 	title := lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(sess.Name)
 	state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).
 		Render(statusGlyph(sess.Status)+" "+statusLabel(sess.Status)) +
-		subtleStyle.Render(" · "+relTime(lastActivity(sess)))
+		subtleStyle.Render(" · "+relSince(lastActivity(sess)))
 
-	facts := []string{tool, displayGroup(sess.Group), "started " + relTime(sess.CreatedAt) + " ago"}
+	facts := []string{tool, displayGroup(sess.Group), "started " + relSince(sess.CreatedAt)}
 	if m.procFor == sess.ID && m.proc.OK {
 		facts = append(facts, fmt.Sprintf("%.1f%% · %s", m.proc.CPUPercent, humanBytes(m.proc.RSS)))
 	}
@@ -409,7 +410,7 @@ func (m *Model) viewGroupAgents(group string, width, height int) string {
 		}
 		dot := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
 		line := rowColumns(dot+" "+valueStyle.Render(sess.Name),
-			subtleStyle.Render(sess.Tool+" · "+relTime(lastActivity(sess))), width)
+			subtleStyle.Render(sess.Tool+" · "+relSince(lastActivity(sess))), width)
 		lines = append(lines, line)
 		shown++
 	}
@@ -446,9 +447,41 @@ func (m *Model) viewQuickBar(width int) string {
 	return subtleStyle.Render(target) + "\n" + m.quick.input.View()
 }
 
-// viewHeader is the top line: the product mark, what is on screen, and the
-// fleet rollup pushed to the right edge.
-func (m *Model) viewHeader() string {
+// viewHeaderRows is the header block: the wordmark when there is room for
+// it, with the scope line and the fleet rollup set against the right edge
+// on the wordmark's own rows.
+func (m *Model) viewHeaderRows() []string {
+	if !m.showBanner() {
+		return []string{m.viewHeader()}
+	}
+	// Each header row offers its readings richest-first and takes the
+	// widest one that still clears the wordmark.
+	right := [][]string{
+		{m.headerScope()},
+		{m.viewStatusCounts(false), m.viewStatusCounts(true)},
+		{m.headerAgents()},
+	}
+	rows := m.viewBanner()
+	for i := range rows {
+		if i >= len(right) {
+			continue
+		}
+		for _, text := range right[i] {
+			if text == "" {
+				continue
+			}
+			gap := m.width - railGutter - ansi.StringWidth(rows[i]) - ansi.StringWidth(text)
+			if gap >= 2 {
+				rows[i] += strings.Repeat(" ", gap) + text
+				break
+			}
+		}
+	}
+	return rows
+}
+
+// headerScope names what the list is showing and badges a newer release.
+func (m *Model) headerScope() string {
 	scope := "active"
 	if m.showArchived {
 		scope = "archived"
@@ -459,18 +492,31 @@ func (m *Model) viewHeader() string {
 			sessionCount++
 		}
 	}
-	left := strings.Repeat(" ", railGutter) +
-		lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("agent manager") +
-		subtleStyle.Render(fmt.Sprintf("   %d %s", sessionCount, scope))
+	line := valueStyle.Render(fmt.Sprintf("%d", sessionCount)) + subtleStyle.Render(" "+scope)
 	if m.updateLatest != "" {
-		left += subtleStyle.Render("   ") +
+		line += subtleStyle.Render("   ") +
 			lipgloss.NewStyle().Foreground(colorAccent).Render("↑ "+m.updateLatest+" available")
 	}
+	return line
+}
 
-	agents := ""
-	if m.agents.count > 0 {
-		agents = subtleStyle.Render(fmt.Sprintf("%.0f%% · %s", m.agents.cpu, humanBytes(m.agents.rss)))
+// headerAgents is the fleet's process cost, empty when nothing is running.
+func (m *Model) headerAgents() string {
+	if m.agents.count == 0 {
+		return ""
 	}
+	return subtleStyle.Render(fmt.Sprintf("%.0f%% · %s", m.agents.cpu, humanBytes(m.agents.rss)))
+}
+
+// viewHeader is the single-line header used when the terminal is too narrow
+// for the wordmark: the product mark, what is on screen, and the fleet
+// rollup pushed to the right edge.
+func (m *Model) viewHeader() string {
+	left := strings.Repeat(" ", railGutter) +
+		lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render(bannerWord) +
+		subtleStyle.Render("   ") + m.headerScope()
+
+	agents := m.headerAgents()
 	for _, right := range []string{
 		joinHeaderRight(m.viewStatusCounts(false), agents),
 		joinHeaderRight(m.viewStatusCounts(true), agents),

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -289,7 +289,7 @@ func (m *Model) contentLines(width, height int) []contentLine {
 	body := ours(splitLines(m.viewDetail(width)))
 	rest := height - len(body) - len(bar) - 1
 	if rest >= 3 {
-		body = append(body, contentLine{text: hrule(width)})
+		body = append(body, contentLine{rule: true})
 		if group, ok := m.selectedGroup(); ok {
 			body = append(body, ours(splitLines(m.viewGroupAgents(group, width, rest)))...)
 		} else {

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -23,13 +23,15 @@ func (m *Model) card(title, body, hint string) string {
 	header := badgeStyle.Render(title)
 	content := header + "\n\n" + body
 	if m.err != "" {
-		content += "\n" + errStyle.Render("✖ "+m.err)
+		content += "\n" + errStyle.Render("✕ "+m.err)
 	}
-	content += "\n\n" + subtleStyle.Render(hint)
+	rule := lipgloss.NewStyle().Foreground(colorBorder).
+		Render(strings.Repeat("─", max(width-2*cardPaddingX, 1)))
+	content += "\n\n" + rule + "\n" + subtleStyle.Render(hint)
 
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(colorAccent).
+		BorderForeground(colorFocus).
 		Padding(1, cardPaddingX).
 		Width(width).
 		Render(content)
@@ -148,12 +150,24 @@ func (m *Model) viewSettings() string {
 			labelStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 		}
 		picker := subtleStyle.Render("◂ ") + valueStyle.Render(value) + subtleStyle.Render(" ▸")
-		return marker + labelStyle.Render(name) + "  " + picker
+		return marker + padRight(labelStyle.Render(name), 18) + picker
 	}
 	body := row(settingsFieldTool, "quick spawn tool", m.settings.toolNames[m.settings.toolIndex]) + "\n" +
+		row(settingsFieldTheme, "theme", themes[m.settings.themeIndex].Name) + "  " +
+		themeSwatch(themes[m.settings.themeIndex]) + "\n" +
 		row(settingsFieldLayout, "review layout", layout) + "\n\n" +
 		subtleStyle.Render("  version ") + valueStyle.Render(m.version) + m.versionStatus()
 	return m.card("⚙ Settings", body, "↑↓ field · ←→ change · ↵/esc save")
+}
+
+// themeSwatch previews a palette as a run of blocks, so a theme can be
+// picked by eye rather than by name.
+func themeSwatch(t Theme) string {
+	var b strings.Builder
+	for _, hex := range []string{t.Accent, t.Accent2, t.Working, t.Waiting, t.Finished, t.Errored} {
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(hex)).Render("█"))
+	}
+	return b.String()
 }
 
 // versionStatus reports whether a newer release is known, as a suffix for

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -9,7 +9,7 @@ import (
 
 func (m *Model) cardWidth() int {
 	width := 60
-	if width > m.width-4 {
+	if m.width >= 28 && width > m.width-4 {
 		width = m.width - 4
 	}
 	return width
@@ -17,25 +17,44 @@ func (m *Model) cardWidth() int {
 
 const cardPaddingX = 3
 
-// card centers a bordered modal with a title and footer hint.
+// card floats a modal on the app backdrop: a lifted panel, no border, its
+// title set in accent above the body and its keys quietly at the foot.
 func (m *Model) card(title, body, hint string) string {
-	width := m.cardWidth()
-	header := badgeStyle.Render(title)
-	content := header + "\n\n" + body
+	return m.cardSized(m.cardWidth(), title, body, hint)
+}
+
+// cardSized is card at an explicit width, for the key map, whose lines are
+// too long to read inside the default column.
+func (m *Model) cardSized(width int, title, body, hint string) string {
+	head := lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render(title)
+	content := head + "\n\n" + body
 	if m.err != "" {
 		content += "\n" + errStyle.Render("✕ "+m.err)
 	}
-	rule := lipgloss.NewStyle().Foreground(colorBorder).
-		Render(strings.Repeat("─", max(width-2*cardPaddingX, 1)))
-	content += "\n\n" + rule + "\n" + subtleStyle.Render(hint)
+	content += "\n\n" + subtleStyle.Render(hint)
 
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(colorFocus).
-		Padding(1, cardPaddingX).
-		Width(width).
-		Render(content)
-	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
+	inner := width - 2*cardPaddingX
+	pad := strings.Repeat(" ", cardPaddingX)
+	var lines []string
+	lines = append(lines, paint("", width, blockHex()))
+	for _, line := range strings.Split(content, "\n") {
+		lines = append(lines, paint(pad+padRight(line, inner), width, blockHex()))
+	}
+	lines = append(lines, paint("", width, blockHex()))
+
+	height := max(m.height, len(lines))
+	left := max((m.width-width)/2, 0)
+	frameWidth := max(m.width, left+width)
+	top := max((height-len(lines))/2, 0)
+	frame := make([]string, 0, height)
+	for i := 0; i < height; i++ {
+		row := ""
+		if i >= top && i-top < len(lines) {
+			row = paint("", left, backdropHex()) + lines[i-top]
+		}
+		frame = append(frame, paint(row, frameWidth, backdropHex()))
+	}
+	return strings.Join(frame, "\n")
 }
 
 func (m *Model) viewForm() string {
@@ -195,6 +214,7 @@ func (m *Model) viewHelp() string {
 		{"g", "new group (name, parent, default path)"},
 		{"r", "rename session / edit group (name + default path)"},
 		{"v", "revive dead session (resumes the agent)"},
+		{"V", "revive every dead session"},
 		{"a / u", "archive / restore"},
 		{"d", "delete session, or group + subtree"},
 		{"shift+↑↓", "reorder row up / down"},
@@ -219,7 +239,11 @@ func (m *Model) viewHelp() string {
 	for _, binding := range rows {
 		b.WriteString(keyStyle.Width(10).Render(binding[0]) + mutedStyle.Render(binding[1]) + "\n")
 	}
-	return m.card("? Keys", strings.TrimRight(b.String(), "\n"), "any key to close")
+	width := 92
+	if m.width >= 28 && width > m.width-4 {
+		width = m.width - 4
+	}
+	return m.cardSized(width, "? Keys", strings.TrimRight(b.String(), "\n"), "any key to close")
 }
 
 func formField(label, value string, focused bool) string {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -238,6 +238,33 @@ type previewSettleMsg struct {
 // a held j/k burst into a single capture.
 const previewSettle = 50 * time.Millisecond
 
+// The selected session's pane is re-captured on its own timer. The full
+// poll is deliberately slow (it lists panes, samples every process tree and
+// writes the store), which left the preview refreshing on the poll cadence
+// and reading as a still image of a live agent. One capture of one pane is
+// cheap, but it is still a tmux exec, so the rate follows the session: an
+// agent that is producing output earns a fast cadence, one that is waiting
+// on a human does not.
+const (
+	previewIntervalLive = 300 * time.Millisecond
+	previewIntervalCalm = 1200 * time.Millisecond
+)
+
+// previewTickMsg drives that timer.
+type previewTickMsg struct{}
+
+// previewTick re-arms the preview timer at the cadence the selection earns.
+func (m *Model) previewTick() tea.Cmd {
+	interval := previewIntervalCalm
+	if sess, ok := m.selected(); ok {
+		switch sess.Status {
+		case status.Working, status.Starting:
+			interval = previewIntervalLive
+		}
+	}
+	return tea.Tick(interval, func(time.Time) tea.Msg { return previewTickMsg{} })
+}
+
 type errMsg struct{ err error }
 
 type attachDoneMsg struct {
@@ -346,7 +373,7 @@ func (m *Model) requestRefresh() {
 
 func (m *Model) Init() tea.Cmd {
 	m.syncPollInput()
-	return tea.Batch(m.refreshExistingSessionUX, m.checkForUpdate, m.bannerTick())
+	return tea.Batch(m.refreshExistingSessionUX, m.checkForUpdate, m.bannerTick(), m.previewTick())
 }
 
 // updateMsg carries the result of the background GitHub release check.
@@ -534,6 +561,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case bannerTickMsg:
 		m.bannerPhase++
 		return m, m.bannerTick()
+
+	case previewTickMsg:
+		// Only the list keeps a live pane on screen; review and the modal
+		// screens have no preview to feed, so they skip the capture and
+		// just keep the timer alive.
+		sess, ok := m.selected()
+		if !ok || (m.mode != modeList && m.mode != modeRename) {
+			return m, m.previewTick()
+		}
+		return m, tea.Batch(m.previewCmd(sess, m.previewGen), m.previewTick())
 
 	case refreshMsg:
 		m.ageError()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -540,6 +540,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if !m.sessionsSized && m.width > 0 && len(m.sessions) > 0 {
 			m.sessionsSized = true
+			// Sessions left from a previous run carry that run's window
+			// size, which our cache knows nothing about, so the first pass
+			// re-asserts geometry for every one of them.
+			m.paneGeom = nil
 			m.resizeSessions()
 		}
 		m.rebuildRows()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -121,6 +121,10 @@ type Model struct {
 	// queue a second of tmux work after the user stops.
 	previewGen uint64
 
+	// bannerPhase advances the wordmark's intro sweep and then stops, so
+	// the frame is not repainted forever.
+	bannerPhase int
+
 	// version is this build's release tag; updateLatest/updateURL hold a
 	// newer release found on GitHub so the header can badge it.
 	version      string
@@ -342,7 +346,7 @@ func (m *Model) requestRefresh() {
 
 func (m *Model) Init() tea.Cmd {
 	m.syncPollInput()
-	return tea.Batch(m.refreshExistingSessionUX, m.checkForUpdate)
+	return tea.Batch(m.refreshExistingSessionUX, m.checkForUpdate, m.bannerTick())
 }
 
 // updateMsg carries the result of the background GitHub release check.
@@ -526,6 +530,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.paneGeom = nil
 		m.resizeSessions()
 		return m, nil
+
+	case bannerTickMsg:
+		m.bannerPhase++
+		return m, m.bannerTick()
 
 	case refreshMsg:
 		m.ageError()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -182,12 +182,14 @@ type quickImageMsg struct {
 type settingsState struct {
 	toolNames   []string
 	toolIndex   int
+	themeIndex  int
 	field       int
 	layoutSplit bool
 }
 
 const (
 	settingsFieldTool = iota
+	settingsFieldTheme
 	settingsFieldLayout
 	settingsFieldCount
 )
@@ -249,6 +251,7 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 	// A missing git binary only disables the diff view; everything else
 	// works without it, so the error surfaces on first use instead.
 	gitDriver, _ := git.New()
+	applyTheme(themes[themeIndex(storedTheme(st))])
 	return &Model{
 		cfg:         cfg,
 		store:       st,
@@ -262,6 +265,16 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 		mode:        modeList,
 		version:     version,
 	}
+}
+
+// storedTheme reads the persisted theme name. A read failure falls back to
+// the default theme: the UI still paints, just not in the chosen palette.
+func storedTheme(st *store.Store) string {
+	name, err := st.Setting(themeSetting)
+	if err != nil {
+		return ""
+	}
+	return name
 }
 
 const collapsedSetting = "collapsed_groups"

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -553,6 +553,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.width = msg.Width
 		m.height = msg.Height
+		// Re-assert the terminal backdrop: a reattach or a fresh outer
+		// terminal delivers a size message and may carry stale colors.
+		SyncTerminalBackground()
 		// Geometry cache is stale for every session after a real resize.
 		m.paneGeom = nil
 		m.resizeSessions()

--- a/internal/ui/preview_live_test.go
+++ b/internal/ui/preview_live_test.go
@@ -1,0 +1,50 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The preview has to follow the pane on its own, without the cursor being
+// touched: a manager whose preview only refreshes on selection is a
+// screenshot, not a monitor.
+func TestPreviewFollowsPaneWithoutCursorMoves(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "watcher", t.TempDir(), "")
+	m.selectSessionRow(t, "watcher")
+	sess := m.sessionRows()[0]
+
+	waitForPane := func(marker string) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			// Only the poll cycle runs here; nothing selects or moves.
+			m.applyCmd(t, m.refreshCmd())
+			if strings.Contains(ansi.Strip(m.preview), marker) {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("preview never picked up %q, has:\n%s", marker, ansi.Strip(m.preview))
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	if err := m.tmux.SendText(sess.ID, "first-line"); err != nil {
+		t.Fatalf("send text: %v", err)
+	}
+	waitForPane("first-line")
+
+	if err := m.tmux.SendText(sess.ID, "second-line"); err != nil {
+		t.Fatalf("send text: %v", err)
+	}
+	waitForPane("second-line")
+
+	// The frame has to carry it too, not just the model field.
+	if view := ansi.Strip(m.View()); !strings.Contains(view, "second-line") {
+		t.Fatalf("frame missing the newest pane content:\n%s", view)
+	}
+}

--- a/internal/ui/review_regression_test.go
+++ b/internal/ui/review_regression_test.go
@@ -1496,7 +1496,7 @@ func TestReviewHeaderTargetLabelCleanAndKeyed(t *testing.T) {
 	}
 
 	header := ansi.Strip(m.viewDiffHeader("hdr"))
-	if !strings.Contains(header, "B ") || !strings.Contains(header, "▏") {
+	if !strings.Contains(header, "B ") || !strings.Contains(header, "main") {
 		t.Fatalf("target pill should wear its B key, got %q", header)
 	}
 	if strings.Contains(header, "@") {

--- a/internal/ui/row_contrast_test.go
+++ b/internal/ui/row_contrast_test.go
@@ -42,8 +42,8 @@ func TestSelectedRowMetaUsesBrightNotSubtle(t *testing.T) {
 			CreatedAt: time.Now().Add(-3 * time.Hour),
 		},
 	}
-	selected := m.renderTreeRow(entry, true, 80)
-	unselected := m.renderTreeRow(entry, false, 80)
+	selected := m.renderTreeRow(entry, true, 80, 0)
+	unselected := m.renderTreeRow(entry, false, 80, 0)
 
 	if !strings.Contains(selected, "\x1b[") {
 		t.Fatal("selected row has no SGR; color profile not active")

--- a/internal/ui/row_contrast_test.go
+++ b/internal/ui/row_contrast_test.go
@@ -59,7 +59,7 @@ func TestSelectedRowMetaUsesBrightNotSubtle(t *testing.T) {
 	if !strings.Contains(selected, brightSeq) {
 		t.Fatalf("selected row missing the bright reapply fg %q:\n%q", brightSeq, selected)
 	}
-	if !strings.Contains(selected, " · grok · ") {
+	if !strings.Contains(selected, " · grok") {
 		t.Fatalf("selected missing meta text:\n%q", selected)
 	}
 }

--- a/internal/ui/row_contrast_test.go
+++ b/internal/ui/row_contrast_test.go
@@ -18,6 +18,17 @@ func forceANSI256(t *testing.T) {
 	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
 }
 
+// sgrOf returns the color sequence a style emits under the active profile,
+// so contrast assertions track the live theme instead of a hardcoded index.
+func sgrOf(rendered string) string {
+	_, seq, found := strings.Cut(rendered, "\x1b[")
+	if !found {
+		return ""
+	}
+	code, _, _ := strings.Cut(seq, "m")
+	return code
+}
+
 func TestSelectedRowMetaUsesBrightNotSubtle(t *testing.T) {
 	forceANSI256(t)
 
@@ -37,14 +48,16 @@ func TestSelectedRowMetaUsesBrightNotSubtle(t *testing.T) {
 	if !strings.Contains(selected, "\x1b[") {
 		t.Fatal("selected row has no SGR; color profile not active")
 	}
-	if strings.Contains(selected, "38;5;240") {
-		t.Fatalf("selected row still uses subtle fg 240:\n%q", selected)
+	subtleSeq := sgrOf(subtleStyle.Render("x"))
+	brightSeq := sgrOf(lipgloss.NewStyle().Foreground(colorBright).Render("x"))
+	if strings.Contains(selected, subtleSeq) {
+		t.Fatalf("selected row still uses the subtle fg %q:\n%q", subtleSeq, selected)
 	}
-	if !strings.Contains(unselected, "38;5;240") {
-		t.Fatalf("unselected row should use subtle fg 240:\n%q", unselected)
+	if !strings.Contains(unselected, subtleSeq) {
+		t.Fatalf("unselected row should use the subtle fg %q:\n%q", subtleSeq, unselected)
 	}
-	if !strings.Contains(selected, "38;5;231") {
-		t.Fatalf("selected row missing bright reapply fg 231:\n%q", selected)
+	if !strings.Contains(selected, brightSeq) {
+		t.Fatalf("selected row missing the bright reapply fg %q:\n%q", brightSeq, selected)
 	}
 	if !strings.Contains(selected, " · grok · ") {
 		t.Fatalf("selected missing meta text:\n%q", selected)

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -40,6 +41,13 @@ func TestZZShot(t *testing.T) {
 		m.version = "0.9.2"
 	case "help":
 		m.mode = modeHelp
+	}
+	if phase := os.Getenv("AM_SHOT_PHASE"); phase != "" {
+		n, err := strconv.Atoi(phase)
+		if err != nil {
+			t.Fatal(err)
+		}
+		m.bannerPhase = n
 	}
 	if err := os.WriteFile(out, []byte(m.View()), 0o644); err != nil {
 		t.Fatal(err)
@@ -107,15 +115,23 @@ const previewSample = "\x1b[38;5;110m◆\x1b[0m claude \x1b[38;5;240m·\x1b[0m a
 	"\x1b[38;5;214m✳\x1b[0m Running tests… (14s · esc to interrupt)\n"
 
 // A frame line wider than the terminal wraps, which pushes the whole
-// layout down a row and tears the panels. Every line the list frame paints
-// has to fit, at any width the panels still make sense at.
-func TestFrameLinesFitTerminalWidth(t *testing.T) {
+// layout down a row and tears the panels. A frame with more rows than the
+// terminal loses its footer to the clamp. Both have to hold at every size
+// the layout still makes sense at, including the width where the header
+// swaps between the wordmark and its one-line form.
+func TestFrameFitsTerminal(t *testing.T) {
 	for _, width := range []int{80, 100, 120, 160, 200} {
-		m := shotModel()
-		m.width = width
-		for i, line := range strings.Split(m.View(), "\n") {
-			if got := ansi.StringWidth(line); got > width {
-				t.Errorf("width %d: line %d is %d wide: %q", width, i, got, ansi.Strip(line))
+		for _, height := range []int{24, 34, 50} {
+			m := shotModel()
+			m.width, m.height = width, height
+			lines := strings.Split(m.View(), "\n")
+			if len(lines) != height {
+				t.Errorf("%dx%d: frame has %d rows", width, height, len(lines))
+			}
+			for i, line := range lines {
+				if got := ansi.StringWidth(line); got > width {
+					t.Errorf("%dx%d: line %d is %d wide: %q", width, height, i, got, ansi.Strip(line))
+				}
 			}
 		}
 	}

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -124,10 +124,13 @@ func TestFrameFitsTerminal(t *testing.T) {
 		for _, height := range []int{24, 34, 50} {
 			m := shotModel()
 			m.width, m.height = width, height
-			lines := strings.Split(m.View(), "\n")
-			if len(lines) != height {
-				t.Errorf("%dx%d: frame has %d rows", width, height, len(lines))
+			// View clamps and pads, which would hide a frame that is a row
+			// short or a row long, so the raw frame is what gets measured.
+			raw := strings.Split(m.viewListFrame(), "\n")
+			if len(raw) != height {
+				t.Errorf("%dx%d: frame paints %d rows", width, height, len(raw))
 			}
+			lines := strings.Split(m.View(), "\n")
 			for i, line := range lines {
 				if got := ansi.StringWidth(line); got > width {
 					t.Errorf("%dx%d: line %d is %d wide: %q", width, height, i, got, ansi.Strip(line))

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -140,10 +140,12 @@ func TestFrameFitsTerminal(t *testing.T) {
 	}
 }
 
-// The pane's soft edges: the opening row bleeds down with ▄, the closing
-// row up with ▀, and every body row ends with the ▌ half-block edge one
-// column past the seam, so the fill extends half a cell beyond its box on
-// all three sides.
+// The pane's soft edges: the opening row bleeds down, the closing row up,
+// and every body row ends with the ▐ half-block edge one column past the
+// seam. The end cells of the edge rows are the corners: the first is a
+// foreground half block so the window margin cannot inherit pane tone and
+// smear past the corner, and the last is a quadrant so the bleed's
+// half-cell fill closes at the corner instead of jutting right.
 func TestPaneSoftEdges(t *testing.T) {
 	m := shotModel()
 	rows := strings.Split(m.View(), "\n")
@@ -151,7 +153,11 @@ func TestPaneSoftEdges(t *testing.T) {
 
 	top := []rune(ansi.Strip(rows[m.headerRows()]))
 	bottom := []rune(ansi.Strip(rows[m.headerRows()+1+m.listBodyHeight()]))
-	for col := 0; col <= leftWidth+1; col++ {
+	if top[0] != '▄' || bottom[0] != '▀' {
+		t.Fatalf("edge rows should open with foreground half blocks, got %q and %q",
+			string(top[0]), string(bottom[0]))
+	}
+	for col := 1; col <= leftWidth; col++ {
 		if top[col] != '▀' {
 			t.Fatalf("top edge col %d is %q, want ▀:\n%s", col, string(top[col]), string(top))
 		}
@@ -159,11 +165,18 @@ func TestPaneSoftEdges(t *testing.T) {
 			t.Fatalf("bottom edge col %d is %q, want ▄:\n%s", col, string(bottom[col]), string(bottom))
 		}
 	}
+	if top[leftWidth+1] != '▜' || bottom[leftWidth+1] != '▟' {
+		t.Fatalf("edge rows should close with corner quadrants, got %q and %q",
+			string(top[leftWidth+1]), string(bottom[leftWidth+1]))
+	}
 	if top[leftWidth+2] == '▀' || bottom[leftWidth+2] == '▄' {
 		t.Fatalf("the bleed should stop after the seam's edge column")
 	}
 	for i := m.headerRows() + 1; i < m.headerRows()+1+m.listBodyHeight(); i++ {
 		row := []rune(ansi.Strip(rows[i]))
+		if cell := row[0]; cell != '█' {
+			t.Fatalf("row %d: first column is %q, want █:\n%s", i, string(cell), string(row))
+		}
 		if cell := row[leftWidth+1]; cell != '▐' && cell != '─' {
 			t.Fatalf("row %d: edge column is %q, want ▐:\n%s", i, string(cell), string(row))
 		}

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -51,7 +51,8 @@ func shotModel() *Model {
 	sess := func(name, group, tool, st string, age time.Duration) store.Session {
 		return store.Session{
 			ID: name, Name: name, Group: group, Tool: tool, Status: st,
-			Cwd: "/Users/yoan/dev/spaze/api", CreatedAt: now.Add(-age),
+			Cwd: "/Users/yoan/dev/spaze/api", CreatedAt: now.Add(-24 * time.Hour),
+			LastStatusAt: now.Add(-age),
 		}
 	}
 	sessions := []store.Session{

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -167,7 +167,7 @@ func TestSeamJunctionsMeetTheRules(t *testing.T) {
 		}
 		cell := row[seamCol]
 		switch cell {
-		case '│', '├':
+		case '│', '├', '┤', '┼':
 			sawTee[cell] = true
 		default:
 			t.Fatalf("row %d: seam cell is %q, not a joint glyph:\n%s", i, string(cell), string(row))
@@ -176,7 +176,7 @@ func TestSeamJunctionsMeetTheRules(t *testing.T) {
 	if footer := ansi.Strip(rows[m.headerRows()+1+m.listBodyHeight()]); []rune(footer)[seamCol] != '┴' {
 		t.Fatalf("closing rule carries no ┴ at the seam: %q", footer)
 	}
-	if !sawTee['├'] {
-		t.Fatalf("the content rule never tees into the seam: %v", sawTee)
+	if !sawTee['├'] || !sawTee['┤'] {
+		t.Fatalf("body rules never tee into the seam: %v", sawTee)
 	}
 }

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -139,3 +139,44 @@ func TestFrameFitsTerminal(t *testing.T) {
 		}
 	}
 }
+
+// Every cell of the column seam must be a joint glyph, and the rules that
+// cross it must land as junctions, not butt against a bare bar.
+func TestSeamJunctionsMeetTheRules(t *testing.T) {
+	m := shotModel()
+	rows := strings.Split(m.View(), "\n")
+	// Columns are counted in runes: the rule row is all multi-byte glyphs,
+	// so a byte index would name a column far right of the real seam.
+	header := []rune(ansi.Strip(rows[m.headerRows()]))
+	seamCol := -1
+	for i, r := range header {
+		if r == '┬' {
+			seamCol = i
+			break
+		}
+	}
+	if seamCol < 0 {
+		t.Fatalf("header rule carries no ┬:\n%s", string(header))
+	}
+
+	sawTee := map[rune]bool{}
+	for i := m.headerRows() + 1; i < m.headerRows()+1+m.listBodyHeight(); i++ {
+		row := []rune(ansi.Strip(rows[i]))
+		if seamCol >= len(row) {
+			t.Fatalf("row %d shorter than the seam column: %q", i, string(row))
+		}
+		cell := row[seamCol]
+		switch cell {
+		case '│', '├', '┤', '┼':
+			sawTee[cell] = true
+		default:
+			t.Fatalf("row %d: seam cell is %q, not a joint glyph:\n%s", i, string(cell), string(row))
+		}
+	}
+	if footer := ansi.Strip(rows[m.headerRows()+1+m.listBodyHeight()]); []rune(footer)[seamCol] != '┴' {
+		t.Fatalf("closing rule carries no ┴ at the seam: %q", footer)
+	}
+	if !sawTee['├'] || !sawTee['┤'] {
+		t.Fatalf("body rules never tee into the seam: %v", sawTee)
+	}
+}

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -167,7 +167,7 @@ func TestSeamJunctionsMeetTheRules(t *testing.T) {
 		}
 		cell := row[seamCol]
 		switch cell {
-		case '│', '├', '┤', '┼':
+		case '│', '├':
 			sawTee[cell] = true
 		default:
 			t.Fatalf("row %d: seam cell is %q, not a joint glyph:\n%s", i, string(cell), string(row))
@@ -176,7 +176,7 @@ func TestSeamJunctionsMeetTheRules(t *testing.T) {
 	if footer := ansi.Strip(rows[m.headerRows()+1+m.listBodyHeight()]); []rune(footer)[seamCol] != '┴' {
 		t.Fatalf("closing rule carries no ┴ at the seam: %q", footer)
 	}
-	if !sawTee['├'] || !sawTee['┤'] {
-		t.Fatalf("body rules never tee into the seam: %v", sawTee)
+	if !sawTee['├'] {
+		t.Fatalf("the content rule never tees into the seam: %v", sawTee)
 	}
 }

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -1,0 +1,121 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/sysstat"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+)
+
+// TestZZShot renders a full frame to disk for visual review. Skipped
+// unless AM_SHOT names an output path.
+func TestZZShot(t *testing.T) {
+	out := os.Getenv("AM_SHOT")
+	if out == "" {
+		t.Skip("set AM_SHOT to render a frame")
+	}
+	if name := os.Getenv("AM_SHOT_THEME"); name != "" {
+		applyTheme(themes[themeIndex(name)])
+		t.Cleanup(func() { applyTheme(themes[0]) })
+	}
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	m := shotModel()
+	switch os.Getenv("AM_SHOT_MODE") {
+	case "settings":
+		m.mode = modeSettings
+		m.settings = settingsState{
+			toolNames: []string{"claude", "codex", "grok", "opencode"},
+			toolIndex: 0, themeIndex: 1, field: settingsFieldTheme, layoutSplit: true,
+		}
+		m.version = "0.9.2"
+	case "help":
+		m.mode = modeHelp
+	}
+	if err := os.WriteFile(out, []byte(m.View()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func shotModel() *Model {
+	now := time.Now()
+	sess := func(name, group, tool, st string, age time.Duration) store.Session {
+		return store.Session{
+			ID: name, Name: name, Group: group, Tool: tool, Status: st,
+			Cwd: "/Users/yoan/dev/spaze/api", CreatedAt: now.Add(-age),
+		}
+	}
+	sessions := []store.Session{
+		sess("db-migrations", "", "opencode", status.Waiting, 3*time.Minute),
+		sess("notes", "", "grok", status.Idle, 12*time.Minute),
+		sess("auth-refresh", "backend", "claude", status.Finished, 2*time.Minute),
+		sess("add-rate-limiting", "backend", "claude", status.Working, 41*time.Second),
+		sess("ui-polish", "backend/web", "codex", status.Working, 6*time.Minute),
+		sess("flaky-e2e", "backend/web", "claude", status.Errored, 22*time.Minute),
+	}
+	rows := []treeRow{
+		{sess: sessions[0]},
+		{sess: sessions[1]},
+		{isGroup: true, group: "backend"},
+		{depth: 1, sess: sessions[2]},
+		{depth: 1, sess: sessions[3]},
+		{isGroup: true, group: "backend/web", depth: 1},
+		{depth: 2, sess: sessions[4]},
+		{depth: 2, sess: sessions[5]},
+	}
+	m := &Model{
+		width: 120, height: 34, mode: modeList, cursor: 4,
+		sessions: sessions, rows: rows, collapsed: map[string]bool{},
+		groupPaths: map[string]string{"backend": "/Users/yoan/dev/spaze/api"},
+		splitRatio: defaultSplitRatio,
+		agents:     agentStats{count: 4, cpu: 37, rss: 1_530_000_000},
+		netRates:   true, netDown: 9_400_000, netUp: 2_100_000,
+		snap: sysstat.Snapshot{
+			CPUOK: true, CPUPercent: 22,
+			MemOK: true, MemPercent: 75, MemUsed: 12_100_000_000, MemTotal: 16_000_000_000,
+			SwapOK: true, SwapPercent: 43, SwapUsed: 4_500_000_000, SwapTotal: 8_000_000_000,
+			DiskOK: true, DiskPercent: 88, DiskUsed: 400_000_000_000, DiskTotal: 500_000_000_000,
+			CPUTempOK: true, CPUTemp: 61, GPUTempOK: true, GPUTemp: 55,
+		},
+		preview: previewSample,
+		proc:    sysstat.ProcStat{OK: true, CPUPercent: 4.2, RSS: 612_000_000},
+		procFor: "add-rate-limiting",
+	}
+	return m
+}
+
+const previewSample = "\x1b[38;5;110m◆\x1b[0m claude \x1b[38;5;240m·\x1b[0m add-rate-limiting\n" +
+	"\n" +
+	"\x1b[38;5;250m❯ Add a token bucket limiter to the public API\x1b[0m\n" +
+	"\n" +
+	"\x1b[38;5;240m●\x1b[0m Read(internal/api/router.go)\n" +
+	"  \x1b[38;5;240m└\x1b[0m 214 lines\n" +
+	"\n" +
+	"\x1b[38;5;240m●\x1b[0m Edit(internal/api/limiter.go)\n" +
+	"  \x1b[38;5;240m└\x1b[0m +48 −3\n" +
+	"\n" +
+	"\x1b[38;5;214m✳\x1b[0m Running tests… (14s · esc to interrupt)\n"
+
+// A frame line wider than the terminal wraps, which pushes the whole
+// layout down a row and tears the panels. Every line the list frame paints
+// has to fit, at any width the panels still make sense at.
+func TestFrameLinesFitTerminalWidth(t *testing.T) {
+	for _, width := range []int{80, 100, 120, 160, 200} {
+		m := shotModel()
+		m.width = width
+		for i, line := range strings.Split(m.View(), "\n") {
+			if got := ansi.StringWidth(line); got > width {
+				t.Errorf("width %d: line %d is %d wide: %q", width, i, got, ansi.Strip(line))
+			}
+		}
+	}
+}

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -167,5 +167,10 @@ func TestPaneSoftEdges(t *testing.T) {
 		if cell := row[leftWidth+1]; cell != '▌' && cell != '─' {
 			t.Fatalf("row %d: edge column is %q, want ▌:\n%s", i, string(cell), string(row))
 		}
+		// The seam is fill, not a drawn line: the glyphs of the old line
+		// seam appearing here mean a stale seam renderer shipped again.
+		if cell := row[leftWidth]; cell != ' ' && cell != '─' {
+			t.Fatalf("row %d: seam column is %q, want pane fill:\n%s", i, string(cell), string(row))
+		}
 	}
 }

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -152,20 +152,20 @@ func TestPaneSoftEdges(t *testing.T) {
 	top := []rune(ansi.Strip(rows[m.headerRows()]))
 	bottom := []rune(ansi.Strip(rows[m.headerRows()+1+m.listBodyHeight()]))
 	for col := 0; col <= leftWidth+1; col++ {
-		if top[col] != '▄' {
-			t.Fatalf("top edge col %d is %q, want ▄:\n%s", col, string(top[col]), string(top))
+		if top[col] != '▀' {
+			t.Fatalf("top edge col %d is %q, want ▀:\n%s", col, string(top[col]), string(top))
 		}
-		if bottom[col] != '▀' {
-			t.Fatalf("bottom edge col %d is %q, want ▀:\n%s", col, string(bottom[col]), string(bottom))
+		if bottom[col] != '▄' {
+			t.Fatalf("bottom edge col %d is %q, want ▄:\n%s", col, string(bottom[col]), string(bottom))
 		}
 	}
-	if top[leftWidth+2] == '▄' || bottom[leftWidth+2] == '▀' {
+	if top[leftWidth+2] == '▀' || bottom[leftWidth+2] == '▄' {
 		t.Fatalf("the bleed should stop after the seam's edge column")
 	}
 	for i := m.headerRows() + 1; i < m.headerRows()+1+m.listBodyHeight(); i++ {
 		row := []rune(ansi.Strip(rows[i]))
-		if cell := row[leftWidth+1]; cell != '▌' && cell != '─' {
-			t.Fatalf("row %d: edge column is %q, want ▌:\n%s", i, string(cell), string(row))
+		if cell := row[leftWidth+1]; cell != '▐' && cell != '─' {
+			t.Fatalf("row %d: edge column is %q, want ▐:\n%s", i, string(cell), string(row))
 		}
 		// The seam is fill, not a drawn line: the glyphs of the old line
 		// seam appearing here mean a stale seam renderer shipped again.

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -140,43 +140,32 @@ func TestFrameFitsTerminal(t *testing.T) {
 	}
 }
 
-// Every cell of the column seam must be a joint glyph, and the rules that
-// cross it must land as junctions, not butt against a bare bar.
-func TestSeamJunctionsMeetTheRules(t *testing.T) {
+// The pane's soft edges: the opening row bleeds down with ▄, the closing
+// row up with ▀, and every body row ends with the ▌ half-block edge one
+// column past the seam, so the fill extends half a cell beyond its box on
+// all three sides.
+func TestPaneSoftEdges(t *testing.T) {
 	m := shotModel()
 	rows := strings.Split(m.View(), "\n")
-	// Columns are counted in runes: the rule row is all multi-byte glyphs,
-	// so a byte index would name a column far right of the real seam.
-	header := []rune(ansi.Strip(rows[m.headerRows()]))
-	seamCol := -1
-	for i, r := range header {
-		if r == '┬' {
-			seamCol = i
-			break
+	leftWidth, _ := m.splitWidths()
+
+	top := []rune(ansi.Strip(rows[m.headerRows()]))
+	bottom := []rune(ansi.Strip(rows[m.headerRows()+1+m.listBodyHeight()]))
+	for col := 0; col <= leftWidth+1; col++ {
+		if top[col] != '▄' {
+			t.Fatalf("top edge col %d is %q, want ▄:\n%s", col, string(top[col]), string(top))
+		}
+		if bottom[col] != '▀' {
+			t.Fatalf("bottom edge col %d is %q, want ▀:\n%s", col, string(bottom[col]), string(bottom))
 		}
 	}
-	if seamCol < 0 {
-		t.Fatalf("header rule carries no ┬:\n%s", string(header))
+	if top[leftWidth+2] == '▄' || bottom[leftWidth+2] == '▀' {
+		t.Fatalf("the bleed should stop after the seam's edge column")
 	}
-
-	sawTee := map[rune]bool{}
 	for i := m.headerRows() + 1; i < m.headerRows()+1+m.listBodyHeight(); i++ {
 		row := []rune(ansi.Strip(rows[i]))
-		if seamCol >= len(row) {
-			t.Fatalf("row %d shorter than the seam column: %q", i, string(row))
+		if cell := row[leftWidth+1]; cell != '▌' && cell != '─' {
+			t.Fatalf("row %d: edge column is %q, want ▌:\n%s", i, string(cell), string(row))
 		}
-		cell := row[seamCol]
-		switch cell {
-		case '│', '├', '┤', '┼':
-			sawTee[cell] = true
-		default:
-			t.Fatalf("row %d: seam cell is %q, not a joint glyph:\n%s", i, string(cell), string(row))
-		}
-	}
-	if footer := ansi.Strip(rows[m.headerRows()+1+m.listBodyHeight()]); []rune(footer)[seamCol] != '┴' {
-		t.Fatalf("closing rule carries no ┴ at the seam: %q", footer)
-	}
-	if !sawTee['├'] || !sawTee['┤'] {
-		t.Fatalf("body rules never tee into the seam: %v", sawTee)
 	}
 }

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -135,7 +135,7 @@ const listChromeRows = 2
 // listBodyHeight is the vertical budget for the sessions/sidebar panels.
 // Matches View: height - (header, blank, status, footer baseline).
 func (m *Model) listBodyHeight() int {
-	bodyHeight := m.height - 4 - lipgloss.Height(m.viewFooter())
+	bodyHeight := m.height - 3 - lipgloss.Height(m.viewFooter())
 	if bodyHeight < 3 {
 		bodyHeight = 3
 	}

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -134,7 +134,9 @@ func (m *Model) listChromeRows() int { return m.headerRows() + 1 }
 // listBodyHeight is the vertical budget for the sessions/sidebar panels.
 // Matches View: height - (header, blank, status, footer baseline).
 func (m *Model) listBodyHeight() int {
-	bodyHeight := m.height - m.listChromeRows() - 3 - lipgloss.Height(m.viewFooter())
+	// The frame is the chrome rows, the body, the seam above the footer,
+	// the status line, and the footer itself.
+	bodyHeight := m.height - m.listChromeRows() - 2 - lipgloss.Height(m.viewFooter())
 	if bodyHeight < 3 {
 		bodyHeight = 3
 	}

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"strconv"
-	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -239,21 +238,4 @@ func (m *Model) handleMouseWheel(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	default:
 		return m, nil
 	}
-}
-
-// resizeGrip is the 1-column accent bar drawn between the panels while
-// resize mode is active so the drag target is obvious.
-func (m *Model) resizeGrip(height int) string {
-	style := lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
-	if m.splitDragging {
-		style = lipgloss.NewStyle().Foreground(colorAccent2).Bold(true)
-	}
-	if height < 1 {
-		height = 1
-	}
-	lines := make([]string, height)
-	for i := range lines {
-		lines[i] = style.Render("║")
-	}
-	return strings.Join(lines, "\n")
 }

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -126,15 +126,15 @@ func (m *Model) nudgeSplit(delta int) {
 	m.setSplitFromX(left + delta)
 }
 
-// listChromeRows is the number of rows above the sessions/sidebar body
-// in list mode: header + blank separator. Shared by View and bodyYRange
-// so hit-testing cannot drift from paint.
-const listChromeRows = 2
+// listChromeRows is the number of rows above the sessions/content body:
+// the header (one line, or the wordmark's three) and the seam under it.
+// Shared by View and bodyYRange so hit-testing cannot drift from paint.
+func (m *Model) listChromeRows() int { return m.headerRows() + 1 }
 
 // listBodyHeight is the vertical budget for the sessions/sidebar panels.
 // Matches View: height - (header, blank, status, footer baseline).
 func (m *Model) listBodyHeight() int {
-	bodyHeight := m.height - 3 - lipgloss.Height(m.viewFooter())
+	bodyHeight := m.height - m.listChromeRows() - 3 - lipgloss.Height(m.viewFooter())
 	if bodyHeight < 3 {
 		bodyHeight = 3
 	}
@@ -144,7 +144,7 @@ func (m *Model) listBodyHeight() int {
 // bodyYRange is the inclusive-start exclusive-end row range of the main
 // sessions/sidebar body, matching the layout in View.
 func (m *Model) bodyYRange() (start, end int) {
-	return listChromeRows, listChromeRows + m.listBodyHeight()
+	return m.listChromeRows(), m.listChromeRows() + m.listBodyHeight()
 }
 
 // dividerX is the column index of the sessions/sidebar junction (first

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -127,9 +127,10 @@ func (m *Model) nudgeSplit(delta int) {
 }
 
 // listChromeRows is the number of rows above the sessions/content body:
-// the header (one line, or the wordmark's three) and the seam under it.
-// Shared by View and bodyYRange so hit-testing cannot drift from paint.
-func (m *Model) listChromeRows() int { return m.headerRows() + 1 }
+// the header, which shares the rail and content surfaces with the body
+// below it. Shared by View and bodyYRange so hit-testing cannot drift
+// from paint.
+func (m *Model) listChromeRows() int { return m.headerRows() }
 
 // listBodyHeight is the vertical budget for the sessions/sidebar panels.
 // Matches View: height - (header, blank, status, footer baseline).

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -127,10 +127,9 @@ func (m *Model) nudgeSplit(delta int) {
 }
 
 // listChromeRows is the number of rows above the sessions/content body:
-// the header, which shares the rail and content surfaces with the body
-// below it. Shared by View and bodyYRange so hit-testing cannot drift
-// from paint.
-func (m *Model) listChromeRows() int { return m.headerRows() }
+// the full-width header band and the rule that closes it. Shared by View
+// and bodyYRange so hit-testing cannot drift from paint.
+func (m *Model) listChromeRows() int { return m.headerRows() + 1 }
 
 // listBodyHeight is the vertical budget for the sessions/sidebar panels.
 // Matches View: height - (header, blank, status, footer baseline).

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -196,7 +196,7 @@ func TestDragReleasePersistsAndExits(t *testing.T) {
 	m = updated.(*Model)
 
 	div := m.dividerX()
-	// Body starts at listChromeRows; any y inside the body range works.
+	// Body starts at the header's height; any y inside the body range works.
 	updated, _ = m.handleMouse(tea.MouseMsg{
 		X: div, Y: 5, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
 	})
@@ -304,8 +304,8 @@ func TestPressOutsideBodyDoesNotDrag(t *testing.T) {
 		t.Fatal("press on header row must not start drag")
 	}
 	y0, y1 := m.bodyYRange()
-	if y0 != listChromeRows {
-		t.Fatalf("body start = %d want %d", y0, listChromeRows)
+	if y0 != m.listChromeRows() {
+		t.Fatalf("body start = %d want %d", y0, m.listChromeRows())
 	}
 	updated, _ = m.handleMouse(tea.MouseMsg{
 		X: div, Y: y1, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
@@ -335,18 +335,18 @@ func TestEnterResizeBlockedWhenSearchingOrQuick(t *testing.T) {
 func TestBodyYRangeMatchesListChrome(t *testing.T) {
 	m := &Model{width: 120, height: 40, splitRatio: defaultSplitRatio, mode: modeList}
 	start, end := m.bodyYRange()
-	if start != listChromeRows {
-		t.Fatalf("start = %d want listChromeRows=%d", start, listChromeRows)
+	if start != m.listChromeRows() {
+		t.Fatalf("start = %d want listChromeRows=%d", start, m.listChromeRows())
 	}
-	wantH := m.height - 3 - lipgloss.Height(m.viewFooter())
+	wantH := m.height - m.listChromeRows() - 3 - lipgloss.Height(m.viewFooter())
 	if wantH < 3 {
 		wantH = 3
 	}
 	if m.listBodyHeight() != wantH {
 		t.Fatalf("listBodyHeight = %d want %d", m.listBodyHeight(), wantH)
 	}
-	if end != listChromeRows+wantH {
-		t.Fatalf("end = %d want %d", end, listChromeRows+wantH)
+	if end != m.listChromeRows()+wantH {
+		t.Fatalf("end = %d want %d", end, m.listChromeRows()+wantH)
 	}
 }
 

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -338,7 +338,7 @@ func TestBodyYRangeMatchesListChrome(t *testing.T) {
 	if start != m.listChromeRows() {
 		t.Fatalf("start = %d want listChromeRows=%d", start, m.listChromeRows())
 	}
-	wantH := m.height - m.listChromeRows() - 3 - lipgloss.Height(m.viewFooter())
+	wantH := m.height - m.listChromeRows() - 2 - lipgloss.Height(m.viewFooter())
 	if wantH < 3 {
 		wantH = 3
 	}

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -338,7 +338,7 @@ func TestBodyYRangeMatchesListChrome(t *testing.T) {
 	if start != listChromeRows {
 		t.Fatalf("start = %d want listChromeRows=%d", start, listChromeRows)
 	}
-	wantH := m.height - 4 - lipgloss.Height(m.viewFooter())
+	wantH := m.height - 3 - lipgloss.Height(m.viewFooter())
 	if wantH < 3 {
 		wantH = 3
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -8,51 +8,81 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
+// Colors are resolved from the active Theme by applyTheme; nothing here
+// hardcodes a palette. See theme.go for the token meanings.
 var (
-	colorText    = lipgloss.Color("252")
-	colorDim     = lipgloss.Color("245")
-	colorSubtle  = lipgloss.Color("240")
-	colorBorder  = lipgloss.Color("238")
-	colorBg      = lipgloss.Color("236")
-	colorSelBg   = lipgloss.Color("239")
-	colorBright  = lipgloss.Color("231")
-	colorAccent  = lipgloss.Color("111")
-	colorAccent2 = lipgloss.Color("79")
+	colorBg      lipgloss.Color
+	colorSurface lipgloss.Color
+	colorOverlay lipgloss.Color
+	colorBorder  lipgloss.Color
+	colorFocus   lipgloss.Color
+	colorBright  lipgloss.Color
+	colorText    lipgloss.Color
+	colorDim     lipgloss.Color
+	colorSubtle  lipgloss.Color
+	colorAccent  lipgloss.Color
+	colorAccent2 lipgloss.Color
+	colorSelBg   lipgloss.Color
 
-	colorWorking  = lipgloss.Color("214")
-	colorWaiting  = lipgloss.Color("213")
-	colorFinished = lipgloss.Color("82")
-	colorErrored  = lipgloss.Color("203")
-	colorIdle     = lipgloss.Color("244")
+	colorWorking  lipgloss.Color
+	colorWaiting  lipgloss.Color
+	colorFinished lipgloss.Color
+	colorErrored  lipgloss.Color
+	colorIdle     lipgloss.Color
+)
 
+var (
+	badgeStyle       lipgloss.Style
+	sectionStyle     lipgloss.Style
+	selectedRowStyle lipgloss.Style
+
+	mutedStyle  lipgloss.Style
+	subtleStyle lipgloss.Style
+	valueStyle  lipgloss.Style
+	labelStyle  lipgloss.Style
+	errStyle    lipgloss.Style
+	keyStyle    lipgloss.Style
+
+	annotationStyle lipgloss.Style
+
+	chipStyle             lipgloss.Style
+	imageChipStyle        lipgloss.Style
+	imageChipPastingStyle lipgloss.Style
+)
+
+func init() { applyTheme(themes[0]) }
+
+// rebuildStyles re-derives every style from the colors applyTheme just set.
+func rebuildStyles() {
 	badgeStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(colorBg).
-			Background(colorAccent).
-			Padding(0, 1)
+		Bold(true).
+		Foreground(colorBg).
+		Background(colorAccent).
+		Padding(0, 1)
 
 	sectionStyle = lipgloss.NewStyle().Bold(true).Foreground(colorAccent)
 
 	selectedRowStyle = lipgloss.NewStyle().Background(colorSelBg).Foreground(colorBright)
 
-	// selectedRowReapply is the SGR sequence re-applied after every inner
-	// SGR reset inside a selected row. lipgloss's .Render emits one reset
-	// per call, so wrapping pre-styled content with selectedRowStyle leaves
-	// the background set only on the first segment. renderSelectedRow
-	// substitutes each inner reset with reset+reapply so the selected bg
-	// holds across the whole row.
-	selectedRowReapply = "\x1b[0m\x1b[48;5;" + string(colorSelBg) + "m\x1b[38;5;" + string(colorBright) + "m"
-
-	mutedStyle  = lipgloss.NewStyle().Foreground(colorDim)
+	mutedStyle = lipgloss.NewStyle().Foreground(colorDim)
 	subtleStyle = lipgloss.NewStyle().Foreground(colorSubtle)
-	valueStyle  = lipgloss.NewStyle().Foreground(colorText)
-	labelStyle  = lipgloss.NewStyle().Foreground(colorDim)
-	errStyle    = lipgloss.NewStyle().Foreground(colorErrored).Bold(true)
-	keyStyle    = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+	valueStyle = lipgloss.NewStyle().Foreground(colorText)
+	labelStyle = lipgloss.NewStyle().Foreground(colorSubtle)
+	errStyle = lipgloss.NewStyle().Foreground(colorErrored).Bold(true)
+	keyStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 
 	annotationStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
-	annotationBg    = "\x1b[48;2;28;32;46m"
-)
+
+	chipStyle = lipgloss.NewStyle().Background(colorSurface).Padding(0, 1)
+	imageChipStyle = lipgloss.NewStyle().
+		Foreground(colorBright).
+		Background(colorSurface).
+		Padding(0, 1)
+	imageChipPastingStyle = lipgloss.NewStyle().
+		Foreground(colorWorking).
+		Background(colorSurface).
+		Padding(0, 1)
+}
 
 // renderSelectedRow wraps a pre-styled line with the selected row's
 // background and foreground. Internal SGR resets emitted by per-segment
@@ -61,7 +91,16 @@ var (
 // Re-applying the selected bg+fg after every reset keeps the row tinted
 // end-to-end.
 func renderSelectedRow(s string) string {
-	return selectedRowStyle.Render(strings.ReplaceAll(s, "\x1b[0m", selectedRowReapply))
+	reapply := "\x1b[0m" + bgSeq(current.Surface) + fgSeq(current.Bright)
+	return selectedRowStyle.Render(strings.ReplaceAll(s, "\x1b[0m", reapply))
+}
+
+// annotationBg is the wash behind a reviewer's inline comment: the theme's
+// backdrop lifted toward the accent, so the note reads as ours rather than
+// as part of the diff. Resolved per call so it follows the live color
+// profile as well as the live theme.
+func annotationBg() string {
+	return bgSeq(mix(current.Bg, current.Accent, 0.18))
 }
 
 func statusColor(s string) lipgloss.Color {
@@ -79,6 +118,9 @@ func statusColor(s string) lipgloss.Color {
 	}
 }
 
+// statusGlyph is one geometric mark per state, all from the same weight
+// family so a column of them reads as a single scale rather than a mix of
+// punctuation. Shape carries the state; color reinforces it.
 func statusGlyph(s string) string {
 	switch s {
 	case status.Working:
@@ -86,11 +128,11 @@ func statusGlyph(s string) string {
 	case status.Starting:
 		return "◌"
 	case status.Waiting:
-		return "?"
+		return "◆"
 	case status.Finished:
-		return "✔"
+		return "●"
 	case status.Errored, status.Dead:
-		return "✖"
+		return "✕"
 	default:
 		return "○"
 	}
@@ -105,10 +147,16 @@ func statusLabel(s string) string {
 	return s
 }
 
-// titledPanel draws a rounded box with the title embedded in the top
-// border, its body clipped and padded to fill the given outer size.
-func titledPanel(title, body string, width, height int) string {
-	bs := lipgloss.NewStyle().Foreground(colorBorder)
+// titledPanel draws a rounded box with the title set into the top border,
+// its body clipped and padded to fill the given outer size. A focused
+// panel wears the accent border and a filled title chip, so which side
+// takes the keys is readable without hunting for the cursor.
+func titledPanel(title, body string, width, height int, focused bool) string {
+	borderColor := colorBorder
+	if focused {
+		borderColor = colorFocus
+	}
+	bs := lipgloss.NewStyle().Foreground(borderColor)
 	inner := width - 4
 	if inner < 1 {
 		inner = 1
@@ -118,8 +166,8 @@ func titledPanel(title, body string, width, height int) string {
 		bodyRows = 1
 	}
 
-	titleText := sectionStyle.Render(title)
-	dashCount := inner - ansi.StringWidth(title) - 1
+	titleText := panelTitle(title, focused)
+	dashCount := inner - ansi.StringWidth(ansi.Strip(titleText)) - 1
 	if dashCount < 0 {
 		dashCount = 0
 	}
@@ -141,6 +189,19 @@ func titledPanel(title, body string, width, height int) string {
 	return b.String()
 }
 
+// panelTitle styles a panel's border title: a solid chip when the panel has
+// focus, quiet text when it does not.
+func panelTitle(title string, focused bool) string {
+	if focused {
+		return lipgloss.NewStyle().
+			Bold(true).
+			Foreground(colorBg).
+			Background(colorFocus).
+			Render(" " + title + " ")
+	}
+	return lipgloss.NewStyle().Foreground(colorDim).Render(title)
+}
+
 // padRight pads or clips a possibly-styled string to an exact display width.
 func padRight(s string, width int) string {
 	w := ansi.StringWidth(s)
@@ -157,7 +218,33 @@ func padRight(s string, width int) string {
 	return s
 }
 
-// gauge renders a colored bar meter for a 0-100 percentage.
+// padLeft right-aligns a possibly-styled string inside an exact width, for
+// meta columns that should end on a shared right edge.
+func padLeft(s string, width int) string {
+	w := ansi.StringWidth(s)
+	if w > width {
+		s = ansi.Truncate(s, width, "…")
+		w = ansi.StringWidth(s)
+	}
+	if w < width {
+		s = strings.Repeat(" ", width-w) + s
+	}
+	if strings.ContainsRune(s, 0x1b) {
+		s += "\x1b[0m"
+	}
+	return s
+}
+
+// gaugeGlyph is the meter's bar unit: a heavy rule reads as a slim
+// continuous line rather than a row of stacked blocks.
+const (
+	gaugeGlyph = "━"
+	gaugeHalf  = "╸"
+)
+
+// gauge renders a meter for a 0-100 percentage: a colored run over a muted
+// track, the color ramping from calm to alarming as it fills, with a
+// half-width cap so small changes still move the bar.
 func gauge(percent float64, width int) string {
 	if width < 1 {
 		width = 1
@@ -168,25 +255,44 @@ func gauge(percent float64, width int) string {
 	if percent > 100 {
 		percent = 100
 	}
-	filled := int(percent/100*float64(width) + 0.5)
-	color := colorFinished
+	units := percent / 100 * float64(width)
+	filled := int(units)
+	if filled > width {
+		filled = width
+	}
+	half := units-float64(filled) >= 0.5
+
+	color := lipgloss.Color(gaugeRamp(percent))
+	bar := lipgloss.NewStyle().Foreground(color).Render(strings.Repeat(gaugeGlyph, filled))
+	rest := width - filled
+	if half && rest > 0 {
+		bar += lipgloss.NewStyle().Foreground(color).Render(gaugeHalf)
+		rest--
+	}
+	track := lipgloss.NewStyle().Foreground(colorOverlay).Render(strings.Repeat(gaugeGlyph, rest))
+	return bar + track
+}
+
+// gaugeRamp blends the meter color across the load range so a gauge reads
+// as a temperature rather than three discrete buckets.
+func gaugeRamp(percent float64) string {
 	switch {
 	case percent >= 85:
-		color = colorErrored
+		return current.Errored
 	case percent >= 60:
-		color = colorWorking
+		return mix(current.Working, current.Errored, (percent-60)/25)
+	default:
+		return mix(current.Finished, current.Working, percent/60)
 	}
-	on := lipgloss.NewStyle().Foreground(color).Render(strings.Repeat("▰", filled))
-	off := subtleStyle.Render(strings.Repeat("▱", width-filled))
-	return on + off
 }
 
-// pill renders a small rounded label chip.
+// pill renders a small label chip: tinted text on the surface fill, so a
+// row of them reads as tokens rather than as more prose.
 func pill(text string, fg lipgloss.Color) string {
-	return lipgloss.NewStyle().Foreground(fg).Render("▏" + text)
+	return chipStyle.Foreground(fg).Render(text)
 }
 
-// keyPill renders a pill with the key that changes it dimmed in front, so
+// keyPill renders a chip with the key that changes it dimmed in front, so
 // the header doubles as a key legend: each changeable value wears its
 // shortcut. The key is dim enough to lose to the value at a glance but
 // reads clearly when hunted.
@@ -194,19 +300,10 @@ func keyPill(key, text string, fg lipgloss.Color) string {
 	return subtleStyle.Render(key+" ") + pill(text, fg)
 }
 
-// imageChipStyle is the soft pill used for inline pasted-image tokens in
-// the quick prompt (same visual family as badges, quieter so the text wins).
-var imageChipStyle = lipgloss.NewStyle().
-	Foreground(colorBright).
-	Background(colorSelBg).
-	Padding(0, 1)
-
-// imageChipPastingStyle is the in-flight variant while the clipboard image
-// is still being captured.
-var imageChipPastingStyle = lipgloss.NewStyle().
-	Foreground(colorWorking).
-	Background(colorSelBg).
-	Padding(0, 1)
+// keyCap renders one footer binding: the key in accent, its action muted.
+func keyCap(key, label string) string {
+	return keyStyle.Render(key) + " " + mutedStyle.Render(label)
+}
 
 // imageChip renders an inline pasted-image token: icon + short label.
 func imageChip(label string) string {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -32,7 +32,6 @@ var (
 )
 
 var (
-	badgeStyle       lipgloss.Style
 	sectionStyle     lipgloss.Style
 	selectedRowStyle lipgloss.Style
 
@@ -54,12 +53,6 @@ func init() { applyTheme(themes[0]) }
 
 // rebuildStyles re-derives every style from the colors applyTheme just set.
 func rebuildStyles() {
-	badgeStyle = lipgloss.NewStyle().
-		Bold(true).
-		Foreground(colorBg).
-		Background(colorAccent).
-		Padding(0, 1)
-
 	sectionStyle = lipgloss.NewStyle().Bold(true).Foreground(colorAccent)
 
 	selectedRowStyle = lipgloss.NewStyle().Background(colorSelBg).Foreground(colorBright)
@@ -147,61 +140,6 @@ func statusLabel(s string) string {
 	return s
 }
 
-// titledPanel draws a rounded box with the title set into the top border,
-// its body clipped and padded to fill the given outer size. A focused
-// panel wears the accent border and a filled title chip, so which side
-// takes the keys is readable without hunting for the cursor.
-func titledPanel(title, body string, width, height int, focused bool) string {
-	borderColor := colorBorder
-	if focused {
-		borderColor = colorFocus
-	}
-	bs := lipgloss.NewStyle().Foreground(borderColor)
-	inner := width - 4
-	if inner < 1 {
-		inner = 1
-	}
-	bodyRows := height - 2
-	if bodyRows < 1 {
-		bodyRows = 1
-	}
-
-	titleText := panelTitle(title, focused)
-	dashCount := inner - ansi.StringWidth(ansi.Strip(titleText)) - 1
-	if dashCount < 0 {
-		dashCount = 0
-	}
-	top := bs.Render("╭─ ") + titleText + " " + bs.Render(strings.Repeat("─", dashCount)+"╮")
-	bottom := bs.Render("╰" + strings.Repeat("─", width-2) + "╯")
-
-	side := bs.Render("│")
-	lines := strings.Split(body, "\n")
-	var b strings.Builder
-	b.WriteString(top + "\n")
-	for i := 0; i < bodyRows; i++ {
-		content := ""
-		if i < len(lines) {
-			content = lines[i]
-		}
-		b.WriteString(side + " " + padRight(content, inner) + " " + side + "\n")
-	}
-	b.WriteString(bottom)
-	return b.String()
-}
-
-// panelTitle styles a panel's border title: a solid chip when the panel has
-// focus, quiet text when it does not.
-func panelTitle(title string, focused bool) string {
-	if focused {
-		return lipgloss.NewStyle().
-			Bold(true).
-			Foreground(colorBg).
-			Background(colorFocus).
-			Render(" " + title + " ")
-	}
-	return lipgloss.NewStyle().Foreground(colorDim).Render(title)
-}
-
 // padRight pads or clips a possibly-styled string to an exact display width.
 func padRight(s string, width int) string {
 	w := ansi.StringWidth(s)
@@ -211,23 +149,6 @@ func padRight(s string, width int) string {
 	}
 	if w < width {
 		s += strings.Repeat(" ", width-w)
-	}
-	if strings.ContainsRune(s, 0x1b) {
-		s += "\x1b[0m"
-	}
-	return s
-}
-
-// padLeft right-aligns a possibly-styled string inside an exact width, for
-// meta columns that should end on a shared right edge.
-func padLeft(s string, width int) string {
-	w := ansi.StringWidth(s)
-	if w > width {
-		s = ansi.Truncate(s, width, "…")
-		w = ansi.StringWidth(s)
-	}
-	if w < width {
-		s = strings.Repeat(" ", width-w) + s
 	}
 	if strings.ContainsRune(s, 0x1b) {
 		s += "\x1b[0m"
@@ -273,17 +194,15 @@ func gauge(percent float64, width int) string {
 	return bar + track
 }
 
-// gaugeRamp blends the meter color across the load range so a gauge reads
-// as a temperature rather than three discrete buckets.
+// gaugeRamp blends a meter from the theme's calm color to its alarm color
+// as the load climbs. The anchors are deliberately "finished" and "errored"
+// rather than any state color: a machine meter is a temperature, and a
+// theme whose working color is blue would otherwise paint a cold gauge.
 func gaugeRamp(percent float64) string {
-	switch {
-	case percent >= 85:
+	if percent >= 85 {
 		return current.Errored
-	case percent >= 60:
-		return mix(current.Working, current.Errored, (percent-60)/25)
-	default:
-		return mix(current.Finished, current.Working, percent/60)
 	}
+	return mix(current.Finished, current.Errored, percent/85)
 }
 
 // pill renders a small label chip: tinted text on the surface fill, so a

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -15,7 +15,6 @@ var (
 	colorSurface lipgloss.Color
 	colorOverlay lipgloss.Color
 	colorBorder  lipgloss.Color
-	colorFocus   lipgloss.Color
 	colorBright  lipgloss.Color
 	colorText    lipgloss.Color
 	colorDim     lipgloss.Color

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -3,13 +3,14 @@ package ui
 import (
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
 
 // The list view is built from painted surfaces rather than drawn boxes:
 // the app fills a backdrop, the sessions rail sits on a slightly lifted
-// panel tone, and the selected entry lifts once more. Nothing is separated
-// by a rule, so the eye reads depth instead of chrome.
+// panel tone, and the selected entry lifts once more. Depth carries the
+// structure; a hairline marks each seam where two surfaces meet.
 
 // backdropHex is the tone behind the whole frame.
 func backdropHex() string { return current.Bg }
@@ -23,6 +24,37 @@ func blockHex() string { return mix(current.Bg, current.Surface, 0.18) }
 
 // selectedHex is the band under the cursor's entry.
 func selectedHex() string { return mix(current.Bg, current.Surface, 0.72) }
+
+// ruleHex is the hairline tone: lifted just far enough off the backdrop to
+// draw a seam without becoming a border.
+func ruleHex() string { return mix(current.Bg, current.Text, 0.17) }
+
+// hrule is a horizontal seam across a painted row.
+func hrule(width int) string {
+	if width < 1 {
+		return ""
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(ruleHex())).Render(strings.Repeat("─", width))
+}
+
+// vruleColumn is the seam between two painted columns. It doubles as the
+// resize grip, taking the accent while the divider is being moved.
+func (m *Model) vruleColumn(height int) []string {
+	color := lipgloss.Color(ruleHex())
+	glyph := "│"
+	switch {
+	case m.splitDragging:
+		color, glyph = colorAccent2, "║"
+	case m.resizeMode:
+		color, glyph = colorAccent, "║"
+	}
+	cell := lipgloss.NewStyle().Foreground(color).Render(glyph)
+	lines := make([]string, height)
+	for i := range lines {
+		lines[i] = paint(cell, 1, panelHex())
+	}
+	return lines
+}
 
 // paint pads a possibly-styled line to an exact width and fills every cell
 // with bg. Inner SGR resets emitted by per-segment renders would drop the

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -46,20 +46,37 @@ func hrule(width int) string {
 // cell past its box, which is as far as a character cell can be divided —
 // and across the content it draws the thin rule, whose center line meets
 // the half blocks' edge at the same height.
-// The half-cell edges are drawn inverted: the cell's background carries
-// the pane tone and the glyph paints the backdrop half in the theme's
-// backdrop color. Fonts give block glyphs a hair of side bearing, and a
-// leak through that bearing shows the cell background — inverted, the
-// leak is pane tone and fuses with the fill instead of cutting a thin
-// gap into its edge.
+// The run's interior is drawn inverted — the cell background carries the
+// pane tone and the glyph paints the backdrop half in the theme's backdrop
+// color — but both end cells are not. The terminal extends a row's edge
+// cell background into the window margin at full cell height, so an
+// inverted first cell smears pane tone past the pane's corner; drawing it
+// as a foreground half block keeps the margin on the terminal's own
+// background. The last cell sits over the bleed column, whose fill is only
+// half a cell wide, so it takes a quadrant instead of a half block and the
+// pane tone stops at the corner instead of jutting past it.
 func (m *Model) boundedRuleRow(paneWidth, width int, edge string) string {
-	if paneWidth < 0 || paneWidth >= width {
+	if paneWidth < 2 || paneWidth >= width {
 		return paint(hrule(width), width, backdropHex())
 	}
-	bleed := lipgloss.NewStyle().Foreground(colorBg).
-		Render(strings.Repeat(edge, paneWidth+1))
-	return paint(bleed, paneWidth+1, panelHex()) +
+	facing, corner := "▄", "▜"
+	if edge == "▄" {
+		facing, corner = "▀", "▟"
+	}
+	first := plain(lipgloss.NewStyle().Foreground(lipgloss.Color(panelHex())).Render(facing), 1)
+	interior := lipgloss.NewStyle().Foreground(colorBg).
+		Render(strings.Repeat(edge, paneWidth-1))
+	last := lipgloss.NewStyle().Foreground(colorBg).Render(corner)
+	return first + paint(interior, paneWidth-1, panelHex()) + paint(last, 1, panelHex()) +
 		paint(hrule(width-paneWidth-1), width-paneWidth-1, backdropHex())
+}
+
+// railEdgeCell is one row of the pane's first column, drawn as a foreground
+// block in the row's own tone rather than as cell background. The window
+// margin beside it inherits the cell's background — the terminal's own —
+// so the pane's left edge lands exactly on the cell grid.
+func railEdgeCell(tone string) string {
+	return plain(lipgloss.NewStyle().Foreground(lipgloss.Color(tone)).Render("█"), 1)
 }
 
 // vruleColumn is the seam between two painted columns. It doubles as the
@@ -136,11 +153,13 @@ func plain(s string, width int) string {
 
 // contentLine is one row of the content column: ours to paint, a seam that
 // spans the column edge to edge, or captured output that must keep the
-// terminal's own backdrop.
+// terminal's own backdrop. Rail rows also carry the tone their fill uses,
+// so the edge column beside them can match the selected entry's band.
 type contentLine struct {
 	text string
 	raw  bool
 	rule bool
+	tone string
 }
 
 // paintContent paints a content column, leaving raw rows unfilled.

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -8,26 +8,31 @@ import (
 )
 
 // The list view is built from painted surfaces rather than drawn boxes:
-// the app fills a backdrop, the sessions rail sits on a slightly lifted
-// panel tone, and the selected entry lifts once more. Depth carries the
-// structure; a hairline marks each seam where two surfaces meet.
+// the backdrop is the terminal's own background, the sessions rail sits on
+// a lifted panel tone, and the selected entry lifts once more. Depth
+// carries the structure; a hairline marks each seam where two surfaces
+// meet. The backdrop is deliberately not painted: terminals blend window
+// padding and transparency into their default background, and only cells
+// left on that default blend the same way, so an app-painted backdrop
+// always rings the frame in a slightly wrong tone.
 
-// backdropHex is the tone behind the whole frame.
-func backdropHex() string { return current.Bg }
+// backdropHex is the backdrop's fill: none. paint treats it as "pad, but
+// leave the terminal's background alone".
+func backdropHex() string { return "" }
 
-// panelHex is the sessions rail: one subtle step above the backdrop.
-func panelHex() string { return mix(current.Bg, current.Surface, 0.34) }
+// panelHex is the sessions rail: one step above the backdrop.
+func panelHex() string { return mix(current.Bg, current.Surface, 0.55) }
 
 // blockHex is a section block inside the content area, quieter than the
 // rail so it groups without announcing itself.
-func blockHex() string { return mix(current.Bg, current.Surface, 0.18) }
+func blockHex() string { return mix(current.Bg, current.Surface, 0.35) }
 
 // selectedHex is the band under the cursor's entry.
-func selectedHex() string { return mix(current.Bg, current.Surface, 0.72) }
+func selectedHex() string { return current.Surface }
 
 // ruleHex is the hairline tone: lifted just far enough off the backdrop to
 // draw a seam without becoming a border.
-func ruleHex() string { return mix(current.Bg, current.Text, 0.17) }
+func ruleHex() string { return mix(current.Bg, current.Text, 0.22) }
 
 // hrule is a horizontal seam across a painted row.
 func hrule(width int) string {
@@ -86,6 +91,9 @@ func (m *Model) seamCell(leftRule, rightRule bool) string {
 // with bg. Inner SGR resets emitted by per-segment renders would drop the
 // fill partway across, so each reset re-applies it.
 func paint(s string, width int, bg string) string {
+	if bg == "" {
+		return plain(s, width)
+	}
 	fill := bgSeq(bg)
 	s = strings.ReplaceAll(s, "\x1b[0m", "\x1b[0m"+fill)
 	if w := ansi.StringWidth(s); w > width {

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -8,20 +8,18 @@ import (
 )
 
 // The list view sits on the terminal's own background, with the sessions
-// rail on a lifted panel card and the selected entry lifted once more.
-// One rule governs every fill: painted color never touches a window edge.
-// A terminal blends window padding and transparency into its default
-// background, so a fill flush against the window sits beside that blend
-// as a slightly different tone — an accident. Behind a margin of the
-// terminal's own background, the same fill reads as a card, which is a
-// choice. The margin column between the rail and the window edge is that
-// rule made visible.
+// rail filling its pane flush — header rule to footer rule, window edge to
+// seam — and the selected entry lifted once more. The backdrop itself is
+// never painted: the terminal background sync keeps the terminal's default
+// at the theme's tone, so the window padding around the cell grid carries
+// the same color as the unpainted cells and the frame meets the window
+// without a ring of a different tone.
 
 // backdropHex is the backdrop's fill: none. paint treats it as "pad, but
 // leave the terminal's background alone".
 func backdropHex() string { return "" }
 
-// panelHex is the rail card's fill: one step above the backdrop.
+// panelHex is the rail's fill: one step above the backdrop.
 func panelHex() string { return mix(current.Bg, current.Surface, 0.55) }
 
 // blockHex is a section block inside the content area, quieter than the

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -41,17 +41,19 @@ func hrule(width int) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(ruleHex())).Render(strings.Repeat("─", width))
 }
 
-// boundedRuleRow is the horizontal rule that opens or closes the body,
-// with its junction where the seam tees in. The rule rows sit on the
-// backdrop: the pane's fill spans the body rows between them and claims
-// the seam column, so the box ends flush on its right line while the
-// horizontal rules read as frame, not as part of the fill.
-func (m *Model) boundedRuleRow(paneWidth, width int, junction string) string {
+// boundedRuleRow is the row that opens or closes the body. Over the pane
+// it draws half blocks in the pane's own tone — the fill bleeding half a
+// cell past its box, which is as far as a character cell can be divided —
+// and across the content it draws the thin rule, whose center line meets
+// the half blocks' edge at the same height.
+func (m *Model) boundedRuleRow(paneWidth, width int, edge string) string {
 	if paneWidth < 0 || paneWidth >= width {
 		return paint(hrule(width), width, backdropHex())
 	}
-	style := lipgloss.NewStyle().Foreground(lipgloss.Color(ruleHex()))
-	return paint(hrule(paneWidth)+style.Render(junction)+hrule(width-paneWidth-1), width, backdropHex())
+	bleed := lipgloss.NewStyle().Foreground(lipgloss.Color(panelHex())).
+		Render(strings.Repeat(edge, paneWidth+1))
+	return paint(bleed, paneWidth+1, backdropHex()) +
+		paint(hrule(width-paneWidth-1), width-paneWidth-1, backdropHex())
 }
 
 // vruleColumn is the seam between two painted columns. It doubles as the
@@ -60,6 +62,17 @@ func (m *Model) vruleColumn(height int) []string {
 	lines := make([]string, height)
 	for i := range lines {
 		lines[i] = m.seamCell(false, false)
+	}
+	return lines
+}
+
+// bleedColumn finishes a pane's right edge: a half block in the pane's
+// tone on the backdrop, extending the fill half a cell past the seam.
+func (m *Model) bleedColumn(height int) []string {
+	cell := paint(lipgloss.NewStyle().Foreground(lipgloss.Color(panelHex())).Render("▌"), 1, backdropHex())
+	lines := make([]string, height)
+	for i := range lines {
+		lines[i] = cell
 	}
 	return lines
 }

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -82,11 +82,13 @@ func plain(s string, width int) string {
 	return "\x1b[0m" + s + "\x1b[0m"
 }
 
-// contentLine is one row of the content column: ours to paint, or captured
-// output that must keep the terminal's backdrop.
+// contentLine is one row of the content column: ours to paint, a seam that
+// spans the column edge to edge, or captured output that must keep the
+// terminal's own backdrop.
 type contentLine struct {
 	text string
 	raw  bool
+	rule bool
 }
 
 // paintContent paints a content column, leaving raw rows unfilled.
@@ -95,6 +97,12 @@ func paintContent(lines []contentLine, width, height int, bg string) []string {
 	for i := 0; i < height; i++ {
 		if i >= len(lines) {
 			out[i] = paint("", width, bg)
+			continue
+		}
+		if lines[i].rule {
+			// Seams are drawn at the column's full width, not the inset the
+			// text uses, so they meet the frame's edges exactly.
+			out[i] = paint(hrule(width), width, bg)
 			continue
 		}
 		if lines[i].raw {

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -41,17 +41,17 @@ func hrule(width int) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(ruleHex())).Render(strings.Repeat("─", width))
 }
 
-// boundedRuleRow is the horizontal rule that opens or closes the body: its
-// left segment and the junction ride the pane's fill, so the fill reaches
-// its own boundary lines instead of stopping a row short of them, and the
-// remainder crosses the content on the backdrop.
+// boundedRuleRow is the horizontal rule that opens or closes the body,
+// with its junction where the seam tees in. The rule rows sit on the
+// backdrop: the pane's fill spans the body rows between them and claims
+// the seam column, so the box ends flush on its right line while the
+// horizontal rules read as frame, not as part of the fill.
 func (m *Model) boundedRuleRow(paneWidth, width int, junction string) string {
 	if paneWidth < 0 || paneWidth >= width {
 		return paint(hrule(width), width, backdropHex())
 	}
 	style := lipgloss.NewStyle().Foreground(lipgloss.Color(ruleHex()))
-	return paint(hrule(paneWidth)+style.Render(junction), paneWidth+1, panelHex()) +
-		paint(hrule(width-paneWidth-1), width-paneWidth-1, backdropHex())
+	return paint(hrule(paneWidth)+style.Render(junction)+hrule(width-paneWidth-1), width, backdropHex())
 }
 
 // vruleColumn is the seam between two painted columns. It doubles as the

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -41,17 +41,17 @@ func hrule(width int) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(ruleHex())).Render(strings.Repeat("─", width))
 }
 
-// hruleJoined is a horizontal seam that meets the vertical one at column x,
-// carrying the junction glyph so the two lines connect instead of crossing.
-func hruleJoined(width, x int, junction string) string {
-	if width < 1 {
-		return ""
-	}
-	if x < 0 || x >= width {
-		return hrule(width)
+// boundedRuleRow is the horizontal rule that opens or closes the body: its
+// left segment and the junction ride the pane's fill, so the fill reaches
+// its own boundary lines instead of stopping a row short of them, and the
+// remainder crosses the content on the backdrop.
+func (m *Model) boundedRuleRow(paneWidth, width int, junction string) string {
+	if paneWidth < 0 || paneWidth >= width {
+		return paint(hrule(width), width, backdropHex())
 	}
 	style := lipgloss.NewStyle().Foreground(lipgloss.Color(ruleHex()))
-	return style.Render(strings.Repeat("─", x) + junction + strings.Repeat("─", width-x-1))
+	return paint(hrule(paneWidth)+style.Render(junction), paneWidth+1, panelHex()) +
+		paint(hrule(width-paneWidth-1), width-paneWidth-1, backdropHex())
 }
 
 // vruleColumn is the seam between two painted columns. It doubles as the

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -70,6 +70,42 @@ func paint(s string, width int, bg string) string {
 	return fill + s + "\x1b[0m"
 }
 
+// plain pads a line to width without filling it, leaving the terminal's own
+// background showing through. Captured agent output is drawn this way so a
+// session's CLI looks exactly as it does inside the session.
+func plain(s string, width int) string {
+	if w := ansi.StringWidth(s); w > width {
+		s = ansi.Truncate(s, width, "")
+	} else if w < width {
+		s += strings.Repeat(" ", width-w)
+	}
+	return "\x1b[0m" + s + "\x1b[0m"
+}
+
+// contentLine is one row of the content column: ours to paint, or captured
+// output that must keep the terminal's backdrop.
+type contentLine struct {
+	text string
+	raw  bool
+}
+
+// paintContent paints a content column, leaving raw rows unfilled.
+func paintContent(lines []contentLine, width, height int, bg string) []string {
+	out := make([]string, height)
+	for i := 0; i < height; i++ {
+		if i >= len(lines) {
+			out[i] = paint("", width, bg)
+			continue
+		}
+		if lines[i].raw {
+			out[i] = plain(lines[i].text, width)
+			continue
+		}
+		out[i] = paint(lines[i].text, width, bg)
+	}
+	return out
+}
+
 // paintRows paints each line of a block, padding the block itself out to
 // height so a short column still fills its side of the frame.
 func paintRows(lines []string, width, height int, bg string) []string {

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -7,21 +7,22 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// The list view is built from painted surfaces rather than drawn boxes:
-// the backdrop is the terminal's own background, the sessions rail sits on
-// a lifted panel tone, and the selected entry lifts once more. Depth
-// carries the structure; a hairline marks each seam where two surfaces
-// meet. The backdrop is deliberately not painted: terminals blend window
-// padding and transparency into their default background, and only cells
-// left on that default blend the same way, so an app-painted backdrop
-// always rings the frame in a slightly wrong tone.
+// The list view is built on the terminal's own background everywhere: the
+// only filled cells are the selection band, chips and modal cards — small
+// shapes that read as deliberate highlights and never touch a window edge.
+// Structure comes from the seams and from type weight instead of from
+// area fills, because a terminal blends window padding and transparency
+// into its default background, and any large painted region sits beside
+// that blend as an obviously different tone, like a stray child element
+// carrying the background its container should have.
 
 // backdropHex is the backdrop's fill: none. paint treats it as "pad, but
 // leave the terminal's background alone".
 func backdropHex() string { return "" }
 
-// panelHex is the sessions rail: one step above the backdrop.
-func panelHex() string { return mix(current.Bg, current.Surface, 0.55) }
+// panelHex is the sessions rail's fill: none, same reasoning as the
+// backdrop — the rail spans the window's whole left edge.
+func panelHex() string { return "" }
 
 // blockHex is a section block inside the content area, quieter than the
 // rail so it groups without announcing itself.

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -1,0 +1,93 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The list view is built from painted surfaces rather than drawn boxes:
+// the app fills a backdrop, the sessions rail sits on a slightly lifted
+// panel tone, and the selected entry lifts once more. Nothing is separated
+// by a rule, so the eye reads depth instead of chrome.
+
+// backdropHex is the tone behind the whole frame.
+func backdropHex() string { return current.Bg }
+
+// panelHex is the sessions rail: one subtle step above the backdrop.
+func panelHex() string { return mix(current.Bg, current.Surface, 0.34) }
+
+// blockHex is a section block inside the content area, quieter than the
+// rail so it groups without announcing itself.
+func blockHex() string { return mix(current.Bg, current.Surface, 0.18) }
+
+// selectedHex is the band under the cursor's entry.
+func selectedHex() string { return mix(current.Bg, current.Surface, 0.72) }
+
+// paint pads a possibly-styled line to an exact width and fills every cell
+// with bg. Inner SGR resets emitted by per-segment renders would drop the
+// fill partway across, so each reset re-applies it.
+func paint(s string, width int, bg string) string {
+	fill := bgSeq(bg)
+	s = strings.ReplaceAll(s, "\x1b[0m", "\x1b[0m"+fill)
+	if w := ansi.StringWidth(s); w > width {
+		s = ansi.Truncate(s, width, "…")
+	} else if w < width {
+		s += strings.Repeat(" ", width-w)
+	}
+	return fill + s + "\x1b[0m"
+}
+
+// paintRows paints each line of a block, padding the block itself out to
+// height so a short column still fills its side of the frame.
+func paintRows(lines []string, width, height int, bg string) []string {
+	out := make([]string, height)
+	for i := 0; i < height; i++ {
+		content := ""
+		if i < len(lines) {
+			content = lines[i]
+		}
+		out[i] = paint(content, width, bg)
+	}
+	return out
+}
+
+// joinColumns stitches painted columns row by row.
+func joinColumns(columns ...[]string) []string {
+	height := 0
+	for _, col := range columns {
+		if len(col) > height {
+			height = len(col)
+		}
+	}
+	rows := make([]string, height)
+	for i := 0; i < height; i++ {
+		var b strings.Builder
+		for _, col := range columns {
+			if i < len(col) {
+				b.WriteString(col[i])
+			}
+		}
+		rows[i] = b.String()
+	}
+	return rows
+}
+
+// indentLines insets a block by n columns.
+func indentLines(lines []string, n int) []string {
+	pad := strings.Repeat(" ", n)
+	out := make([]string, len(lines))
+	for i, line := range lines {
+		out[i] = pad + line
+	}
+	return out
+}
+
+// splitLines splits a rendered block into lines, treating the empty string
+// as no lines rather than one blank line.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -37,6 +37,19 @@ func hrule(width int) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(ruleHex())).Render(strings.Repeat("─", width))
 }
 
+// hruleJoined is a horizontal seam that meets the vertical one at column x,
+// carrying the junction glyph so the two lines connect instead of crossing.
+func hruleJoined(width, x int, junction string) string {
+	if width < 1 {
+		return ""
+	}
+	if x < 0 || x >= width {
+		return hrule(width)
+	}
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color(ruleHex()))
+	return style.Render(strings.Repeat("─", x) + junction + strings.Repeat("─", width-x-1))
+}
+
 // vruleColumn is the seam between two painted columns. It doubles as the
 // resize grip, taking the accent while the divider is being moved.
 func (m *Model) vruleColumn(height int) []string {
@@ -48,10 +61,12 @@ func (m *Model) vruleColumn(height int) []string {
 	case m.resizeMode:
 		color, glyph = colorAccent, "║"
 	}
+	// The seam sits on the backdrop, not on the rail: painting it with the
+	// rail's fill makes the rail look a column wider than it is.
 	cell := lipgloss.NewStyle().Foreground(color).Render(glyph)
 	lines := make([]string, height)
 	for i := range lines {
-		lines[i] = paint(cell, 1, panelHex())
+		lines[i] = paint(cell, 1, backdropHex())
 	}
 	return lines
 }

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -82,21 +82,21 @@ func (m *Model) bleedColumn(height int) []string {
 // instead of butting against each other; while the divider is being moved
 // the whole seam becomes the grip and junctions give way to it.
 func (m *Model) seamCell(leftRule, rightRule bool) string {
-	color := lipgloss.Color(ruleHex())
-	glyph := "│"
-	switch {
-	case m.splitDragging:
-		color, glyph = colorAccent2, "║"
-	case m.resizeMode:
-		color, glyph = colorAccent, "║"
-	case leftRule && rightRule:
-		glyph = "┼"
-	case leftRule:
-		glyph = "┤"
-	case rightRule:
-		glyph = "├"
+	// While the divider is being moved the seam becomes the grip.
+	if m.splitDragging || m.resizeMode {
+		color := colorAccent
+		if m.splitDragging {
+			color = colorAccent2
+		}
+		return paint(lipgloss.NewStyle().Foreground(color).Render("║"), 1, panelHex())
 	}
-	return paint(lipgloss.NewStyle().Foreground(color).Render(glyph), 1, backdropHex())
+	// Otherwise the seam is the pane's own fill — its edge is drawn by the
+	// bleed column beside it, not by a line — and a rule arriving from
+	// either side crosses it as a rule cell on that fill.
+	if leftRule || rightRule {
+		return paint(hrule(1), 1, panelHex())
+	}
+	return paint("", 1, panelHex())
 }
 
 // paint pads a possibly-styled line to an exact width and fills every cell

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -7,22 +7,22 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// The list view is built on the terminal's own background everywhere: the
-// only filled cells are the selection band, chips and modal cards — small
-// shapes that read as deliberate highlights and never touch a window edge.
-// Structure comes from the seams and from type weight instead of from
-// area fills, because a terminal blends window padding and transparency
-// into its default background, and any large painted region sits beside
-// that blend as an obviously different tone, like a stray child element
-// carrying the background its container should have.
+// The list view sits on the terminal's own background, with the sessions
+// rail on a lifted panel card and the selected entry lifted once more.
+// One rule governs every fill: painted color never touches a window edge.
+// A terminal blends window padding and transparency into its default
+// background, so a fill flush against the window sits beside that blend
+// as a slightly different tone — an accident. Behind a margin of the
+// terminal's own background, the same fill reads as a card, which is a
+// choice. The margin column between the rail and the window edge is that
+// rule made visible.
 
 // backdropHex is the backdrop's fill: none. paint treats it as "pad, but
 // leave the terminal's background alone".
 func backdropHex() string { return "" }
 
-// panelHex is the sessions rail's fill: none, same reasoning as the
-// backdrop — the rail spans the window's whole left edge.
-func panelHex() string { return "" }
+// panelHex is the rail card's fill: one step above the backdrop.
+func panelHex() string { return mix(current.Bg, current.Surface, 0.55) }
 
 // blockHex is a section block inside the content area, quieter than the
 // rail so it groups without announcing itself.

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -53,6 +53,18 @@ func hruleJoined(width, x int, junction string) string {
 // vruleColumn is the seam between two painted columns. It doubles as the
 // resize grip, taking the accent while the divider is being moved.
 func (m *Model) vruleColumn(height int) []string {
+	lines := make([]string, height)
+	for i := range lines {
+		lines[i] = m.seamCell(false, false)
+	}
+	return lines
+}
+
+// seamCell is one row of the vertical seam. A rule arriving from either
+// side turns the cell into the matching junction, so crossing lines meet
+// instead of butting against each other; while the divider is being moved
+// the whole seam becomes the grip and junctions give way to it.
+func (m *Model) seamCell(leftRule, rightRule bool) string {
 	color := lipgloss.Color(ruleHex())
 	glyph := "│"
 	switch {
@@ -60,15 +72,14 @@ func (m *Model) vruleColumn(height int) []string {
 		color, glyph = colorAccent2, "║"
 	case m.resizeMode:
 		color, glyph = colorAccent, "║"
+	case leftRule && rightRule:
+		glyph = "┼"
+	case leftRule:
+		glyph = "┤"
+	case rightRule:
+		glyph = "├"
 	}
-	// The seam sits on the backdrop, not on the rail: painting it with the
-	// rail's fill makes the rail look a column wider than it is.
-	cell := lipgloss.NewStyle().Foreground(color).Render(glyph)
-	lines := make([]string, height)
-	for i := range lines {
-		lines[i] = paint(cell, 1, backdropHex())
-	}
-	return lines
+	return paint(lipgloss.NewStyle().Foreground(color).Render(glyph), 1, backdropHex())
 }
 
 // paint pads a possibly-styled line to an exact width and fills every cell

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -46,13 +46,19 @@ func hrule(width int) string {
 // cell past its box, which is as far as a character cell can be divided —
 // and across the content it draws the thin rule, whose center line meets
 // the half blocks' edge at the same height.
+// The half-cell edges are drawn inverted: the cell's background carries
+// the pane tone and the glyph paints the backdrop half in the theme's
+// backdrop color. Fonts give block glyphs a hair of side bearing, and a
+// leak through that bearing shows the cell background — inverted, the
+// leak is pane tone and fuses with the fill instead of cutting a thin
+// gap into its edge.
 func (m *Model) boundedRuleRow(paneWidth, width int, edge string) string {
 	if paneWidth < 0 || paneWidth >= width {
 		return paint(hrule(width), width, backdropHex())
 	}
-	bleed := lipgloss.NewStyle().Foreground(lipgloss.Color(panelHex())).
+	bleed := lipgloss.NewStyle().Foreground(colorBg).
 		Render(strings.Repeat(edge, paneWidth+1))
-	return paint(bleed, paneWidth+1, backdropHex()) +
+	return paint(bleed, paneWidth+1, panelHex()) +
 		paint(hrule(width-paneWidth-1), width-paneWidth-1, backdropHex())
 }
 
@@ -69,7 +75,7 @@ func (m *Model) vruleColumn(height int) []string {
 // bleedColumn finishes a pane's right edge: a half block in the pane's
 // tone on the backdrop, extending the fill half a cell past the seam.
 func (m *Model) bleedColumn(height int) []string {
-	cell := paint(lipgloss.NewStyle().Foreground(lipgloss.Color(panelHex())).Render("▌"), 1, backdropHex())
+	cell := paint(lipgloss.NewStyle().Foreground(colorBg).Render("▐"), 1, panelHex())
 	lines := make([]string, height)
 	for i := range lines {
 		lines[i] = cell

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -61,8 +61,8 @@ var themes = []Theme{
 		Accent:  "#6f9fd0",
 		Accent2: "#6cb6a4",
 
-		Working:  "#5f9ecf",
-		Waiting:  "#d4a55c",
+		Working:  "#d08442",
+		Waiting:  "#d9b45c",
 		Finished: "#85b26f",
 		Errored:  "#cc6a6a",
 		Idle:     "#646c78",

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 
@@ -281,13 +282,42 @@ var current = themes[0]
 // color, so the two must be the same color for the frame's edges to look
 // exact. Terminals without OSC 11 ignore it.
 func SyncTerminalBackground() {
-	os.Stdout.WriteString("]11;" + current.Bg + "")
+	emitToTerminal("\x1b]11;" + current.Bg + "\x07")
 }
 
 // ResetTerminalBackground restores the terminal's own background (OSC 111)
 // when the manager exits.
 func ResetTerminalBackground() {
-	os.Stdout.WriteString("]111")
+	emitToTerminal("\x1b]111\x07")
+}
+
+// emitToTerminal sends a control sequence to whatever is actually drawing
+// the window. Run under tmux, a plain sequence stops at the multiplexer
+// (which at most recolors our pane), so it goes out twice: once plain and
+// once wrapped in tmux's passthrough envelope for the outer terminal.
+// EnableTerminalPassthrough must have opened that envelope first.
+func emitToTerminal(seq string) {
+	os.Stdout.WriteString(seq)
+	if os.Getenv("TMUX") != "" {
+		os.Stdout.WriteString(tmuxPassthrough(seq))
+	}
+}
+
+// tmuxPassthrough wraps a sequence in DCS tmux;…ST, doubling every ESC as
+// tmux's passthrough protocol requires.
+func tmuxPassthrough(seq string) string {
+	return "\x1bPtmux;" + strings.ReplaceAll(seq, "\x1b", "\x1b\x1b") + "\x1b\\"
+}
+
+// EnableTerminalPassthrough asks the hosting tmux, when there is one, to
+// let this pane's passthrough sequences reach the outer terminal. Off by
+// default since tmux 3.3, and without it the backdrop sync above dies at
+// the multiplexer.
+func EnableTerminalPassthrough() {
+	if os.Getenv("TMUX") == "" {
+		return
+	}
+	_ = exec.Command("tmux", "set-option", "-p", "allow-passthrough", "on").Run()
 }
 
 // bgSeq is the raw "set background" SGR for a hex color, for the few spots

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -1,0 +1,288 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Theme is the full token set every rendered pixel of the TUI resolves
+// through. Colors are hex so terminals with truecolor get the exact
+// palette; lipgloss degrades them to the closest 256 index elsewhere.
+//
+// No token paints a full-screen background: the terminal's own backdrop
+// shows through, and Bg is only ever used as the text color sitting on an
+// accent fill.
+type Theme struct {
+	Name string
+
+	// Surfaces and structure.
+	Bg      string // deepest tone, used as ink on accent fills
+	Surface string // selected row / chip fill
+	Overlay string // raised fill for gauges tracks and gutters
+	Border  string // idle panel border
+	Focus   string // focused panel border
+
+	// Type.
+	Bright string // emphasized text (selected names, values that must win)
+	Text   string // body text
+	Dim    string // secondary text
+	Subtle string // tertiary text, rules, separators
+
+	// Brand.
+	Accent  string // primary: focus, keys, brand
+	Accent2 string // secondary: groups, scopes
+
+	// Agent states.
+	Working  string
+	Waiting  string
+	Finished string
+	Errored  string
+	Idle     string
+}
+
+// themes is the built-in palette set, in picker order. Mocha leads: it is
+// the default and the palette the layout was tuned against.
+var themes = []Theme{
+	{
+		Name:    "catppuccin mocha",
+		Bg:      "#11111b",
+		Surface: "#313244",
+		Overlay: "#45475a",
+		Border:  "#45475a",
+		Focus:   "#cba6f7",
+		Bright:  "#f5f5ff",
+		Text:    "#cdd6f4",
+		Dim:     "#a6adc8",
+		Subtle:  "#6c7086",
+		Accent:  "#cba6f7",
+		Accent2: "#94e2d5",
+
+		Working:  "#fab387",
+		Waiting:  "#f5c2e7",
+		Finished: "#a6e3a1",
+		Errored:  "#f38ba8",
+		Idle:     "#7f849c",
+	},
+	{
+		Name:    "tokyo night",
+		Bg:      "#1a1b26",
+		Surface: "#292e42",
+		Overlay: "#3b4261",
+		Border:  "#3b4261",
+		Focus:   "#7aa2f7",
+		Bright:  "#ffffff",
+		Text:    "#c0caf5",
+		Dim:     "#9aa5ce",
+		Subtle:  "#565f89",
+		Accent:  "#7aa2f7",
+		Accent2: "#7dcfff",
+
+		Working:  "#e0af68",
+		Waiting:  "#bb9af7",
+		Finished: "#9ece6a",
+		Errored:  "#f7768e",
+		Idle:     "#565f89",
+	},
+	{
+		Name:    "gruvbox dark",
+		Bg:      "#1d2021",
+		Surface: "#3c3836",
+		Overlay: "#504945",
+		Border:  "#504945",
+		Focus:   "#83a598",
+		Bright:  "#fbf1c7",
+		Text:    "#ebdbb2",
+		Dim:     "#bdae93",
+		Subtle:  "#928374",
+		Accent:  "#83a598",
+		Accent2: "#8ec07c",
+
+		Working:  "#fabd2f",
+		Waiting:  "#d3869b",
+		Finished: "#b8bb26",
+		Errored:  "#fb4934",
+		Idle:     "#928374",
+	},
+	{
+		Name:    "nord",
+		Bg:      "#2e3440",
+		Surface: "#3b4252",
+		Overlay: "#434c5e",
+		Border:  "#434c5e",
+		Focus:   "#88c0d0",
+		Bright:  "#eceff4",
+		Text:    "#d8dee9",
+		Dim:     "#aebacf",
+		Subtle:  "#616e88",
+		Accent:  "#88c0d0",
+		Accent2: "#8fbcbb",
+
+		Working:  "#ebcb8b",
+		Waiting:  "#b48ead",
+		Finished: "#a3be8c",
+		Errored:  "#bf616a",
+		Idle:     "#6b7689",
+	},
+	{
+		Name:    "dracula",
+		Bg:      "#21222c",
+		Surface: "#343746",
+		Overlay: "#44475a",
+		Border:  "#44475a",
+		Focus:   "#bd93f9",
+		Bright:  "#ffffff",
+		Text:    "#f8f8f2",
+		Dim:     "#c3c3d0",
+		Subtle:  "#6272a4",
+		Accent:  "#bd93f9",
+		Accent2: "#8be9fd",
+
+		Working:  "#ffb86c",
+		Waiting:  "#ff79c6",
+		Finished: "#50fa7b",
+		Errored:  "#ff5555",
+		Idle:     "#6272a4",
+	},
+	{
+		Name:    "rosé pine",
+		Bg:      "#191724",
+		Surface: "#26233a",
+		Overlay: "#403d52",
+		Border:  "#403d52",
+		Focus:   "#c4a7e7",
+		Bright:  "#e0def4",
+		Text:    "#e0def4",
+		Dim:     "#908caa",
+		Subtle:  "#6e6a86",
+		Accent:  "#c4a7e7",
+		Accent2: "#9ccfd8",
+
+		Working:  "#f6c177",
+		Waiting:  "#ebbcba",
+		Finished: "#31748f",
+		Errored:  "#eb6f92",
+		Idle:     "#6e6a86",
+	},
+	{
+		Name:    "monochrome",
+		Bg:      "#0d0d0f",
+		Surface: "#26262b",
+		Overlay: "#3a3a41",
+		Border:  "#3a3a41",
+		Focus:   "#d8d8e0",
+		Bright:  "#ffffff",
+		Text:    "#d0d0d8",
+		Dim:     "#9a9aa4",
+		Subtle:  "#63636d",
+		Accent:  "#d8d8e0",
+		Accent2: "#a8a8b4",
+
+		Working:  "#e8e8ef",
+		Waiting:  "#c8c8d2",
+		Finished: "#a8a8b4",
+		Errored:  "#f0f0f6",
+		Idle:     "#63636d",
+	},
+}
+
+const themeSetting = "theme"
+
+// themeNames lists the built-in themes in picker order.
+func themeNames() []string {
+	names := make([]string, len(themes))
+	for i, t := range themes {
+		names[i] = t.Name
+	}
+	return names
+}
+
+// themeIndex finds a theme by name, falling back to the default when the
+// stored name is unknown (a theme removed between releases).
+func themeIndex(name string) int {
+	for i, t := range themes {
+		if t.Name == name {
+			return i
+		}
+	}
+	return 0
+}
+
+// applyTheme rebuilds every package-level style from a token set. The TUI
+// runs one model per process, so the styles stay package-level and a theme
+// switch simply repaints from the next frame on.
+func applyTheme(t Theme) {
+	current = t
+
+	colorBg = lipgloss.Color(t.Bg)
+	colorSurface = lipgloss.Color(t.Surface)
+	colorOverlay = lipgloss.Color(t.Overlay)
+	colorBorder = lipgloss.Color(t.Border)
+	colorFocus = lipgloss.Color(t.Focus)
+	colorBright = lipgloss.Color(t.Bright)
+	colorText = lipgloss.Color(t.Text)
+	colorDim = lipgloss.Color(t.Dim)
+	colorSubtle = lipgloss.Color(t.Subtle)
+	colorAccent = lipgloss.Color(t.Accent)
+	colorAccent2 = lipgloss.Color(t.Accent2)
+	colorSelBg = colorSurface
+
+	colorWorking = lipgloss.Color(t.Working)
+	colorWaiting = lipgloss.Color(t.Waiting)
+	colorFinished = lipgloss.Color(t.Finished)
+	colorErrored = lipgloss.Color(t.Errored)
+	colorIdle = lipgloss.Color(t.Idle)
+
+	rebuildStyles()
+}
+
+// current is the live token set; renderers that need a raw SGR sequence
+// (rather than a lipgloss style) read their hex from here.
+var current = themes[0]
+
+// bgSeq is the raw "set background" SGR for a hex color, for the few spots
+// that paint a background around content lipgloss already styled. It goes
+// through the live color profile, so a 256-color terminal gets an indexed
+// sequence rather than a truecolor one lipgloss would have downsampled.
+func bgSeq(hex string) string {
+	return "\x1b[" + lipgloss.ColorProfile().Color(hex).Sequence(true) + "m"
+}
+
+// fgSeq is the raw "set foreground" SGR for a hex color.
+func fgSeq(hex string) string {
+	return "\x1b[" + lipgloss.ColorProfile().Color(hex).Sequence(false) + "m"
+}
+
+// hexRGB parses "#rrggbb"; an unparseable value reads as black, which is
+// visible enough in a diff to be caught rather than silently mistinted.
+func hexRGB(hex string) (int, int, int) {
+	hex = strings.TrimPrefix(hex, "#")
+	if len(hex) != 6 {
+		return 0, 0, 0
+	}
+	val, err := strconv.ParseUint(hex, 16, 32)
+	if err != nil {
+		return 0, 0, 0
+	}
+	return int(val>>16) & 0xff, int(val>>8) & 0xff, int(val) & 0xff
+}
+
+// mix blends two hex colors, ratio 0 returning a and 1 returning b. Used
+// for derived tones (row gutters, gauge tracks) so a theme only has to
+// declare its anchors.
+func mix(a, b string, ratio float64) string {
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
+	ar, ag, ab := hexRGB(a)
+	br, bg, bb := hexRGB(b)
+	blend := func(x, y int) int {
+		return int(float64(x)*(1-ratio) + float64(y)*ratio + 0.5)
+	}
+	return fmt.Sprintf("#%02x%02x%02x", blend(ar, br), blend(ag, bg), blend(ab, bb))
+}

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -25,7 +25,6 @@ type Theme struct {
 	Surface string // selected row / chip fill
 	Overlay string // raised fill for gauges tracks and gutters
 	Border  string // idle panel border
-	Focus   string // focused panel border
 
 	// Type.
 	Bright string // emphasized text (selected names, values that must win)
@@ -55,7 +54,6 @@ var themes = []Theme{
 		Surface: "#232830",
 		Overlay: "#2d333d",
 		Border:  "#2d333d",
-		Focus:   "#6f9fd0",
 		Bright:  "#eceff4",
 		Text:    "#c6ccd6",
 		Dim:     "#98a0ac",
@@ -75,7 +73,6 @@ var themes = []Theme{
 		Surface: "#073642",
 		Overlay: "#0e4753",
 		Border:  "#0e4753",
-		Focus:   "#268bd2",
 		Bright:  "#eee8d5",
 		Text:    "#93a1a1",
 		Dim:     "#839496",
@@ -95,7 +92,6 @@ var themes = []Theme{
 		Surface: "#313244",
 		Overlay: "#45475a",
 		Border:  "#45475a",
-		Focus:   "#cba6f7",
 		Bright:  "#f5f5ff",
 		Text:    "#cdd6f4",
 		Dim:     "#a6adc8",
@@ -115,7 +111,6 @@ var themes = []Theme{
 		Surface: "#292e42",
 		Overlay: "#3b4261",
 		Border:  "#3b4261",
-		Focus:   "#7aa2f7",
 		Bright:  "#ffffff",
 		Text:    "#c0caf5",
 		Dim:     "#9aa5ce",
@@ -135,7 +130,6 @@ var themes = []Theme{
 		Surface: "#3c3836",
 		Overlay: "#504945",
 		Border:  "#504945",
-		Focus:   "#83a598",
 		Bright:  "#fbf1c7",
 		Text:    "#ebdbb2",
 		Dim:     "#bdae93",
@@ -155,7 +149,6 @@ var themes = []Theme{
 		Surface: "#3b4252",
 		Overlay: "#434c5e",
 		Border:  "#434c5e",
-		Focus:   "#88c0d0",
 		Bright:  "#eceff4",
 		Text:    "#d8dee9",
 		Dim:     "#aebacf",
@@ -175,7 +168,6 @@ var themes = []Theme{
 		Surface: "#343746",
 		Overlay: "#44475a",
 		Border:  "#44475a",
-		Focus:   "#bd93f9",
 		Bright:  "#ffffff",
 		Text:    "#f8f8f2",
 		Dim:     "#c3c3d0",
@@ -195,7 +187,6 @@ var themes = []Theme{
 		Surface: "#26233a",
 		Overlay: "#403d52",
 		Border:  "#403d52",
-		Focus:   "#c4a7e7",
 		Bright:  "#e0def4",
 		Text:    "#e0def4",
 		Dim:     "#908caa",
@@ -215,7 +206,6 @@ var themes = []Theme{
 		Surface: "#26262b",
 		Overlay: "#3a3a41",
 		Border:  "#3a3a41",
-		Focus:   "#d8d8e0",
 		Bright:  "#ffffff",
 		Text:    "#d0d0d8",
 		Dim:     "#9a9aa4",
@@ -254,7 +244,6 @@ func applyTheme(t Theme) {
 	colorSurface = lipgloss.Color(t.Surface)
 	colorOverlay = lipgloss.Color(t.Overlay)
 	colorBorder = lipgloss.Color(t.Border)
-	colorFocus = lipgloss.Color(t.Focus)
 	colorBright = lipgloss.Color(t.Bright)
 	colorText = lipgloss.Color(t.Text)
 	colorDim = lipgloss.Color(t.Dim)

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -43,9 +43,50 @@ type Theme struct {
 	Idle     string
 }
 
-// themes is the built-in palette set, in picker order. Mocha leads: it is
-// the default and the palette the layout was tuned against.
+// themes is the built-in palette set, in picker order. Classic leads: it
+// is the default, a restrained take on the sixteen colors every terminal
+// has had for decades.
 var themes = []Theme{
+	{
+		Name:    "classic",
+		Bg:      "#0f1115",
+		Surface: "#232830",
+		Overlay: "#2d333d",
+		Border:  "#2d333d",
+		Focus:   "#6f9fd0",
+		Bright:  "#eceff4",
+		Text:    "#c6ccd6",
+		Dim:     "#98a0ac",
+		Subtle:  "#646c78",
+		Accent:  "#6f9fd0",
+		Accent2: "#6cb6a4",
+
+		Working:  "#5f9ecf",
+		Waiting:  "#d4a55c",
+		Finished: "#85b26f",
+		Errored:  "#cc6a6a",
+		Idle:     "#646c78",
+	},
+	{
+		Name:    "solarized dark",
+		Bg:      "#002b36",
+		Surface: "#073642",
+		Overlay: "#0e4753",
+		Border:  "#0e4753",
+		Focus:   "#268bd2",
+		Bright:  "#eee8d5",
+		Text:    "#93a1a1",
+		Dim:     "#839496",
+		Subtle:  "#586e75",
+		Accent:  "#268bd2",
+		Accent2: "#2aa198",
+
+		Working:  "#268bd2",
+		Waiting:  "#b58900",
+		Finished: "#859900",
+		Errored:  "#dc322f",
+		Idle:     "#586e75",
+	},
 	{
 		Name:    "catppuccin mocha",
 		Bg:      "#11111b",
@@ -189,15 +230,6 @@ var themes = []Theme{
 }
 
 const themeSetting = "theme"
-
-// themeNames lists the built-in themes in picker order.
-func themeNames() []string {
-	names := make([]string, len(themes))
-	for i, t := range themes {
-		names[i] = t.Name
-	}
-	return names
-}
 
 // themeIndex finds a theme by name, falling back to the default when the
 // stored name is unknown (a theme removed between releases).

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -273,6 +274,21 @@ func applyTheme(t Theme) {
 // current is the live token set; renderers that need a raw SGR sequence
 // (rather than a lipgloss style) read their hex from here.
 var current = themes[0]
+
+// SyncTerminalBackground repaints the terminal's own background to the
+// theme's backdrop (OSC 11). The frame can only paint its cell grid; any
+// window padding the terminal draws around that grid keeps the terminal's
+// color, so the two must be the same color for the frame's edges to look
+// exact. Terminals without OSC 11 ignore it.
+func SyncTerminalBackground() {
+	os.Stdout.WriteString("]11;" + current.Bg + "")
+}
+
+// ResetTerminalBackground restores the terminal's own background (OSC 111)
+// when the manager exits.
+func ResetTerminalBackground() {
+	os.Stdout.WriteString("]111")
+}
 
 // bgSeq is the raw "set background" SGR for a hex color, for the few spots
 // that paint a background around content lipgloss already styled. It goes

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -292,15 +292,17 @@ func ResetTerminalBackground() {
 }
 
 // emitToTerminal sends a control sequence to whatever is actually drawing
-// the window. Run under tmux, a plain sequence stops at the multiplexer
-// (which at most recolors our pane), so it goes out twice: once plain and
-// once wrapped in tmux's passthrough envelope for the outer terminal.
-// EnableTerminalPassthrough must have opened that envelope first.
+// the window. Run under tmux, only the passthrough envelope goes out: a
+// plain OSC would make tmux recolor our pane's default background, and a
+// recolored pane paints as explicit color while the terminal's padding
+// keeps blending its own — the exact ring the backdrop scheme exists to
+// avoid. EnableTerminalPassthrough must have opened the envelope first.
 func emitToTerminal(seq string) {
-	os.Stdout.WriteString(seq)
 	if os.Getenv("TMUX") != "" {
 		os.Stdout.WriteString(tmuxPassthrough(seq))
+		return
 	}
+	os.Stdout.WriteString(seq)
 }
 
 // tmuxPassthrough wraps a sequence in DCS tmux;…ST, doubling every ESC as

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -1,0 +1,14 @@
+package ui
+
+import "testing"
+
+// tmux forwards a passthrough payload after undoubling ESC bytes; a
+// sequence wrapped without the doubling reaches the terminal truncated at
+// its own first ESC.
+func TestTmuxPassthroughDoublesEscapes(t *testing.T) {
+	got := tmuxPassthrough("\x1b]11;#0f1115\x07")
+	want := "\x1bPtmux;\x1b\x1b]11;#0f1115\x07\x1b\\"
+	if got != want {
+		t.Fatalf("wrapped = %q, want %q", got, want)
+	}
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2110,7 +2110,7 @@ func TestDiffReviewShowsWholeFile(t *testing.T) {
 	}
 
 	view := ansi.Strip(m.View())
-	if !strings.Contains(view, "Review · coder") || !strings.Contains(view, "files") {
+	if !strings.Contains(view, "review · coder") || !strings.Contains(view, "files") {
 		t.Fatalf("fullscreen review layout missing:\n%s", view)
 	}
 	if !strings.Contains(view, "package main") || !strings.Contains(view, "println(1)") {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2110,7 +2110,7 @@ func TestDiffReviewShowsWholeFile(t *testing.T) {
 	}
 
 	view := ansi.Strip(m.View())
-	if !strings.Contains(view, "Review · coder") || !strings.Contains(view, "Files") {
+	if !strings.Contains(view, "Review · coder") || !strings.Contains(view, "files") {
 		t.Fatalf("fullscreen review layout missing:\n%s", view)
 	}
 	if !strings.Contains(view, "package main") || !strings.Contains(view, "println(1)") {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2292,6 +2292,10 @@ func TestSettingsTogglesReviewLayout(t *testing.T) {
 		t.Fatal("settings should open on split by default")
 	}
 	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.settings.field != settingsFieldTheme {
+		t.Fatalf("first down should focus theme field, got %d", m.settings.field)
+	}
+	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyDown})
 	if m.settings.field != settingsFieldLayout {
 		t.Fatalf("down should focus layout field, got %d", m.settings.field)
 	}

--- a/internal/ui/update_badge_test.go
+++ b/internal/ui/update_badge_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestHeaderShowsUpdateBadge(t *testing.T) {
 	m := &Model{width: 120, updateLatest: "v0.9.0"}
-	if got := m.viewHeader(); !strings.Contains(got, "v0.9.0") || !strings.Contains(got, "available") {
+	if got := m.headerScope(); !strings.Contains(got, "v0.9.0") || !strings.Contains(got, "available") {
 		t.Errorf("header missing update badge: %q", got)
 	}
 	m.updateLatest = ""
-	if got := m.viewHeader(); strings.Contains(got, "available") {
+	if got := m.headerScope(); strings.Contains(got, "available") {
 		t.Errorf("header should have no badge when up to date: %q", got)
 	}
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -37,41 +37,6 @@ func (m *Model) View() string {
 	return clampFrame(frame, m.height)
 }
 
-// viewListFrame is the sessions/sidebar layout used in list mode.
-func (m *Model) viewListFrame() string {
-	leftWidth, rightWidth := m.splitWidths()
-	footer := m.viewFooter()
-	bodyHeight := m.listBodyHeight()
-
-	// Grip column sits between the panels in resize mode so the drag
-	// target is visible; steal it from the right panel to keep total width.
-	gripWidth := 0
-	if m.resizeMode && rightWidth > 1 {
-		gripWidth = 1
-		rightWidth--
-	}
-
-	listInner := leftWidth - 4
-	leftBody := m.viewList(listInner, bodyHeight-2)
-	stats := m.viewComputer(listInner)
-	listHeight := bodyHeight - 2 - lipgloss.Height(stats)
-	if listHeight >= 3 {
-		leftBody = padToHeight(m.viewList(listInner, listHeight), listHeight) + "\n" + stats
-	}
-	sidebarFocused := m.quick.active
-	left := titledPanel("Sessions", leftBody, leftWidth, bodyHeight, !sidebarFocused)
-	right := titledPanel(m.sidebarTitle(), m.viewSidebar(rightWidth-4, bodyHeight-2), rightWidth, bodyHeight, sidebarFocused)
-	var body string
-	if gripWidth > 0 {
-		body = lipgloss.JoinHorizontal(lipgloss.Top, left, m.resizeGrip(bodyHeight), right)
-	} else {
-		body = lipgloss.JoinHorizontal(lipgloss.Top, left, right)
-	}
-
-	// listChromeRows (header + blank) must stay aligned with bodyYRange.
-	return strings.Join([]string{m.viewHeader(), "", body, m.viewStatus(), footer}, "\n")
-}
-
 // clampFrame pins a rendered frame to exactly height rows so the outer
 // terminal cannot scroll the TUI away when a layout overshoots.
 func clampFrame(frame string, height int) string {
@@ -113,7 +78,7 @@ func (m *Model) previewPaneWidth() int {
 		// Grip steals one column from the right panel while resize is on.
 		rightWidth--
 	}
-	w := rightWidth - 4
+	w := rightWidth - 2*contentGutter
 	if w < 1 {
 		return 1
 	}
@@ -128,25 +93,20 @@ func (m *Model) previewPaneHeight() int {
 	if m.height < 1 {
 		return 1
 	}
-	sidebarInner := m.listBodyHeight() - 2
-	if sidebarInner < 1 {
+	avail := m.listBodyHeight()
+	if avail < 1 {
 		return 1
 	}
-	avail := sidebarInner
 	if m.quick.active {
-		barH := lipgloss.Height(m.viewQuickBar(width)) + 1
-		avail -= barH
-		if avail < 3 {
-			avail = 3
-		}
+		avail -= lipgloss.Height(m.viewQuickBar(width)) + 1
 	}
-	detailH := lipgloss.Height(divider("Details", width) + "\n" + m.viewDetail(width))
-	rest := avail - detailH - 1
+	// Mirrors contentLines: the detail head, a blank, then the preview
+	// under its label.
+	rest := avail - lipgloss.Height(m.viewDetail(width)) - 1
 	if rest < 3 {
 		// Preview section is hidden; keep a tiny pane for create/attach paths.
 		return 3
 	}
-	// viewPreview spends one row on its "Preview" divider.
 	h := rest - 1
 	if h < 1 {
 		return 1
@@ -159,207 +119,24 @@ func (m *Model) previewPaneHeight() int {
 func (m *Model) viewStatus() string {
 	switch {
 	case m.mode == modeConfirmDelete:
-		return padRight(errStyle.Render(" ⚠ "+m.confirm.label)+subtleStyle.Render("  y/n"), m.width)
+		return "  " + errStyle.Render("⚠ "+m.confirm.label) + subtleStyle.Render("  y/n")
 	case m.resizeMode:
 		hint := "←→ resize · drag divider · | set · esc cancel"
 		if m.splitDragging {
 			hint = "release to set · esc cancels"
 		}
-		return padRight(keyStyle.Render(" resize ")+subtleStyle.Render(hint), m.width)
+		return "  " + keyStyle.Render("resize ") + subtleStyle.Render(hint)
 	case m.searching:
 		cursor := lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
-		line := keyStyle.Render(" search ") + valueStyle.Render(m.search) + cursor +
+		return "  " + keyStyle.Render("search ") + valueStyle.Render(m.search) + cursor +
 			subtleStyle.Render("  enter/esc to close")
-		return padRight(line, m.width)
 	case m.err != "":
-		return padRight(errStyle.Render(" ✖ "+m.err), m.width)
+		return "  " + errStyle.Render("✕ "+m.err)
 	case m.diff.notice != "":
-		return padRight(lipgloss.NewStyle().Foreground(colorFinished).Render(" ✔ "+m.diff.notice), m.width)
+		return "  " + lipgloss.NewStyle().Foreground(colorFinished).Render("● "+m.diff.notice)
 	default:
 		return ""
 	}
-}
-
-func (m *Model) viewHeader() string {
-	scope := "active"
-	if m.showArchived {
-		scope = "archived"
-	}
-	sessionCount := 0
-	for _, entry := range m.rows {
-		if !entry.isGroup {
-			sessionCount++
-		}
-	}
-	brand := badgeStyle.Render("◆ agent manager")
-	meta := valueStyle.Render(fmt.Sprintf("%d", sessionCount)) +
-		mutedStyle.Render(" sessions") +
-		subtleStyle.Render("  ·  ") +
-		lipgloss.NewStyle().Foreground(colorAccent2).Render(scope)
-	if m.updateLatest != "" {
-		meta += subtleStyle.Render("  ·  ") +
-			lipgloss.NewStyle().Foreground(colorAccent).Bold(true).
-				Render("↑ "+m.updateLatest+" available")
-	}
-	left := brand + "  " + meta
-
-	agents := ""
-	if m.agents.count > 0 {
-		agents = labelStyle.Render("agents ") +
-			valueStyle.Render(fmt.Sprintf("%.0f%%", m.agents.cpu)) +
-			subtleStyle.Render(" · ") +
-			valueStyle.Render(humanBytes(m.agents.rss)) + " "
-	}
-
-	// The right side gives way as the terminal narrows: the fleet strip
-	// first sheds its words, then the process stat drops, then the strip
-	// itself, so the brand and scope never get pushed off the line.
-	for _, right := range []string{
-		joinHeaderRight(m.viewStatusCounts(false), agents),
-		joinHeaderRight(m.viewStatusCounts(true), agents),
-		joinHeaderRight(m.viewStatusCounts(true), ""),
-		"",
-	} {
-		gap := m.width - ansi.StringWidth(left) - ansi.StringWidth(right)
-		if gap >= 2 {
-			return left + strings.Repeat(" ", gap) + right
-		}
-	}
-	return padRight(left, m.width)
-}
-
-func joinHeaderRight(counts, agents string) string {
-	switch {
-	case counts == "":
-		return agents
-	case agents == "":
-		return counts
-	default:
-		return counts + subtleStyle.Render("   ") + agents
-	}
-}
-
-// viewStatusCounts is the fleet-at-a-glance strip: one colored glyph and
-// count per status present among the listed sessions.
-func (m *Model) viewStatusCounts(compact bool) string {
-	counts := map[string]int{}
-	for _, sess := range m.sessions {
-		if !sess.Archived {
-			counts[sess.Status]++
-		}
-	}
-	var parts []string
-	for _, st := range []string{status.Waiting, status.Working, status.Finished, status.Idle, status.Errored, status.Dead} {
-		if counts[st] == 0 {
-			continue
-		}
-		label := fmt.Sprintf("%s %d %s", statusGlyph(st), counts[st], st)
-		if compact {
-			label = fmt.Sprintf("%s %d", statusGlyph(st), counts[st])
-		}
-		parts = append(parts, pill(label, statusColor(st)))
-	}
-	return strings.Join(parts, " ")
-}
-
-// viewComputer is the compact machine gauge block docked at the bottom
-// of the Sessions panel: cpu, memory (with used/total), swap, root-disk
-// free space, and network rates.
-func (m *Model) viewComputer(width int) string {
-	snap := m.snap
-	meter := func(label string, percent float64, ok bool, extra string) string {
-		if !ok {
-			return labelStyle.Width(5).Render(label) + mutedStyle.Render("n/a") + "\n"
-		}
-		line := labelStyle.Width(5).Render(label) + gauge(percent, 8) +
-			valueStyle.Render(fmt.Sprintf(" %3.0f%%", percent))
-		if extra != "" {
-			line += subtleStyle.Render(" " + extra)
-		}
-		return line + "\n"
-	}
-	var b strings.Builder
-	b.WriteString(divider("Computer", width) + "\n")
-	b.WriteString(meter("cpu", snap.CPUPercent, snap.CPUOK, ""))
-	b.WriteString(meter("mem", snap.MemPercent, snap.MemOK,
-		humanBytes(snap.MemUsed)+"/"+humanBytes(snap.MemTotal)))
-	if snap.SwapOK && snap.SwapTotal > 0 {
-		b.WriteString(meter("swap", snap.SwapPercent, true, humanBytes(snap.SwapUsed)))
-	}
-	b.WriteString(meter("disk", snap.DiskPercent, snap.DiskOK,
-		humanBytes(snap.DiskTotal-snap.DiskUsed)+" free"))
-	var temps []string
-	if snap.CPUTempOK {
-		temps = append(temps, fmt.Sprintf("cpu %.0f°C", snap.CPUTemp))
-	}
-	if snap.GPUTempOK {
-		temps = append(temps, fmt.Sprintf("gpu %.0f°C", snap.GPUTemp))
-	}
-	if snap.SoCTempOK {
-		temps = append(temps, fmt.Sprintf("soc %.0f°C", snap.SoCTemp))
-	}
-	if len(temps) > 0 {
-		b.WriteString(labelStyle.Width(5).Render("temp") +
-			valueStyle.Render(strings.Join(temps, "  ")) + "\n")
-	}
-	if m.netRates {
-		b.WriteString(labelStyle.Width(5).Render("net") +
-			valueStyle.Render("↓ "+humanBytes(m.netDown)+"/s") +
-			subtleStyle.Render("  ↑ "+humanBytes(m.netUp)+"/s") + "\n")
-	}
-	return strings.TrimRight(b.String(), "\n")
-}
-
-func (m *Model) sidebarTitle() string {
-	if sess, ok := m.selected(); ok {
-		return "Session · " + sess.Name
-	}
-	if entry, ok := m.selectedRow(); ok && entry.isGroup {
-		return "Group · " + displayGroup(entry.group)
-	}
-	return "Session"
-}
-
-func (m *Model) viewList(width, height int) string {
-	if len(m.rows) == 0 {
-		title := "No sessions yet"
-		hint := keyCap("n", "starts one") + subtleStyle.Render("  ·  ") + keyCap("g", "makes a group")
-		if m.showArchived {
-			title = "Nothing archived"
-			hint = keyCap("t", "goes back to active sessions")
-		}
-		if strings.TrimSpace(m.search) != "" {
-			title = "No matches for \"" + m.search + "\""
-			hint = keyCap("esc", "clears the search")
-		}
-		return "\n  " + lipgloss.NewStyle().Foreground(colorDim).Render(title) +
-			"\n  " + subtleStyle.Render(strings.Repeat("─", max(ansi.StringWidth(title), 1))) +
-			"\n  " + hint
-	}
-
-	start, end := scrollWindow(len(m.rows), m.cursor, height)
-	var b strings.Builder
-	if start > 0 {
-		b.WriteString(subtleStyle.Render(fmt.Sprintf("  ↑ %d more", start)) + "\n")
-	}
-	for i := start; i < end; i++ {
-		b.WriteString(m.renderTreeRow(m.rows[i], i == m.cursor, width) + "\n")
-	}
-	if end < len(m.rows) {
-		b.WriteString(subtleStyle.Render(fmt.Sprintf("  ↓ %d more", len(m.rows)-end)))
-	}
-	return strings.TrimRight(b.String(), "\n")
-}
-
-func treeGuides(depth int, selected bool) string {
-	if depth <= 0 {
-		return ""
-	}
-	guides := strings.Repeat("│ ", depth)
-	if selected {
-		return guides
-	}
-	return subtleStyle.Render(guides)
 }
 
 // inGroupSubtree reports whether a session's group sits at or below the
@@ -376,99 +153,6 @@ func (m *Model) groupSessionCount(path string) int {
 		}
 	}
 	return count
-}
-
-// scrollWindow keeps the cursor visible inside a height-limited window,
-// reserving one line for each overflow indicator when needed.
-func scrollWindow(total, cursor, height int) (int, int) {
-	if total <= height {
-		return 0, total
-	}
-	visible := height - 2
-	if visible < 1 {
-		visible = 1
-	}
-	start := cursor - visible/2
-	if start < 0 {
-		start = 0
-	}
-	if start+visible > total {
-		start = total - visible
-	}
-	return start, start + visible
-}
-
-func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
-	bar := " "
-	if selected {
-		bar = lipgloss.NewStyle().Foreground(colorAccent).Render("▌")
-	}
-	guides := treeGuides(entry.depth, selected)
-
-	if m.renamingRow(entry) {
-		line := bar + " " + guides + m.renameRowInput(entry, width-2-ansi.StringWidth(guides))
-		return renderSelectedRow(padRight(line, width))
-	}
-
-	secondary := func(s string) string {
-		if selected {
-			return s
-		}
-		return subtleStyle.Render(s)
-	}
-
-	var lead, meta string
-	if entry.isGroup {
-		marker := "▾"
-		if m.collapsed[entry.group] {
-			marker = "▸"
-		}
-		name := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true).Render(baseName(entry.group))
-		lead = secondary(marker) + " " + name
-		meta = secondary(fmt.Sprintf("%d", m.groupSessionCount(entry.group))) +
-			m.groupStatusGlyphs(entry.group)
-	} else {
-		sess := entry.sess
-		glyph := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
-		nameStyle := valueStyle
-		if selected {
-			nameStyle = lipgloss.NewStyle().Foreground(colorBright).Bold(true)
-		}
-		lead = glyph + " " + nameStyle.Render(sess.Name)
-		state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusLabel(sess.Status))
-		// Meta gives up detail before the name gives up characters: age
-		// goes first, then the tool, leaving the state as the last thing
-		// standing next to the name.
-		meta = fitMeta(ansi.StringWidth(lead), width-2-ansi.StringWidth(guides),
-			state+secondary(" · "+sess.Tool+" · "+relTime(sess.CreatedAt)),
-			state+secondary(" · "+sess.Tool),
-			state,
-		)
-	}
-
-	line := bar + " " + guides + rowColumns(lead, meta, width-2-ansi.StringWidth(guides))
-	if ansi.StringWidth(line) > width {
-		line = ansi.Truncate(line, width-1, "…") + "\x1b[0m"
-	}
-	line = padRight(line, width)
-	if selected {
-		return renderSelectedRow(line)
-	}
-	return line
-}
-
-// fitMeta picks the richest meta variant that still leaves the name room,
-// so narrow panels lose detail rather than lose names.
-func fitMeta(leadWidth, rowWidth int, variants ...string) string {
-	for _, variant := range variants {
-		if leadWidth+2+ansi.StringWidth(variant) <= rowWidth {
-			return variant
-		}
-	}
-	if len(variants) == 0 {
-		return ""
-	}
-	return variants[len(variants)-1]
 }
 
 // rowColumns lays a list row out as a name column and a right-aligned meta
@@ -522,51 +206,6 @@ func divider(label string, width int) string {
 		dashes = 0
 	}
 	return head + lipgloss.NewStyle().Foreground(colorBorder).Render(strings.Repeat("─", dashes))
-}
-
-// viewSidebar lays out session details on top, with the live preview
-// filling the rest of the panel below. The quick bar, when active, docks
-// at the very bottom in the same spot for sessions and groups alike.
-func (m *Model) viewSidebar(width, height int) string {
-	bar := ""
-	if m.quick.active {
-		bar = m.viewQuickBar(width)
-		if height -= lipgloss.Height(bar) + 1; height < 3 {
-			height = 3
-		}
-	}
-	detail := divider("Details", width) + "\n" + m.viewDetail(width)
-	body := detail
-	if rest := height - lipgloss.Height(detail) - 1; rest >= 3 {
-		if group, ok := m.selectedGroup(); ok {
-			body = detail + "\n" + m.viewGroupAgents(group, width, rest)
-		} else {
-			body = detail + "\n" + m.viewPreview(width, rest)
-		}
-	}
-	if bar == "" {
-		return body
-	}
-	return padToHeight(body, height) + "\n" + bar
-}
-
-// viewQuickBar is the docked prompt input: enter answers the selected
-// session, or spawns a fresh agent when a group row is selected.
-func (m *Model) viewQuickBar(width int) string {
-	target := "no selection"
-	if entry, ok := m.selectedRow(); ok {
-		if entry.isGroup {
-			target = "new " + m.quickTool() + " agent in " + displayGroup(entry.group)
-		} else {
-			target = "answer " + entry.sess.Name
-		}
-	}
-	// Chips live in the textarea prompt so they sit on the same line as the
-	// typed text (Claude-style inline chips), not on a separate strip below.
-	m.syncQuickInlineChips()
-	m.quick.input.SetWidth(width)
-	m.quick.input.SetHeight(m.quickBarRows(width - 2))
-	return divider("Quick Prompt · "+target, width) + "\n" + m.quick.input.View()
 }
 
 // syncQuickInlineChips rebuilds the line-0 prompt as "> [chip] [chip] " so
@@ -644,79 +283,6 @@ func (m *Model) selectedGroup() (string, bool) {
 	return "", false
 }
 
-func (m *Model) viewDetail(width int) string {
-	sess, ok := m.selected()
-	if !ok {
-		if group, isGroup := m.selectedGroup(); isGroup {
-			return m.viewGroupDetail(group, width)
-		}
-		return "\n" + mutedStyle.Render("Select a session to inspect it.")
-	}
-	var b strings.Builder
-	tool := sess.Tool
-	if m.mode == modeRename && !m.rename.isGroup && m.rename.sessID == sess.ID {
-		if picked := m.renameTool(); picked != "" {
-			tool = picked
-		}
-	}
-	b.WriteString(pill(sess.Status, statusColor(sess.Status)) + "  " +
-		pill(tool, colorAccent) + "\n")
-	b.WriteString(kv("group", displayGroup(sess.Group)))
-	b.WriteString(kv("dir", truncateTail(sess.Cwd, width-8)))
-	b.WriteString(kv("age", relTime(sess.CreatedAt)))
-	if m.procFor == sess.ID && m.proc.OK {
-		b.WriteString(kv("proc", fmt.Sprintf("%.1f%% · %s", m.proc.CPUPercent, humanBytes(m.proc.RSS))))
-	}
-	return b.String()
-}
-
-// viewGroupDetail fills the details panel for a selected group: default
-// path (own or inherited), direct subgroup count, and a status breakdown
-// of every agent in the subtree.
-func (m *Model) viewGroupDetail(group string, width int) string {
-	var b strings.Builder
-	count := m.groupSessionCount(group)
-	countLabel := fmt.Sprintf("%d agents", count)
-	if count == 1 {
-		countLabel = "1 agent"
-	}
-	b.WriteString(pill("group", colorAccent2) + "  " + pill(countLabel, colorAccent) + "\n")
-
-	if m.renamingGroup(group) {
-		label := labelStyle
-		if m.rename.focus == 1 {
-			label = lipgloss.NewStyle().Foreground(colorAccent)
-		}
-		if fieldWidth := width - 8; fieldWidth >= 10 {
-			m.rename.dir.Width = fieldWidth
-		}
-		b.WriteString(label.Width(6).Render("path") + m.rename.dir.View() + "\n")
-		if m.rename.focus == 1 && m.pathSugg.active() {
-			b.WriteString(m.viewPathSuggestions() + "\n")
-		}
-	} else {
-		path := m.groupPaths[group]
-		source := ""
-		if path == "" {
-			path = m.groupDefaultDir(group)
-			source = subtleStyle.Render(" · inherited")
-		}
-		b.WriteString(labelStyle.Width(6).Render("path") +
-			valueStyle.Render(truncateTail(path, width-8)) + source + "\n")
-	}
-
-	if group != "" {
-		b.WriteString(kv("group", displayGroup(parentGroup(group))))
-	}
-	if subgroups := m.directSubgroupCount(group); subgroups > 0 {
-		b.WriteString(kv("subs", fmt.Sprintf("%d", subgroups)))
-	}
-	if breakdown := m.groupStatusBreakdown(group); breakdown != "" {
-		b.WriteString(labelStyle.Width(6).Render("state") + breakdown + "\n")
-	}
-	return b.String()
-}
-
 func parentGroup(group string) string {
 	if idx := strings.LastIndex(group, "/"); idx >= 0 {
 		return group[:idx]
@@ -770,58 +336,6 @@ func (m *Model) groupStatusGlyphs(group string) string {
 		}
 	}
 	return b.String()
-}
-
-// viewGroupAgents lists the subtree's sessions where a session's pane
-// preview would sit, so a group row reads as a group pane.
-func (m *Model) viewGroupAgents(group string, width, height int) string {
-	var b strings.Builder
-	b.WriteString(divider("Agents", width) + "\n")
-	shown, total := 0, m.groupSessionCount(group)
-	if total == 0 {
-		b.WriteString(mutedStyle.Render("(no agents yet — press space to spawn one)"))
-		return padToHeight(b.String(), height)
-	}
-	for _, sess := range m.visibleSessions() {
-		if !inGroupSubtree(sess.Group, group) {
-			continue
-		}
-		if shown >= height-2 && total > shown+1 {
-			b.WriteString(subtleStyle.Render(fmt.Sprintf("  … %d more", total-shown)))
-			break
-		}
-		glyph := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
-		line := glyph + " " + valueStyle.Render(sess.Name) +
-			subtleStyle.Render("  "+sess.Tool+" · "+relTime(sess.CreatedAt))
-		if ansi.StringWidth(line) > width {
-			line = ansi.Truncate(line, width-1, "…")
-		}
-		b.WriteString(line + "\n")
-		shown++
-	}
-	return padToHeight(strings.TrimRight(b.String(), "\n"), height)
-}
-
-// viewPreview renders the selected session's tmux pane 1:1 with its
-// original ANSI colors. The pane is sized to this box, so the capture is
-// painted top-to-bottom without tail/collapse transforms that would make
-// it look unlike being inside the session.
-func (m *Model) viewPreview(width, height int) string {
-	var b strings.Builder
-	b.WriteString(divider("Preview", width) + "\n")
-	contentRows := height - 1
-	if contentRows < 1 {
-		return padToHeight(b.String(), height)
-	}
-	lines := paneExact(m.preview, contentRows)
-	if len(lines) == 0 {
-		b.WriteString(mutedStyle.Render("(no output yet)"))
-		return padToHeight(b.String(), height)
-	}
-	for _, line := range lines {
-		b.WriteString(previewLine(line, width) + "\n")
-	}
-	return padToHeight(strings.TrimRight(b.String(), "\n"), height)
 }
 
 // previewDangerSeqs strips capture sequences that would scroll or clear the
@@ -944,13 +458,13 @@ func footerLine(pairs [][2]string, width int) string {
 		partWidth := ansi.StringWidth(part)
 		switch {
 		case line == "":
-			line, lineWidth = " "+part, 1+partWidth
+			line, lineWidth = strings.Repeat(" ", railGutter)+part, railGutter+partWidth
 		case lineWidth+sepWidth+partWidth <= width:
 			line += sep + part
 			lineWidth += sepWidth + partWidth
 		default:
 			lines = append(lines, line)
-			line, lineWidth = " "+part, 1+partWidth
+			line, lineWidth = strings.Repeat(" ", railGutter)+part, railGutter+partWidth
 		}
 	}
 	return strings.Join(append(lines, line), "\n")
@@ -1001,4 +515,24 @@ func truncateTail(s string, max int) string {
 		return s
 	}
 	return "…" + string(runes[len(runes)-max+1:])
+}
+
+// scrollWindow keeps the cursor visible inside a height-limited window of
+// single-line rows, reserving one line for each overflow indicator.
+func scrollWindow(total, cursor, height int) (int, int) {
+	if total <= height {
+		return 0, total
+	}
+	visible := height - 2
+	if visible < 1 {
+		visible = 1
+	}
+	start := cursor - visible/2
+	if start < 0 {
+		start = 0
+	}
+	if start+visible > total {
+		start = total - visible
+	}
+	return start, start + visible
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -48,7 +48,9 @@ func clampFrame(frame string, height int) string {
 		lines = lines[:height]
 	}
 	for len(lines) < height {
-		lines = append(lines, "")
+		// Padding rows carry the backdrop too; a bare row would show the
+		// terminal's own background through the bottom of a short frame.
+		lines = append(lines, paint("", 1, backdropHex()))
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -74,11 +74,8 @@ func (m *Model) splitWidths() (int, int) {
 // fit the panel instead of getting clipped on the right.
 func (m *Model) previewPaneWidth() int {
 	_, rightWidth := m.splitWidths()
-	if m.resizeMode && rightWidth > 1 {
-		// Grip steals one column from the right panel while resize is on.
-		rightWidth--
-	}
-	w := rightWidth - 2*contentGutter
+	// The seam column between the rail and the content is not the pane's.
+	w := rightWidth - 1 - 2*contentGutter
 	if w < 1 {
 		return 1
 	}
@@ -307,8 +304,11 @@ func (m *Model) groupStatusBreakdown(group string) string {
 	var parts []string
 	for _, st := range []string{status.Working, status.Waiting, status.Finished, status.Errored, status.Idle, status.Dead} {
 		if counts[st] > 0 {
+			// The count carries the state's color, the word stays quiet: a
+			// rollup line should read as one texture, not as six labels
+			// competing with the session names above it.
 			parts = append(parts, lipgloss.NewStyle().Foreground(statusColor(st)).
-				Render(fmt.Sprintf("%d %s", counts[st], st)))
+				Render(fmt.Sprintf("%d", counts[st]))+subtleStyle.Render(" "+st))
 		}
 	}
 	return strings.Join(parts, subtleStyle.Render(" · "))

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -97,14 +97,14 @@ func (m *Model) previewPaneHeight() int {
 	if m.quick.active {
 		avail -= lipgloss.Height(m.viewQuickBar(width)) + 1
 	}
-	// Mirrors contentLines: the detail head, a blank, then the preview
-	// under its label.
+	// Mirrors contentLines: the detail head, the seam, then the preview
+	// under its label and the blank line beneath it.
 	rest := avail - lipgloss.Height(m.viewDetail(width)) - 1
 	if rest < 3 {
 		// Preview section is hidden; keep a tiny pane for create/attach paths.
 		return 3
 	}
-	h := rest - 1
+	h := rest - 2
 	if h < 1 {
 		return 1
 	}
@@ -491,7 +491,9 @@ func relTime(t time.Time) string {
 	d := time.Since(t)
 	switch {
 	case d < time.Minute:
-		return fmt.Sprintf("%ds", int(d.Seconds()))
+		// Five-second steps: a column of ages that ticks every second is
+		// motion the eye chases for no information.
+		return fmt.Sprintf("%ds", int(d.Seconds()/5)*5)
 	case d < time.Hour:
 		return fmt.Sprintf("%dm", int(d.Minutes()))
 	case d < 24*time.Hour:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -58,8 +58,9 @@ func (m *Model) viewListFrame() string {
 	if listHeight >= 3 {
 		leftBody = padToHeight(m.viewList(listInner, listHeight), listHeight) + "\n" + stats
 	}
-	left := titledPanel("Sessions", leftBody, leftWidth, bodyHeight)
-	right := titledPanel(m.sidebarTitle(), m.viewSidebar(rightWidth-4, bodyHeight-2), rightWidth, bodyHeight)
+	sidebarFocused := m.quick.active
+	left := titledPanel("Sessions", leftBody, leftWidth, bodyHeight, !sidebarFocused)
+	right := titledPanel(m.sidebarTitle(), m.viewSidebar(rightWidth-4, bodyHeight-2), rightWidth, bodyHeight, sidebarFocused)
 	var body string
 	if gripWidth > 0 {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, left, m.resizeGrip(bodyHeight), right)
@@ -190,39 +191,57 @@ func (m *Model) viewHeader() string {
 			sessionCount++
 		}
 	}
-	brand := badgeStyle.Render("◆ Agent Manager")
-	meta := mutedStyle.Render(fmt.Sprintf("%d sessions", sessionCount)) +
-		subtleStyle.Render(" · ") +
+	brand := badgeStyle.Render("◆ agent manager")
+	meta := valueStyle.Render(fmt.Sprintf("%d", sessionCount)) +
+		mutedStyle.Render(" sessions") +
+		subtleStyle.Render("  ·  ") +
 		lipgloss.NewStyle().Foreground(colorAccent2).Render(scope)
 	if m.updateLatest != "" {
-		meta += subtleStyle.Render(" · ") +
+		meta += subtleStyle.Render("  ·  ") +
 			lipgloss.NewStyle().Foreground(colorAccent).Bold(true).
 				Render("↑ "+m.updateLatest+" available")
 	}
 	left := brand + "  " + meta
 
-	right := m.viewStatusCounts()
+	agents := ""
 	if m.agents.count > 0 {
-		agents := labelStyle.Render("agents ") +
+		agents = labelStyle.Render("agents ") +
 			valueStyle.Render(fmt.Sprintf("%.0f%%", m.agents.cpu)) +
 			subtleStyle.Render(" · ") +
-			valueStyle.Render(humanBytes(m.agents.rss))
-		if right != "" {
-			right += subtleStyle.Render("   ")
-		}
-		right += agents + " "
+			valueStyle.Render(humanBytes(m.agents.rss)) + " "
 	}
 
-	gap := m.width - ansi.StringWidth(left) - ansi.StringWidth(right)
-	if gap < 1 {
-		return padRight(left, m.width)
+	// The right side gives way as the terminal narrows: the fleet strip
+	// first sheds its words, then the process stat drops, then the strip
+	// itself, so the brand and scope never get pushed off the line.
+	for _, right := range []string{
+		joinHeaderRight(m.viewStatusCounts(false), agents),
+		joinHeaderRight(m.viewStatusCounts(true), agents),
+		joinHeaderRight(m.viewStatusCounts(true), ""),
+		"",
+	} {
+		gap := m.width - ansi.StringWidth(left) - ansi.StringWidth(right)
+		if gap >= 2 {
+			return left + strings.Repeat(" ", gap) + right
+		}
 	}
-	return left + strings.Repeat(" ", gap) + right
+	return padRight(left, m.width)
+}
+
+func joinHeaderRight(counts, agents string) string {
+	switch {
+	case counts == "":
+		return agents
+	case agents == "":
+		return counts
+	default:
+		return counts + subtleStyle.Render("   ") + agents
+	}
 }
 
 // viewStatusCounts is the fleet-at-a-glance strip: one colored glyph and
 // count per status present among the listed sessions.
-func (m *Model) viewStatusCounts() string {
+func (m *Model) viewStatusCounts(compact bool) string {
 	counts := map[string]int{}
 	for _, sess := range m.sessions {
 		if !sess.Archived {
@@ -234,10 +253,13 @@ func (m *Model) viewStatusCounts() string {
 		if counts[st] == 0 {
 			continue
 		}
-		glyph := lipgloss.NewStyle().Foreground(statusColor(st)).Render(statusGlyph(st))
-		parts = append(parts, glyph+mutedStyle.Render(fmt.Sprintf(" %d %s", counts[st], st)))
+		label := fmt.Sprintf("%s %d %s", statusGlyph(st), counts[st], st)
+		if compact {
+			label = fmt.Sprintf("%s %d", statusGlyph(st), counts[st])
+		}
+		parts = append(parts, pill(label, statusColor(st)))
 	}
-	return strings.Join(parts, subtleStyle.Render("  "))
+	return strings.Join(parts, " ")
 }
 
 // viewComputer is the compact machine gauge block docked at the bottom
@@ -300,14 +322,19 @@ func (m *Model) sidebarTitle() string {
 
 func (m *Model) viewList(width, height int) string {
 	if len(m.rows) == 0 {
-		hint := "Press " + keyStyle.Render("n") + mutedStyle.Render(" to create a session.")
+		title := "No sessions yet"
+		hint := keyCap("n", "starts one") + subtleStyle.Render("  ·  ") + keyCap("g", "makes a group")
 		if m.showArchived {
-			hint = mutedStyle.Render("No archived sessions. ") + keyStyle.Render("t") + mutedStyle.Render(" goes back.")
+			title = "Nothing archived"
+			hint = keyCap("t", "goes back to active sessions")
 		}
 		if strings.TrimSpace(m.search) != "" {
-			hint = mutedStyle.Render("No matches for ") + valueStyle.Render("\""+m.search+"\"")
+			title = "No matches for \"" + m.search + "\""
+			hint = keyCap("esc", "clears the search")
 		}
-		return "\n  " + subtleStyle.Render("✦") + "  " + hint
+		return "\n  " + lipgloss.NewStyle().Foreground(colorDim).Render(title) +
+			"\n  " + subtleStyle.Render(strings.Repeat("─", max(ansi.StringWidth(title), 1))) +
+			"\n  " + hint
 	}
 
 	start, end := scrollWindow(len(m.rows), m.cursor, height)
@@ -374,7 +401,7 @@ func scrollWindow(total, cursor, height int) (int, int) {
 func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 	bar := " "
 	if selected {
-		bar = lipgloss.NewStyle().Foreground(colorAccent).Render("▎")
+		bar = lipgloss.NewStyle().Foreground(colorAccent).Render("▌")
 	}
 	guides := treeGuides(entry.depth, selected)
 
@@ -390,15 +417,16 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 		return subtleStyle.Render(s)
 	}
 
-	var content string
+	var lead, meta string
 	if entry.isGroup {
 		marker := "▾"
 		if m.collapsed[entry.group] {
 			marker = "▸"
 		}
-		count := secondary(fmt.Sprintf(" (%d)", m.groupSessionCount(entry.group)))
 		name := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true).Render(baseName(entry.group))
-		content = secondary(marker) + " " + name + count + m.groupStatusGlyphs(entry.group)
+		lead = secondary(marker) + " " + name
+		meta = secondary(fmt.Sprintf("%d", m.groupSessionCount(entry.group))) +
+			m.groupStatusGlyphs(entry.group)
 	} else {
 		sess := entry.sess
 		glyph := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
@@ -406,13 +434,19 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 		if selected {
 			nameStyle = lipgloss.NewStyle().Foreground(colorBright).Bold(true)
 		}
-		name := nameStyle.Render(sess.Name)
+		lead = glyph + " " + nameStyle.Render(sess.Name)
 		state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusLabel(sess.Status))
-		meta := state + secondary(" · "+sess.Tool+" · "+relTime(sess.CreatedAt))
-		content = glyph + " " + name + "  " + meta
+		// Meta gives up detail before the name gives up characters: age
+		// goes first, then the tool, leaving the state as the last thing
+		// standing next to the name.
+		meta = fitMeta(ansi.StringWidth(lead), width-2-ansi.StringWidth(guides),
+			state+secondary(" · "+sess.Tool+" · "+relTime(sess.CreatedAt)),
+			state+secondary(" · "+sess.Tool),
+			state,
+		)
 	}
 
-	line := bar + " " + guides + content
+	line := bar + " " + guides + rowColumns(lead, meta, width-2-ansi.StringWidth(guides))
 	if ansi.StringWidth(line) > width {
 		line = ansi.Truncate(line, width-1, "…") + "\x1b[0m"
 	}
@@ -421,6 +455,37 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width int) string {
 		return renderSelectedRow(line)
 	}
 	return line
+}
+
+// fitMeta picks the richest meta variant that still leaves the name room,
+// so narrow panels lose detail rather than lose names.
+func fitMeta(leadWidth, rowWidth int, variants ...string) string {
+	for _, variant := range variants {
+		if leadWidth+2+ansi.StringWidth(variant) <= rowWidth {
+			return variant
+		}
+	}
+	if len(variants) == 0 {
+		return ""
+	}
+	return variants[len(variants)-1]
+}
+
+// rowColumns lays a list row out as a name column and a right-aligned meta
+// column, so status, tool and age line up down the list instead of ragging
+// off the end of each name. Rows too narrow to split keep meta inline and
+// let the caller's truncation decide what survives.
+func rowColumns(lead, meta string, width int) string {
+	if meta == "" {
+		return lead
+	}
+	const gap = 2
+	leadWidth := ansi.StringWidth(lead)
+	metaWidth := ansi.StringWidth(meta)
+	if width < 1 || leadWidth+gap+metaWidth > width {
+		return lead + strings.Repeat(" ", gap) + meta
+	}
+	return lead + strings.Repeat(" ", width-leadWidth-metaWidth) + meta
 }
 
 func (m *Model) renamingGroup(group string) bool {
@@ -448,14 +513,15 @@ func (m *Model) renameRowInput(entry treeRow, width int) string {
 	return lead + " " + m.rename.input.View()
 }
 
-// divider renders a labeled section rule that fills the given width.
+// divider renders a labeled section rule that fills the given width: an
+// accent tick, the label, then a hairline out to the edge.
 func divider(label string, width int) string {
-	head := sectionStyle.Render(label) + " "
-	dashes := width - ansi.StringWidth(label) - 1
+	head := sectionStyle.Render("▍"+label) + " "
+	dashes := width - ansi.StringWidth(label) - 2
 	if dashes < 0 {
 		dashes = 0
 	}
-	return head + subtleStyle.Render(strings.Repeat("─", dashes))
+	return head + lipgloss.NewStyle().Foreground(colorBorder).Render(strings.Repeat("─", dashes))
 }
 
 // viewSidebar lays out session details on top, with the live preview
@@ -837,11 +903,12 @@ func padToHeight(s string, height int) string {
 // viewFooter lists every shortcut, wrapping onto extra lines when the
 // terminal is too narrow for one.
 func (m *Model) viewFooter() string {
+	// The footer carries the handful of keys a session is actually driven
+	// with; ? opens the full map, so the rest stay out of the frame.
 	pairs := [][2]string{
 		{"↑↓", "navigate"}, {"↵", "attach"}, {"n", "new"}, {"g", "group"},
-		{"⇧↑↓", "reorder"}, {"space", "quick prompt"}, {"ctrl+r", "review"}, {"F", "fold all"}, {"m", "move"}, {"r", "rename/edit"},
-		{"v", "revive"}, {"V", "revive all"}, {"a", "archive"}, {"u", "restore"}, {"d", "delete"}, {"/", "search"},
-		{"t", "archived"}, {"s", "settings"}, {"|", "resize"}, {"?", "help"}, {"q", "quit"},
+		{"space", "prompt"}, {"ctrl+r", "review"}, {"/", "search"},
+		{"s", "settings"}, {"?", "keys"}, {"q", "quit"},
 	}
 	if m.quick.active {
 		pairs = [][2]string{
@@ -873,7 +940,7 @@ func footerLine(pairs [][2]string, width int) string {
 	var lines []string
 	line, lineWidth := "", 0
 	for _, p := range pairs {
-		part := keyStyle.Render(p[0]) + " " + mutedStyle.Render(p[1])
+		part := keyCap(p[0], p[1])
 		partWidth := ansi.StringWidth(part)
 		switch {
 		case line == "":

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -290,16 +290,6 @@ func parentGroup(group string) string {
 	return ""
 }
 
-func (m *Model) directSubgroupCount(group string) int {
-	count := 0
-	for path := range groupClosure(m.groups, m.sessions) {
-		if parentGroup(path) == group && path != group {
-			count++
-		}
-	}
-	return count
-}
-
 // groupStatusBreakdown renders "2 working · 1 waiting" for the subtree,
 // each count tinted in its status color, skipping zero statuses.
 func (m *Model) groupStatusBreakdown(group string) string {
@@ -325,20 +315,6 @@ func (m *Model) groupStatusCounts(group string) map[string]int {
 		}
 	}
 	return counts
-}
-
-// groupStatusGlyphs is the compact per-row rollup of a group subtree's
-// live statuses (" ◐2 ?1"), idle omitted so quiet groups stay clean.
-func (m *Model) groupStatusGlyphs(group string) string {
-	counts := m.groupStatusCounts(group)
-	var b strings.Builder
-	for _, st := range []string{status.Working, status.Waiting, status.Finished, status.Errored, status.Dead} {
-		if counts[st] > 0 {
-			b.WriteString(" " + lipgloss.NewStyle().Foreground(statusColor(st)).
-				Render(fmt.Sprintf("%s%d", statusGlyph(st), counts[st])))
-		}
-	}
-	return b.String()
 }
 
 // previewDangerSeqs strips capture sequences that would scroll or clear the
@@ -377,32 +353,6 @@ func paneExact(pane string, n int) []string {
 	// capture-pane often ends with a trailing newline; drop only that.
 	pane = strings.TrimSuffix(pane, "\n")
 	lines := strings.Split(pane, "\n")
-	if len(lines) > n {
-		lines = lines[len(lines)-n:]
-	}
-	return lines
-}
-
-// paneTail returns the last n content-bearing lines of pane text with
-// blank runs collapsed. Used by tests and any caller that wants a dense
-// log-style excerpt rather than a 1:1 TUI frame.
-func paneTail(pane string, n int) []string {
-	if n <= 0 || pane == "" {
-		return nil
-	}
-	blank := func(line string) bool {
-		return strings.TrimSpace(ansi.Strip(line)) == ""
-	}
-	var lines []string
-	for _, line := range strings.Split(pane, "\n") {
-		if blank(line) && len(lines) > 0 && blank(lines[len(lines)-1]) {
-			continue
-		}
-		lines = append(lines, line)
-	}
-	for len(lines) > 0 && blank(lines[len(lines)-1]) {
-		lines = lines[:len(lines)-1]
-	}
 	if len(lines) > n {
 		lines = lines[len(lines)-n:]
 	}
@@ -478,10 +428,6 @@ func displayGroup(path string) string {
 		return "root"
 	}
 	return path
-}
-
-func kv(key, value string) string {
-	return labelStyle.Width(6).Render(key) + valueStyle.Render(value) + "\n"
 }
 
 // relSince is relTime worded as a moment in the past, for columns that

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -481,6 +481,12 @@ func kv(key, value string) string {
 	return labelStyle.Width(6).Render(key) + valueStyle.Render(value) + "\n"
 }
 
+// relSince is relTime worded as a moment in the past, for columns that
+// answer "when did this last happen" rather than "how long has this run".
+func relSince(t time.Time) string {
+	return relTime(t) + " ago"
+}
+
 func relTime(t time.Time) string {
 	d := time.Since(t)
 	switch {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -76,8 +76,9 @@ func (m *Model) splitWidths() (int, int) {
 // fit the panel instead of getting clipped on the right.
 func (m *Model) previewPaneWidth() int {
 	_, rightWidth := m.splitWidths()
-	// The seam column between the rail and the content is not the pane's.
-	w := rightWidth - 1 - 2*contentGutter
+	// The seam and bleed columns between the rail and the content are not
+	// the pane's.
+	w := rightWidth - 2 - 2*contentGutter
 	if w < 1 {
 		return 1
 	}

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -68,36 +68,6 @@ func TestClampFrame(t *testing.T) {
 	}
 }
 
-func TestPaneTail(t *testing.T) {
-	pane := "one\ntwo\nthree\n\n\n"
-	got := paneTail(pane, 2)
-	if len(got) != 2 || got[0] != "two" || got[1] != "three" {
-		t.Fatalf("paneTail = %v", got)
-	}
-	if paneTail("", 5) != nil {
-		t.Fatal("empty pane should return nil")
-	}
-	if paneTail("x", 0) != nil {
-		t.Fatal("zero budget should return nil")
-	}
-	ansiBlank := "real\n\x1b[38;5;42m   \x1b[0m\n"
-	got = paneTail(ansiBlank, 5)
-	if len(got) != 1 || got[0] != "real" {
-		t.Fatalf("ANSI-only blank lines should be trimmed, got %v", got)
-	}
-	sparse := "top\n\n\n\n\nmiddle\n\n\n\nbottom\n\n\n"
-	got = paneTail(sparse, 10)
-	want := []string{"top", "", "middle", "", "bottom"}
-	if len(got) != len(want) {
-		t.Fatalf("blank runs should collapse to one: %q", got)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("blank runs should collapse to one: %q", got)
-		}
-	}
-}
-
 func TestPreviewLine(t *testing.T) {
 	colored := "\x1b[38;5;42mgreen text\x1b[39m"
 	got := previewLine(colored, 80)

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -54,8 +54,17 @@ func TestClampFrame(t *testing.T) {
 	}
 	short := "x"
 	got = clampFrame(short, 3)
-	if got != "x\n\n" {
+	lines := strings.Split(got, "\n")
+	if len(lines) != 3 || lines[0] != "x" {
 		t.Fatalf("clampFrame pad = %q", got)
+	}
+	for _, line := range lines[1:] {
+		// Padding rows wear the backdrop fill rather than being bare, so
+		// a short frame cannot show the terminal's background through its
+		// bottom rows.
+		if !strings.Contains(line, " ") {
+			t.Fatalf("padding row is bare: %q", line)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -160,8 +160,12 @@ func run() error {
 	if err := ui.EnableAlternateScroll(); err != nil {
 		return err
 	}
+	// The terminal's own background follows the theme while the manager
+	// runs, so window padding outside the cell grid matches the frame.
+	ui.SyncTerminalBackground()
 	model.StartPoller(program.Send)
 	_, runErr := program.Run()
+	ui.ResetTerminalBackground()
 	if err := ui.DisableAlternateScroll(); err != nil && runErr == nil {
 		runErr = err
 	}

--- a/main.go
+++ b/main.go
@@ -161,7 +161,9 @@ func run() error {
 		return err
 	}
 	// The terminal's own background follows the theme while the manager
-	// runs, so window padding outside the cell grid matches the frame.
+	// runs, so window padding outside the cell grid matches the frame —
+	// through tmux's passthrough envelope when a multiplexer is hosting us.
+	ui.EnableTerminalPassthrough()
 	ui.SyncTerminalBackground()
 	model.StartPoller(program.Send)
 	_, runErr := program.Run()


### PR DESCRIPTION
## What

A full visual redesign of the list and review screens, herdr-inspired: no drawn borders, separation carried by background tone.

- **Theme system** (`theme.go`): truecolor token themes — classic (default, orange working state), solarized dark, catppuccin mocha, tokyo night, gruvbox, nord, dracula, rosé pine, monochrome — switchable live from settings.
- **Terminal background sync**: OSC 11 keeps the terminal's own background at the theme's backdrop (with a tmux passthrough envelope when hosted inside tmux), so window padding and unpainted cells share one tone.
- **Painted surfaces** (`surface.go`): the sessions rail fills its pane flush, edged with half-block bleeds and quadrant corners so the fill lands on the pixel grid on all four sides; the preview stays unpainted so agent CLIs keep their own colors.
- **List view** (`listview.go`): two-line entries, tree branch connectors (`├─`/`╰─`) hanging children off their groups, full-width header band with wordmark and fleet rollup, labelled stats, docked machine meters.
- **Review mode**: same two-surface frame; scroll math counts painted rows, so soft-wrapped files can always reach their last line.
- **Live preview**: a dedicated adaptive timer (300ms while working, 1.2s calm) instead of refreshing only on selection.
- **Activity times**: entries show time since last response (`40s ago`), not uptime.

## Testing

- Cell-level frame assertions: `TestPaneSoftEdges`, `TestFrameFitsTerminal` (15 sizes), diff frame fit (52 combos), review reachability including soft-wrapped files, cursor visibility walk, live-preview tracking.
- Frame benchmark: 0.36ms/frame; observed ~2.4% CPU live.
- Corner geometry verified by parsing rendered ANSI cell-by-cell plus zoomed pixel renders.