### PR TITLE
fix(tmux): fall back to window-size largest on tmux older than 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Installs tmux with it if missing.
 go install github.com/YoanWai/agent-manager@latest
 ```
 
-Requires Go 1.26+ and tmux; installs to `$(go env GOPATH)/bin`.
+Requires Go 1.26+ and tmux 3.0+; installs to `$(go env GOPATH)/bin`.
 
 ### Prebuilt binaries
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 )
 
@@ -26,6 +28,9 @@ const reviewOption = "@am_review"
 type Driver struct {
 	bin    string
 	socket string
+
+	attachSizeOnce sync.Once
+	attachSize     string
 }
 
 func New() (*Driver, error) {
@@ -332,8 +337,36 @@ func (d *Driver) Resize(id string, width, height int) error {
 // the manual size Resize pinned for the preview would leave the client's
 // extra columns painted with tmux's out-of-bounds dotted overlay.
 func (d *Driver) PrepareAttach(id string) error {
-	_, err := d.run("set-window-option", "-t", sessionName(id), "window-size", "latest")
+	_, err := d.run("set-window-option", "-t", sessionName(id), "window-size", d.attachWindowSize())
 	return err
+}
+
+// attachWindowSize picks the window-size value PrepareAttach sets. "latest"
+// only exists since tmux 3.1; on older servers "largest" tracks the single
+// attaching client the same way (issue #114, Ubuntu 20.04 ships tmux 3.0a).
+func (d *Driver) attachWindowSize() string {
+	d.attachSizeOnce.Do(func() {
+		d.attachSize = "latest"
+		banner, err := exec.Command(d.bin, "-V").CombinedOutput()
+		if err == nil && versionBefore31(string(banner)) {
+			d.attachSize = "largest"
+		}
+	})
+	return d.attachSize
+}
+
+var versionPattern = regexp.MustCompile(`(\d+)\.(\d+)`)
+
+// versionBefore31 reports whether a `tmux -V` banner names a release older
+// than 3.1. Banners without a version number (master builds) count as modern.
+func versionBefore31(banner string) bool {
+	match := versionPattern.FindStringSubmatch(banner)
+	if match == nil {
+		return false
+	}
+	major, _ := strconv.Atoi(match[1])
+	minor, _ := strconv.Atoi(match[2])
+	return major < 3 || (major == 3 && minor < 1)
 }
 
 func (d *Driver) PanePID(id string) (int, error) {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5,11 +5,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 )
 
@@ -29,8 +27,7 @@ type Driver struct {
 	bin    string
 	socket string
 
-	attachSizeOnce sync.Once
-	attachSize     string
+	attachSizeLargest atomic.Bool
 }
 
 func New() (*Driver, error) {
@@ -336,37 +333,21 @@ func (d *Driver) Resize(id string, width, height int) error {
 // attaching client and tracks terminal resizes while attached. Without it,
 // the manual size Resize pinned for the preview would leave the client's
 // extra columns painted with tmux's out-of-bounds dotted overlay.
+// "latest" needs tmux 3.1 (issue #114, Ubuntu 20.04 ships 3.0a); a server
+// that rejects it gets "largest", which sizes to the single attaching
+// client the same way. The rejection is the server's own verdict, so this
+// stays correct when client binary and running server versions diverge.
 func (d *Driver) PrepareAttach(id string) error {
-	_, err := d.run("set-window-option", "-t", sessionName(id), "window-size", d.attachWindowSize())
-	return err
-}
-
-// attachWindowSize picks the window-size value PrepareAttach sets. "latest"
-// only exists since tmux 3.1; on older servers "largest" tracks the single
-// attaching client the same way (issue #114, Ubuntu 20.04 ships tmux 3.0a).
-func (d *Driver) attachWindowSize() string {
-	d.attachSizeOnce.Do(func() {
-		d.attachSize = "latest"
-		banner, err := exec.Command(d.bin, "-V").CombinedOutput()
-		if err == nil && versionBefore31(string(banner)) {
-			d.attachSize = "largest"
-		}
-	})
-	return d.attachSize
-}
-
-var versionPattern = regexp.MustCompile(`(\d+)\.(\d+)`)
-
-// versionBefore31 reports whether a `tmux -V` banner names a release older
-// than 3.1. Banners without a version number (master builds) count as modern.
-func versionBefore31(banner string) bool {
-	match := versionPattern.FindStringSubmatch(banner)
-	if match == nil {
-		return false
+	if d.attachSizeLargest.Load() {
+		_, err := d.run("set-window-option", "-t", sessionName(id), "window-size", "largest")
+		return err
 	}
-	major, _ := strconv.Atoi(match[1])
-	minor, _ := strconv.Atoi(match[2])
-	return major < 3 || (major == 3 && minor < 1)
+	_, err := d.run("set-window-option", "-t", sessionName(id), "window-size", "latest")
+	if err != nil && strings.Contains(err.Error(), "unknown value") {
+		d.attachSizeLargest.Store(true)
+		_, err = d.run("set-window-option", "-t", sessionName(id), "window-size", "largest")
+	}
+	return err
 }
 
 func (d *Driver) PanePID(id string) (int, error) {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -69,41 +69,46 @@ func TestPrepareAttachRestoresAutoSize(t *testing.T) {
 	if err := driver.PrepareAttach(id); err != nil {
 		t.Fatalf("PrepareAttach: %v", err)
 	}
-	if got, want := windowSizeOption(t, id), driver.attachWindowSize(); got != want {
+	want := "latest"
+	if driver.attachSizeLargest.Load() {
+		want = "largest"
+	}
+	if got := windowSizeOption(t, id); got != want {
 		t.Fatalf("after PrepareAttach, window-size = %q, want %q", got, want)
 	}
 }
 
-// attachWindowSize shells out to `tmux -V`, so point bin at a stub that
-// reports an old version and check the pre-3.1 fallback kicks in.
-func TestAttachWindowSizeFallsBackOnOldTmux(t *testing.T) {
-	stub := t.TempDir() + "/tmux"
-	if err := os.WriteFile(stub, []byte("#!/bin/sh\necho 'tmux 3.0a'\n"), 0o700); err != nil {
+// A pre-3.1 server rejects window-size "latest" with "unknown value";
+// PrepareAttach must retry with "largest" and remember the verdict. A stub
+// tmux that rejects "latest" stands in for the old server and logs its
+// calls, so the test also proves the second attach skips the doomed try.
+func TestPrepareAttachFallsBackWhenLatestRejected(t *testing.T) {
+	dir := t.TempDir()
+	callLog := dir + "/calls"
+	stub := dir + "/tmux"
+	script := "#!/bin/sh\necho \"$@\" >> " + callLog + "\ncase \"$*\" in *latest*) echo 'unknown value: latest' >&2; exit 1;; esac\nexit 0\n"
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil {
 		t.Fatalf("stub: %v", err)
 	}
 	driver := &Driver{bin: stub, socket: testSocket}
-	if got := driver.attachWindowSize(); got != "largest" {
-		t.Fatalf("attachWindowSize on tmux 3.0a = %q, want largest", got)
-	}
-}
 
-func TestVersionBefore31(t *testing.T) {
-	cases := []struct {
-		banner string
-		want   bool
-	}{
-		{"tmux 3.0a", true},
-		{"tmux 2.9", true},
-		{"tmux 3.1", false},
-		{"tmux 3.1b", false},
-		{"tmux 3.7b", false},
-		{"tmux next-3.4", false},
-		{"tmux master", false},
-		{"", false},
+	if err := driver.PrepareAttach("x1"); err != nil {
+		t.Fatalf("PrepareAttach with rejecting server: %v", err)
 	}
-	for _, c := range cases {
-		if got := versionBefore31(c.banner); got != c.want {
-			t.Errorf("versionBefore31(%q) = %v, want %v", c.banner, got, c.want)
+	if err := driver.PrepareAttach("x1"); err != nil {
+		t.Fatalf("second PrepareAttach: %v", err)
+	}
+	logged, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read call log: %v", err)
+	}
+	calls := strings.Split(strings.TrimSpace(string(logged)), "\n")
+	if len(calls) != 3 {
+		t.Fatalf("got %d tmux calls, want 3 (latest, largest, largest):\n%s", len(calls), logged)
+	}
+	for i, wantValue := range []string{"latest", "largest", "largest"} {
+		if !strings.HasSuffix(calls[i], "window-size "+wantValue) {
+			t.Fatalf("call %d = %q, want window-size %s", i, calls[i], wantValue)
 		}
 	}
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -69,8 +69,42 @@ func TestPrepareAttachRestoresAutoSize(t *testing.T) {
 	if err := driver.PrepareAttach(id); err != nil {
 		t.Fatalf("PrepareAttach: %v", err)
 	}
-	if got := windowSizeOption(t, id); got != "latest" {
-		t.Fatalf("after PrepareAttach, window-size = %q, want latest", got)
+	if got, want := windowSizeOption(t, id), driver.attachWindowSize(); got != want {
+		t.Fatalf("after PrepareAttach, window-size = %q, want %q", got, want)
+	}
+}
+
+// attachWindowSize shells out to `tmux -V`, so point bin at a stub that
+// reports an old version and check the pre-3.1 fallback kicks in.
+func TestAttachWindowSizeFallsBackOnOldTmux(t *testing.T) {
+	stub := t.TempDir() + "/tmux"
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\necho 'tmux 3.0a'\n"), 0o700); err != nil {
+		t.Fatalf("stub: %v", err)
+	}
+	driver := &Driver{bin: stub, socket: testSocket}
+	if got := driver.attachWindowSize(); got != "largest" {
+		t.Fatalf("attachWindowSize on tmux 3.0a = %q, want largest", got)
+	}
+}
+
+func TestVersionBefore31(t *testing.T) {
+	cases := []struct {
+		banner string
+		want   bool
+	}{
+		{"tmux 3.0a", true},
+		{"tmux 2.9", true},
+		{"tmux 3.1", false},
+		{"tmux 3.1b", false},
+		{"tmux 3.7b", false},
+		{"tmux next-3.4", false},
+		{"tmux master", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := versionBefore31(c.banner); got != c.want {
+			t.Errorf("versionBefore31(%q) = %v, want %v", c.banner, got, c.want)
+		}
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -374,23 +374,27 @@ func (m *Model) attachCmd(id string) tea.Cmd {
 	// attachDoneMsg re-pins it to the preview width on detach. Clearing the
 	// cached hash first keeps the poller from reading this reflow as
 	// streaming output, same as the detach-side resize (reflowSessions).
+	// A failure here still attaches: the worst outcome is a stale window
+	// size, which beats locking the session out (issue #114).
 	var prepErr error
 	m.poller.reflowSessions([]string{id}, func() {
 		prepErr = m.tmux.PrepareAttach(id)
 	})
 	if prepErr != nil {
 		m.err = prepErr.Error()
-		return nil
 	}
 	return tea.ExecProcess(m.tmux.AttachCommand(id), func(err error) tea.Msg {
 		return attachDoneMsg{sessID: id, err: err}
 	})
 }
 
+// warn carries a PrepareAttach failure: shown to the user, but the attach
+// still proceeds, unlike err which cancels it.
 type reattachPreparedMsg struct {
 	sessID  string
 	diffGen int
 	err     error
+	warn    string
 }
 
 func (m *Model) reattach(id string, diffGen int) tea.Cmd {
@@ -417,7 +421,11 @@ func (m *Model) reattach(id string, diffGen int) tea.Cmd {
 		poller.reflowSessions([]string{id}, func() {
 			prepErr = driver.PrepareAttach(id)
 		})
-		return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: prepErr}
+		var warn string
+		if prepErr != nil {
+			warn = prepErr.Error()
+		}
+		return reattachPreparedMsg{sessID: id, diffGen: diffGen, warn: warn}
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -717,7 +717,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err.Error()
 			return m, nil
 		}
-		m.err = ""
+		m.err = msg.warn
 		return m, tea.ExecProcess(m.tmux.AttachCommand(msg.sessID), func(err error) tea.Msg {
 			return attachDoneMsg{sessID: msg.sessID, err: err}
 		})


### PR DESCRIPTION
Fixes #114.

`PrepareAttach` set `window-size latest`, which tmux understands only since 3.1. On tmux 3.0 (Ubuntu 20.04) the command failed with `unknown value: latest`, and both attach paths treated that as fatal, so no session could be entered.

## Changes
- `PrepareAttach` detects the server version once (`tmux -V`) and sends `largest` on pre-3.1 servers; with a single attaching client it sizes the window the same way.
- A `PrepareAttach` failure surfaces in the footer but no longer cancels the attach (sessions list and review reattach), since a stale window size beats a lockout.
- README documents tmux 3.0+ as the supported baseline.

## Verification
- Built tmux 3.0a from source and reproduced the exact failure: `set-window-option window-size latest` exits 1 with `unknown value: latest`; `largest` applies cleanly.
- `go test ./internal/tmux/... ./internal/ui/...` passes with the 3.0a binary first on PATH (isolated socket), and the full suite passes on tmux 3.7b.
- New tests: version-banner parsing table, and a stubbed `tmux -V` reporting 3.0a yields `largest`.