### PR TITLE
Add empty group visibility toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `s` | Settings (quick-spawn tool, theme, review layout, after quick send) |
 | `\|` | Resize the split: `←→` nudge the divider, `enter` commits, `esc` cancels |
 | `t` | Toggle archived view |
+| `e` | Hide / show empty groups |
 | `/` | Search |
 | `?` | Help |
 | `q` | Quit (sessions keep running) |
@@ -200,7 +201,7 @@ Comments stay on the review screen until you send them: `C` flattens every one o
 
 ### Groups
 
-Groups are paths (`backend/api/auth`) forming a tree of unlimited depth. Sessions can live at any node, including the root. Create subgroups inline with `g`, reorder both groups and sessions with `K` / `J` (or `shift+↑↓`; the order persists), fold a subtree with `enter` on its row, fold or unfold the whole tree with `F`, and edit a group's name and default path with `r`. On a session, `r` renames it and `tab` cycles the tool (status rules and revive follow the new tool; useful when you quit one agent in the pane and start another).
+Groups are paths (`backend/api/auth`) forming a tree of unlimited depth. Sessions can live at any node, including the root. Create subgroups inline with `g`, reorder both groups and sessions with `K` / `J` (or `shift+↑↓`; the order persists), fold a subtree with `enter` on its row, fold or unfold the whole tree with `F`, hide or restore empty groups visually with `e`, and edit a group's name and default path with `r`. On a session, `r` renames it and `tab` cycles the tool (status rules and revive follow the new tool; useful when you quit one agent in the pane and start another).
 
 ### Status
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -118,6 +118,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "t":
 		m.showArchived = !m.showArchived
 		m.requestRefresh()
+	case "e":
+		return m, m.toggleEmptyGroups()
 	case "/":
 		m.searching = true
 		m.err = ""
@@ -343,6 +345,35 @@ func (m *Model) toggleCollapseAll() {
 	}
 	m.persistCollapsed()
 	m.rebuildRows()
