### PR TITLE
feat: add install script, mise instructions, and AUR packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y tmux
       - name: gofmt
         run: test -z "$(gofmt -l .)"
+      - name: Shellcheck install script
+        run: shellcheck install.sh
       - name: Vet
         run: go vet ./...
       - name: Test

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,3 +39,26 @@ brews:
       - name: tmux
     test: |
       system "#{bin}/agent-manager", "--version"
+
+# git_url resolves to an empty string without AUR_KEY in the environment, and
+# goreleaser skips the publish on an empty url, so a release without the key
+# still succeeds.
+aurs:
+  - name: agent-manager-bin
+    homepage: https://github.com/YoanWai/agent-manager
+    description: Terminal UI to manage AI coding-agent tmux sessions
+    license: MIT
+    maintainers:
+      - Yoan Wai <106609173+YoanWai@users.noreply.github.com>
+    depends:
+      - tmux
+      - git
+    provides:
+      - agent-manager
+    conflicts:
+      - agent-manager
+    private_key: '{{ index .Env "AUR_KEY" }}'
+    git_url: '{{ if index .Env "AUR_KEY" }}ssh://aur@aur.archlinux.org/agent-manager-bin.git{{ end }}'
+    package: |-
+      install -Dm755 "./agent-manager" "${pkgdir}/usr/bin/agent-manager"
+      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/agent-manager-bin/LICENSE"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ brew install yoanwai/tap/agent-manager
 
 Installs tmux with it if missing.
 
+### Install script (macOS / Linux)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/YoanWai/agent-manager/main/install.sh | sh
+```
+
+Downloads the latest release for your platform, verifies it against the published checksums, and installs it to `~/.local/bin`. Set `AGENT_MANAGER_INSTALL_DIR` for another directory and `AGENT_MANAGER_VERSION` to pin a version. Install tmux with your own package manager.
+
+### mise
+
+```bash
+mise use -g ubi:YoanWai/agent-manager
+```
+
+Reads the GitHub release directly, so it needs no registry entry. Install tmux with your own package manager.
+
 ### Go
 
 ```bash
