### PR TITLE
Fix smooth session and group reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 | `g` | New group (name, parent, default path) |
 | `enter` | Attach session / fold group |
 | `ctrl+q` | Inside a session: back to the manager |
-| `shift+↑` / `shift+↓` | Reorder session or group among its siblings |
+| `K` / `J` (or `shift+↑` / `shift+↓`) | Reorder session or group among its visible siblings |
 | `m` | Move session to another group |
 | `r` | Rename session / edit tool; edit group name and default path |
 | `v` | Revive a dead session (`revive_command`, e.g. `claude --continue`, resumes the conversation) |
@@ -123,7 +123,7 @@ Press `c` on a line to write a comment; `C` flattens every comment into one revi
 
 ### Groups
 
-Groups are paths (`backend/api/auth`) forming a tree of unlimited depth. Sessions can live at any node, including the root. Create subgroups inline with `g`, reorder both groups and sessions with `shift+↑↓` (the order persists), fold a subtree with `f`, and edit a group's name and default path with `r`. On a session, `r` renames it and `tab` cycles the tool (status rules and revive follow the new tool; useful when you quit one agent in the pane and start another).
+Groups are paths (`backend/api/auth`) forming a tree of unlimited depth. Sessions can live at any node, including the root. Create subgroups inline with `g`, reorder both groups and sessions with `K` / `J` (or `shift+↑↓`; the order persists), fold a subtree with `f`, and edit a group's name and default path with `r`. On a session, `r` renames it and `tab` cycles the tool (status rules and revive follow the new tool; useful when you quit one agent in the pane and start another).
 
 ### Status
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -739,20 +739,75 @@ func (s *Store) ReorderSession(id string, delta int, includeArchived bool) (bool
 	}
 
 	siblings[current], siblings[target] = siblings[target], siblings[current]
