### PR TITLE
Flag the archived view with a bold badge

### DIFF
--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -87,7 +87,13 @@ func (m *Model) railLines(width, height int) []contentLine {
 		listHeight, meters = height, nil
 	}
 	rows := []contentLine{{}}
-	rows = append(rows, m.entryLines(width, listHeight-1)...)
+	if m.showArchived {
+		rows = append(rows,
+			contentLine{text: strings.Repeat(" ", railInset) + scopeBadgeStyle.Render("ARCHIVED") +
+				subtleStyle.Render("  ") + keyCap("t", "back to active")},
+			contentLine{})
+	}
+	rows = append(rows, m.entryLines(width, listHeight-len(rows))...)
 	for len(rows) < listHeight {
 		rows = append(rows, contentLine{})
 	}
@@ -576,17 +582,16 @@ func joinHeaderPieces(sep string, pieces ...string) string {
 // the two lines always add up; counting painted rows instead would drop
 // everything folded inside a collapsed group.
 func (m *Model) headerScope() string {
-	scope := "active"
-	if m.showArchived {
-		scope = "archived"
-	}
 	count := len(m.visibleSessions())
 	label := " sessions"
 	if count == 1 {
 		label = " session"
 	}
-	line := valueStyle.Render(fmt.Sprintf("%d", count)) + subtleStyle.Render(label) +
-		subtleStyle.Render(" · "+scope)
+	scope := subtleStyle.Render(" · active")
+	if m.showArchived {
+		scope = subtleStyle.Render(" · ") + scopeBadgeStyle.Render("ARCHIVED")
+	}
+	line := valueStyle.Render(fmt.Sprintf("%d", count)) + subtleStyle.Render(label) + scope
 	if m.updateLatest != "" {
 		line += subtleStyle.Render("   ") +
 			lipgloss.NewStyle().Foreground(colorAccent).Render("↑ "+m.updateLatest+" available")

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -42,6 +42,7 @@ var (
 	keyStyle    lipgloss.Style
 
 	annotationStyle lipgloss.Style
+	scopeBadgeStyle lipgloss.Style
 
 	chipStyle             lipgloss.Style
 	imageChipStyle        lipgloss.Style
@@ -64,6 +65,7 @@ func rebuildStyles() {
 	keyStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 
 	annotationStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+	scopeBadgeStyle = lipgloss.NewStyle().Foreground(colorBg).Background(colorAccent2).Bold(true).Padding(0, 1)
 
 	chipStyle = lipgloss.NewStyle().Background(colorSurface).Padding(0, 1)
 	imageChipStyle = lipgloss.NewStyle().


### PR DESCRIPTION
Pressing `t` swapped the list to the archive with almost no visual signal: the scope showed as a grey `· archived` at the far right of the header.

The scope now paints as an inverted badge in the header, and repeats directly above the session tree alongside `t back to active`, so the archived view announces itself where the eye already is.

The badge derives its colors from the active theme (`colorBg` on `colorAccent2`), so it follows every palette.

Verified: `go build ./...`, `go test ./internal/ui/` pass, and a rendered frame shows the badge in both places.