### PR TITLE
feat(ui): settings toggle to close the quick bar after sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Sessions run inside tmux (`am_*` namespace), so they survive the manager quittin
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
 | `ctrl+r` | Review the selected session's changes: full-screen whole-file diffs, line comments sent to the agent |
 | `f` | Fold / unfold group |
-| `s` | Settings (quick-spawn tool, theme, review layout) |
+| `s` | Settings (quick-spawn tool, theme, review layout, after quick send) |
 | `t` | Toggle archived view |
 | `e` | Hide / show empty groups |
 | `/` | Search |

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -1110,7 +1110,13 @@ func (m *Model) openQuickMode() {
 	input.Focus()
 	m.err = ""
 	names, index := m.defaultToolSelection()
-	m.quick = quickState{active: true, input: input, toolNames: names, toolIndex: index}
+	m.quick = quickState{
+		active:         true,
+		input:          input,
+		toolNames:      names,
+		toolIndex:      index,
+		closeAfterSend: m.quickCloseAfterSend(),
+	}
 }
 
 // defaultToolSelection returns the sorted tool names with the index of
@@ -1199,8 +1205,7 @@ func (m *Model) submitQuick() (tea.Model, tea.Cmd) {
 	}
 	// The prompt is delivered: clear the input before anything else can
 	// fail, so a retry cannot send it twice.
-	m.quick.input.SetValue("")
-	m.quick.attachments = nil
+	m.clearQuickAfterSend()
 	m.err = ""
 	// A queued answer means the user expects a fresh finished alert.
 	if err := m.store.SetAcked(entry.sess.ID, false); err != nil {
@@ -1230,10 +1235,20 @@ func (m *Model) quickSpawn(group, prompt string) (tea.Model, tea.Cmd) {
 		m.err = err.Error()
 		return m, nil
 	}
-	m.quick.input.SetValue("")
-	m.quick.attachments = nil
+	m.clearQuickAfterSend()
 	m.err = ""
 	return m, m.refreshCmd()
+}
+
+// clearQuickAfterSend empties the bar for the next prompt, and dismisses it
+// entirely when the settings toggle asks for that.
+func (m *Model) clearQuickAfterSend() {
+	m.quick.input.SetValue("")
+	m.quick.attachments = nil
+	if m.quick.closeAfterSend {
+		m.quick.active = false
+		m.quick.pasting = false
+	}
 }
 
 // quickTool is the spawn CLI for the current quick-mode run: the settings
@@ -1280,6 +1295,20 @@ func (m *Model) defaultSplitLayout() bool {
 	return chosen != "unified"
 }
 
