### PR TITLE
feat(ui): list every shortcut in the list and review footers

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1524,20 +1524,20 @@ func (m *Model) viewDiffFooter() string {
 	if m.diff.annotating {
 		return footerLine([][2]string{{"↵", "save"}, {"esc", "cancel"}}, m.width)
 	}
+	repo := "repo"
+	if len(m.diff.repoRoots) > 0 {
+		repo = "repo: " + filepath.Base(m.diff.repoSel)
+	}
+	send := "send"
+	if count := len(m.diff.annotations[m.reviewKey()]); count > 0 {
+		send = fmt.Sprintf("send %d", count)
+	}
 	pairs := [][2]string{
 		{"↑↓/jk", "scroll line"}, {"ctrl+d/ctrl+u", "half page"}, {"g/G", "top/bottom"}, {"tab/J K/shift+tab", "file"},
 		{"n/N", "change"}, {"space", "reviewed"}, {"u", "layout"},
-		{"s", "scope: " + m.diff.scope.String()}, {"B", "target"}, {"c", "comment"},
+		{"s", "scope: " + m.diff.scope.String()}, {"r", repo}, {"b", "branch"}, {"B", "target"},
+		{"c", "comment"}, {"d", "remove"}, {"C", send},
+		{"esc/q", "close"}, {"ctrl+c", "quit"},
 	}
-	if len(m.diff.repoRoots) > 0 {
-		pairs = append(pairs, [2]string{"r", "repo: " + filepath.Base(m.diff.repoSel)})
-	}
-	if len(m.diff.worktrees) > 1 {
-		pairs = append(pairs, [2]string{"b", "branch"})
-	}
-	if count := len(m.diff.annotations[m.reviewKey()]); count > 0 {
-		pairs = append(pairs, [2]string{"C", fmt.Sprintf("send %d", count)}, [2]string{"d", "remove"})
-	}
-	pairs = append(pairs, [2]string{"esc/q", "close"}, [2]string{"ctrl+c", "quit"})
 	return footerLine(pairs, m.width)
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -393,12 +393,13 @@ func padToHeight(s string, height int) string {
 // viewFooter lists every shortcut, wrapping onto extra lines when the
 // terminal is too narrow for one.
 func (m *Model) viewFooter() string {
-	// The footer carries the handful of keys a session is actually driven
-	// with; ? opens the full map, so the rest stay out of the frame.
 	pairs := [][2]string{
-		{"↑↓", "navigate"}, {"↵", "attach"}, {"n", "new"}, {"g", "group"},
-		{"space", "prompt"}, {"ctrl+r", "review"}, {"/", "search"},
-		{"s", "settings"}, {"?", "keys"}, {"q", "quit"},
+		{"↑↓/jk", "navigate"}, {"shift+↑↓", "reorder"}, {"↵", "attach / fold"},
+		{"F", "fold all"}, {"n", "new"}, {"g", "group"}, {"space", "prompt"},
+		{"ctrl+r", "review"}, {"r", "rename"}, {"m", "move"},
+		{"v/V", "revive / all"}, {"a/u", "archive / restore"}, {"d", "delete"},
+		{"t", "archived"}, {"/", "search"}, {"|", "resize"}, {"s", "settings"},
+		{"?", "keys"}, {"q", "quit"},
 	}
 	if m.quick.active {
 		pairs = [][2]string{


### PR DESCRIPTION
The list footer showed 10 of the 19 keys list mode handles, so reorder, move, rename, revive, archive/restore, delete, archived view and resize lived only in the `?` help card. Review gated repo, branch, remove and send behind state checks.

Both footers now name every key their mode handles:

```
  ↑↓/jk navigate · shift+↑↓ reorder · ↵ attach / fold · F fold all · n new · g group · space prompt · ctrl+r review
  r rename · m move · v/V revive / all · a/u archive / restore · d delete · t archived · / search · | resize
  s settings · ? keys · q quit
```

`r` reads plain `repo` when the session holds one repo, `C` plain `send` until comments exist; `s` and `r` keep their live value suffixes.

Contextual overlays keep their own small sets: quick prompt, resize, rename, and the review annotate bar.

`footerLine` wraps onto extra rows and both layouts already subtract the footer's height, so the frame still paints exactly the terminal it was given: `TestFrameFitsTerminal` and `TestDiffFrameFitsTerminal` cover 60x16 through 240x70 in split and annotating modes, and the whole `internal/ui` suite passes.