### PR TITLE
Speed up review mode

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -45,6 +45,7 @@ type FileDiff struct {
 	Truncated bool
 	Err       error
 	statKnown bool
+	loaded    bool
 	rows      []Row
 }
 
@@ -58,16 +59,17 @@ type Set struct {
 }
 
 const (
-	maxFileBytes  = 1 << 20
-	maxFileLines  = 10000
-	maxEagerFiles = 200
-	maxSpanLine   = 1000
-	maxSpanBlock  = 200
+	maxFileBytes = 1 << 20
+	maxFileLines = 10000
+	maxSpanLine  = 1000
+	maxSpanBlock = 200
 )
 
-// BuildSet loads and diffs every changed file for a scope. A non-empty
-// baseOverride selects the ScopeBranch base and fails loudly when it no
-// longer resolves; empty keeps auto-detection.
+// BuildSet loads only the changed-file metadata for a scope. File contents and
+// line models are loaded on demand so large reviews can show their file list
+// without waiting for every file to be read and diffed. A non-empty
+// baseOverride selects the ScopeBranch base and fails loudly when it no longer
+// resolves; empty keeps auto-detection.
 func BuildSet(driver *git.Driver, cwd string, scope git.Scope, baseOverride string) (Set, error) {
 	repo, err := driver.OpenRepo(cwd)
 	if err != nil {
@@ -115,38 +117,49 @@ func BuildSet(driver *git.Driver, cwd string, scope git.Scope, baseOverride stri
 		return Set{}, statsErr
 	}
 
-	for i, file := range files {
+	for _, file := range files {
 		stat, known := stats[file.Path]
 		fd := FileDiff{File: file, Stat: stat, statKnown: known}
-		if !known && file.Status == git.Untracked {
-			if err := countUnknownStat(driver, repo.Root, &fd); err != nil {
-				fd.Err = err
-				set.Files = append(set.Files, fd)
-				continue
-			}
-		}
-		if i < maxEagerFiles {
-			loadFile(driver, repo.Root, scope, baseRef, &fd)
-		}
 		set.Files = append(set.Files, fd)
 	}
 	return set, nil
 }
 
-// EnsureFile lazily loads a file skipped past the eager cap.
+// EnsureFile synchronously loads one file. Interactive callers should use
+// LoadFile from a background command and install the returned value on their
+// event loop instead.
 func EnsureFile(driver *git.Driver, set *Set, index int) {
 	if index < 0 || index >= len(set.Files) {
 		return
 	}
 	fd := &set.Files[index]
-	if fd.Lines != nil || fd.Binary || fd.Err != nil {
+	if fd.loaded {
 		return
 	}
-	baseRef := set.BaseRef
-	loadFile(driver, set.Repo.Root, set.Scope, baseRef, fd)
+	*fd = LoadFile(driver, *set, index)
+}
+
+// LoadFile builds one file's line model without mutating set, which makes it
+// safe to call from an asynchronous UI command using a snapshot of the set.
+func LoadFile(driver *git.Driver, set Set, index int) FileDiff {
+	if index < 0 || index >= len(set.Files) {
+		return FileDiff{}
+	}
+	fd := set.Files[index]
+	if !fd.loaded {
+		loadFile(driver, set.Repo.Root, set.Scope, set.BaseRef, &fd)
+	}
+	return fd
 }
 
 func loadFile(driver *git.Driver, root string, scope git.Scope, baseRef string, fd *FileDiff) {
+	fd.loaded = true
+	if !fd.statKnown && fd.File.Status == git.Untracked {
+		if err := countUnknownStat(driver, root, fd); err != nil {
+			fd.Err = err
+			return
+		}
+	}
 	oldContent, newContent, err := fileSides(driver, root, scope, baseRef, fd.File)
 	if err != nil {
 		fd.Err = err
@@ -163,6 +176,7 @@ func loadFile(driver *git.Driver, root string, scope git.Scope, baseRef string, 
 	known := fd.statKnown
 	*fd = BuildFile(oldContent, newContent, fd.File, fd.Stat)
 	fd.statKnown = known
+	fd.loaded = true
 }
 
 // Counting raw bytes keeps untracked files correct past the diff model's caps.
@@ -182,6 +196,9 @@ func countUnknownStat(driver *git.Driver, root string, fd *FileDiff) error {
 
 // StatKnown reports whether Stat holds a real count rather than an unknown one.
 func (fd *FileDiff) StatKnown() bool { return fd.statKnown }
+
+// Loaded reports whether the file's contents have been read and modeled.
+func (fd *FileDiff) Loaded() bool { return fd.loaded }
 
 func fileSides(driver *git.Driver, root string, scope git.Scope, baseRef string, file git.ChangedFile) (oldContent, newContent []byte, err error) {
 	oldRef, newRef := "", ""
@@ -222,7 +239,7 @@ func fileSides(driver *git.Driver, root string, scope git.Scope, baseRef string,
 // every new-file line in order, with deleted old lines interleaved
 // ahead of the lines that replaced them.
 func BuildFile(oldContent, newContent []byte, file git.ChangedFile, stat git.FileStat) FileDiff {
-	fd := FileDiff{File: file, Stat: stat}
+	fd := FileDiff{File: file, Stat: stat, loaded: true}
 	oldText, oldTruncated := capLines(string(oldContent))
 	newText, newTruncated := capLines(string(newContent))
 	fd.Truncated = oldTruncated || newTruncated

--- a/internal/diff/diff_bench_test.go
+++ b/internal/diff/diff_bench_test.go
@@ -1,0 +1,53 @@
+package diff
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/git"
+)
+
+func BenchmarkBuildSetManyFiles(b *testing.B) {
+	driver, err := git.New()
+	if err != nil {
+		b.Skip("git not installed")
+	}
+	dir := b.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=bench", "GIT_AUTHOR_EMAIL=bench@example.com",
+			"GIT_COMMITTER_NAME=bench", "GIT_COMMITTER_EMAIL=bench@example.com")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			b.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	content := strings.Repeat("line with enough content to exercise the diff model\n", 400)
+	for i := 0; i < 200; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("file-%03d.txt", i))
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	run("add", ".")
+	run("commit", "-m", "baseline")
+	for i := 0; i < 200; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("file-%03d.txt", i))
+		if err := os.WriteFile(path, []byte("changed\n"+content), 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := BuildSet(driver, dir, git.ScopeUncommitted, ""); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -166,6 +166,9 @@ func TestUntrackedFileGetsLineCount(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	for i := range set.Files {
+		EnsureFile(driver, &set, i)
+	}
 	byPath := map[string]FileDiff{}
 	for _, fd := range set.Files {
 		byPath[fd.File.Path] = fd
@@ -215,6 +218,8 @@ func TestUntrackedFileOverLineCapCountsTrueLines(t *testing.T) {
 	if huge == nil {
 		t.Fatal("huge.txt missing from the set")
 	}
+	EnsureFile(driver, &set, 0)
+	huge = &set.Files[0]
 	if !huge.StatKnown() {
 		t.Fatal("huge.txt stat should be known")
 	}
@@ -249,6 +254,8 @@ func TestUntrackedFileOverByteCapStillCounts(t *testing.T) {
 	if wide == nil {
 		t.Fatal("wide.txt missing from the set")
 	}
+	EnsureFile(driver, &set, 0)
+	wide = &set.Files[0]
 	if !wide.StatKnown() {
 		t.Fatal("wide.txt stat should be known")
 	}
@@ -280,6 +287,7 @@ func TestTruncatedTrackedFileKeepsNumstat(t *testing.T) {
 	if len(set.Files) != 1 {
 		t.Fatalf("files = %d, want 1", len(set.Files))
 	}
+	EnsureFile(driver, &set, 0)
 	big := set.Files[0]
 	if !big.StatKnown() {
 		t.Fatal("big.txt stat should stay known after the truncated load")
@@ -289,13 +297,12 @@ func TestTruncatedTrackedFileKeepsNumstat(t *testing.T) {
 	}
 }
 
-// The header sums every file's Stat, so all must be set before any lazy load.
-func TestHeaderTotalStableWithoutLazyLoad(t *testing.T) {
+func TestUntrackedStatsLoadLazily(t *testing.T) {
 	driver, dir := testRepo(t)
 	write(t, dir, "tracked.go", "package a\n")
 	commit(t, dir, "init")
 
-	const files, linesEach = maxEagerFiles + 5, 3
+	const files, linesEach = 205, 3
 	for i := 0; i < files; i++ {
 		write(t, dir, fmt.Sprintf("untracked%03d.txt", i), linesOf(linesEach))
 	}
@@ -308,31 +315,29 @@ func TestHeaderTotalStableWithoutLazyLoad(t *testing.T) {
 		t.Fatalf("files = %d, want %d", len(set.Files), files)
 	}
 
-	adds := 0
 	for i := range set.Files {
 		fd := set.Files[i]
-		if !fd.StatKnown() {
-			t.Fatalf("%s has no stat after BuildSet", fd.File.Path)
+		if fd.StatKnown() {
+			t.Fatalf("%s should keep its stat deferred after BuildSet", fd.File.Path)
 		}
-		if fd.Stat.Adds != linesEach {
-			t.Errorf("%s adds = %d, want %d (index %d)", fd.File.Path, fd.Stat.Adds, linesEach, i)
+		if fd.Loaded() {
+			t.Fatalf("%s should keep its contents deferred after BuildSet", fd.File.Path)
+		}
+	}
+
+	for i := range set.Files {
+		EnsureFile(driver, &set, i)
+	}
+	adds := 0
+	for _, fd := range set.Files {
+		if !fd.StatKnown() || fd.Stat.Adds != linesEach {
+			t.Errorf("%s stat = %+v known=%v, want %d adds",
+				fd.File.Path, fd.Stat, fd.StatKnown(), linesEach)
 		}
 		adds += fd.Stat.Adds
 	}
 	if want := files * linesEach; adds != want {
 		t.Fatalf("total adds = %d, want %d", adds, want)
-	}
-
-	// Loading the files the eager pass skipped must not move the total.
-	for i := range set.Files {
-		EnsureFile(driver, &set, i)
-	}
-	after := 0
-	for _, fd := range set.Files {
-		after += fd.Stat.Adds
-	}
-	if after != adds {
-		t.Fatalf("total drifted after lazy loading: %d -> %d", adds, after)
 	}
 }
 
@@ -354,6 +359,9 @@ func TestUnreadableUntrackedFileDoesNotAbortSet(t *testing.T) {
 	set, err := BuildSet(driver, dir, git.ScopeUncommitted, "")
 	if err != nil {
 		t.Fatalf("BuildSet aborted on one unreadable file: %v", err)
+	}
+	for i := range set.Files {
+		EnsureFile(driver, &set, i)
 	}
 	byPath := map[string]FileDiff{}
 	for _, fd := range set.Files {

--- a/internal/ui/cursor_visible_test.go
+++ b/internal/ui/cursor_visible_test.go
@@ -53,7 +53,7 @@ func TestDiffFileListCursorAlwaysPainted(t *testing.T) {
 	dir := gitRepoWithManyFiles(t, 40)
 	createSession(t, m, "coder", dir, "")
 	m.selectSessionRow(t, "coder")
-	m.applyCmd(t, m.openDiff())
+	m.drainCmds(t, m.openDiff())
 	if m.diff.loading || len(m.diff.set.Files) < 2 {
 		t.Fatalf("diff did not load: %q", m.diff.errText)
 	}
@@ -62,6 +62,7 @@ func TestDiffFileListCursorAlwaysPainted(t *testing.T) {
 	for _, size := range []struct{ w, h int }{{80, 20}, {100, 30}, {140, 44}} {
 		m.width, m.height = size.w, size.h
 		m.diff.fileIdx = last
+		m.drainCmds(t, m.loadCurrentDiffFile())
 		view := ansi.Strip(m.viewDiffFull())
 		name := m.diff.set.Files[last].File.Path
 		if !strings.Contains(view, name) {

--- a/internal/ui/diff_frame_test.go
+++ b/internal/ui/diff_frame_test.go
@@ -16,7 +16,7 @@ func TestDiffFrameFitsTerminal(t *testing.T) {
 	dir := gitRepoWithLongFile(t, 400)
 	createSession(t, m, "coder", dir, "")
 	m.selectSessionRow(t, "coder")
-	m.applyCmd(t, m.openDiff())
+	m.drainCmds(t, m.openDiff())
 	if m.diff.loading || len(m.diff.set.Files) == 0 {
 		t.Fatalf("diff did not load: %q", m.diff.errText)
 	}
@@ -64,7 +64,7 @@ func TestDiffCursorStaysOnScreen(t *testing.T) {
 	dir := gitRepoWithLongFile(t, lines)
 	createSession(t, m, "coder", dir, "")
 	m.selectSessionRow(t, "coder")
-	m.applyCmd(t, m.openDiff())
+	m.drainCmds(t, m.openDiff())
 	if m.diff.loading || len(m.diff.set.Files) == 0 {
 		t.Fatalf("diff did not load: %q", m.diff.errText)
 	}

--- a/internal/ui/diff_reach_test.go
+++ b/internal/ui/diff_reach_test.go
@@ -62,7 +62,7 @@ func TestDiffReviewReachesLastLine(t *testing.T) {
 			dir := gitRepoWithLongFile(t, lines)
 			createSession(t, m, "coder", dir, "")
 			m.selectSessionRow(t, "coder")
-			m.applyCmd(t, m.openDiff())
+			m.drainCmds(t, m.openDiff())
 			if m.diff.loading || len(m.diff.set.Files) == 0 {
 				t.Fatalf("diff did not load: %q", m.diff.errText)
 			}
@@ -102,7 +102,7 @@ func TestDiffReviewStepsDownToTheEnd(t *testing.T) {
 	dir := gitRepoWithLongFile(t, lines)
 	createSession(t, m, "coder", dir, "")
 	m.selectSessionRow(t, "coder")
-	m.applyCmd(t, m.openDiff())
+	m.drainCmds(t, m.openDiff())
 	if m.diff.loading || len(m.diff.set.Files) == 0 {
 		t.Fatalf("diff did not load: %q", m.diff.errText)
 	}
@@ -166,7 +166,7 @@ func TestDiffReviewReachesEndWithWrappedLines(t *testing.T) {
 			dir := gitRepoWithWideFile(t, lines, 220)
 			createSession(t, m, "coder", dir, "")
 			m.selectSessionRow(t, "coder")
-			m.applyCmd(t, m.openDiff())
+			m.drainCmds(t, m.openDiff())
 			if m.diff.loading || len(m.diff.set.Files) == 0 {
 				t.Fatalf("diff did not load: %q", m.diff.errText)
 			}

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -54,6 +54,8 @@ type diffState struct {
 	probeTick   int
 	hl          *hlCache
 	hlPending   hlKey
+	fileLoading map[int]bool
+	reanchor    map[string]bool
 
 	// repoRoots holds the git repos found under the session cwd; the r key picks
 	// between them. repoSel is the selected repo's root path, the stable identity
@@ -96,6 +98,18 @@ type diffHLMsg struct {
 	key hlKey
 	hl  *fileHL
 }
+
+type diffFileLoadedMsg struct {
+	sessID   string
+	scope    git.Scope
+	gen      int
+	repoRoot string
+	index    int
+	path     string
+	fd       diff.FileDiff
+}
+
+type diffFilesLoadedMsg []diffFileLoadedMsg
 
 type diffProbeMsg struct {
 	sessID   string
@@ -190,6 +204,39 @@ func (m *Model) diffHLCmd(fd diff.FileDiff, key hlKey) tea.Cmd {
 	}
 }
 
+func (m *Model) diffFileLoadCmd(set diff.Set, sessID string, scope git.Scope, gen, index int, path string) tea.Cmd {
+	driver := m.gitDrv
+	return func() tea.Msg {
+		return diffFileLoadedMsg{
+			sessID:   sessID,
+			scope:    scope,
+			gen:      gen,
+			repoRoot: set.Repo.Root,
+			index:    index,
+			path:     path,
+			fd:       diff.LoadFile(driver, set, 0),
+		}
+	}
+}
+
+func diffFilesLoadCmd(cmds []tea.Cmd) tea.Cmd {
+	if len(cmds) == 0 {
+		return nil
+	}
+	return func() tea.Msg {
+		msgs := make(diffFilesLoadedMsg, 0, len(cmds))
+		for _, cmd := range cmds {
+			if cmd == nil {
+				continue
+			}
+			if msg, ok := cmd().(diffFileLoadedMsg); ok {
+				msgs = append(msgs, msg)
+			}
+		}
+		return msgs
+	}
+}
+
 func (m *Model) diffProbeCmd(sess store.Session, scope git.Scope) tea.Cmd {
 	driver := m.gitDrv
 	// The override is keyed by the raw selection while the git operations run
@@ -231,6 +278,8 @@ func (m *Model) retargetDiff(sess store.Session) tea.Cmd {
 	m.diff.cursorLine = 0
 	m.diff.repoRoots = nil
 	m.diff.repoSel = ""
+	m.diff.fileLoading = nil
+	m.diff.reanchor = nil
 	if picked, ok := m.pickedRepos[sess.ID]; ok {
 		m.diff.repoSel = picked
 	} else if declared, err := m.store.ReviewRepo(sess.ID); err != nil {
@@ -277,6 +326,8 @@ func (m *Model) cycleDiffScope() tea.Cmd {
 	m.diff.fileIdx = 0
 	m.diff.scroll = 0
 	m.diff.cursorLine = 0
+	m.diff.fileLoading = nil
+	m.diff.reanchor = nil
 	if m.diff.repoSel != "" && len(m.diff.repoRoots) > 0 {
 		override, err := m.store.ReviewBase(sess.ID, resolveSymlinksOrSelf(m.diff.repoSel))
 		if err != nil {
@@ -347,8 +398,13 @@ func (m *Model) handleDiffLoaded(msg diffLoadedMsg) tea.Cmd {
 	// Re-anchor only on a silent same-scope refresh. A scope cycle or session
 	// switch loads a different file set, where matching a comment by excerpt
 	// would rewrite its line against content it was never made against.
+	m.diff.fileLoading = map[int]bool{}
+	m.diff.reanchor = nil
 	if msg.refresh {
-		m.reanchorAnnotations()
+		m.diff.reanchor = map[string]bool{}
+		for _, note := range m.diff.annotations[m.reviewKey()] {
+			m.diff.reanchor[note.file] = true
+		}
 	}
 	// Keep the user's place across silent reloads.
 	m.diff.fileIdx = 0
@@ -358,8 +414,83 @@ func (m *Model) handleDiffLoaded(msg diffLoadedMsg) tea.Cmd {
 			break
 		}
 	}
-	// The restored file may have been past the eager-load cap in the fresh set.
-	diff.EnsureFile(m.gitDrv, &m.diff.set, m.diff.fileIdx)
+	m.clampDiffCursor()
+	currentLoad := m.loadCurrentDiffFile()
+	var statefulLoads []tea.Cmd
+	if msg.refresh {
+		stateful := map[string]bool{}
+		for path, hash := range m.diff.reviewed[m.reviewKey()] {
+			if hash != 0 {
+				stateful[path] = true
+			}
+		}
+		for _, note := range m.diff.annotations[m.reviewKey()] {
+			stateful[note.file] = true
+		}
+		for i := range m.diff.set.Files {
+			if stateful[m.diff.set.Files[i].File.Path] {
+				if cmd := m.loadDiffFile(i); cmd != nil {
+					statefulLoads = append(statefulLoads, cmd)
+				}
+			}
+		}
+	}
+	// The selected file gets its own command so it becomes usable immediately.
+	// Less urgent review-state files load serially in one background command,
+	// avoiding an unbounded git/process fan-out after a large review refresh.
+	return tea.Batch(currentLoad, diffFilesLoadCmd(statefulLoads))
+}
+
+func (m *Model) loadCurrentDiffFile() tea.Cmd {
+	return m.loadDiffFile(m.diff.fileIdx)
+}
+
+func (m *Model) loadDiffFile(index int) tea.Cmd {
+	if index < 0 || index >= len(m.diff.set.Files) {
+		return nil
+	}
+	fd := &m.diff.set.Files[index]
+	if fd.Loaded() {
+		if index == m.diff.fileIdx {
+			return m.ensureHighlight()
+		}
+		return nil
+	}
+	if m.diff.fileLoading == nil {
+		m.diff.fileLoading = map[int]bool{}
+	}
+	if m.diff.fileLoading[index] {
+		return nil
+	}
+	m.diff.fileLoading[index] = true
+
+	// Copy the requested row into a one-file set before the command starts.
+	// The model can switch files or replace its set while the load runs.
+	snapshot := m.diff.set
+	snapshot.Files = []diff.FileDiff{*fd}
+	return m.diffFileLoadCmd(snapshot, m.diff.sessID, m.diff.scope, m.diff.gen,
+		index, fd.File.Path)
+}
+
+func (m *Model) handleDiffFileLoaded(msg diffFileLoadedMsg) tea.Cmd {
+	if !m.diff.active || msg.sessID != m.diff.sessID || msg.scope != m.diff.scope ||
+		msg.gen != m.diff.gen || msg.repoRoot != m.diff.set.Repo.Root {
+		return nil
+	}
+	if msg.index < 0 || msg.index >= len(m.diff.set.Files) ||
+		m.diff.set.Files[msg.index].File.Path != msg.path {
+		return nil
+	}
+	delete(m.diff.fileLoading, msg.index)
+	m.diff.set.Files[msg.index] = msg.fd
+	clearStaleReviewedMark(m, msg.path)
+	if m.diff.reanchor[msg.path] {
+		m.reanchorAnnotationsFor(msg.path)
+		delete(m.diff.reanchor, msg.path)
+	}
+	if msg.index != m.diff.fileIdx {
+		return nil
+	}
 	m.clampDiffCursor()
 	return m.ensureHighlight()
 }
@@ -425,7 +556,7 @@ func (m *Model) currentFileDiff() *diff.FileDiff {
 // its highlighted lines are not cached yet.
 func (m *Model) ensureHighlight() tea.Cmd {
 	fd := m.currentFileDiff()
-	if fd == nil || fd.Binary || fd.Err != nil || len(fd.Lines) == 0 {
+	if fd == nil || !fd.Loaded() || fd.Binary || fd.Err != nil || len(fd.Lines) == 0 {
 		return nil
 	}
 	key := hlKey{sessID: m.diff.sessID, scope: m.diff.scope, path: fd.File.Path, hash: contentHash(fd)}
@@ -459,12 +590,11 @@ func (m *Model) switchDiffFile(delta int) tea.Cmd {
 		m.diff.scrollByFile[m.scrollKey(fd.File.Path)] = m.diff.scroll
 	}
 	m.diff.fileIdx = (m.diff.fileIdx + delta + count) % count
-	diff.EnsureFile(m.gitDrv, &m.diff.set, m.diff.fileIdx)
 	fd := m.currentFileDiff()
 	m.diff.scroll = m.diff.scrollByFile[m.scrollKey(fd.File.Path)]
 	m.diff.cursorLine = m.diff.scroll
 	m.clampDiffCursor()
-	return m.ensureHighlight()
+	return m.loadCurrentDiffFile()
 }
 
 func (m *Model) clampDiffCursor() {
@@ -631,16 +761,7 @@ func (m *Model) handleDiffKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+c":
 		return m, tea.Quit
 	case "q", "esc":
-		m.mode = modeList
-		m.diff.active = false
-		// Review opened from inside a session returns to that session, not
-		// the list, so Ctrl+R then esc is a round trip back to where it began.
-		if id := m.diff.reattachID; id != "" {
-			m.diff.reattachID = ""
-			if cmd := m.reattach(id); cmd != nil {
-				return m, cmd
-			}
-		}
+		return m, m.closeDiff()
 	case "up", "k":
 		m.moveDiffCursor(-1, height)
 	case "down", "j":
@@ -693,9 +814,38 @@ func (m *Model) handleDiffKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m *Model) closeDiff() tea.Cmd {
+	reattachID := m.diff.reattachID
+	m.mode = modeList
+	m.diff.active = false
+	m.diff.gen++
+	m.diff.loading = false
+	m.diff.errText = ""
+	m.diff.set = diff.Set{}
+	m.diff.sessID = ""
+	m.diff.fileIdx = 0
+	m.diff.scroll = 0
+	m.diff.cursorLine = 0
+	m.diff.fingerprint = 0
+	m.diff.repoRoots = nil
+	m.diff.repoSel = ""
+	m.diff.worktrees = nil
+	m.diff.fileLoading = nil
+	m.diff.reanchor = nil
+	m.diff.hlPending = hlKey{}
+	m.diff.hl = nil
+	m.diff.annotating = false
+	m.diff.sendConfirm = false
+	m.diff.reattachID = ""
+	if reattachID != "" {
+		return m.reattach(reattachID, m.diff.gen)
+	}
+	return nil
+}
+
 func (m *Model) toggleReviewed() tea.Cmd {
 	fd := m.currentFileDiff()
-	if fd == nil {
+	if fd == nil || !fd.Loaded() {
 		return nil
 	}
 	marks := m.diff.reviewed[m.reviewKey()]
@@ -734,9 +884,25 @@ func clearStaleReviewedMarks(m *Model) {
 			continue
 		}
 		fd := m.fileDiffByPath(path)
-		if fd == nil || contentHash(fd) != stored {
+		if fd == nil {
+			delete(marks, path)
+			continue
+		}
+		if fd.Loaded() && contentHash(fd) != stored {
 			delete(marks, path)
 		}
+	}
+}
+
+func clearStaleReviewedMark(m *Model, path string) {
+	marks := m.diff.reviewed[m.reviewKey()]
+	stored := marks[path]
+	if stored == 0 {
+		return
+	}
+	fd := m.fileDiffByPath(path)
+	if fd == nil || (fd.Loaded() && contentHash(fd) != stored) {
+		delete(marks, path)
 	}
 }
 
@@ -804,9 +970,16 @@ func (m *Model) annotationAt(path string, line diff.Line) *annotation {
 // edits while the user reviews), choosing the nearest match. A comment
 // whose line vanished entirely keeps its number as the best guess.
 func (m *Model) reanchorAnnotations() {
+	m.reanchorAnnotationsFor("")
+}
+
+func (m *Model) reanchorAnnotationsFor(path string) {
 	notes := m.diff.annotations[m.reviewKey()]
 	for i := range notes {
 		note := &notes[i]
+		if path != "" && note.file != path {
+			continue
+		}
 		// A blank line's excerpt is empty and would match every blank line;
 		// only a distinctive excerpt can re-anchor.
 		if note.excerpt == "" {
@@ -1018,6 +1191,8 @@ func (m *Model) diffEmptyText() string {
 
 func (m *Model) diffBodyNote(fd *diff.FileDiff) string {
 	switch {
+	case !fd.Loaded():
+		return mutedStyle.Render("(loading file…)")
 	case fd.Err != nil:
 		return errStyle.Render("✖ " + fd.Err.Error())
 	case fd.Binary:

--- a/internal/ui/frame_bench_test.go
+++ b/internal/ui/frame_bench_test.go
@@ -1,6 +1,12 @@
 package ui
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/diff"
+	"github.com/YoanWai/agent-manager/internal/git"
+)
 
 func BenchmarkListFrame(b *testing.B) {
 	m := shotModel()
@@ -8,5 +14,23 @@ func BenchmarkListFrame(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = m.View()
+	}
+}
+
+func BenchmarkCloseLargeReview(b *testing.B) {
+	m := shotModel()
+	files := make([]diff.FileDiff, 10000)
+	for i := range files {
+		files[i].File = git.ChangedFile{Path: fmt.Sprintf("path/to/file-%05d.go", i)}
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		m.mode = modeDiff
+		m.diff.active = true
+		m.diff.sessID = "bench"
+		m.diff.set = diff.Set{Files: files}
+		b.StartTimer()
+		m.closeDiff()
 	}
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -145,8 +145,10 @@ func (m *Model) openDiff() tea.Cmd {
 		m.diff.scrollByFile = map[string]int{}
 		m.diff.reviewed = map[string]map[string]uint64{}
 		m.diff.annotations = map[string][]annotation{}
-		m.diff.hl = newHLCache()
 		m.diff.sideBySide = m.defaultSplitLayout()
+	}
+	if m.diff.hl == nil {
+		m.diff.hl = newHLCache()
 	}
 	m.diff.active = true
 	m.mode = modeDiff
@@ -385,22 +387,38 @@ func (m *Model) attachCmd(id string) tea.Cmd {
 	})
 }
 
-func (m *Model) reattach(id string) tea.Cmd {
-	if !m.tmux.Exists(id) {
-		m.err = "session is dead - press v to revive"
-		return nil
+type reattachPreparedMsg struct {
+	sessID  string
+	diffGen int
+	err     error
+}
+
+func (m *Model) reattach(id string, diffGen int) tea.Cmd {
+	driver := m.tmux
+	stor := m.store
+	poller := m.poller
+	return func() tea.Msg {
+		if !driver.Exists(id) {
+			return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: errors.New("session is dead - press v to revive")}
+		}
+		sess, err := stor.Get(id)
+		if err != nil {
+			return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: err}
+		}
+		if sess.Status == status.Finished {
+			if err := stor.UpdateStatus(sess.ID, status.Idle); err != nil {
+				return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: err}
+			}
+			if err := stor.SetAcked(sess.ID, true); err != nil {
+				return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: err}
+			}
+		}
+		var prepErr error
+		poller.reflowSessions([]string{id}, func() {
+			prepErr = driver.PrepareAttach(id)
+		})
+		return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: prepErr}
 	}
-	m.err = ""
-	sess, err := m.store.Get(id)
-	if err != nil {
-		m.err = err.Error()
-		return nil
-	}
-	if err := m.acknowledgeFinished(sess); err != nil {
-		m.err = err.Error()
-		return nil
-	}
-	return m.attachCmd(id)
 }
 
 // reviveSelected relaunches a dead session's tmux session under the same

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -636,6 +636,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case diffLoadedMsg:
 		return m, m.handleDiffLoaded(msg)
 
+	case diffFileLoadedMsg:
+		return m, m.handleDiffFileLoaded(msg)
+
+	case diffFilesLoadedMsg:
+		var cmds []tea.Cmd
+		for _, loaded := range msg {
+			if cmd := m.handleDiffFileLoaded(loaded); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+		return m, tea.Batch(cmds...)
+
 	case diffHLMsg:
 		m.handleDiffHL(msg)
 		return m, nil
@@ -693,6 +705,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.requestRefresh()
 		return m, nil
+
+	case reattachPreparedMsg:
+		if msg.diffGen != m.diff.gen || m.diff.active {
+			return m, nil
+		}
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			return m, nil
+		}
+		m.err = ""
+		return m, tea.ExecProcess(m.tmux.AttachCommand(msg.sessID), func(err error) tea.Msg {
+			return attachDoneMsg{sessID: msg.sessID, err: err}
+		})
 
 	case tea.MouseMsg:
 		return m.handleMouse(msg)

--- a/internal/ui/repopicker.go
+++ b/internal/ui/repopicker.go
@@ -207,6 +207,8 @@ func (m *Model) selectRepo(root string) tea.Cmd {
 	m.diff.fileIdx = 0
 	m.diff.scroll = 0
 	m.diff.cursorLine = 0
+	m.diff.fileLoading = nil
+	m.diff.reanchor = nil
 	return m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, false)
 }
 
@@ -232,6 +234,8 @@ func (m *Model) selectBase(ref string) tea.Cmd {
 	m.diff.fileIdx = 0
 	m.diff.scroll = 0
 	m.diff.cursorLine = 0
+	m.diff.fileLoading = nil
+	m.diff.reanchor = nil
 	if m.diff.repoSel != "" && len(m.diff.repoRoots) > 0 {
 		return m.diffReloadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, ref, m.diff.repoRoots)
 	}

--- a/internal/ui/review_reattach_test.go
+++ b/internal/ui/review_reattach_test.go
@@ -59,7 +59,7 @@ func TestListReviewLeavesToListWithoutReattach(t *testing.T) {
 	createSession(t, m, "listreview", t.TempDir(), "")
 	m.selectSessionRow(t, "listreview")
 
-	m.applyCmd(t, m.openDiff())
+	m.drainCmds(t, m.openDiff())
 	if m.mode != modeDiff {
 		t.Fatalf("openDiff should enter review, mode = %v, err = %q", m.mode, m.err)
 	}
@@ -109,11 +109,30 @@ func TestReattachAcknowledgesFinished(t *testing.T) {
 	if cmd == nil {
 		t.Fatalf("esc should re-attach, err = %q", m.err)
 	}
+	prepared, ok := cmd().(reattachPreparedMsg)
+	if !ok {
+		t.Fatal("re-attach preparation should run in the returned command")
+	}
+	if prepared.err != nil {
+		t.Fatalf("prepare re-attach: %v", prepared.err)
+	}
 	got, err := m.store.Get(sess.ID)
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
 	if got.Status != status.Idle || !got.Acked {
 		t.Fatalf("re-attach should acknowledge finished: status = %q acked = %v", got.Status, got.Acked)
+	}
+}
+
+func TestStaleReattachDoesNotInterruptReopenedReview(t *testing.T) {
+	m := &Model{mode: modeDiff, diff: diffState{active: true, gen: 9}}
+	updated, cmd := m.Update(reattachPreparedMsg{sessID: "old", diffGen: 8})
+	m = updated.(*Model)
+	if cmd != nil {
+		t.Fatal("stale re-attach should not return an attach command")
+	}
+	if m.mode != modeDiff || !m.diff.active {
+		t.Fatal("stale re-attach should leave the reopened review untouched")
 	}
 }

--- a/internal/ui/review_regression_test.go
+++ b/internal/ui/review_regression_test.go
@@ -6,7 +6,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/YoanWai/agent-manager/internal/diff"
@@ -335,6 +337,12 @@ func (m *Model) drainCmds(t *testing.T, cmd tea.Cmd) {
 		if msg == nil {
 			return
 		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, child := range batch {
+				m.drainCmds(t, child)
+			}
+			return
+		}
 		updated, next := m.Update(msg)
 		*m = *updated.(*Model)
 		cmd = next
@@ -375,6 +383,97 @@ func openReviewOn(t *testing.T, m *Model, name, dir string) {
 	m.drainCmds(t, m.openDiff())
 	if m.mode != modeDiff {
 		t.Fatalf("openDiff should enter review, err = %q", m.err)
+	}
+}
+
+func TestReviewLoadsFilesOnDemand(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "lazy", gitRepoWithTwoChangedFiles(t))
+	if len(m.diff.set.Files) != 2 {
+		t.Fatalf("want 2 files, got %d", len(m.diff.set.Files))
+	}
+	if !m.diff.set.Files[0].Loaded() {
+		t.Fatal("selected file should be loaded after its background command lands")
+	}
+	if m.diff.set.Files[1].Loaded() {
+		t.Fatal("unselected file should remain unloaded")
+	}
+
+	cmd := m.switchDiffFile(1)
+	if cmd == nil {
+		t.Fatal("switching to an unloaded file should schedule a load")
+	}
+	if m.currentFileDiff().Loaded() {
+		t.Fatal("file loading should not block the navigation handler")
+	}
+	if body := ansi.Strip(m.viewDiffCode(80, 20)); !strings.Contains(body, "loading file") {
+		t.Fatalf("unloaded file should render a loading state, got %q", body)
+	}
+	m.drainCmds(t, cmd)
+	if !m.currentFileDiff().Loaded() {
+		t.Fatal("file should install after its background command lands")
+	}
+}
+
+func TestReviewCloseReleasesStateAndIgnoresLateLoad(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "close", gitRepoWithTwoChangedFiles(t))
+	load := m.switchDiffFile(1)
+	if load == nil {
+		t.Fatal("switch should leave a file load in flight")
+	}
+
+	if cmd := m.closeDiff(); cmd != nil {
+		t.Fatal("list-opened review should close without re-attaching")
+	}
+	if m.mode != modeList || m.diff.active || m.diff.sessID != "" {
+		t.Fatalf("review did not close cleanly: mode=%v active=%v session=%q",
+			m.mode, m.diff.active, m.diff.sessID)
+	}
+	if len(m.diff.set.Files) != 0 || m.diff.hlPending != (hlKey{}) {
+		t.Fatal("close should release diff and pending highlight state immediately")
+	}
+
+	late := load()
+	updated, next := m.Update(late)
+	*m = *updated.(*Model)
+	if next != nil || len(m.diff.set.Files) != 0 || m.diff.active {
+		t.Fatal("a file load landing after close must be ignored")
+	}
+}
+
+func TestRefreshFileLoadsRunSerially(t *testing.T) {
+	var active atomic.Int32
+	var peak atomic.Int32
+	cmds := make([]tea.Cmd, 8)
+	for i := range cmds {
+		index := i
+		cmds[i] = func() tea.Msg {
+			now := active.Add(1)
+			for {
+				seen := peak.Load()
+				if now <= seen || peak.CompareAndSwap(seen, now) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+			active.Add(-1)
+			return diffFileLoadedMsg{index: index}
+		}
+	}
+
+	msgs, ok := diffFilesLoadCmd(cmds)().(diffFilesLoadedMsg)
+	if !ok || len(msgs) != len(cmds) {
+		t.Fatalf("serial load returned %T with %d results", msgs, len(msgs))
+	}
+	if got := peak.Load(); got != 1 {
+		t.Fatalf("refresh loads peaked at %d concurrent jobs, want 1", got)
 	}
 }
 
@@ -651,6 +750,13 @@ func TestBinaryFileShowsBinaryNotZeroCounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	openReviewOn(t, m, "binary", dir)
+	for i := range m.diff.set.Files {
+		if m.diff.set.Files[i].File.Path == "logo.png" {
+			m.diff.fileIdx = i
+			m.drainCmds(t, m.loadCurrentDiffFile())
+			break
+		}
+	}
 
 	rendered := m.viewDiffFileList(60, 20)
 	row := ""

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2321,7 +2321,7 @@ func TestDiffReviewShowsWholeFile(t *testing.T) {
 	createSession(t, m, "coder", dir, "")
 	m.selectSessionRow(t, "coder")
 
-	m.applyCmd(t, m.openDiff())
+	m.drainCmds(t, m.openDiff())
 	if !m.diff.active || m.mode != modeDiff || m.diff.loading {
 		t.Fatalf("diff should be loaded fullscreen, active=%v mode=%v err=%q", m.diff.active, m.mode, m.diff.errText)
 	}
@@ -2346,7 +2346,7 @@ func TestDiffScopeCycleAndLayout(t *testing.T) {
 	dir := gitTestRepo(t)
 	createSession(t, m, "coder", dir, "")
 	m.selectSessionRow(t, "coder")
-	m.applyCmd(t, m.openDiff())
+	m.drainCmds(t, m.openDiff())
 
 	m.applyCmd(t, m.cycleDiffScope())
 	if m.diff.scope.String() != "vs target" {
@@ -2364,7 +2364,7 @@ func TestDiffAnnotateAndSend(t *testing.T) {
 	dir := gitTestRepo(t)
 	createSession(t, m, "coder", dir, "")
 	m.selectSessionRow(t, "coder")
-	m.applyCmd(t, m.openDiff())
+	m.drainCmds(t, m.openDiff())
 	m.diff.sideBySide = false
 
 	for i, fd := range m.diff.set.Files {
@@ -2372,6 +2372,7 @@ func TestDiffAnnotateAndSend(t *testing.T) {
 			m.diff.fileIdx = i
 		}
 	}
+	m.drainCmds(t, m.loadCurrentDiffFile())
 	fd := m.currentFileDiff()
 	target := -1
 	for i, line := range fd.Lines {
@@ -2464,7 +2465,7 @@ func TestDiffCommentVisibleInBothLayouts(t *testing.T) {
 	dir := gitTestRepo(t)
 	createSession(t, m, "coder", dir, "")
 	m.selectSessionRow(t, "coder")
-	m.applyCmd(t, m.openDiff())
+	m.drainCmds(t, m.openDiff())
 	m.diff.sideBySide = false
 
 	for i, fd := range m.diff.set.Files {
@@ -2472,6 +2473,7 @@ func TestDiffCommentVisibleInBothLayouts(t *testing.T) {
 			m.diff.fileIdx = i
 		}
 	}
+	m.drainCmds(t, m.loadCurrentDiffFile())
 	fd := m.currentFileDiff()
 	for i, line := range fd.Lines {
 		if line.NewNum > 0 && strings.Contains(line.Text, "println") {


### PR DESCRIPTION
## What changed

- build review sets from changed-file metadata only
- load the selected file asynchronously and load other files on demand
- refresh reviewed/commented files serially in the background to avoid process fan-out
- release diff/highlight state immediately when review closes
- move tmux re-attach preparation off the UI event loop and ignore stale re-attach results
- add lifecycle regressions and open/close benchmarks

## Why

Review mode eagerly read and built full-file diff models for up to 200 files before it became useful. On a representative 200-file repository that path took 4.6–6.25 seconds. Closing an in-session review also performed tmux and store work synchronously.

The metadata-first path now takes about 97–117 ms on the same benchmark, while the selected file continues loading in the background. A synthetic 10,000-file close takes about 83–88 ns with zero allocations.

## User impact

Review opens quickly even for large changes, file navigation remains responsive while content loads, and `q`/Escape exits review immediately. Existing reviewed marks and annotations remain correct across refreshes.

## Validation

- `test -z "$(gofmt -l .)"`
- `go vet ./...`
- `go build ./...`
- `go test -race -coverprofile=coverage.out -covermode=atomic ./...`
- `go test ./internal/diff -run '^$' -bench '^BenchmarkBuildSetManyFiles$' -benchtime=5x -count=2`
- `go test ./internal/ui -run '^$' -bench '^BenchmarkCloseLargeReview$' -benchtime=100000x -count=2`
