### PR TITLE
fix(ui): clear the pane hash on attach so entering a session keeps its status

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -336,9 +336,15 @@ func (m *Model) acknowledgeFinished(sess store.Session) error {
 
 func (m *Model) attachCmd(id string) tea.Cmd {
 	// Flip the window back to auto-sizing so it fills the terminal on attach;
-	// attachDoneMsg re-pins it to the preview width on detach.
-	if err := m.tmux.PrepareAttach(id); err != nil {
-		m.err = err.Error()
+	// attachDoneMsg re-pins it to the preview width on detach. Clearing the
+	// cached hash first keeps the poller from reading this reflow as
+	// streaming output, same as the detach-side resize (reflowSessions).
+	var prepErr error
+	m.poller.reflowSessions([]string{id}, func() {
+		prepErr = m.tmux.PrepareAttach(id)
+	})
+	if prepErr != nil {
+		m.err = prepErr.Error()
 		return nil
 	}
 	return tea.ExecProcess(m.tmux.AttachCommand(id), func(err error) tea.Msg {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1119,18 +1119,29 @@ func TestAttachClearsStaleHashBeforeReflow(t *testing.T) {
 	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
 		t.Fatalf("set finished: %v", err)
 	}
+	sess.Status = status.Finished
 	m.sessions[0].Status = status.Finished
 	m.rebuildRows()
 	m.selectSessionRow(t, "attach-reflow")
 
-	seedRegionHash(t, m, sess, "final answer line that wraps differently before attach\n❯ \n")
+	before := "final answer line that wraps differently after attach\n❯ \n"
+	after := "final answer line that wraps\ndifferently after attach\n❯ \n"
+	seedRegionHash(t, m, sess, before)
+	// Without clearing, the widened pane looks like streaming work.
+	if got := deriveStatus(t, m, sess, after, true); got != status.Working {
+		t.Fatalf("reflow with a prior hash should look like working (precondition), got %q", got)
+	}
 
 	if _, cmd := m.attachSelected(); cmd == nil {
 		t.Fatalf("attach did not start, err = %q", m.err)
 	}
 
-	if _, seen := m.poller.paneHashes[sess.ID]; seen {
-		t.Fatal("attach must clear the cached pane hash so the post-attach reflow is not read as streaming")
+	entered, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got := deriveStatus(t, m, entered, after, true); got != status.Idle {
+		t.Fatalf("attach must rebaseline the pane hash instead of flashing working, got %q", got)
 	}
 }
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1094,6 +1094,46 @@ func TestAttachKeepsWorking(t *testing.T) {
 	}
 }
 
+// PrepareAttach flips window-size to auto, which reflows the pane the same
+// way the detach-side resize does; without clearing the cached hash first,
+// the next poll compares the reflowed pane against a pre-attach hash and
+// reads it as working (TestRebaselineKeepsFinishedWithoutFlashingWorking
+// proves that precondition). Attach must clear it the same way detach does.
+func TestAttachClearsStaleHashBeforeReflow(t *testing.T) {
+	m := buildModel(t)
+	m.openForm()
+	m.form.name.SetValue("attach-reflow")
+	m.form.dir.SetValue(t.TempDir())
+	m.form.toolIndex = 1 // claude-hooked: configured with an activity region to hash
+	pickGroup(t, m, "")
+	_, cmd := m.submitForm()
+	if m.mode != modeList {
+		t.Fatalf("after submit, mode = %v, err = %q", m.mode, m.err)
+	}
+	m.applyCmd(t, cmd)
+
+	sess := m.sessionRows()[0]
+	if sess.Tool != "claude-hooked" {
+		t.Fatalf("session tool = %q, want claude-hooked", sess.Tool)
+	}
+	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
+		t.Fatalf("set finished: %v", err)
+	}
+	m.sessions[0].Status = status.Finished
+	m.rebuildRows()
+	m.selectSessionRow(t, "attach-reflow")
+
+	seedRegionHash(t, m, sess, "final answer line that wraps differently before attach\n❯ \n")
+
+	if _, cmd := m.attachSelected(); cmd == nil {
+		t.Fatalf("attach did not start, err = %q", m.err)
+	}
+
+	if _, seen := m.poller.paneHashes[sess.ID]; seen {
+		t.Fatal("attach must clear the cached pane hash so the post-attach reflow is not read as streaming")
+	}
+}
+
 func TestReviveRecreatesDeadSession(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "phoenix", t.TempDir(), "")


### PR DESCRIPTION
## What

Entering a finished session and leaving it round-tripped its status: finished, working for a moment, then finished again.

## Why

`attachCmd` calls `PrepareAttach`, which flips the tmux window back to auto-sizing so it fills the terminal. That reflows the pane to full width. The poller keeps running on its own goroutine while the TUI is suspended inside the attach, so it captured the reflowed pane and compared its activity region against the pre-attach hash. A changed region means streaming output, so the session derived `working` for that tick.

That stray tick then cleared the acked flag (`poller.go:294-300`, "any real transition re-arms the finished alert"). On the next poll the hook status file still said `finished`, but with `acked` now false the `acked + finished -> idle` branch no longer applied, so it settled on `finished` instead of `idle`.

The detach side already handles this: PR #61 wrapped its resize in `reflowSessions`, which drops the cached hash under the poller lock so the post-resize capture rebaselines instead of reading as work. Attach performs the same reflow and now gets the same treatment.

## Test

`TestAttachClearsStaleHashBeforeReflow` seeds a region hash, attaches, and asserts the hash was dropped. It fails on the unpatched code and passes with the fix. Full suite and `go vet` are green.