### PR TITLE
fix(ui): agents total usage as share of this machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 | `f` | Fold / unfold group |
 | `s` | Settings (quick-spawn tool, theme, review layout) |
 | `t` | Toggle archived view |
+| `e` | Hide / show empty groups |
 | `/` | Search |
 | `?` | Help |
 | `q` | Quit (sessions keep running) |
@@ -123,7 +124,7 @@ Press `c` on a line to write a comment; `C` flattens every comment into one revi
 
 ### Groups
 
-Groups are paths (`backend/api/auth`) forming a tree of unlimited depth. Sessions can live at any node, including the root. Create subgroups inline with `g`, reorder both groups and sessions with `K` / `J` (or `shift+↑↓`; the order persists), fold a subtree with `f`, and edit a group's name and default path with `r`. On a session, `r` renames it and `tab` cycles the tool (status rules and revive follow the new tool; useful when you quit one agent in the pane and start another).
+Groups are paths (`backend/api/auth`) forming a tree of unlimited depth. Sessions can live at any node, including the root. Create subgroups inline with `g`, reorder both groups and sessions with `K` / `J` (or `shift+↑↓`; the order persists), fold a subtree with `f`, hide or restore empty groups visually with `e`, and edit a group's name and default path with `r`. On a session, `r` renames it and `tab` cycles the tool (status rules and revive follow the new tool; useful when you quit one agent in the pane and start another).
 
 ### Status
 
