### PR TITLE
fix(sysstat): accurate computer mem, swap, disk, and net

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For Claude Code, status comes first-hand from [hook events](https://docs.anthrop
 The header shows a fleet summary: per-status session counts, plus `agents N% · X GB`, the combined CPU and RSS memory of every live agent's full process tree (shell, agent, and children). Agent CPU uses `ps` semantics where 100% equals one full core, so the total can exceed 100% on multi-core machines. The Computer block in the sessions panel shows machine gauges:
 
 - **CPU**: whole-machine utilization (0-100%)
-- **Memory**: used/total. On macOS this matches Activity Monitor's Memory Used (app + wired + compressed). On Linux it is `Total - MemAvailable`, so file cache is not counted as used.
+- **Memory**: used/total. On macOS this matches Activity Monitor's Memory Used (resident RAM minus free, speculative, and reclaimable file cache). On Linux it is `Total - MemAvailable`, so file cache is not counted as used.
 - **Swap**: used/total of the current swap allocation (`used/total * 100`). On macOS the swap file grows under pressure, so the denominator is the live size from `vm.swapusage`, not a fixed partition.
 - **Disk**: fill of the root filesystem (used / (used + available)), with free space from the kernel's available figure
 - **Network**: up/down rates on real NICs only (loopback, utun, bridges, and similar virtual interfaces are excluded)

--- a/README.md
+++ b/README.md
@@ -148,7 +148,14 @@ For Claude Code, status comes first-hand from [hook events](https://docs.anthrop
 
 ### Stats
 
-The header shows a fleet summary: per-status session counts, plus `agents N% · X GB`, the combined CPU and RSS memory of every live agent's full process tree (shell, agent, and children). Agent CPU uses `ps` semantics where 100% equals one full core, so the total can exceed 100% on multi-core machines. The Computer block in the sessions panel shows machine gauges: CPU (normalized to the whole machine, capped at 100%), memory (used/total), swap, root-disk free space, and network up/down rates.
+The header shows a fleet summary: per-status session counts, plus `agents N% · X GB`, the combined CPU and RSS memory of every live agent's full process tree (shell, agent, and children). Agent CPU uses `ps` semantics where 100% equals one full core, so the total can exceed 100% on multi-core machines. The Computer block in the sessions panel shows machine gauges:
+
+- **CPU**: whole-machine utilization (0-100%)
+- **Memory**: used/total. On macOS this matches Activity Monitor's Memory Used (app + wired + compressed). On Linux it is `Total - MemAvailable`, so file cache is not counted as used.
+- **Swap**: used/total of the current swap allocation (`used/total * 100`). On macOS the swap file grows under pressure, so the denominator is the live size from `vm.swapusage`, not a fixed partition.
+- **Disk**: fill of the root filesystem (used / (used + available)), with free space from the kernel's available figure
+- **Network**: up/down rates on real NICs only (loopback, utun, bridges, and similar virtual interfaces are excluded)
+
 
 ### Themes
 

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,11 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/muesli/termenv v0.16.0
 	github.com/sergi/go-diff v1.4.0
 	github.com/shirou/gopsutil/v4 v4.26.6
 	golang.design/x/clipboard v0.8.0
+	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.53.0
 )
 
@@ -40,7 +42,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
@@ -57,7 +58,6 @@ require (
 	golang.org/x/image v0.28.0 // indirect
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
 golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
 golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=

--- a/internal/sysstat/mem_darwin.go
+++ b/internal/sysstat/mem_darwin.go
@@ -10,21 +10,17 @@ import (
 )
 
 // sampleMemory on macOS matches Activity Monitor's "Memory Used":
-//
-//	App Memory + Wired + Compressed
-//	  = (anonymous - purgeable) + wired + compressor pages
-//
-// gopsutil's VirtualMemory treats all inactive pages as available, which
-// drifts from Activity Monitor under memory pressure (anonymous inactive
-// is not free). vm_stat is the same source Activity Monitor-style tools
-// use and keeps the number honest without CGO.
+// resident RAM minus free, speculative, and reclaimable file cache.
+// gopsutil's VirtualMemory treats all inactive pages as available and
+// under-counts kernel/other pages; vm_stat keeps the number honest
+// without CGO.
 func sampleMemory(snap *Snapshot) {
 	total, err := unix.SysctlUint64("hw.memsize")
 	if err != nil || total == 0 {
 		sampleMemoryFallback(snap)
 		return
 	}
-	used, ok := memoryUsedFromVMStat()
+	used, ok := memoryUsedFromVMStat(total)
 	if !ok {
 		sampleMemoryFallback(snap)
 		return
@@ -53,10 +49,10 @@ func sampleMemoryFallback(snap *Snapshot) {
 	snap.MemOK = true
 }
 
-func memoryUsedFromVMStat() (uint64, bool) {
+func memoryUsedFromVMStat(total uint64) (uint64, bool) {
 	out, err := exec.Command("vm_stat").Output()
 	if err != nil {
 		return 0, false
 	}
-	return parseVMStatMemoryUsed(string(out), uint64(unix.Getpagesize()))
+	return parseVMStatMemoryUsed(string(out), total, uint64(unix.Getpagesize()))
 }

--- a/internal/sysstat/mem_darwin.go
+++ b/internal/sysstat/mem_darwin.go
@@ -1,0 +1,62 @@
+//go:build darwin
+
+package sysstat
+
+import (
+	"os/exec"
+
+	"github.com/shirou/gopsutil/v4/mem"
+	"golang.org/x/sys/unix"
+)
+
+// sampleMemory on macOS matches Activity Monitor's "Memory Used":
+//
+//	App Memory + Wired + Compressed
+//	  = (anonymous - purgeable) + wired + compressor pages
+//
+// gopsutil's VirtualMemory treats all inactive pages as available, which
+// drifts from Activity Monitor under memory pressure (anonymous inactive
+// is not free). vm_stat is the same source Activity Monitor-style tools
+// use and keeps the number honest without CGO.
+func sampleMemory(snap *Snapshot) {
+	total, err := unix.SysctlUint64("hw.memsize")
+	if err != nil || total == 0 {
+		sampleMemoryFallback(snap)
+		return
+	}
+	used, ok := memoryUsedFromVMStat()
+	if !ok {
+		sampleMemoryFallback(snap)
+		return
+	}
+	if used > total {
+		used = total
+	}
+	snap.MemTotal = total
+	snap.MemUsed = used
+	snap.MemPercent = usedPercent(used, total)
+	snap.MemOK = true
+}
+
+func sampleMemoryFallback(snap *Snapshot) {
+	vm, err := mem.VirtualMemory()
+	if err != nil {
+		return
+	}
+	snap.MemTotal = vm.Total
+	if vm.Total >= vm.Available {
+		snap.MemUsed = vm.Total - vm.Available
+	} else {
+		snap.MemUsed = vm.Used
+	}
+	snap.MemPercent = usedPercent(snap.MemUsed, snap.MemTotal)
+	snap.MemOK = true
+}
+
+func memoryUsedFromVMStat() (uint64, bool) {
+	out, err := exec.Command("vm_stat").Output()
+	if err != nil {
+		return 0, false
+	}
+	return parseVMStatMemoryUsed(string(out), uint64(unix.Getpagesize()))
+}

--- a/internal/sysstat/mem_other.go
+++ b/internal/sysstat/mem_other.go
@@ -1,0 +1,23 @@
+//go:build !darwin
+
+package sysstat
+
+import "github.com/shirou/gopsutil/v4/mem"
+
+// sampleMemory uses the kernel's available figure so file cache is not
+// counted as used (Linux MemAvailable, and the same field on other
+// platforms gopsutil maps to Available). Percent is always used/total.
+func sampleMemory(snap *Snapshot) {
+	vm, err := mem.VirtualMemory()
+	if err != nil {
+		return
+	}
+	snap.MemTotal = vm.Total
+	if vm.Total >= vm.Available {
+		snap.MemUsed = vm.Total - vm.Available
+	} else {
+		snap.MemUsed = vm.Used
+	}
+	snap.MemPercent = usedPercent(snap.MemUsed, snap.MemTotal)
+	snap.MemOK = true
+}

--- a/internal/sysstat/sysstat.go
+++ b/internal/sysstat/sysstat.go
@@ -24,6 +24,7 @@ type Snapshot struct {
 	SwapPercent float64
 	SwapOK      bool
 	DiskUsed    uint64
+	DiskFree    uint64
 	DiskTotal   uint64
 	DiskPercent float64
 	DiskOK      bool
@@ -53,41 +54,102 @@ func Sample(diskPath string) Snapshot {
 		snap.CPUOK = true
 	}
 
-	if vm, err := mem.VirtualMemory(); err == nil {
-		snap.MemUsed = vm.Used
-		snap.MemTotal = vm.Total
-		snap.MemPercent = vm.UsedPercent
-		snap.MemOK = true
-	}
-
-	if sm, err := mem.SwapMemory(); err == nil {
-		snap.SwapUsed = sm.Used
-		snap.SwapTotal = sm.Total
-		snap.SwapPercent = sm.UsedPercent
-		snap.SwapOK = true
-	}
-
-	if diskPath == "" {
-		diskPath = "/"
-	}
-	if usage, err := disk.Usage(diskPath); err == nil {
-		snap.DiskUsed = usage.Used
-		snap.DiskTotal = usage.Total
-		snap.DiskPercent = usage.UsedPercent
-		snap.DiskOK = true
-	}
-
-	// Cumulative bytes across all interfaces since boot; the caller
-	// diffs consecutive snapshots to get transfer rates.
-	if counters, err := net.IOCounters(false); err == nil && len(counters) > 0 {
-		snap.NetSent = counters[0].BytesSent
-		snap.NetRecv = counters[0].BytesRecv
-		snap.NetOK = true
-	}
-
+	sampleMemory(&snap)
+	sampleSwap(&snap)
+	sampleDisk(&snap, diskPath)
+	sampleNet(&snap)
 	sampleTemps(&snap)
 
 	return snap
+}
+
+// sampleSwap reads swap usage and sets SwapPercent as used/total.
+// That is the only meaningful fill fraction: on macOS the swap file
+// grows under pressure, so the denominator is the current allocation
+// from vm.swapusage, not a fixed partition size.
+func sampleSwap(snap *Snapshot) {
+	sm, err := mem.SwapMemory()
+	if err != nil {
+		return
+	}
+	snap.SwapUsed = sm.Used
+	snap.SwapTotal = sm.Total
+	snap.SwapPercent = usedPercent(sm.Used, sm.Total)
+	snap.SwapOK = true
+}
+
+func sampleDisk(snap *Snapshot, diskPath string) {
+	if diskPath == "" {
+		diskPath = "/"
+	}
+	usage, err := disk.Usage(diskPath)
+	if err != nil {
+		return
+	}
+	snap.DiskUsed = usage.Used
+	snap.DiskFree = usage.Free
+	snap.DiskTotal = usage.Total
+	// used/(used+free) matches df Capacity and ignores reserved blocks
+	// that sit in Total but are not available to ordinary processes.
+	if usable := usage.Used + usage.Free; usable > 0 {
+		snap.DiskPercent = usedPercent(usage.Used, usable)
+	} else {
+		snap.DiskPercent = usage.UsedPercent
+	}
+	snap.DiskOK = true
+}
+
+// sampleNet sums counters for real NICs only. Loopback and common
+// virtual interfaces would otherwise dominate the rate on a busy local
+// machine (IPC, VPN tunnels, AWDL).
+func sampleNet(snap *Snapshot) {
+	counters, err := net.IOCounters(true)
+	if err != nil || len(counters) == 0 {
+		return
+	}
+	var sent, recv uint64
+	var any bool
+	for _, counter := range counters {
+		if !countNetInterface(counter.Name) {
+			continue
+		}
+		sent += counter.BytesSent
+		recv += counter.BytesRecv
+		any = true
+	}
+	if !any {
+		return
+	}
+	snap.NetSent = sent
+	snap.NetRecv = recv
+	snap.NetOK = true
+}
+
+func countNetInterface(name string) bool {
+	n := strings.ToLower(name)
+	if n == "lo" || n == "lo0" {
+		return false
+	}
+	for _, prefix := range netSkipPrefixes {
+		if strings.HasPrefix(n, prefix) {
+			return false
+		}
+	}
+	return true
+}
+
+// Virtual / point-to-point / container bridges that are not "the network".
+var netSkipPrefixes = []string{
+	"utun", "awdl", "llw", "bridge", "gif", "stf", "anpi", "ap",
+	"vmenet", "vboxnet", "docker", "br-", "veth", "cni", "flannel",
+	"virbr", "tun", "tap", "wg", "zt", "tailscale", "ipsec", "vmnet",
+}
+
+func usedPercent(used, total uint64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return 100 * float64(used) / float64(total)
 }
 
 // sampleTemps categorizes hardware temperature sensors into CPU and GPU

--- a/internal/sysstat/sysstat_test.go
+++ b/internal/sysstat/sysstat_test.go
@@ -130,8 +130,9 @@ func TestUsedPercent(t *testing.T) {
 }
 
 func TestParseVMStatMemoryUsed(t *testing.T) {
-	// App = anon - purgeable = 1000 - 100 = 900
-	// Used pages = 900 + 2000 + 3000 = 5900 → 5900 * 16384 bytes
+	// total pages = 10000 * 16384
+	// reclaimable = free(100)+spec(50)+file(2000)+purg(100) = 2250
+	// used pages = 10000 - 2250 = 7750
 	const body = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
 Pages free:                               100.
 Pages active:                            5000.
@@ -140,26 +141,30 @@ Pages speculative:                        50.
 Pages wired down:                       2000.
 Pages purgeable:                         100.
 Anonymous pages:                        1000.
+File-backed pages:                      2000.
 Pages occupied by compressor:           3000.
 `
-	used, ok := parseVMStatMemoryUsed(body, 4096)
+	total := uint64(10000) * 16384
+	used, ok := parseVMStatMemoryUsed(body, total, 4096)
 	if !ok {
 		t.Fatal("expected parse ok")
 	}
-	want := uint64(5900) * 16384
+	want := uint64(7750) * 16384
 	if used != want {
 		t.Fatalf("used=%d want=%d", used, want)
 	}
 }
 
-func TestParseVMStatMemoryUsedLegacyCompressorLabel(t *testing.T) {
+func TestParseVMStatMemoryUsedLegacyWithoutFileBacked(t *testing.T) {
+	// No File-backed line: fall back to app+wired+comp.
 	const body = `Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages free:                             1.
 Pages wired down:                       10.
 Pages purgeable:                         0.
 Anonymous pages:                        20.
 Pages used by compressor:               5.
 `
-	used, ok := parseVMStatMemoryUsed(body, 4096)
+	used, ok := parseVMStatMemoryUsed(body, 0, 4096)
 	if !ok {
 		t.Fatal("expected parse ok")
 	}
@@ -176,12 +181,11 @@ func TestSampleMemoryMatchesVMStatOnDarwin(t *testing.T) {
 	if !snap.MemOK {
 		t.Fatal("mem not ok")
 	}
-	// Re-parse live vm_stat; allow a little drift between samples.
 	out, err := exec.Command("vm_stat").Output()
 	if err != nil {
 		t.Fatal(err)
 	}
-	want, ok := parseVMStatMemoryUsed(string(out), 0)
+	want, ok := parseVMStatMemoryUsed(string(out), snap.MemTotal, 0)
 	if !ok {
 		t.Fatal("vm_stat parse failed")
 	}
@@ -189,8 +193,6 @@ func TestSampleMemoryMatchesVMStatOnDarwin(t *testing.T) {
 	if delta < 0 {
 		delta = -delta
 	}
-	// 256 MiB of movement between two back-to-back samples is normal
-	// under load; anything larger means we are not on the AM formula.
 	if delta > 256<<20 {
 		t.Fatalf("mem used %d drifted %v from live vm_stat %d", snap.MemUsed, delta, want)
 	}

--- a/internal/sysstat/sysstat_test.go
+++ b/internal/sysstat/sysstat_test.go
@@ -1,7 +1,10 @@
 package sysstat
 
 import (
+	"math"
 	"os"
+	"os/exec"
+	"runtime"
 	"testing"
 )
 
@@ -10,8 +13,36 @@ func TestSample(t *testing.T) {
 	if snap.MemOK && snap.MemTotal == 0 {
 		t.Fatal("mem reported OK but total is zero")
 	}
+	if snap.MemOK {
+		if snap.MemUsed > snap.MemTotal {
+			t.Fatalf("mem used %d > total %d", snap.MemUsed, snap.MemTotal)
+		}
+		want := usedPercent(snap.MemUsed, snap.MemTotal)
+		if math.Abs(snap.MemPercent-want) > 0.01 {
+			t.Fatalf("mem percent %v != used/total %v", snap.MemPercent, want)
+		}
+	}
+	if snap.SwapOK && snap.SwapTotal > 0 {
+		want := usedPercent(snap.SwapUsed, snap.SwapTotal)
+		if math.Abs(snap.SwapPercent-want) > 0.01 {
+			t.Fatalf("swap percent %v != used/total %v", snap.SwapPercent, want)
+		}
+		if snap.SwapUsed > snap.SwapTotal {
+			t.Fatalf("swap used %d > total %d", snap.SwapUsed, snap.SwapTotal)
+		}
+	}
 	if snap.DiskOK && snap.DiskTotal == 0 {
 		t.Fatal("disk reported OK but total is zero")
+	}
+	if snap.DiskOK {
+		if snap.DiskFree == 0 && snap.DiskUsed == 0 {
+			t.Fatal("disk free and used both zero")
+		}
+		// Free is what the UI shows; it must be the kernel's available
+		// figure (Bavail), not Total-Used (which includes reserved).
+		if snap.DiskFree > snap.DiskTotal {
+			t.Fatalf("disk free %d > total %d", snap.DiskFree, snap.DiskTotal)
+		}
 	}
 	if snap.CPUTempOK && snap.CPUTemp <= 0 {
 		t.Fatal("cpu temp reported OK but not positive")
@@ -68,5 +99,102 @@ func TestTreesInvalid(t *testing.T) {
 	}
 	if len(Trees(nil)) != 0 {
 		t.Fatal("no pids should yield no stats")
+	}
+}
+
+func TestCountNetInterface(t *testing.T) {
+	keep := []string{"en0", "en1", "eth0", "wlan0", "wlp2s0"}
+	for _, name := range keep {
+		if !countNetInterface(name) {
+			t.Fatalf("expected to count %q", name)
+		}
+	}
+	skip := []string{"lo", "lo0", "utun4", "awdl0", "llw0", "bridge0", "docker0", "br-abc", "veth0", "vmenet0", "ap1"}
+	for _, name := range skip {
+		if countNetInterface(name) {
+			t.Fatalf("expected to skip %q", name)
+		}
+	}
+}
+
+func TestUsedPercent(t *testing.T) {
+	if usedPercent(0, 0) != 0 {
+		t.Fatal("zero total should yield 0")
+	}
+	if usedPercent(1, 4) != 25 {
+		t.Fatalf("got %v", usedPercent(1, 4))
+	}
+	if usedPercent(3, 3) != 100 {
+		t.Fatalf("got %v", usedPercent(3, 3))
+	}
+}
+
+func TestParseVMStatMemoryUsed(t *testing.T) {
+	// App = anon - purgeable = 1000 - 100 = 900
+	// Used pages = 900 + 2000 + 3000 = 5900 → 5900 * 16384 bytes
+	const body = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               100.
+Pages active:                            5000.
+Pages inactive:                          4000.
+Pages speculative:                        50.
+Pages wired down:                       2000.
+Pages purgeable:                         100.
+Anonymous pages:                        1000.
+Pages occupied by compressor:           3000.
+`
+	used, ok := parseVMStatMemoryUsed(body, 4096)
+	if !ok {
+		t.Fatal("expected parse ok")
+	}
+	want := uint64(5900) * 16384
+	if used != want {
+		t.Fatalf("used=%d want=%d", used, want)
+	}
+}
+
+func TestParseVMStatMemoryUsedLegacyCompressorLabel(t *testing.T) {
+	const body = `Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages wired down:                       10.
+Pages purgeable:                         0.
+Anonymous pages:                        20.
+Pages used by compressor:               5.
+`
+	used, ok := parseVMStatMemoryUsed(body, 4096)
+	if !ok {
+		t.Fatal("expected parse ok")
+	}
+	if used != 35*4096 {
+		t.Fatalf("used=%d", used)
+	}
+}
+
+func TestSampleMemoryMatchesVMStatOnDarwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin only")
+	}
+	snap := Sample("/")
+	if !snap.MemOK {
+		t.Fatal("mem not ok")
+	}
+	// Re-parse live vm_stat; allow a little drift between samples.
+	out, err := exec.Command("vm_stat").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, ok := parseVMStatMemoryUsed(string(out), 0)
+	if !ok {
+		t.Fatal("vm_stat parse failed")
+	}
+	delta := float64(snap.MemUsed) - float64(want)
+	if delta < 0 {
+		delta = -delta
+	}
+	// 256 MiB of movement between two back-to-back samples is normal
+	// under load; anything larger means we are not on the AM formula.
+	if delta > 256<<20 {
+		t.Fatalf("mem used %d drifted %v from live vm_stat %d", snap.MemUsed, delta, want)
+	}
+	if snap.MemTotal == 0 || snap.MemUsed > snap.MemTotal {
+		t.Fatalf("bad mem bounds used=%d total=%d", snap.MemUsed, snap.MemTotal)
 	}
 }

--- a/internal/sysstat/vmstat.go
+++ b/internal/sysstat/vmstat.go
@@ -11,9 +11,12 @@ var (
 	vmStatLine     = regexp.MustCompile(`^([^:]+):\s+(\d+)\.?$`)
 )
 
-// parseVMStatMemoryUsed implements Activity Monitor "Memory Used" from a
-// vm_stat snapshot: (anonymous - purgeable) + wired + compressor pages.
-func parseVMStatMemoryUsed(out string, defaultPageSize uint64) (uint64, bool) {
+// parseVMStatMemoryUsed implements Activity Monitor "Memory Used": all
+// resident RAM except free, speculative (treated as free), and reclaimable
+// cache (file-backed + purgeable). That is total minus those page classes,
+// which also counts kernel/other pages that app+wired+compressed omits
+// (~0.5–1 GiB on a loaded Mac) and matches the Memory tab more closely.
+func parseVMStatMemoryUsed(out string, total, defaultPageSize uint64) (uint64, bool) {
 	pageSize := defaultPageSize
 	if pageSize == 0 {
 		pageSize = 4096
@@ -38,6 +41,23 @@ func parseVMStatMemoryUsed(out string, defaultPageSize uint64) (uint64, bool) {
 		pages[strings.TrimSpace(m[1])] = n
 	}
 
+	free, okFree := pages["Pages free"]
+	if !okFree {
+		return 0, false
+	}
+	speculative := pages["Pages speculative"]
+	purgeable := pages["Pages purgeable"]
+	fileBacked, okFile := pages["File-backed pages"]
+	if okFile && total > 0 {
+		reclaimable := free + speculative + fileBacked + purgeable
+		totalPages := total / pageSize
+		if reclaimable >= totalPages {
+			return 0, true
+		}
+		return (totalPages - reclaimable) * pageSize, true
+	}
+
+	// Older macOS without file-backed: App + Wired + Compressed.
 	wired, okW := pages["Pages wired down"]
 	anon, okA := pages["Anonymous pages"]
 	if !okW || !okA {
@@ -50,7 +70,6 @@ func parseVMStatMemoryUsed(out string, defaultPageSize uint64) (uint64, bool) {
 	if !okC {
 		return 0, false
 	}
-	purgeable := pages["Pages purgeable"]
 	app := anon
 	if anon >= purgeable {
 		app = anon - purgeable

--- a/internal/sysstat/vmstat.go
+++ b/internal/sysstat/vmstat.go
@@ -1,0 +1,61 @@
+package sysstat
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	vmStatPageSize = regexp.MustCompile(`page size of (\d+) bytes`)
+	vmStatLine     = regexp.MustCompile(`^([^:]+):\s+(\d+)\.?$`)
+)
+
+// parseVMStatMemoryUsed implements Activity Monitor "Memory Used" from a
+// vm_stat snapshot: (anonymous - purgeable) + wired + compressor pages.
+func parseVMStatMemoryUsed(out string, defaultPageSize uint64) (uint64, bool) {
+	pageSize := defaultPageSize
+	if pageSize == 0 {
+		pageSize = 4096
+	}
+	pages := map[string]uint64{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if m := vmStatPageSize.FindStringSubmatch(line); len(m) == 2 {
+			if n, err := strconv.ParseUint(m[1], 10, 64); err == nil && n > 0 {
+				pageSize = n
+			}
+			continue
+		}
+		m := vmStatLine.FindStringSubmatch(line)
+		if len(m) != 3 {
+			continue
+		}
+		n, err := strconv.ParseUint(m[2], 10, 64)
+		if err != nil {
+			continue
+		}
+		pages[strings.TrimSpace(m[1])] = n
+	}
+
+	wired, okW := pages["Pages wired down"]
+	anon, okA := pages["Anonymous pages"]
+	if !okW || !okA {
+		return 0, false
+	}
+	compressor, okC := pages["Pages occupied by compressor"]
+	if !okC {
+		compressor, okC = pages["Pages used by compressor"]
+	}
+	if !okC {
+		return 0, false
+	}
+	purgeable := pages["Pages purgeable"]
+	app := anon
+	if anon >= purgeable {
+		app = anon - purgeable
+	} else {
+		app = 0
+	}
+	return (app + wired + compressor) * pageSize, true
+}

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -340,10 +340,17 @@ func (m *Model) computerLines(width int) []string {
 		meter("mem", snap.MemPercent, snap.MemOK, humanBytes(snap.MemUsed)+"/"+humanBytes(snap.MemTotal)),
 	)
 	if snap.SwapOK && snap.SwapTotal > 0 {
-		lines = append(lines, meter("swap", snap.SwapPercent, true, humanBytes(snap.SwapUsed)))
+		// Percent is used/total of the current swap allocation (macOS
+		// grows the file under pressure; Linux uses the fixed swap size).
+		lines = append(lines, meter("swap", snap.SwapPercent, true,
+			humanBytes(snap.SwapUsed)+"/"+humanBytes(snap.SwapTotal)))
 	}
-	lines = append(lines, meter("disk", snap.DiskPercent, snap.DiskOK,
-		humanBytes(snap.DiskTotal-snap.DiskUsed)+" free"))
+	if snap.DiskOK {
+		lines = append(lines, meter("disk", snap.DiskPercent, true,
+			humanBytes(snap.DiskFree)+" free"))
+	} else {
+		lines = append(lines, meter("disk", 0, false, ""))
+	}
 	if m.netRates {
 		lines = append(lines, pad+labelStyle.Width(5).Render("net")+
 			valueStyle.Render("↓ "+humanBytes(m.netDown)+"/s")+

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -92,7 +92,7 @@ func shotModel() *Model {
 			CPUOK: true, CPUPercent: 22,
 			MemOK: true, MemPercent: 75, MemUsed: 12_100_000_000, MemTotal: 16_000_000_000,
 			SwapOK: true, SwapPercent: 43, SwapUsed: 4_500_000_000, SwapTotal: 8_000_000_000,
-			DiskOK: true, DiskPercent: 88, DiskUsed: 400_000_000_000, DiskTotal: 500_000_000_000,
+			DiskOK: true, DiskPercent: 88, DiskUsed: 400_000_000_000, DiskFree: 100_000_000_000, DiskTotal: 500_000_000_000,
 			CPUTempOK: true, CPUTemp: 61, GPUTempOK: true, GPUTemp: 55,
 		},
 		preview: previewSample,


### PR DESCRIPTION
## Summary
- macOS memory used matches Activity Monitor (resident RAM minus free, speculative, and reclaimable file cache)
- Swap percent is always used/total; UI shows used/total
- Disk free uses kernel available; net rates skip loopback and virtual interfaces
- Linux memory stays Total − Available (file cache not counted as used)

## Test plan
- [x] `go test ./internal/sysstat/ ./internal/ui/`
- [x] Live compare vs `vm_stat`, `sysctl vm.swapusage`, `df`, Activity Monitor