-	tx, err := s.db.Begin()
-	if err != nil {
-		return false, err
+	ids := make([]string, len(siblings))
+	for i, sibling := range siblings {
+		ids[i] = sibling.id
 	}
-	defer tx.Rollback()
-	for i, sib := range siblings {
-		if _, err := tx.Exec(`UPDATE sessions SET sort_order = ? WHERE id = ?`, i, sib.id); err != nil {
-			return false, err
-		}
-	}
-	if err := tx.Commit(); err != nil {
+	if err := s.persistSessionOrder(ids); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// SwapSessionOrder exchanges two sessions in the same group. The caller can
+// choose visible siblings even when filtered sessions sit between them.
+func (s *Store) SwapSessionOrder(id, targetID string) error {
+	sess, err := s.Get(id)
+	if err != nil {
+		return err
+	}
+	target, err := s.Get(targetID)
+	if err != nil {
+		return err
+	}
+	if sess.Group != target.Group {
+		return fmt.Errorf("sessions %s and %s are not siblings", id, targetID)
+	}
+
+	rows, err := s.db.Query(
+		`SELECT id FROM sessions WHERE group_name = ?
+		 ORDER BY sort_order, created_at`, sess.Group)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	var ids []string
+	current, targetIndex := -1, -1
+	for rows.Next() {
+		var siblingID string
+		if err := rows.Scan(&siblingID); err != nil {
+			return err
+		}
+		switch siblingID {
+		case id:
+			current = len(ids)
+		case targetID:
+			targetIndex = len(ids)
+		}
+		ids = append(ids, siblingID)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if current < 0 || targetIndex < 0 {
+		return fmt.Errorf("session order changed while reordering")
+	}
+	ids[current], ids[targetIndex] = ids[targetIndex], ids[current]
+	return s.persistSessionOrder(ids)
+}
+
+func (s *Store) persistSessionOrder(ids []string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for i, id := range ids {
+		if _, err := tx.Exec(`UPDATE sessions SET sort_order = ? WHERE id = ?`, i, id); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // ReorderGroup moves a group one step among the groups sharing its
@@ -807,20 +862,69 @@ func (s *Store) ReorderGroup(path string, delta int) (bool, error) {
 	}
 
 	groups[current], groups[target] = groups[target], groups[current]
+	if err := s.persistGroupOrder(groups); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SwapGroupOrder exchanges two groups with the same parent. siblingOrder
+// materializes displayed ancestors so their manual order can persist too.
+func (s *Store) SwapGroupOrder(path, targetPath string, siblingOrder ...string) error {
+	if path == "" || targetPath == "" {
+		return fmt.Errorf("cannot reorder the root group")
+	}
+	parent := parentPath(path)
+	if parent != parentPath(targetPath) {
+		return fmt.Errorf("groups %s and %s are not siblings", path, targetPath)
+	}
+	for _, sibling := range siblingOrder {
+		if parentPath(sibling) != parent {
+			return fmt.Errorf("group %s is not a sibling of %s", sibling, path)
+		}
+		if err := s.ensureGroup(sibling); err != nil {
+			return err
+		}
+	}
+	groups, err := s.Groups()
+	if err != nil {
+		return err
+	}
+	current, target := -1, -1
+	for i, group := range groups {
+		switch group.Name {
+		case path:
+			current = i
+		case targetPath:
+			target = i
+		}
+	}
+	if current < 0 || target < 0 {
+		return fmt.Errorf("group order changed while reordering")
+	}
+	groups[current], groups[target] = groups[target], groups[current]
+	return s.persistGroupOrder(groups)
+}
+
+func parentPath(path string) string {
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		return path[:idx]
+	}
+	return ""
+}
+
+func (s *Store) persistGroupOrder(groups []Group) error {
 	tx, err := s.db.Begin()
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer tx.Rollback()
 	for i, g := range groups {
 		if _, err := tx.Exec(`UPDATE groups SET sort_order = ? WHERE name = ?`, i, g.Name); err != nil {
-			return false, err
+			return err
 		}
 	}
-	if err := tx.Commit(); err != nil {
-		return false, err
-	}
-	return true, nil
+	return tx.Commit()
 }
 
 func requireRow(res sql.Result, id string) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,7 +3,9 @@ package store
 import (
 	"errors"
 	"path/filepath"
+	"slices"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -408,6 +410,20 @@ func TestReorderSessionSkipsArchivedInActiveView(t *testing.T) {
 	}
 }
 
+func TestSwapSessionOrderCrossesFilteredSibling(t *testing.T) {
+	st := newTestStore(t)
+	st.CreateSession(sample("a", "g1"))
+	st.CreateSession(sample("hidden", "g1"))
+	st.CreateSession(sample("c", "g1"))
+
+	if err := st.SwapSessionOrder("c", "a"); err != nil {
+		t.Fatalf("swap: %v", err)
+	}
+	if got, want := listIDs(t, st, false), []string{"c", "hidden", "a"}; !slices.Equal(got, want) {
+		t.Fatalf("order = %v want %v", got, want)
+	}
+}
+
 func TestReorderGroup(t *testing.T) {
 	st := newTestStore(t)
 	st.CreateGroup("alpha", "")
@@ -436,6 +452,54 @@ func TestReorderGroup(t *testing.T) {
 	// Nested group only swaps with same-parent siblings; sole child is a no-op.
 	if moved, err := st.ReorderGroup("alpha/sub", -1); err != nil || moved {
 		t.Fatalf("nested sole child: moved=%v err=%v, want no-op", moved, err)
+	}
+}
+
+func TestSwapGroupOrderCrossesFilteredSibling(t *testing.T) {
+	st := newTestStore(t)
+	st.CreateGroup("alpha", "")
+	st.CreateGroup("hidden", "")
+	st.CreateGroup("gamma", "")
+
+	if err := st.SwapGroupOrder("gamma", "alpha"); err != nil {
+		t.Fatalf("swap: %v", err)
+	}
+	groups, err := st.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	got := make([]string, len(groups))
+	for i, group := range groups {
+		got[i] = group.Name
+	}
+	if want := []string{"gamma", "hidden", "alpha"}; !slices.Equal(got, want) {
+		t.Fatalf("order = %v want %v", got, want)
+	}
+}
+
+func TestSwapGroupOrderMaterializesSyntheticAncestors(t *testing.T) {
+	st := newTestStore(t)
+	for _, group := range []string{"alpha/deep", "beta/deep", "gamma/deep"} {
+		if err := st.CreateGroup(group, ""); err != nil {
+			t.Fatalf("create group %q: %v", group, err)
+		}
+	}
+
+	if err := st.SwapGroupOrder("gamma", "beta", "alpha", "beta", "gamma"); err != nil {
+		t.Fatalf("swap: %v", err)
+	}
+	groups, err := st.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	var roots []string
+	for _, group := range groups {
+		if !strings.Contains(group.Name, "/") {
+			roots = append(roots, group.Name)
+		}
+	}
+	if want := []string{"alpha", "gamma", "beta"}; !slices.Equal(roots, want) {
+		t.Fatalf("root order = %v want %v", roots, want)
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -78,9 +78,9 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.moveCursor(-1)
 	case "down", "j":
 		return m, m.moveCursor(1)
-	case "shift+up":
+	case "shift+up", "K", "shift+k":
 		return m.reorderSelected(-1)
-	case "shift+down":
+	case "shift+down", "J", "shift+j":
 		return m.reorderSelected(1)
 	case "enter":
 		if entry, ok := m.selectedRow(); ok && entry.isGroup {
@@ -193,18 +193,8 @@ func (m *Model) reorderSelected(delta int) (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	var moved bool
-	var err error
-	if entry.isGroup {
-		moved, err = m.store.ReorderGroup(entry.group, delta)
-	} else {
-		moved, err = m.store.ReorderSession(entry.sess.ID, delta, m.showArchived)
-	}
-	if err != nil {
-		m.err = err.Error()
-		return m, nil
-	}
-	if !moved {
+	target, ok := m.visibleReorderTarget(entry, delta)
+	if !ok {
 		edge := "top"
 		if delta > 0 {
 			edge = "bottom"
@@ -216,59 +206,100 @@ func (m *Model) reorderSelected(delta int) (tea.Model, tea.Cmd) {
 		m.err = fmt.Sprintf("%s already at the %s of its level", what, edge)
 		return m, nil
 	}
+
+	var err error
+	var groupSiblings []string
+	if entry.isGroup {
+		groupSiblings = m.knownGroupSiblings(parentGroup(entry.group))
+		err = m.store.SwapGroupOrder(entry.group, target.group, groupSiblings...)
+	} else {
+		err = m.store.SwapSessionOrder(entry.sess.ID, target.sess.ID)
+	}
+	if err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
 	// Mirror the swap in memory so the list redraws instantly; the next
 	// poll re-reads the authoritative order from the store.
 	if entry.isGroup {
-		m.swapGroupLocal(entry.group, delta)
+		m.materializeGroupsLocal(groupSiblings)
+		m.swapGroupLocal(entry.group, target.group)
 	} else {
-		m.swapSessionLocal(entry.sess.ID, delta)
+		m.swapSessionLocal(entry.sess.ID, target.sess.ID)
 	}
+	m.err = ""
 	m.rebuildRows()
 	m.requestRefresh()
 	return m, nil
 }
 
-func (m *Model) swapSessionLocal(id string, delta int) {
+// visibleReorderTarget finds the next rendered sibling. Filters and archive
+// scope therefore cannot turn a successful reorder into an invisible swap.
+func (m *Model) visibleReorderTarget(entry treeRow, delta int) (treeRow, bool) {
 	step := 1
 	if delta < 0 {
 		step = -1
 	}
-	for i, sess := range m.sessions {
-		if sess.ID != id {
+	for i := m.cursor + step; i >= 0 && i < len(m.rows); i += step {
+		candidate := m.rows[i]
+		if entry.isGroup {
+			if candidate.isGroup && parentGroup(candidate.group) == parentGroup(entry.group) {
+				return candidate, true
+			}
 			continue
 		}
-		neighbor := i + step
-		if neighbor >= 0 && neighbor < len(m.sessions) && m.sessions[neighbor].Group == sess.Group {
-			m.sessions[i], m.sessions[neighbor] = m.sessions[neighbor], m.sessions[i]
+		if !candidate.isGroup && candidate.sess.Group == entry.sess.Group {
+			return candidate, true
 		}
-		return
+	}
+	return treeRow{}, false
+}
+
+func (m *Model) knownGroupSiblings(parent string) []string {
+	paths := groupClosure(m.groups, m.sessions)
+	return childIndex(paths, m.groups)[parent]
+}
+
+func (m *Model) materializeGroupsLocal(paths []string) {
+	known := make(map[string]bool, len(m.groups))
+	for _, group := range m.groups {
+		known[group] = true
+	}
+	for _, path := range paths {
+		if !known[path] {
+			m.groups = append(m.groups, path)
+			known[path] = true
+		}
 	}
 }
 
-func (m *Model) swapGroupLocal(path string, delta int) {
-	parent := parentGroup(path)
-	isSibling := func(name string) bool {
-		return parentGroup(name) == parent
-	}
-	step := 1
-	if delta < 0 {
-		step = -1
-	}
-	current := -1
-	for i, name := range m.groups {
-		if name == path {
+func (m *Model) swapSessionLocal(id, targetID string) {
+	current, target := -1, -1
+	for i, sess := range m.sessions {
+		switch sess.ID {
+		case id:
 			current = i
-			break
+		case targetID:
+			target = i
 		}
 	}
-	if current < 0 {
-		return
+	if current >= 0 && target >= 0 {
+		m.sessions[current], m.sessions[target] = m.sessions[target], m.sessions[current]
 	}
-	for i := current + step; i >= 0 && i < len(m.groups); i += step {
-		if isSibling(m.groups[i]) {
-			m.groups[current], m.groups[i] = m.groups[i], m.groups[current]
-			return
+}
+
+func (m *Model) swapGroupLocal(path, targetPath string) {
+	current, target := -1, -1
+	for i, name := range m.groups {
+		switch name {
+		case path:
+			current = i
+		case targetPath:
+			target = i
 		}
+	}
+	if current >= 0 && target >= 0 {
+		m.groups[current], m.groups[target] = m.groups[target], m.groups[current]
 	}
 }
 

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -217,7 +217,7 @@ func (m *Model) viewHelp() string {
 		{"V", "revive every dead session"},
 		{"a / u", "archive / restore"},
 		{"d", "delete session, or group + subtree"},
-		{"shift+↑↓", "reorder row up / down"},
+		{"K / J", "reorder row up / down (shift+↑↓ also works)"},
 		{"space", "quick prompt: answer session / spawn agent in group"},
 		{"⇥", "in quick prompt: switch spawn tool"},
 		{"^v", "in quick prompt: paste image as an inline chip"},

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -133,6 +134,43 @@ func (m *Model) groupRowPaths() []string {
 		}
 	}
 	return paths
+}
+
+func loadStoredRows(t *testing.T, m *Model) {
+	t.Helper()
+	sessions, err := m.store.ListSessions(true)
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	groups, err := m.store.Groups()
+	if err != nil {
+		t.Fatalf("list groups: %v", err)
+	}
+	m.sessions = sessions
+	m.groups = make([]string, len(groups))
+	m.groupPaths = make(map[string]string, len(groups))
+	m.archivedGroups = make(map[string]bool, len(groups))
+	for i, group := range groups {
+		m.groups[i] = group.Name
+		m.groupPaths[group.Name] = group.Path
+		if group.Archived {
+			m.archivedGroups[group.Name] = true
+		}
+	}
+	m.rebuildRows()
+}
+
+func listSessionIDs(t *testing.T, st *store.Store) []string {
+	t.Helper()
+	sessions, err := st.ListSessions(false)
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	ids := make([]string, len(sessions))
+	for i, sess := range sessions {
+		ids[i] = sess.ID
+	}
+	return ids
 }
 
 func pickGroup(t *testing.T, m *Model, path string) {
@@ -343,6 +381,104 @@ func TestNestedGroupsTree(t *testing.T) {
 
 	if m.View() == "" {
 		t.Fatal("View should render non-empty")
+	}
+}
+
+func TestPortableReorderKeysSwapVisibleSessions(t *testing.T) {
+	m := buildModel(t)
+	for _, sess := range []store.Session{
+		{ID: "a", Name: "keep-alpha", Tool: "claude", Cwd: "/tmp", Status: "idle"},
+		{ID: "hidden", Name: "filtered", Tool: "claude", Cwd: "/tmp", Status: "idle"},
+		{ID: "c", Name: "keep-charlie", Tool: "claude", Cwd: "/tmp", Status: "idle"},
+	} {
+		if err := m.store.CreateSession(sess); err != nil {
+			t.Fatalf("create session %q: %v", sess.ID, err)
+		}
+	}
+	m.search = "keep"
+	loadStoredRows(t, m)
+	m.selectSessionRow(t, "keep-charlie")
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}})
+	m = updated.(*Model)
+	if got, want := []string{m.sessionRows()[0].ID, m.sessionRows()[1].ID}, []string{"c", "a"}; !slices.Equal(got, want) {
+		t.Fatalf("visible order after K = %v want %v", got, want)
+	}
+	if got, want := listSessionIDs(t, m.store), []string{"c", "hidden", "a"}; !slices.Equal(got, want) {
+		t.Fatalf("stored order after K = %v want %v", got, want)
+	}
+
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'J'}})
+	m = updated.(*Model)
+	if got, want := listSessionIDs(t, m.store), []string{"a", "hidden", "c"}; !slices.Equal(got, want) {
+		t.Fatalf("stored order after J = %v want %v", got, want)
+	}
+
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyShiftUp})
+	m = updated.(*Model)
+	if got, want := listSessionIDs(t, m.store), []string{"c", "hidden", "a"}; !slices.Equal(got, want) {
+		t.Fatalf("stored order after shift+up = %v want %v", got, want)
+	}
+}
+
+func TestReorderGroupSkipsFilteredSibling(t *testing.T) {
+	m := buildModel(t)
+	for _, group := range []string{"alpha", "hidden", "gamma"} {
+		if err := m.store.CreateGroup(group, ""); err != nil {
+			t.Fatalf("create group %q: %v", group, err)
+		}
+	}
+	for _, sess := range []store.Session{
+		{ID: "a", Name: "keep-alpha", Tool: "claude", Cwd: "/tmp", Group: "alpha", Status: "idle"},
+		{ID: "hidden", Name: "filtered", Tool: "claude", Cwd: "/tmp", Group: "hidden", Status: "idle"},
+		{ID: "g", Name: "keep-gamma", Tool: "claude", Cwd: "/tmp", Group: "gamma", Status: "idle"},
+	} {
+		if err := m.store.CreateSession(sess); err != nil {
+			t.Fatalf("create session %q: %v", sess.ID, err)
+		}
+	}
+	m.search = "keep"
+	loadStoredRows(t, m)
+	m.selectGroupRow(t, "gamma")
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}})
+	m = updated.(*Model)
+	if got, want := m.groupRowPaths(), []string{"gamma", "alpha"}; !slices.Equal(got, want) {
+		t.Fatalf("visible group order after K = %v want %v", got, want)
+	}
+	groups, err := m.store.Groups()
+	if err != nil {
+		t.Fatalf("list groups: %v", err)
+	}
+	got := make([]string, len(groups))
+	for i, group := range groups {
+		got[i] = group.Name
+	}
+	if want := []string{"gamma", "hidden", "alpha"}; !slices.Equal(got, want) {
+		t.Fatalf("stored group order after K = %v want %v", got, want)
+	}
+}
+
+func TestReorderSyntheticGroupUpdatesImmediately(t *testing.T) {
+	m := buildModel(t)
+	for _, group := range []string{"alpha/deep", "beta/deep", "gamma/deep"} {
+		if err := m.store.CreateGroup(group, ""); err != nil {
+			t.Fatalf("create group %q: %v", group, err)
+		}
+	}
+	loadStoredRows(t, m)
+	m.selectGroupRow(t, "gamma")
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}})
+	m = updated.(*Model)
+	var roots []string
+	for _, group := range m.groupRowPaths() {
+		if !strings.Contains(group, "/") {
+			roots = append(roots, group)
+		}
+	}
+	if want := []string{"alpha", "gamma", "beta"}; !slices.Equal(roots, want) {
+		t.Fatalf("root order after K = %v want %v", roots, want)
 	}
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -394,7 +394,7 @@ func padToHeight(s string, height int) string {
 // terminal is too narrow for one.
 func (m *Model) viewFooter() string {
 	pairs := [][2]string{
-		{"↑↓/jk", "navigate"}, {"shift+↑↓", "reorder"}, {"↵", "attach / fold"},
+		{"↑↓/jk", "navigate"}, {"K/J", "reorder"}, {"↵", "attach / fold"},
 		{"F", "fold all"}, {"n", "new"}, {"g", "group"}, {"space", "prompt"},
 		{"ctrl+r", "review"}, {"r", "rename"}, {"m", "move"},
 		{"v/V", "revive / all"}, {"a/u", "archive / restore"}, {"d", "delete"},


### PR DESCRIPTION
## What changed

- add portable `K` / `J` reorder bindings while keeping `Shift+Up` / `Shift+Down`
- reorder sessions and groups against the next visible sibling, crossing filtered or archived rows in one action
- persist synthesized parent-group ordering and mirror swaps locally for immediate feedback
- update shortcut help and documentation

## Why

Modified arrow-key escape sequences are not delivered consistently by macOS terminals, tmux, and terminal keyboard protocols. The previous store-level neighbor swap could also target a hidden row, making a successful reorder look like it did nothing.

## Impact

Reordering now responds immediately and consistently across terminal environments. Search, archive, hidden-row, nested-group, and synthesized-parent cases preserve the expected visible order.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- focused store/UI regression coverage for portable keys, hidden siblings, and synthesized groups