### PR TITLE
feat(mcp): add review_mode tool to let agents set diff scope

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -208,6 +208,24 @@ func (m *Manager) RemoveReviewBase(id string) error {
 	return removeIfExists(m.ReviewBaseFile(id))
 }
 
+// ReviewScopeFile is the mailbox the review-mode MCP tool writes the
+// diff scope into; the poller applies and deletes it.
+func (m *Manager) ReviewScopeFile(id string) string {
+	return filepath.Join(m.dir, id+".reviewscope")
+}
+
+func (m *Manager) ReadReviewScope(id string) (scope string, found bool) {
+	raw, err := os.ReadFile(m.ReviewScopeFile(id))
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(raw)), true
+}
+
+func (m *Manager) RemoveReviewScope(id string) error {
+	return removeIfExists(m.ReviewScopeFile(id))
+}
+
 func removeIfExists(path string) error {
 	err := os.Remove(path)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -27,6 +27,10 @@ type reviewBaseArgs struct {
 	RepoPath string `json:"repo_path,omitempty" jsonschema:"path inside the repo the ref belongs to; defaults to the current working directory"`
 }
 
+type reviewModeArgs struct {
+	Scope string `json:"scope" jsonschema:"diff scope: uncommitted, branch (vs target), last_commit, or staged"`
+}
+
 // NewServer builds the MCP server with every session tool registered.
 // Split from Run so tests can connect an in-process client.
 func NewServer(configDir, sessionID, version string) *mcp.Server {
@@ -66,6 +70,17 @@ func NewServer(configDir, sessionID, version string) *mcp.Server {
 			ref = ""
 		}
 		return textResult(sessioncmd.ReviewBase(configDir, sessionID, cwd, ref))
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "review_mode",
+		Description: "Set the diff scope the manager's review screen shows for this session. " +
+			"Valid values: uncommitted (working dir changes), branch (vs target/merge base), " +
+			"last_commit (HEAD diff), staged (cached changes). " +
+			"Call when you want the review to show a different scope, e.g. switch from " +
+			"uncommitted to staged before committing.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args reviewModeArgs) (*mcp.CallToolResult, any, error) {
+		return textResult(sessioncmd.ReviewScope(configDir, sessionID, args.Scope))
 	})
 
 	return server

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -71,7 +71,7 @@ func TestListsAllTools(t *testing.T) {
 	for _, tool := range tools.Tools {
 		names[tool.Name] = true
 	}
-	for _, want := range []string{"rename", "review_repo", "review_base"} {
+	for _, want := range []string{"rename", "review_repo", "review_base", "review_mode"} {
 		if !names[want] {
 			t.Fatalf("missing tool %q in %v", want, names)
 		}
@@ -148,9 +148,31 @@ func TestBadInputsReturnToolErrors(t *testing.T) {
 	if text, isError := callText(t, session, "review_base", map[string]any{"ref": "nope-branch", "repo_path": gitRepo(t)}); !isError {
 		t.Fatalf("unknown ref should error, got %q", text)
 	}
+	if text, isError := callText(t, session, "review_mode", map[string]any{"scope": "bogus"}); !isError {
+		t.Fatalf("unknown scope should error, got %q", text)
+	}
 
 	noSession := connect(t, configDir, "")
 	if text, isError := callText(t, noSession, "rename", map[string]any{"name": "x"}); !isError || !strings.Contains(text, "AGENT_MANAGER_SESSION_ID") {
 		t.Fatalf("missing session id should error, got %q", text)
+	}
+}
+
+func TestReviewModeWritesMailbox(t *testing.T) {
+	configDir := t.TempDir()
+	session := connect(t, configDir, "abc123")
+
+	for _, scope := range []string{"uncommitted", "branch", "last_commit", "staged"} {
+		text, isError := callText(t, session, "review_mode", map[string]any{"scope": scope})
+		if isError {
+			t.Fatalf("review_mode(%q) error: %q", scope, text)
+		}
+		content, err := os.ReadFile(hooks.NewManager(configDir).ReviewScopeFile("abc123"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := strings.TrimSpace(string(content)); got != scope {
+			t.Fatalf("mailbox scope = %q, want %q", got, scope)
+		}
 	}
 }

--- a/internal/sessioncmd/sessioncmd.go
+++ b/internal/sessioncmd/sessioncmd.go
@@ -122,6 +122,57 @@ func ReviewBase(configDir, sessionID, cwd, ref string) (string, error) {
 	return "review base set to " + ref, nil
 }
 
+var validScopes = map[string]bool{
+	"uncommitted": true,
+	"branch":      true,
+	"last_commit": true,
+	"staged":      true,
+}
+
+func scopeToString(s git.Scope) string {
+	switch s {
+	case git.ScopeBranch:
+		return "branch"
+	case git.ScopeLastCommit:
+		return "last_commit"
+	case git.ScopeStaged:
+		return "staged"
+	default:
+		return "uncommitted"
+	}
+}
+
+func parseScope(s string) (git.Scope, bool) {
+	switch strings.TrimSpace(s) {
+	case "branch":
+		return git.ScopeBranch, true
+	case "last_commit":
+		return git.ScopeLastCommit, true
+	case "staged":
+		return git.ScopeStaged, true
+	case "uncommitted":
+		return git.ScopeUncommitted, true
+	default:
+		return 0, false
+	}
+}
+
+// ReviewScope records the diff scope the review screen should open with
+// for this session: uncommitted, branch (vs target), last_commit, or staged.
+func ReviewScope(configDir, sessionID, scope string) (string, error) {
+	scope = strings.TrimSpace(scope)
+	if !validScopes[scope] {
+		return "", fmt.Errorf("unknown scope %q (uncommitted, branch, last_commit, staged)", scope)
+	}
+	if err := validSession(sessionID); err != nil {
+		return "", err
+	}
+	if err := writeMailbox(hooks.NewManager(configDir).ReviewScopeFile(sessionID), scope); err != nil {
+		return "", err
+	}
+	return "review scope set to " + scope, nil
+}
+
 // Both sides are resolved first because git reports a toplevel with symlinks expanded.
 func pathWithin(path, root string) bool {
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -104,6 +104,10 @@ CREATE TABLE IF NOT EXISTS settings (
 			base_ref   TEXT NOT NULL,
 			PRIMARY KEY (session_id, repo_root)
 		)`,
+		`CREATE TABLE IF NOT EXISTS review_scopes (
+			session_id TEXT PRIMARY KEY,
+			scope      TEXT NOT NULL
+		)`,
 	}
 	for _, migration := range migrations {
 		if _, err := s.db.Exec(migration); err != nil {
@@ -176,6 +180,31 @@ func (s *Store) ReviewBase(sessionID, repoRoot string) (string, error) {
 		return "", err
 	}
 	return ref, nil
+}
+
+func (s *Store) SetReviewScope(sessionID, scope string) error {
+	if scope == "" {
+		_, err := s.db.Exec(`DELETE FROM review_scopes WHERE session_id = ?`, sessionID)
+		return err
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO review_scopes (session_id, scope) VALUES (?, ?)
+		 ON CONFLICT(session_id) DO UPDATE SET scope = excluded.scope`,
+		sessionID, scope,
+	)
+	return err
+}
+
+func (s *Store) ReviewScope(sessionID string) (string, error) {
+	var scope string
+	err := s.db.QueryRow(`SELECT scope FROM review_scopes WHERE session_id = ?`, sessionID).Scan(&scope)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return scope, nil
 }
 
 func (s *Store) SetSetting(key, value string) error {
@@ -375,6 +404,9 @@ func (s *Store) Delete(id string) error {
 		return err
 	}
 	if _, err := s.db.Exec(`DELETE FROM review_bases WHERE session_id = ?`, id); err != nil {
+		return err
+	}
+	if _, err := s.db.Exec(`DELETE FROM review_scopes WHERE session_id = ?`, id); err != nil {
 		return err
 	}
 	res, err := s.db.Exec(`DELETE FROM sessions WHERE id = ?`, id)

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -241,6 +241,26 @@ func (m *Model) retargetDiff(sess store.Session) tea.Cmd {
 	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, false)
 }
 
+func (m *Model) applyStoredScope(sessionID string) {
+	if m.store == nil {
+		return
+	}
+	stored, err := m.store.ReviewScope(sessionID)
+	if err != nil || stored == "" {
+		return
+	}
+	switch stored {
+	case "branch":
+		m.diff.scope = git.ScopeBranch
+	case "last_commit":
+		m.diff.scope = git.ScopeLastCommit
+	case "staged":
+		m.diff.scope = git.ScopeStaged
+	case "uncommitted":
+		m.diff.scope = git.ScopeUncommitted
+	}
+}
+
 func (m *Model) cycleDiffScope() tea.Cmd {
 	if !m.diff.active {
 		return nil

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -153,6 +153,7 @@ func (m *Model) openDiff() tea.Cmd {
 	// Default to returning to the list; the in-session Ctrl+R path sets this
 	// afterward when review should return to the session instead.
 	m.diff.reattachID = ""
+	m.applyStoredScope(sess.ID)
 	return m.retargetDiff(sess)
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -670,6 +670,10 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.err = err.Error()
 					return m, nil
 				}
+				if err := m.hooks.RemoveReviewScope(sess.ID); err != nil {
+					m.err = err.Error()
+					return m, nil
+				}
 				delete(m.pickedRepos, sess.ID)
 				if err := m.store.Delete(sess.ID); err != nil {
 					m.err = err.Error()

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -261,6 +261,9 @@ func (p *poller) refreshOnce() tea.Msg {
 		if err := p.applyPendingReviewBase(&sessions[i]); err != nil {
 			return errMsg{err}
 		}
+		if err := p.applyPendingReviewScope(&sessions[i]); err != nil {
+			return errMsg{err}
+		}
 		newStatus := status.Dead
 		if pid := panes[sess.ID]; pid > 0 {
 			stat := trees[pid]
@@ -499,6 +502,17 @@ func (p *poller) applyPendingReviewBase(sess *store.Session) error {
 		}
 	}
 	return p.hooks.RemoveReviewBase(sess.ID)
+}
+
+func (p *poller) applyPendingReviewScope(sess *store.Session) error {
+	scope, found := p.hooks.ReadReviewScope(sess.ID)
+	if !found {
+		return nil
+	}
+	if err := p.store.SetReviewScope(sess.ID, scope); err != nil {
+		return err
+	}
+	return p.hooks.RemoveReviewScope(sess.ID)
 }
 
 // reflowSessions drops activity-region hashes for ids and runs reflow


### PR DESCRIPTION
## Summary

- Adds MCP tool `review_mode` so agents can set the review screen's diff scope (`uncommitted`, `branch`, `last_commit`, `staged`).
- Full pipeline mirrors `review_base`: mailbox file → poller → sqlite `review_scopes` → applied when the user opens review.
- Scope is sticky per session until the next `review_mode` call.

## Test plan

- [x] `go test ./internal/mcpserver/ ./internal/store/ ./internal/hooks/`
- [x] MCP tests: tool listed, bogus scope errors, valid scopes write mailbox
- [ ] Manual: call `review_mode` with `staged` from a session, open review (`Ctrl+R` / list `d`), confirm scope pill matches
- [ ] Manual: call again with `branch`, reopen review, confirm scope updates
- [ ] Manual: delete session, confirm no leftover mailbox / sqlite row issues