### PR TITLE
Fix Codex quick prompt submission

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -233,7 +233,11 @@ func (d *Driver) pasteAndEnter(target, text string) error {
 	if _, err := d.run("load-buffer", "-b", buf, path); err != nil {
 		return err
 	}
-	if _, err := d.run("paste-buffer", "-d", "-b", buf, "-t", target); err != nil {
+	// Preserve bracketed-paste boundaries when the pane application requests
+	// them. Codex uses paste-burst detection without these markers and can
+	// consume the immediately following Enter as part of the paste, leaving
+	// the prompt in its composer instead of submitting it.
+	if _, err := d.run("paste-buffer", "-p", "-d", "-b", buf, "-t", target); err != nil {
 		_, _ = d.run("delete-buffer", "-b", buf)
 		return err
 	}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -127,6 +128,40 @@ func TestSendText(t *testing.T) {
 	if !strings.Contains(pane, "hello world") {
 		t.Fatalf("cat should echo the sent line, pane: %q", pane)
 	}
+}
+
+func TestSendTextKeepsEnterOutsideBracketedPaste(t *testing.T) {
+	driver := requireTmux(t)
+	id := "bracket" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	marker := "/tmp/am-bracket-" + id
+	t.Cleanup(func() { os.Remove(marker) })
+
+	text := "hello world"
+	want := "\x1b[200~" + text + "\x1b[201~\r"
+	command := "stty raw -echo; printf '\\033[?2004h'; dd bs=1 count=" +
+		strconv.Itoa(len(want)) + " of=" + ShellQuote(marker) + " 2>/dev/null"
+	if err := driver.Create(id, "/tmp", command, nil, 0, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+
+	// Let tmux observe the application's bracketed-paste mode request before
+	// delivering the message.
+	time.Sleep(100 * time.Millisecond)
+	if err := driver.SendText(id, text); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := os.ReadFile(marker)
+		if err == nil && string(got) == want {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	got, _ := os.ReadFile(marker)
+	t.Fatalf("pane input = %q, want bracketed paste followed by Enter %q", got, want)
 }
 
 // Create used to type the launch line with send-keys, which silently


### PR DESCRIPTION
## What changed

- deliver quick prompts through tmux using bracketed-paste boundaries when the target application requests them
- add a regression test that verifies the pasted text is bracketed and the Enter key remains a separate input event

## Why

Codex applies paste-burst detection to unbracketed terminal input. The quick-prompt path pasted the message and immediately injected Enter, which Codex could consume as part of the paste. The prompt therefore remained in the composer until the user entered the session and pressed Enter manually.

## Impact

Quick prompts sent to Codex sessions now submit immediately. The change is compatible with other tools because tmux only emits bracket markers when the pane application has requested bracketed-paste mode.

## Validation

- reproduced the failure against Codex CLI 0.145.0
- verified bracketed paste submits the same prompt immediately
- `go test ./...`
- `git diff --check`