### PR TITLE
Fix chooser navigation and Codex quick-prompt submission

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -233,7 +233,11 @@ func (d *Driver) pasteAndEnter(target, text string) error {
 	if _, err := d.run("load-buffer", "-b", buf, path); err != nil {
 		return err
 	}
-	if _, err := d.run("paste-buffer", "-d", "-b", buf, "-t", target); err != nil {
+	// Preserve bracketed-paste boundaries when the pane application requests
+	// them. Codex uses paste-burst detection without these markers and can
+	// consume the immediately following Enter as part of the paste, leaving
+	// the prompt in its composer instead of submitting it.
+	if _, err := d.run("paste-buffer", "-p", "-d", "-b", buf, "-t", target); err != nil {
 		_, _ = d.run("delete-buffer", "-b", buf)
 		return err
 	}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -127,6 +128,40 @@ func TestSendText(t *testing.T) {
 	if !strings.Contains(pane, "hello world") {
 		t.Fatalf("cat should echo the sent line, pane: %q", pane)
 	}
+}
+
+func TestSendTextKeepsEnterOutsideBracketedPaste(t *testing.T) {
+	driver := requireTmux(t)
+	id := "bracket" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	marker := "/tmp/am-bracket-" + id
+	t.Cleanup(func() { os.Remove(marker) })
+
+	text := "hello world"
+	want := "\x1b[200~" + text + "\x1b[201~\r"
+	command := "stty raw -echo; printf '\\033[?2004h'; dd bs=1 count=" +
+		strconv.Itoa(len(want)) + " of=" + ShellQuote(marker) + " 2>/dev/null"
+	if err := driver.Create(id, "/tmp", command, nil, 0, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+
+	// Let tmux observe the application's bracketed-paste mode request before
+	// delivering the message.
+	time.Sleep(100 * time.Millisecond)
+	if err := driver.SendText(id, text); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := os.ReadFile(marker)
+		if err == nil && string(got) == want {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	got, _ := os.ReadFile(marker)
+	t.Fatalf("pane input = %q, want bracketed paste followed by Enter %q", got, want)
 }
 
 // Create used to type the launch line with send-keys, which silently

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -231,18 +231,26 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "up":
 		if m.form.focus == fieldGroup {
-			m.moveGroupCursor(-1)
+			if !m.moveGroupCursor(-1) {
+				m.formFocus(-1)
+			}
 		} else if dirSuggesting {
-			m.pathSugg.move(-1)
+			if !m.pathSugg.move(-1) {
+				m.formFocus(-1)
+			}
 		} else {
 			m.formFocus(-1)
 		}
 		return m, nil
 	case "down":
 		if m.form.focus == fieldGroup {
-			m.moveGroupCursor(1)
+			if !m.moveGroupCursor(1) {
+				m.formFocus(1)
+			}
 		} else if dirSuggesting {
-			m.pathSugg.move(1)
+			if !m.pathSugg.move(1) {
+				m.formFocus(1)
+			}
 		} else {
 			m.formFocus(1)
 		}
@@ -279,20 +287,21 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m *Model) moveGroupCursor(delta int) {
-	m.form.groupIndex += delta
-	if m.form.groupIndex < 0 {
-		m.form.groupIndex = 0
+// moveGroupCursor moves within the expanded group picker without wrapping.
+// A false result lets the form move focus to the adjacent field.
+func (m *Model) moveGroupCursor(delta int) bool {
+	next := m.form.groupIndex + delta
+	if next < 0 || next >= len(m.form.groups) {
+		return false
 	}
-	if m.form.groupIndex >= len(m.form.groups) {
-		m.form.groupIndex = len(m.form.groups) - 1
-	}
+	m.form.groupIndex = next
 	if m.mode == modeForm && m.form.dirAuto {
 		m.form.dir.SetValue(m.groupDefaultDir(m.selectedGroupPath()))
 	}
 	if m.mode == modeGroupForm && m.groupForm.pathAuto {
 		m.groupForm.path.SetValue(m.ancestorGroupDir(m.selectedGroupPath()))
 	}
+	return true
 }
 
 func (m *Model) formFocus(delta int) {
@@ -529,18 +538,26 @@ func (m *Model) handleGroupFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "up":
 		if m.groupForm.focus == gfParent {
-			m.moveGroupCursor(-1)
+			if !m.moveGroupCursor(-1) {
+				m.groupFormFocus(-1)
+			}
 		} else if pathSuggesting {
-			m.pathSugg.move(-1)
+			if !m.pathSugg.move(-1) {
+				m.groupFormFocus(-1)
+			}
 		} else {
 			m.groupFormFocus(-1)
 		}
 		return m, nil
 	case "down":
 		if m.groupForm.focus == gfParent {
-			m.moveGroupCursor(1)
+			if !m.moveGroupCursor(1) {
+				m.groupFormFocus(1)
+			}
 		} else if pathSuggesting {
-			m.pathSugg.move(1)
+			if !m.pathSugg.move(1) {
+				m.groupFormFocus(1)
+			}
 		} else {
 			m.groupFormFocus(1)
 		}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -803,13 +803,21 @@ func (m *Model) handleRenameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if pathSuggesting {
 			if msg.String() == "up" {
-				m.pathSugg.move(-1)
+				if !m.pathSugg.move(-1) {
+					m.renameFocus(-1)
+				}
 			} else {
-				m.pathSugg.move(1)
+				if !m.pathSugg.move(1) {
+					m.renameFocus(1)
+				}
 			}
 			return m, nil
 		}
-		m.renameFocus(1)
+		if msg.String() == "up" {
+			m.renameFocus(-1)
+		} else {
+			m.renameFocus(1)
+		}
 		return m, nil
 	case "enter":
 		if pathSuggesting && m.pathSugg.chosen {
@@ -1287,10 +1295,14 @@ func (m *Model) handleMoveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.mode = modeList
 		return m, nil
 	case "up":
-		m.moveGroupCursor(-1)
+		if !m.moveGroupCursor(-1) && len(m.form.groups) > 0 {
+			m.form.groupIndex = len(m.form.groups) - 1
+		}
 		return m, nil
 	case "down":
-		m.moveGroupCursor(1)
+		if !m.moveGroupCursor(1) && len(m.form.groups) > 0 {
+			m.form.groupIndex = 0
+		}
 		return m, nil
 	case "enter":
 		group := m.selectedGroupPath()

--- a/internal/ui/pathcomplete.go
+++ b/internal/ui/pathcomplete.go
@@ -22,12 +22,28 @@ func (pc *pathComplete) reset() {
 
 func (pc *pathComplete) active() bool { return len(pc.suggestions) > 0 }
 
-func (pc *pathComplete) move(delta int) {
+// move advances within the suggestions without wrapping. It returns false
+// when the cursor is already at the requested edge so the containing form can
+// continue focus navigation instead of trapping the user in this list.
+func (pc *pathComplete) move(delta int) bool {
 	if !pc.active() {
-		return
+		return false
 	}
-	pc.index = (pc.index + delta + len(pc.suggestions)) % len(pc.suggestions)
+	if !pc.chosen {
+		if delta < 0 {
+			return false
+		}
+		pc.index = 0
+		pc.chosen = true
+		return true
+	}
+	next := pc.index + delta
+	if next < 0 || next >= len(pc.suggestions) {
+		return false
+	}
+	pc.index = next
 	pc.chosen = true
+	return true
 }
 
 func (pc *pathComplete) selected() string {

--- a/internal/ui/pathcomplete_test.go
+++ b/internal/ui/pathcomplete_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func setupCompletionDir(t *testing.T) string {
@@ -79,6 +81,103 @@ func TestApplyPathSuggestionFillsDirField(t *testing.T) {
 	}
 	if m.form.dirAuto {
 		t.Fatal("dirAuto should be cleared after completion")
+	}
+}
+
+func TestPathSuggestionsExitToAdjacentFormFields(t *testing.T) {
+	root := setupCompletionDir(t)
+	m := buildModel(t)
+	m.openForm()
+	m.form.focus = fieldDir
+	m.form.name.Blur()
+	m.form.dir.Focus()
+	m.pathSugg.recompute(filepath.Join(root, "a"))
+
+	m.handleFormKey(tea.KeyMsg{Type: tea.KeyDown})
+	if !m.pathSugg.chosen || m.pathSugg.index != 0 {
+		t.Fatalf("first down should select the first suggestion, chosen=%v index=%d",
+			m.pathSugg.chosen, m.pathSugg.index)
+	}
+	m.handleFormKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.pathSugg.index != 1 {
+		t.Fatalf("second down should select the second suggestion, index=%d", m.pathSugg.index)
+	}
+	m.handleFormKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.form.focus != fieldPrompt {
+		t.Fatalf("down past the last suggestion should focus prompt, focus=%d", m.form.focus)
+	}
+
+	m.formFocus(-1)
+	m.pathSugg.recompute(filepath.Join(root, "a"))
+	m.pathSugg.chosen = true
+	m.handleFormKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m.form.focus != fieldTool {
+		t.Fatalf("up past the first suggestion should focus tool, focus=%d", m.form.focus)
+	}
+}
+
+func TestGroupPickerExitsToAdjacentFields(t *testing.T) {
+	m := buildModel(t)
+
+	m.openGroupForm()
+	m.groupFormFocus(1)
+	m.form.groupIndex = 0
+	m.handleGroupFormKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m.groupForm.focus != gfName {
+		t.Fatalf("up past first parent should focus name, focus=%d", m.groupForm.focus)
+	}
+
+	m.openGroupForm()
+	m.groupFormFocus(1)
+	m.form.groupIndex = len(m.form.groups) - 1
+	m.handleGroupFormKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.groupForm.focus != gfPath {
+		t.Fatalf("down past last parent should focus path, focus=%d", m.groupForm.focus)
+	}
+
+	m.openForm()
+	m.form.focus = fieldGroup
+	m.form.name.Blur()
+	m.form.groupIndex = len(m.form.groups) - 1
+	m.handleFormKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.form.focus != fieldName {
+		t.Fatalf("down past last group should wrap to name, focus=%d", m.form.focus)
+	}
+}
+
+func TestStandaloneGroupPickerWrapsWhenThereAreNoAdjacentFields(t *testing.T) {
+	m := buildModel(t)
+	m.form.groups = []groupOption{{path: ""}, {path: "alpha"}, {path: "beta"}}
+	m.mode = modeMove
+
+	m.form.groupIndex = 0
+	m.handleMoveKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m.form.groupIndex != 2 {
+		t.Fatalf("up past first group should wrap to last, index=%d", m.form.groupIndex)
+	}
+
+	m.handleMoveKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.form.groupIndex != 0 {
+		t.Fatalf("down past last group should wrap to first, index=%d", m.form.groupIndex)
+	}
+}
+
+func TestRenamePathSuggestionsExitToName(t *testing.T) {
+	root := setupCompletionDir(t)
+	m := buildModel(t)
+	m.mode = modeRename
+	m.rename.isGroup = true
+	m.rename.input = textField("", 60)
+	m.rename.dir = textField("", 400)
+	m.rename.focus = 1
+	m.rename.dir.Focus()
+	m.pathSugg.recompute(filepath.Join(root, "a"))
+	m.pathSugg.chosen = true
+	m.pathSugg.index = len(m.pathSugg.suggestions) - 1
+
+	m.handleRenameKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.rename.focus != 0 {
+		t.Fatalf("down past last suggestion should wrap to name, focus=%d", m.rename.focus)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Let directory autocomplete and group/folder pickers leave their list at an edge and continue to the adjacent form input.
- Preserve form-wide wrapping, and wrap standalone group pickers when no adjacent input exists.
- Make the first Down key select the first directory suggestion instead of skipping it.
- Send tmux paste buffers with bracketed-paste boundaries so Codex receives Enter as a separate submission key.
- Add regression coverage for New Session, New Group, Move Session, group rename, and bracketed-paste submission.

## Why

Chooser cursors previously clamped or wrapped inside their own lists, trapping keyboard navigation. Separately, tmux pasted Codex prompts without bracketed-paste markers, allowing Codex's paste-burst detection to absorb the following Enter and leave the prompt unsent.

## Impact

Keyboard navigation now flows naturally through every chooser-backed form, while standalone pickers still wrap. Quick prompts sent to Codex submit immediately without requiring the user to attach and press Enter manually.

## Validation

- `go test ./...`
- `git diff --check`