+}
+
+// toggleEmptyGroups hides or restores group rows whose subtree has no
+// sessions in the current active/archive view. It never changes the store.
+func (m *Model) toggleEmptyGroups() tea.Cmd {
+	previousKey := ""
+	if entry, ok := m.selectedRow(); ok {
+		previousKey = rowKey(entry)
+	}
+	m.hideEmptyGroups = !m.hideEmptyGroups
+	m.rebuildRows()
+
+	currentKey := ""
+	if entry, ok := m.selectedRow(); ok {
+		currentKey = rowKey(entry)
+	}
+	if currentKey == previousKey {
+		return nil
+	}
+
+	m.preview = ""
+	m.proc = sysstat.ProcStat{}
+	m.procFor = ""
+	m.previewGen++
+	m.syncPollInput()
+	if _, ok := m.selected(); ok {
+		return m.schedulePreview()
+	}
+	return nil
 }
 
 func (m *Model) attachSelected() (tea.Model, tea.Cmd) {

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -238,6 +238,7 @@ func (m *Model) viewHelp() string {
 		{"s", "settings (quick spawn tool, review layout, after quick send)"},
 		{"|", "resize split (←→ / drag, enter commits, esc cancels)"},
 		{"t", "toggle archived view"},
+		{"e", "hide / show empty groups"},
 		{"/", "search"},
 		{"↑↓ / jk", "move cursor"},
 		{"q", "quit (sessions keep running)"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -76,13 +76,14 @@ type Model struct {
 	prevNetAt   time.Time
 	prevNetOK   bool
 
-	poller       *poller
-	cursor       int
-	mode         mode
-	showArchived bool
-	collapsed    map[string]bool
-	search       string
-	searching    bool
+	poller          *poller
+	cursor          int
+	mode            mode
+	showArchived    bool
+	hideEmptyGroups bool
+	collapsed       map[string]bool
+	search          string
+	searching       bool
 
 	diff      diffState
 	form      form
@@ -840,6 +841,12 @@ func (m *Model) rebuildRows() {
 		if query != "" {
 			paths = pathsWithSessions(paths, sessionsByGroup)
 		}
+	}
+	if m.hideEmptyGroups {
+		// This is a presentation filter only: stored groups remain available
+		// to forms and return to the tree as soon as the toggle is switched
+		// off. Ancestors of groups with visible sessions stay in the tree.
+		paths = pathsWithSessions(paths, sessionsByGroup)
 	}
 	children := childIndex(paths, m.groups)
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -485,6 +485,50 @@ func TestReorderSyntheticGroupUpdatesImmediately(t *testing.T) {
 	}
 }
 
+func TestToggleEmptyGroupsFiltersTreeWithoutDeletingGroups(t *testing.T) {
+	m := buildModel(t)
+	for _, group := range []string{"empty", "work", "work/leaf", "work/unused"} {
+		if err := m.store.CreateGroup(group, ""); err != nil {
+			t.Fatalf("create group %q: %v", group, err)
+		}
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "nested", t.TempDir(), "work/leaf")
+
+	m.selectGroupRow(t, "empty")
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")})
+	if cmd != nil {
+		m.applyCmd(t, cmd)
+	}
+
+	wantVisible := []string{"work", "work/leaf"}
+	if got := m.groupRowPaths(); !slices.Equal(got, wantVisible) {
+		t.Fatalf("groups with empty subtrees should be hidden, got %v want %v", got, wantVisible)
+	}
+	if footer := ansi.Strip(m.viewFooter()); !strings.Contains(footer, "show empty") {
+		t.Fatalf("footer should offer the inverse action while filtered:\n%s", footer)
+	}
+	groups, err := m.store.Groups()
+	if err != nil {
+		t.Fatalf("list stored groups: %v", err)
+	}
+	if len(groups) != 4 {
+		t.Fatalf("visual filter changed stored groups: got %d want 4", len(groups))
+	}
+
+	_, cmd = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")})
+	if cmd != nil {
+		m.applyCmd(t, cmd)
+	}
+	wantAll := []string{"empty", "work", "work/leaf", "work/unused"}
+	if got := m.groupRowPaths(); !slices.Equal(got, wantAll) {
+		t.Fatalf("second toggle should restore empty groups, got %v want %v", got, wantAll)
+	}
+	if footer := ansi.Strip(m.viewFooter()); !strings.Contains(footer, "hide empty") {
+		t.Fatalf("footer should offer hiding while empty groups are visible:\n%s", footer)
+	}
+}
+
 func TestDeleteGroupSubtree(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -352,13 +352,18 @@ func padToHeight(s string, height int) string {
 // viewFooter lists every shortcut, wrapping onto extra lines when the
 // terminal is too narrow for one.
 func (m *Model) viewFooter() string {
+	emptyGroupsAction := "hide empty"
+	if m.hideEmptyGroups {
+		emptyGroupsAction = "show empty"
+	}
 	pairs := [][2]string{
 		{"↑↓/jk", "navigate"}, {"K/J", "reorder"}, {"↵", "attach / fold"},
 		{"F", "fold all"}, {"n", "new"}, {"g", "group"}, {"space", "prompt"},
 		{"ctrl+r", "review"}, {"r", "rename"}, {"m", "move"},
 		{"x/X", "kill / all"}, {"v/V", "revive / all"},
 		{"a/u", "archive / restore"}, {"d", "delete"},
-		{"t", "archived"}, {"/", "search"}, {"|", "resize"}, {"s", "settings"},
+		{"t", "archived"}, {"e", emptyGroupsAction},
+		{"/", "search"}, {"|", "resize"}, {"s", "settings"},
 		{"?", "keys"}, {"q", "quit"},
 	}
 	if m.quick.active {


### PR DESCRIPTION
## What changed

- Add an `e` key binding that hides or restores groups with no visible sessions in their subtree.
- Keep ancestor groups visible when a descendant contains a visible session.
- Update the footer label dynamically between `hide empty` and `show empty`.
- Document the binding in the help modal and README.
- Add regression coverage for nested groups, inverse toggling, and storage preservation.

## Why

Empty groups can make the sessions tree noisy, but deleting or archiving them changes persistent state. This adds a presentation-only filter so users can simplify the TUI without losing configured groups or removing them from group pickers.

## User impact

Press `e` in the main list to hide empty group branches. Press `e` again to restore them. The toggle affects only the current TUI view and does not modify stored groups.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `go test ./internal/ui -run TestToggleEmptyGroupsFiltersTreeWithoutDeletingGroups -count=1`