@@ -148,14 +149,15 @@ For Claude Code, status comes first-hand from [hook events](https://docs.anthrop
 
 ### Stats
 
-The header shows a fleet summary: per-status session counts, plus `agents N% · X GB`, the combined CPU and RSS memory of every live agent's full process tree (shell, agent, and children). Agent CPU uses `ps` semantics where 100% equals one full core, so the total can exceed 100% on multi-core machines. The Computer block in the sessions panel shows machine gauges:
+The header shows a fleet summary: per-status session counts, plus `agents total usage: cpu N% · ram M% · X GB` for every live agent's full process tree (shell, agent, and children). CPU is that tree's CPU time over the last poll as a share of total machine capacity (same 0–100% unit as the computer gauge). RAM is resident set as a share of installed memory, with absolute size beside it. The selected session's detail line uses the same scale for that session alone.
+
+The Computer block in the sessions panel shows machine gauges:
 
 - **CPU**: whole-machine utilization (0-100%)
 - **Memory**: used/total. On macOS this matches Activity Monitor's Memory Used (resident RAM minus free, speculative, and reclaimable file cache). On Linux it is `Total - MemAvailable`, so file cache is not counted as used.
 - **Swap**: used/total of the current swap allocation (`used/total * 100`). On macOS the swap file grows under pressure, so the denominator is the live size from `vm.swapusage`, not a fixed partition.
 - **Disk**: fill of the root filesystem (used / (used + available)), with free space from the kernel's available figure
 - **Network**: up/down rates on real NICs only (loopback, utun, bridges, and similar virtual interfaces are excluded)
-
 
 ### Themes
 

--- a/internal/sysstat/sysstat.go
+++ b/internal/sysstat/sysstat.go
@@ -1,7 +1,9 @@
 package sysstat
 
 import (
+	"fmt"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -40,10 +42,19 @@ type Snapshot struct {
 }
 
 type ProcStat struct {
+	// CPUPercent is host capacity share 0–100 after interval scaling
+	// (or after ScaleToHost's pcpu fallback).
 	CPUPercent float64
+	// RamPercent is 0 until host scaling; then 0–100 of installed RAM.
+	RamPercent float64
 	RSS        uint64
-	Procs      int
-	OK         bool
+	// CPUSeconds is cumulative user+system CPU time for the whole tree.
+	// Used with a previous sample to compute interval host share.
+	CPUSeconds float64
+	// PCPU is the raw ps pcpu sum (100 ≈ one core). Fallback only.
+	PCPU float64
+	Procs int
+	OK    bool
 }
 
 func Sample(diskPath string) Snapshot {
@@ -210,40 +221,170 @@ func isCPUSensor(key string) bool {
 		strings.Contains(key, "package")
 }
 
+// LogicalCPUs is the number of logical processors used as the denominator
+// when converting process-style pcpu into a share of the machine.
+func LogicalCPUs() int {
+	if n, err := cpu.Counts(true); err == nil && n > 0 {
+		return n
+	}
+	if n := runtime.NumCPU(); n > 0 {
+		return n
+	}
+	return 1
+}
+
+// MemTotalBytes is installed RAM, used as the denominator for agent RAM %.
+func MemTotalBytes() (uint64, bool) {
+	vm, err := mem.VirtualMemory()
+	if err != nil || vm.Total == 0 {
+		return 0, false
+	}
+	return vm.Total, true
+}
+
+// HostCPUPercent turns a process-style pcpu sum (100 ≈ one full core) into
+// a percentage of total machine capacity, clamped to [0, 100]. Prefer
+// HostCPUFromDelta when an interval sample is available; pcpu is a coarse
+// fallback and can disagree with the host gauge.
+func HostCPUPercent(pcpu float64, ncpu int) float64 {
+	if ncpu < 1 {
+		ncpu = 1
+	}
+	return clampPct(pcpu / float64(ncpu))
+}
+
+// HostCPUFromDelta is agent CPU time used over an interval as a share of
+// total machine capacity: cpuSec / (elapsed * ncpu) * 100. Same unit as
+// the host gauge (0–100% of the box), so a busy agent fleet cannot
+// honestly read higher than full machine use.
+func HostCPUFromDelta(cpuSecDelta, elapsedSec float64, ncpu int) float64 {
+	if elapsedSec <= 0 || ncpu < 1 {
+		return 0
+	}
+	if cpuSecDelta < 0 {
+		cpuSecDelta = 0
+	}
+	return clampPct(cpuSecDelta / (elapsedSec * float64(ncpu)) * 100)
+}
+
+// HostRAMPercent is rss as a percentage of installed RAM, clamped to [0, 100].
+func HostRAMPercent(rss, memTotal uint64) float64 {
+	if memTotal == 0 {
+		return 0
+	}
+	return clampPct(float64(rss) / float64(memTotal) * 100)
+}
+
+func clampPct(p float64) float64 {
+	if p < 0 {
+		return 0
+	}
+	if p > 100 {
+		return 100
+	}
+	return p
+}
+
+// ScaleToHost sets CPU/RAM to machine shares using pcpu fallback for CPU.
+// Prefer interval scaling in the poller; this path is for one-shot samples
+// (preview) that have no previous CPU-seconds reading.
+func (s ProcStat) ScaleToHost(ncpu int, memTotal uint64) ProcStat {
+	if !s.OK {
+		return s
+	}
+	pcpu := s.PCPU
+	if pcpu == 0 {
+		pcpu = s.CPUPercent
+	}
+	s.CPUPercent = HostCPUPercent(pcpu, ncpu)
+	s.RamPercent = HostRAMPercent(s.RSS, memTotal)
+	return s
+}
+
+// parsePSTime turns a ps time/cputime field into cumulative CPU seconds.
+// Handles DD-HH:MM:SS, HH:MM:SS, and the common Darwin MM:SS.ss form
+// (minutes may exceed 59).
+func parsePSTime(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "-" {
+		return 0, nil
+	}
+	var days float64
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		d, err := strconv.ParseFloat(s[:i], 64)
+		if err != nil {
+			return 0, err
+		}
+		days = d
+		s = s[i+1:]
+	}
+	parts := strings.Split(s, ":")
+	switch len(parts) {
+	case 1:
+		sec, err := strconv.ParseFloat(parts[0], 64)
+		if err != nil {
+			return 0, err
+		}
+		return days*86400 + sec, nil
+	case 2:
+		min, err1 := strconv.ParseFloat(parts[0], 64)
+		sec, err2 := strconv.ParseFloat(parts[1], 64)
+		if err1 != nil || err2 != nil {
+			return 0, fmt.Errorf("ps time %q", s)
+		}
+		return days*86400 + min*60 + sec, nil
+	case 3:
+		hour, err1 := strconv.ParseFloat(parts[0], 64)
+		min, err2 := strconv.ParseFloat(parts[1], 64)
+		sec, err3 := strconv.ParseFloat(parts[2], 64)
+		if err1 != nil || err2 != nil || err3 != nil {
+			return 0, fmt.Errorf("ps time %q", s)
+		}
+		return days*86400 + hour*3600 + min*60 + sec, nil
+	default:
+		return 0, fmt.Errorf("ps time %q", s)
+	}
+}
+
 // Trees reports the combined CPU and resident memory of each requested
 // process and all of its descendants, from a single ps invocation. tmux
 // pane pids are shells whose real work happens in child processes, so a
-// tree sum is the only honest number. ps %cpu is a recent decaying
-// average, which suits a 2s poll.
+// tree sum is the only honest number.
+//
+// CPUSeconds is cumulative CPU time for interval host-share math. PCPU is
+// the raw ps %cpu sum (fallback). Callers convert to host % via
+// HostCPUFromDelta between polls, or ScaleToHost for a one-shot sample.
 func Trees(rootPIDs []int) map[int]ProcStat {
 	stats := make(map[int]ProcStat, len(rootPIDs))
 	if len(rootPIDs) == 0 {
 		return stats
 	}
-	out, err := exec.Command("ps", "-axo", "pid=,ppid=,pcpu=,rss=").Output()
+	out, err := exec.Command("ps", "-axo", "pid=,ppid=,pcpu=,rss=,time=").Output()
 	if err != nil {
 		return stats
 	}
 
 	type proc struct {
-		cpu float64
-		rss uint64
+		pcpu    float64
+		rss     uint64
+		cpuSecs float64
 	}
 	procs := map[int]proc{}
 	children := map[int][]int{}
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		fields := strings.Fields(line)
-		if len(fields) != 4 {
+		if len(fields) != 5 {
 			continue
 		}
 		pid, err1 := strconv.Atoi(fields[0])
 		ppid, err2 := strconv.Atoi(fields[1])
 		cpuPct, err3 := strconv.ParseFloat(fields[2], 64)
 		rssKB, err4 := strconv.ParseUint(fields[3], 10, 64)
-		if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		cpuSecs, err5 := parsePSTime(fields[4])
+		if err1 != nil || err2 != nil || err3 != nil || err4 != nil || err5 != nil {
 			continue
 		}
-		procs[pid] = proc{cpu: cpuPct, rss: rssKB * 1024}
+		procs[pid] = proc{pcpu: cpuPct, rss: rssKB * 1024, cpuSecs: cpuSecs}
 		children[ppid] = append(children[ppid], pid)
 	}
 
@@ -260,13 +401,15 @@ func Trees(rootPIDs []int) map[int]ProcStat {
 			}
 			seen[pid] = true
 			stat.Procs++
-			stat.CPUPercent += procs[pid].cpu
+			stat.PCPU += procs[pid].pcpu
+			stat.CPUSeconds += procs[pid].cpuSecs
 			stat.RSS += procs[pid].rss
 			for _, child := range children[pid] {
 				walk(child)
 			}
 		}
 		walk(root)
+		// Leave CPUPercent 0 until the caller applies interval or fallback.
 		stats[root] = stat
 	}
 	return stats

--- a/internal/sysstat/sysstat.go
+++ b/internal/sysstat/sysstat.go
@@ -52,7 +52,7 @@ type ProcStat struct {
 	// Used with a previous sample to compute interval host share.
 	CPUSeconds float64
 	// PCPU is the raw ps pcpu sum (100 ≈ one core). Fallback only.
-	PCPU float64
+	PCPU  float64
 	Procs int
 	OK    bool
 }

--- a/internal/sysstat/sysstat_test.go
+++ b/internal/sysstat/sysstat_test.go
@@ -200,3 +200,101 @@ func TestSampleMemoryMatchesVMStatOnDarwin(t *testing.T) {
 		t.Fatalf("bad mem bounds used=%d total=%d", snap.MemUsed, snap.MemTotal)
 	}
 }
