### PR TITLE
Fix pane resize persistence

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -27,12 +27,13 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "right", "l":
 			m.nudgeSplit(1)
 			return m, nil
-		case "|":
-			// Second | commits the working ratio (arrows or an unfinished drag).
+		case "|", "enter":
+			// Enter or a second | commits the working ratio.
 			return m.exitResizeMode(true)
 		case "esc":
 			return m.exitResizeMode(false)
 		case "q", "ctrl+c":
+			m.persistSplitRatio()
 			m.resizeMode = false
 			m.splitDragging = false
 			return m, tea.Quit

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -229,7 +229,7 @@ func (m *Model) viewHelp() string {
 		{"B", "in review: pick the target (merge-into branch) the branch diff compares against"},
 		{"F", "fold / unfold all groups"},
 		{"s", "settings (quick spawn tool, review layout)"},
-		{"|", "resize split (←→ / drag, | commits, esc cancels)"},
+		{"|", "resize split (←→ / drag, enter commits, esc cancels)"},
 		{"t", "toggle archived view"},
 		{"/", "search"},
 		{"↑↓ / jk", "move cursor"},

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -162,6 +162,37 @@ func TestArrowNudgeAndPipeCommits(t *testing.T) {
 	}
 }
 
+func TestEnterCommitsResize(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	m := &Model{
+		store:      st,
+		mode:       modeList,
+		width:      100,
+		height:     40,
+		splitRatio: 0.34,
+	}
+	updated, _ := m.enterResizeMode()
+	m = updated.(*Model)
+	m.nudgeSplit(8)
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*Model)
+	if m.resizeMode || m.splitDragging {
+		t.Fatal("enter should commit and leave resize mode")
+	}
+	if cmd != nil {
+		t.Fatal("enter commit should not return a command")
+	}
+	if got := loadSplitRatio(st); got != 0.42 {
+		t.Fatalf("reloaded ratio = %v want 0.42", got)
+	}
+}
+
 func TestArrowCancelRestoresRatio(t *testing.T) {
 	m := &Model{mode: modeList, width: 100, height: 40, splitRatio: 0.34}
 	updated, _ := m.enterResizeMode()
@@ -175,6 +206,40 @@ func TestArrowCancelRestoresRatio(t *testing.T) {
 	}
 	if left, _ := m.splitWidths(); left != 34 {
 		t.Fatalf("esc should restore left=34, got %d", left)
+	}
+}
+
+func TestQuitFromResizePersistsRatio(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	m := &Model{
+		store:      st,
+		mode:       modeList,
+		width:      100,
+		height:     40,
+		splitRatio: 0.34,
+	}
+	updated, _ := m.enterResizeMode()
+	m = updated.(*Model)
+	m.nudgeSplit(8)
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m = updated.(*Model)
+	if m.resizeMode || m.splitDragging {
+		t.Fatal("quit should clear resize state")
+	}
+	if cmd == nil {
+		t.Fatal("quit should return a command")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatal("quit command should produce tea.QuitMsg")
+	}
+	if got := loadSplitRatio(st); got != 0.42 {
+		t.Fatalf("reloaded ratio = %v want 0.42", got)
 	}
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -127,7 +127,7 @@ func (m *Model) viewStatus() string {
 	case m.mode == modeConfirmDelete:
 		return "  " + errStyle.Render("⚠ "+m.confirm.label) + subtleStyle.Render("  y/n")
 	case m.resizeMode:
-		hint := "←→ resize · drag divider · | set · esc cancel"
+		hint := "←→ resize · drag divider · enter set · esc cancel"
 		if m.splitDragging {
 			hint = "release to set · esc cancels"
 		}


### PR DESCRIPTION
## What changed

- Persist the working pane split before quitting from resize mode with `q` or `Ctrl+C`.
- Allow `Enter` to accept the current split and leave resize mode, alongside a second `|`.
- Update the in-app resize hints and help text.
- Add regression coverage for quit-time persistence and Enter-to-commit behavior.

## Why

The split ratio was only written on the explicit commit path. Quitting while resize mode was active cleared the resize state without saving the new ratio, so the next launch restored an older pane layout.

## Impact

Pane sizes now survive a normal quit from resize mode. Users can also press `Enter` to accept and release the divider, while `Esc` continues to cancel.

## Validation

- `go test ./...`
- `git diff --check`