@@ -40,7 +56,7 @@ Download from [Releases](https://github.com/YoanWai/agent-manager/releases) (mac
 
 ### Windows
 
-Run inside [WSL2](https://learn.microsoft.com/windows/wsl/install): agent-manager lives on tmux, which is a Linux/macOS tool. In a WSL shell, install with Homebrew or grab the Linux binary from Releases.
+Run inside [WSL2](https://learn.microsoft.com/windows/wsl/install): agent-manager lives on tmux, which is a Linux/macOS tool. In a WSL shell, install with the install script above, with Homebrew, or grab the Linux binary from Releases.
 
 ### Updating
 
@@ -48,6 +64,8 @@ The manager checks GitHub Releases once a day and shows a `↑ vX.Y.Z available`
 
 ```bash
 brew upgrade yoanwai/tap/agent-manager   # Homebrew
+curl -fsSL https://raw.githubusercontent.com/YoanWai/agent-manager/main/install.sh | sh   # Install script
+mise upgrade --bump ubi:YoanWai/agent-manager   # mise
 go install github.com/YoanWai/agent-manager@latest   # Go
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+set -eu
+
+REPO="YoanWai/agent-manager"
+BINARY="agent-manager"
+
+say() {
+	printf '%s\n' "$*"
+}
+
+err() {
+	printf 'error: %s\n' "$*" >&2
+	exit 1
+}
+
+need_cmd() {
+	command -v "$1" >/dev/null 2>&1 || err "required command not found: $1"
+}
+
+detect_os() {
+	case $(uname -s) in
+	Darwin) echo darwin ;;
+	Linux) echo linux ;;
+	*) err "unsupported operating system: $(uname -s). On Windows, run this inside WSL2." ;;
+	esac
+}
+
+detect_arch() {
+	case $(uname -m) in
+	x86_64 | amd64) echo amd64 ;;
+	arm64 | aarch64) echo arm64 ;;
+	*) err "unsupported architecture: $(uname -m)" ;;
+	esac
+}
+
+resolve_tag() {
+	if [ -n "${AGENT_MANAGER_VERSION:-}" ]; then
+		case $AGENT_MANAGER_VERSION in
+		v*) echo "$AGENT_MANAGER_VERSION" ;;
+		*) echo "v${AGENT_MANAGER_VERSION}" ;;
+		esac
+		return
+	fi
+	latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest") ||
+		err "could not reach GitHub to resolve the latest release"
+	tag=${latest_url##*/}
+	case $tag in
+	v*) echo "$tag" ;;
+	*) err "could not resolve the latest release tag" ;;
+	esac
+}
+
+fetch() {
+	curl -fsSL -o "$2" "$1" || err "download failed: $1"
+}
+
+verify_checksum() {
+	dir=$1
+	file=$2
+	expected=$(awk -v f="$file" '$2 == f {print $1}' "${dir}/checksums.txt")
+	[ -n "$expected" ] || err "no checksum published for ${file}"
+	if command -v sha256sum >/dev/null 2>&1; then
+		actual=$(sha256sum "${dir}/${file}" | awk '{print $1}')
+	elif command -v shasum >/dev/null 2>&1; then
+		actual=$(shasum -a 256 "${dir}/${file}" | awk '{print $1}')
+	else
+		err "need sha256sum or shasum to verify the download"
+	fi
+	[ "$actual" = "$expected" ] || err "checksum mismatch for ${file}"
+}
+
+check_path() {
+	case ":${PATH}:" in
+	*":$1:"*) ;;
+	*) say "add it to your PATH:  export PATH=\"$1:\$PATH\"" ;;
+	esac
+}
+
+check_tmux() {
+	command -v tmux >/dev/null 2>&1 && return 0
+	say "${BINARY} runs its sessions in tmux, so install tmux too: apt install tmux, dnf install tmux, pacman -S tmux, or brew install tmux"
+}
+
+main() {
+	need_cmd curl
+	need_cmd tar
+	need_cmd awk
+	need_cmd mktemp
+
+	os=$(detect_os)
+	arch=$(detect_arch)
+	tag=$(resolve_tag)
+	version=${tag#v}
+
+	archive="${BINARY}_${version}_${os}_${arch}.tar.gz"
+	base_url="https://github.com/${REPO}/releases/download/${tag}"
+
+	tmp=$(mktemp -d)
+	trap 'rm -rf "$tmp"' EXIT INT TERM
+
+	say "downloading ${BINARY} ${tag} for ${os}/${arch}"
+	fetch "${base_url}/${archive}" "${tmp}/${archive}"
+	fetch "${base_url}/checksums.txt" "${tmp}/checksums.txt"
+	verify_checksum "$tmp" "$archive"
+	tar -xzf "${tmp}/${archive}" -C "$tmp" "$BINARY"
+
+	install_dir=${AGENT_MANAGER_INSTALL_DIR:-$HOME/.local/bin}
+	mkdir -p "$install_dir" || err "could not create ${install_dir}"
+	mv "${tmp}/${BINARY}" "${install_dir}/${BINARY}" || err "could not write to ${install_dir}, set AGENT_MANAGER_INSTALL_DIR to a writable directory"
+	chmod 755 "${install_dir}/${BINARY}"
+
+	say "installed $("${install_dir}/${BINARY}" --version) to ${install_dir}"
+	check_path "$install_dir"
+	check_tmux
+}
+
+main "$@"


### PR DESCRIPTION
## What

Three new ways to install agent-manager.

**`install.sh`** — a one-line curl installer for macOS and Linux:

```bash
curl -fsSL https://raw.githubusercontent.com/YoanWai/agent-manager/main/install.sh | sh
```

POSIX sh. Detects darwin/linux and amd64/arm64, resolves the latest tag through the releases redirect (so no GitHub API rate limit), downloads the archive plus `checksums.txt`, verifies sha256, and installs to `~/.local/bin`. `AGENT_MANAGER_INSTALL_DIR` picks another directory, `AGENT_MANAGER_VERSION` pins a version. It warns when the install directory is off PATH and when tmux is missing. Everything lives in `main`, called on the last line, so a truncated pipe runs nothing.

**mise** — `mise use -g ubi:YoanWai/agent-manager` works against the existing releases with no registry entry, so the README documents it.

**AUR** — an `aurs:` block builds `agent-manager-bin` from the release archives, depending on tmux and git.

CI gained a shellcheck step for `install.sh`.

## Why

Homebrew and `go install` serve people who already have brew or a Go toolchain. On Linux, WSL, servers, and dev containers the documented path was downloading a tarball and moving the binary by hand. Recent releases show Linux archive downloads, so those users are real.

## Verification

`install.sh` ran end to end on macOS arm64, Alpine busybox sh (arm64), and Ubuntu amd64 piped through `cat | sh`. Each printed `agent-manager 0.10.5` from the installed binary. Pinning to `v0.10.4` installs 0.10.4, a nonexistent version exits 1 with the failed URL, and checksum mismatch and missing-entry both exit 1. shellcheck passes on 0.9.0, the version preinstalled on `ubuntu-latest`.

The AUR publisher ran against a local bare repository: PKGBUILD and `.SRCINFO` were generated and pushed with both arches and matching sha256 sums. With `AUR_KEY` unset, `git_url` renders empty and the pipe reports `url is empty` while the release succeeds, which matches `internal/client/git.go` returning `pipe.Skip` on an empty URL before the private key is read.

mise was verified in an isolated install: `mise upgrade --bump ubi:YoanWai/agent-manager` moved 0.10.3 to 0.10.4. The full tool name is required, so the Updating section uses it.

## Follow-up

Publishing to the AUR needs an aur.archlinux.org account with an SSH key uploaded, and `AUR_KEY` in the environment at release time. The README gets its `yay -S agent-manager-bin` line once the first push lands.