+
+func TestHostCPUPercent(t *testing.T) {
+	// 100 process-style % on 8 cores = 12.5% of the machine.
+	if got := HostCPUPercent(100, 8); got != 12.5 {
+		t.Fatalf("HostCPUPercent(100, 8) = %v, want 12.5", got)
+	}
+	// Full saturation of every core.
+	if got := HostCPUPercent(800, 8); got != 100 {
+		t.Fatalf("HostCPUPercent(800, 8) = %v, want 100", got)
+	}
+	// Overshoot clamps.
+	if got := HostCPUPercent(900, 8); got != 100 {
+		t.Fatalf("HostCPUPercent clamp = %v, want 100", got)
+	}
+	if got := HostCPUPercent(50, 0); got != 50 {
+		t.Fatalf("HostCPUPercent ncpu=0 fallback = %v, want 50", got)
+	}
+	if got := HostCPUPercent(-1, 4); got != 0 {
+		t.Fatalf("HostCPUPercent negative = %v, want 0", got)
+	}
+}
+
+func TestHostRAMPercent(t *testing.T) {
+	const total = 16 * 1024 * 1024 * 1024
+	if got := HostRAMPercent(total/4, total); got != 25 {
+		t.Fatalf("HostRAMPercent quarter = %v, want 25", got)
+	}
+	if got := HostRAMPercent(total*2, total); got != 100 {
+		t.Fatalf("HostRAMPercent overshoot = %v, want 100", got)
+	}
+	if got := HostRAMPercent(100, 0); got != 0 {
+		t.Fatalf("HostRAMPercent zero total = %v, want 0", got)
+	}
+}
+
+func TestHostCPUFromDelta(t *testing.T) {
+	// 1.0 CPU-second over 1s on 8 cores = 12.5% of the machine.
+	if got := HostCPUFromDelta(1.0, 1.0, 8); got != 12.5 {
+		t.Fatalf("HostCPUFromDelta = %v, want 12.5", got)
+	}
+	// Fully saturate all cores for the window.
+	if got := HostCPUFromDelta(8.0, 1.0, 8); got != 100 {
+		t.Fatalf("HostCPUFromDelta full = %v, want 100", got)
+	}
+	if got := HostCPUFromDelta(20.0, 1.0, 8); got != 100 {
+		t.Fatalf("HostCPUFromDelta clamp = %v, want 100", got)
+	}
+	if got := HostCPUFromDelta(1.0, 0, 8); got != 0 {
+		t.Fatalf("HostCPUFromDelta zero elapsed = %v, want 0", got)
+	}
+	if got := HostCPUFromDelta(-1.0, 1.0, 8); got != 0 {
+		t.Fatalf("HostCPUFromDelta negative delta = %v, want 0", got)
+	}
+}
+
+func TestParsePSTime(t *testing.T) {
+	cases := map[string]float64{
+		"0:00.50":    0.5,
+		"1:30.00":    90,
+		"37:06.59":   37*60 + 6.59,
+		"975:30.99":  975*60 + 30.99,
+		"01:02:03":   1*3600 + 2*60 + 3,
+		"2-01:00:00": 2*86400 + 3600,
+	}
+	for in, want := range cases {
+		got, err := parsePSTime(in)
+		if err != nil {
+			t.Fatalf("parsePSTime(%q): %v", in, err)
+		}
+		if got < want-0.01 || got > want+0.01 {
+			t.Fatalf("parsePSTime(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestScaleToHost(t *testing.T) {
+	raw := ProcStat{OK: true, PCPU: 200, RSS: 1024}
+	scaled := raw.ScaleToHost(4, 4096)
+	if scaled.CPUPercent != 50 {
+		t.Fatalf("cpu = %v, want 50", scaled.CPUPercent)
+	}
+	if scaled.RamPercent != 25 {
+		t.Fatalf("ram = %v, want 25", scaled.RamPercent)
+	}
+	if scaled.RSS != 1024 {
+		t.Fatalf("rss must stay absolute, got %d", scaled.RSS)
+	}
+	dead := ProcStat{PCPU: 99, RSS: 1}.ScaleToHost(2, 100)
+	if dead.OK || dead.PCPU != 99 {
+		t.Fatal("ScaleToHost must leave non-OK stats alone")
+	}
+}
+
+func TestLogicalCPUs(t *testing.T) {
+	if n := LogicalCPUs(); n < 1 {
+		t.Fatalf("LogicalCPUs = %d, want >= 1", n)
+	}
+}

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -447,7 +447,8 @@ func (m *Model) viewDetail(width int) string {
 
 	facts := []string{tool, displayGroup(sess.Group), "started " + relSince(sess.CreatedAt)}
 	if m.procFor == sess.ID && m.proc.OK {
-		facts = append(facts, fmt.Sprintf("cpu %.1f%% · ram %s", m.proc.CPUPercent, humanBytes(m.proc.RSS)))
+		facts = append(facts, fmt.Sprintf("cpu %.1f%% · ram %.1f%% · %s",
+			m.proc.CPUPercent, m.proc.RamPercent, humanBytes(m.proc.RSS)))
 	}
 	meta := subtleStyle.Render(strings.Join(facts, " · "))
 	dir := subtleStyle.Render(truncateTail(sess.Cwd, width))
@@ -606,13 +607,18 @@ func (m *Model) headerScope() string {
 	return line
 }
 
-// headerAgents is the fleet's process cost, empty when nothing is running.
+// headerAgents is the fleet's process cost as shares of this machine,
+// empty when nothing is running. RAM shows both percent and absolute size.
 func (m *Model) headerAgents() string {
 	if m.agents.count == 0 {
 		return ""
 	}
-	return labelStyle.Render("cpu ") + valueStyle.Render(fmt.Sprintf("%.0f%%", m.agents.cpu)) +
-		subtleStyle.Render(" · ") + labelStyle.Render("ram ") + valueStyle.Render(humanBytes(m.agents.rss))
+	title := lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render("agents total usage:")
+	return title + " " +
+		labelStyle.Render("cpu ") + valueStyle.Render(fmt.Sprintf("%.0f%%", m.agents.cpu)) +
+		subtleStyle.Render(" · ") + labelStyle.Render("ram ") +
+		valueStyle.Render(fmt.Sprintf("%.0f%%", m.agents.ram)) +
+		subtleStyle.Render(" · ") + valueStyle.Render(humanBytes(m.agents.rss))
 }
 
 // viewStatusCounts is the fleet-at-a-glance strip: a tinted dot and count

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -199,9 +199,11 @@ const (
 )
 
 // agentStats aggregates process-tree usage across all live sessions.
+// cpu and ram are shares of this machine (0–100); rss is absolute bytes.
 type agentStats struct {
 	count int
 	cpu   float64
+	ram   float64
 	rss   uint64
 }
 
@@ -479,7 +481,8 @@ func (m *Model) previewCmd(sess store.Session, gen uint64) tea.Cmd {
 				msg.preview = pane
 			}
 			if pid, err := m.tmux.PanePID(sess.ID); err == nil {
-				msg.proc = sysstat.Trees([]int{pid})[pid]
+				memTotal, _ := sysstat.MemTotalBytes()
+				msg.proc = sysstat.Trees([]int{pid})[pid].ScaleToHost(sysstat.LogicalCPUs(), memTotal)
 			}
 		}
 		return msg

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -53,6 +53,11 @@ type poller struct {
 	// changing while unmatched; used to debounce marker-less turn ends.
 	quietSince map[string]time.Time
 	tick       int
+	// prevTreeCPU / prevTreeAt drive interval agent CPU: cumulative
+	// CPU-seconds per pane root from the last poll, so host share uses
+	// the same "over this window" idea as the computer gauge.
+	prevTreeCPU map[int]float64
+	prevTreeAt  time.Time
 }
 
 // quietEndGrace is how long a working pane must stay region-stable and
@@ -243,10 +248,17 @@ func (p *poller) refreshOnce() tea.Msg {
 		}
 	}
 	trees := sysstat.Trees(livePIDs)
+	ncpu := sysstat.LogicalCPUs()
+	memTotal, _ := sysstat.MemTotalBytes()
+	now := time.Now()
+	elapsed := now.Sub(p.prevTreeAt).Seconds()
+	haveDelta := !p.prevTreeAt.IsZero() && elapsed > 0.05
+	nextTreeCPU := make(map[int]float64, len(livePIDs))
 
 	preview := ""
 	var proc sysstat.ProcStat
 	var agents agentStats
+	var cpuSecDelta float64
 	paneHashes := make(map[string]uint64, len(sessions))
 	for i, sess := range sessions {
 		if sess.Archived {
@@ -268,9 +280,26 @@ func (p *poller) refreshOnce() tea.Msg {
 		if pid := panes[sess.ID]; pid > 0 {
 			stat := trees[pid]
 			if stat.OK {
+				nextTreeCPU[pid] = stat.CPUSeconds
 				agents.count++
-				agents.cpu += stat.CPUPercent
 				agents.rss += stat.RSS
+				var hostCPU float64
+				if haveDelta {
+					delta := stat.CPUSeconds - p.prevTreeCPU[pid]
+					if delta < 0 {
+						delta = 0
+					}
+					cpuSecDelta += delta
+					hostCPU = sysstat.HostCPUFromDelta(delta, elapsed, ncpu)
+				} else {
+					hostCPU = sysstat.HostCPUPercent(stat.PCPU, ncpu)
+				}
+				stat.CPUPercent = hostCPU
+				stat.RamPercent = sysstat.HostRAMPercent(stat.RSS, memTotal)
+				if !haveDelta {
+					// First sample: fleet CPU still uses pcpu sum path below.
+					agents.cpu += stat.PCPU
+				}
 				if sess.ID == selectedID {
 					proc = stat
 				}
@@ -343,6 +372,17 @@ func (p *poller) refreshOnce() tea.Msg {
 			archivedGroups[g.Name] = true
 		}
 	}
+
+	if agents.count > 0 {
+		if haveDelta {
+			agents.cpu = sysstat.HostCPUFromDelta(cpuSecDelta, elapsed, ncpu)
+		} else {
+			agents.cpu = sysstat.HostCPUPercent(agents.cpu, ncpu)
+		}
+		agents.ram = sysstat.HostRAMPercent(agents.rss, memTotal)
+	}
+	p.prevTreeCPU = nextTreeCPU
+	p.prevTreeAt = now
 
 	msg := refreshMsg{
 		sessions:       sessions,

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -86,8 +86,8 @@ func shotModel() *Model {
 		sessions: sessions, rows: rows, collapsed: map[string]bool{},
 		groupPaths: map[string]string{"backend": "/Users/yoan/dev/spaze/api"},
 		splitRatio: defaultSplitRatio,
-		agents:   agentStats{count: 4, cpu: 12, ram: 9, rss: 1_530_000_000},
-		netRates: true, netDown: 9_400_000, netUp: 2_100_000,
+		agents:     agentStats{count: 4, cpu: 12, ram: 9, rss: 1_530_000_000},
+		netRates:   true, netDown: 9_400_000, netUp: 2_100_000,
 		snap: sysstat.Snapshot{
 			CPUOK: true, CPUPercent: 22,
 			MemOK: true, MemPercent: 75, MemUsed: 12_100_000_000, MemTotal: 16_000_000_000,

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -86,8 +86,8 @@ func shotModel() *Model {
 		sessions: sessions, rows: rows, collapsed: map[string]bool{},
 		groupPaths: map[string]string{"backend": "/Users/yoan/dev/spaze/api"},
 		splitRatio: defaultSplitRatio,
-		agents:     agentStats{count: 4, cpu: 37, rss: 1_530_000_000},
-		netRates:   true, netDown: 9_400_000, netUp: 2_100_000,
+		agents:   agentStats{count: 4, cpu: 12, ram: 9, rss: 1_530_000_000},
+		netRates: true, netDown: 9_400_000, netUp: 2_100_000,
 		snap: sysstat.Snapshot{
 			CPUOK: true, CPUPercent: 22,
 			MemOK: true, MemPercent: 75, MemUsed: 12_100_000_000, MemTotal: 16_000_000_000,
@@ -96,7 +96,7 @@ func shotModel() *Model {
 			CPUTempOK: true, CPUTemp: 61, GPUTempOK: true, GPUTemp: 55,
 		},
 		preview: previewSample,
-		proc:    sysstat.ProcStat{OK: true, CPUPercent: 4.2, RSS: 612_000_000},
+		proc:    sysstat.ProcStat{OK: true, CPUPercent: 4.2, RamPercent: 3.6, RSS: 612_000_000},
 		procFor: "add-rate-limiting",
 	}
 	return m


### PR DESCRIPTION
## Summary
- Header and selected-session CPU/RAM are shares of this machine (interval CPU-seconds and RSS over installed RAM), not raw `ps` core-stacked %
- Label: `agents total usage: cpu N% · ram M% · size`
- Computer gauges unchanged

## Test plan
- [x] `go test ./internal/sysstat/ ./internal/ui/`
- [ ] Restart agent-manager and confirm header shows `agents total usage:`
- [ ] Agent CPU stays ≤ ~100% and tracks under host load after a couple of polls