### PR TITLE
feat(theme): make waiting purple in classic

### DIFF
--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -62,7 +62,7 @@ var themes = []Theme{
 		Accent2: "#6cb6a4",
 
 		Working:  "#d08442",
-		Waiting:  "#d9b45c",
+		Waiting:  "#a78bd0",
 		Finished: "#85b26f",
 		Errored:  "#cc6a6a",
 		Idle:     "#646c78",


### PR DESCRIPTION
Waiting sessions in the classic theme now read as purple (`#a78bd0`) instead of amber, so waiting is distinct from working at a glance. The hue sits at the same lightness and saturation as the theme's blue accent, so rows keep their contrast on both the rail and the backdrop.

`internal/ui` passes, including the row contrast and theme tests.