+const quickCloseSetting = "quick_prompt_close"
+
+// quickCloseAfterSend reports whether the quick bar should dismiss itself
+// once a prompt is delivered. Staying open is the default; a stored "close"
+// choice opts in. A store error is surfaced but still yields the default.
+func (m *Model) quickCloseAfterSend() bool {
+	chosen, err := m.store.Setting(quickCloseSetting)
+	if err != nil {
+		m.err = "reading quick prompt setting: " + err.Error()
+		return false
+	}
+	return chosen == "close"
+}
+
 func (m *Model) openSettings() {
 	if len(m.cfg.Tools) == 0 {
 		m.err = "no tools configured"
@@ -1288,10 +1317,11 @@ func (m *Model) openSettings() {
 	m.err = ""
 	names, index := m.defaultToolSelection()
 	m.settings = settingsState{
-		toolNames:   names,
-		toolIndex:   index,
-		themeIndex:  themeIndex(current.Name),
-		layoutSplit: m.defaultSplitLayout(),
+		toolNames:      names,
+		toolIndex:      index,
+		themeIndex:     themeIndex(current.Name),
+		layoutSplit:    m.defaultSplitLayout(),
+		quickCloseSend: m.quickCloseAfterSend(),
 	}
 	m.mode = modeSettings
 }
@@ -1320,6 +1350,14 @@ func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if err := m.store.SetSetting(diffLayoutSetting, layout); err != nil {
 			m.err = err.Error()
 		}
+		quickClose := "stay"
+		if m.settings.quickCloseSend {
+			quickClose = "close"
+		}
+		if err := m.store.SetSetting(quickCloseSetting, quickClose); err != nil {
+			m.err = err.Error()
+		}
+		m.quick.closeAfterSend = m.settings.quickCloseSend
 		m.mode = modeList
 	}
 	return m, nil
@@ -1338,6 +1376,8 @@ func (m *Model) cycleSetting(step int) {
 		SyncTerminalBackground()
 	case settingsFieldLayout:
 		m.settings.layoutSplit = !m.settings.layoutSplit
+	case settingsFieldQuickClose:
+		m.settings.quickCloseSend = !m.settings.quickCloseSend
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -1179,8 +1179,9 @@ func (m *Model) handleQuickKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // submitQuick answers the selected session, or spawns a new session with
-// the prompt embedded when a group is selected. The bar stays active so
-// consecutive prompts flow without re-arming.
+// the prompt embedded when a group is selected. The bar stays active by
+// default so consecutive prompts flow without re-arming; the "after quick
+// send" setting closes it instead.
 func (m *Model) submitQuick() (tea.Model, tea.Cmd) {
 	entry, ok := m.selectedRow()
 	if !ok {
@@ -1357,7 +1358,6 @@ func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if err := m.store.SetSetting(quickCloseSetting, quickClose); err != nil {
 			m.err = err.Error()
 		}
-		m.quick.closeAfterSend = m.settings.quickCloseSend
 		m.mode = modeList
 	}
 	return m, nil

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -161,6 +161,10 @@ func (m *Model) viewSettings() string {
 	if m.settings.layoutSplit {
 		layout = "split"
 	}
+	quickClose := "stay open"
+	if m.settings.quickCloseSend {
+		quickClose = "close"
+	}
 	row := func(field int, name, value string) string {
 		marker := "  "
 		labelStyle := valueStyle
@@ -174,7 +178,8 @@ func (m *Model) viewSettings() string {
 	body := row(settingsFieldTool, "quick spawn tool", m.settings.toolNames[m.settings.toolIndex]) + "\n" +
 		row(settingsFieldTheme, "theme", themes[m.settings.themeIndex].Name) + "  " +
 		themeSwatch(themes[m.settings.themeIndex]) + "\n" +
-		row(settingsFieldLayout, "review layout", layout) + "\n\n" +
+		row(settingsFieldLayout, "review layout", layout) + "\n" +
+		row(settingsFieldQuickClose, "after quick send", quickClose) + "\n\n" +
 		subtleStyle.Render("  version ") + valueStyle.Render(m.version) + m.versionStatus()
 	return m.card("⚙ Settings", body, "↑↓ field · ←→ change · ↵/esc save")
 }
@@ -228,7 +233,7 @@ func (m *Model) viewHelp() string {
 		{"b", "in review: pick the branch from the repo's worktrees"},
 		{"B", "in review: pick the target (merge-into branch) the branch diff compares against"},
 		{"F", "fold / unfold all groups"},
-		{"s", "settings (quick spawn tool, review layout)"},
+		{"s", "settings (quick spawn tool, review layout, after quick send)"},
 		{"|", "resize split (←→ / drag, enter commits, esc cancels)"},
 		{"t", "toggle archived view"},
 		{"/", "search"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -167,12 +167,13 @@ type renameTarget struct {
 // as inline chips in the prompt (same line as the text); backspace at the
 // text start removes the nearest chip. Paths append on submit only.
 type quickState struct {
-	active      bool
-	input       textarea.Model
-	toolNames   []string
-	toolIndex   int
-	attachments []string
-	pasting     bool
+	active         bool
+	input          textarea.Model
+	toolNames      []string
+	toolIndex      int
+	attachments    []string
+	pasting        bool
+	closeAfterSend bool
 }
 
 // quickImageMsg is the result of an async clipboard image read started
@@ -184,17 +185,19 @@ type quickImageMsg struct {
 }
 
 type settingsState struct {
-	toolNames   []string
-	toolIndex   int
-	themeIndex  int
-	field       int
-	layoutSplit bool
+	toolNames      []string
+	toolIndex      int
+	themeIndex     int
+	field          int
+	layoutSplit    bool
+	quickCloseSend bool
 }
 
 const (
 	settingsFieldTool = iota
 	settingsFieldTheme
 	settingsFieldLayout
+	settingsFieldQuickClose
 	settingsFieldCount
 )
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2507,6 +2507,56 @@ func TestDefaultSplitLayout(t *testing.T) {
 	}
 }
 
+func TestQuickCloseAfterSendDefaultsToStayingOpen(t *testing.T) {
+	m := buildModel(t)
+	if m.quickCloseAfterSend() {
+		t.Fatal("quick bar should stay open by default")
+	}
+	if err := m.store.SetSetting(quickCloseSetting, "close"); err != nil {
+		t.Fatal(err)
+	}
+	if !m.quickCloseAfterSend() {
+		t.Fatal("stored close choice should opt in")
+	}
+}
+
+func TestQuickPromptClosesAfterSendWhenEnabled(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "answer-me", t.TempDir(), "")
+	m.selectSessionRow(t, "answer-me")
+	if err := m.store.SetSetting(quickCloseSetting, "close"); err != nil {
+		t.Fatal(err)
+	}
+
+	m.openQuickMode()
+	m.quick.input.SetValue("carry on with the plan")
+	if _, _ = m.submitQuick(); m.err != "" {
+		t.Fatalf("send: %q", m.err)
+	}
+	if m.quick.active {
+		t.Fatal("quick mode should close after a send when the setting is on")
+	}
+}
+
+func TestSettingsTogglesQuickClose(t *testing.T) {
+	m := buildModel(t)
+	m.openSettings()
+	if m.settings.quickCloseSend {
+		t.Fatal("settings should open on stay-open by default")
+	}
+	for i := 0; i < 3; i++ {
+		m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if m.settings.field != settingsFieldQuickClose {
+		t.Fatalf("third down should focus the quick send field, got %d", m.settings.field)
+	}
+	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyRight})
+	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.quickCloseAfterSend() {
+		t.Fatal("close choice should persist after toggle")
+	}
+}
+
 func TestSettingsTogglesReviewLayout(t *testing.T) {
 	m := buildModel(t)
 	m.openSettings()


### PR DESCRIPTION
## What

Settings gains an **after quick send** field. `stay open` keeps today's behavior: the quick bar stays armed so consecutive prompts flow without reopening it. `close` dismisses the bar once the prompt is delivered.

The choice persists as the `quick_prompt_close` setting and covers both quick-prompt paths: answering the selected session and spawning a new one from a group.

## Verified

- `go test ./...` green (`internal/ui` full suite, 86s).
- New tests: default stays open, stored `close` opts in, the bar closes after a send when enabled, and the settings field persists its toggle.
- Settings modal rendered in both states, showing the new row focused and cycling between `stay open` and `close`.