### PR TITLE
docs: list the AUR package as an install option

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,9 @@ release:
     curl -fsSL https://raw.githubusercontent.com/YoanWai/agent-manager/main/install.sh | sh
     mise use -g ubi:YoanWai/agent-manager
     go install github.com/YoanWai/agent-manager@latest
+
+    # Arch Linux
+    yay -S agent-manager-bin
     ```
 
     Prebuilt macOS and Linux binaries are attached below. Windows runs it inside WSL2.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ curl -fsSL https://raw.githubusercontent.com/YoanWai/agent-manager/main/install.
 
 Downloads the latest release for your platform, verifies it against the published checksums, and installs it to `~/.local/bin`. Set `AGENT_MANAGER_INSTALL_DIR` for another directory and `AGENT_MANAGER_VERSION` to pin a version. Install tmux with your own package manager.
 
+### Arch Linux
+
+```bash
+yay -S agent-manager-bin
+```
+
+[agent-manager-bin](https://aur.archlinux.org/packages/agent-manager-bin) in the AUR installs the released binary and pulls in tmux and git.
+
 ### mise
 
 ```bash


### PR DESCRIPTION
## What

Adds `yay -S agent-manager-bin` to the README install list and to the release notes footer.

## Why

[agent-manager-bin](https://aur.archlinux.org/packages/agent-manager-bin) is published and reachable, so the README can point at it. The `aurs:` block that generates it merged in #119; this is the documentation catching up now that the package exists.

## Verification

In an Arch container: `git clone https://aur.archlinux.org/agent-manager-bin.git`, `makepkg`, `pacman -U` on the result, and `agent-manager --version` prints `agent-manager 0.10.5`. makepkg validated both published sha256 sums as part of that build, and the package lays down `/usr/bin/agent-manager` plus the licence.