### PR TITLE
feat: publish Homebrew as a cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,10 @@ release:
     ## Install
 
     ```bash
-    brew install yoanwai/tap/agent-manager        # macOS / Linux
+    # macOS / Linux
+    brew install yoanwai/tap/agent-manager
+    curl -fsSL https://raw.githubusercontent.com/YoanWai/agent-manager/main/install.sh | sh
+    mise use -g ubi:YoanWai/agent-manager
     go install github.com/YoanWai/agent-manager@latest
     ```
 
@@ -43,20 +46,26 @@ release:
 
     [Discussions](https://github.com/YoanWai/agent-manager/discussions) for questions and setups, [issues](https://github.com/YoanWai/agent-manager/issues) for bugs and ideas, [CONTRIBUTING.md](https://github.com/YoanWai/agent-manager/blob/main/.github/CONTRIBUTING.md) to send a patch.
 
-# brews (formula) instead of homebrew_casks: casks quarantine the
-# downloaded binary and Gatekeeper blocks unsigned CLI tools outright;
-# formulas install without quarantine.
-brews:
+homebrew_casks:
   - repository:
       owner: YoanWai
       name: homebrew-tap
     homepage: https://github.com/YoanWai/agent-manager
     description: Terminal UI to manage AI coding-agent tmux sessions
     license: MIT
+    binaries:
+      - agent-manager
     dependencies:
-      - name: tmux
-    test: |
-      system "#{bin}/agent-manager", "--version"
+      - formula: tmux
+    # Casks quarantine what they download and Gatekeeper blocks an unsigned
+    # binary outright. The OS.mac? guard keeps Linux installs working, where
+    # system_command on a missing /usr/bin/xattr aborts the install.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/agent-manager"]
+          end
 
 # git_url resolves to an empty string without AUR_KEY in the environment, and
 # goreleaser skips the publish on an empty url, so a release without the key

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Status detection currently supports **Claude Code**, **OpenCode**, **Codex**, an
 brew install yoanwai/tap/agent-manager
 ```
 
-Installs tmux with it if missing.
+Installs tmux with it if missing. The tap ships a cask, so an install from the older formula switches over with `brew uninstall agent-manager` followed by the command above.
 
 ### Install script (macOS / Linux)
 


### PR DESCRIPTION
## What

Replaces the `brews` block with `homebrew_casks`, and notes the switch in the README for anyone who installed the old formula.

The cask carries all four archives (macOS and Linux, amd64 and arm64), keeps `depends_on formula: tmux`, and adds a postflight hook that clears `com.apple.quarantine`.

The tap at `YoanWai/homebrew-tap` already carries the cask for v0.10.5 and the formula is gone, so `brew install yoanwai/tap/agent-manager` serves the cask today.

## Why

GoReleaser soft-deprecated `brews` at v2.10 and hard-deprecated it at v2.16, pointing at `homebrew_casks`; every `goreleaser check` on this repo was reporting it. Casks handle prebuilt binaries on both platforms, so the install command in the README stays exactly as it was.

The quarantine hook earns its place: with the hook removed, a cask install leaves `com.apple.quarantine` on the binary and running it dies on SIGKILL (exit 137) with no output. With the hook, the attribute is gone and the binary runs.

The `OS.mac?` guard is load-bearing. GoReleaser's documented guard shells out to `/usr/bin/xattr -h`, which on Linux raises `exited with 127` and rolls the whole install back. That reproduced in a Homebrew Linux container before the guard replaced it.

## Verification

- macOS arm64, cask from the live tap: `brew install yoanwai/tap/agent-manager` installs, `xattr -l` shows only `com.apple.provenance`, and the binary prints `agent-manager 0.10.5`.
- Linux arm64 in the `homebrew/brew` image, same command against the live tap: pours the tmux bottle, links the binary, prints `agent-manager 0.10.5`.
- A/B on the hook, described above.
- `brew install <tap>/<name>` with no `--cask` flag resolves the cask, so the README command is unchanged.
- `goreleaser check` is clean, with the `conflicts.formula` stanza left out since Homebrew removed it.