### PR TITLE
feat(ui): report chip temperatures in the Computer block

### DIFF
--- a/internal/sysstat/sysstat.go
+++ b/internal/sysstat/sysstat.go
@@ -221,7 +221,7 @@ func cachedTemps() tempReading {
 func classifyTemps(read []sensors.TemperatureStat) tempReading {
 	var reading tempReading
 	for _, sensor := range read {
-		if sensor.Temperature <= 0 {
+		if !plausibleTemp(sensor.Temperature) {
 			continue
 		}
 		key := strings.ToLower(sensor.SensorKey)
@@ -247,6 +247,14 @@ func classifyTemps(read []sensors.TemperatureStat) tempReading {
 		reading.soc, reading.socOK = 0, false
 	}
 	return reading
+}
+
+// plausibleTemp keeps a sensor that is reporting silicon rather than its own
+// absence: an unpopulated SMC key reads 0, a detached probe can read NaN or
+// an infinity, and a confused driver can report thousands of degrees. The
+// comparison also rejects NaN, which no ordering would have caught.
+func plausibleTemp(celsius float64) bool {
+	return celsius > 0 && celsius <= 150
 }
 
 func isGPUSensor(key string) bool {

--- a/internal/sysstat/sysstat.go
+++ b/internal/sysstat/sysstat.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/disk"
@@ -163,54 +165,96 @@ func usedPercent(used, total uint64) float64 {
 	return 100 * float64(used) / float64(total)
 }
 
-// sampleTemps categorizes hardware temperature sensors into CPU and GPU
-// readings. Sensor names differ by platform: Intel Macs expose SMC keys
-// (TC0D/TG0D), Linux exposes hwmon labels (coretemp/amdgpu), and Apple
-// Silicon exposes only unlabeled per-chiplet die temperatures. When no
-// CPU/GPU split is available (Apple Silicon), the hottest die temperature
-// is reported as a single SoC reading. Each category keeps the hottest
-// matching sensor.
+// tempRefresh paces the sensor read. On Apple Silicon each read builds an
+// IOKit HID client and costs ~57ms, so temperatures keep a cadence of their
+// own rather than riding every gauge sample.
+const tempRefresh = 5 * time.Second
+
+type tempReading struct {
+	cpu   float64
+	cpuOK bool
+	gpu   float64
+	gpuOK bool
+	soc   float64
+	socOK bool
+}
+
+var tempCache struct {
+	mu     sync.Mutex
+	filled bool
+	at     time.Time
+	last   tempReading
+}
+
 func sampleTemps(snap *Snapshot) {
-	temps, err := sensors.SensorsTemperatures()
-	if err != nil || len(temps) == 0 {
-		return
+	reading := cachedTemps()
+	snap.CPUTemp, snap.CPUTempOK = reading.cpu, reading.cpuOK
+	snap.GPUTemp, snap.GPUTempOK = reading.gpu, reading.gpuOK
+	snap.SoCTemp, snap.SoCTempOK = reading.soc, reading.socOK
+}
+
+func cachedTemps() tempReading {
+	tempCache.mu.Lock()
+	defer tempCache.mu.Unlock()
+	if tempCache.filled && time.Since(tempCache.at) < tempRefresh {
+		return tempCache.last
 	}
-	var cpu, gpu, die float64
-	for _, sensor := range temps {
+	// Linux returns the sensors it could read alongside a warning for the
+	// ones it could not, so a non-nil error still carries usable readings.
+	read, err := sensors.SensorsTemperatures()
+	if len(read) == 0 && err != nil {
+		return tempReading{}
+	}
+	tempCache.last = classifyTemps(read)
+	tempCache.at = time.Now()
+	tempCache.filled = true
+	return tempCache.last
+}
+
+// classifyTemps sorts hardware sensors into CPU and GPU readings. Names
+// differ by platform: Intel Macs expose SMC keys (TC0D/TG0D), Linux joins
+// the hwmon driver to its label (coretemp_core_0, k10temp_tctl, amdgpu_edge)
+// or names a thermal zone by type (cpu-thermal, x86_pkg_temp), and Apple
+// Silicon exposes only unlabeled per-chiplet die temperatures. When no
+// CPU/GPU split is available, the hottest die is reported as a single SoC
+// reading. Each category keeps its hottest sensor.
+func classifyTemps(read []sensors.TemperatureStat) tempReading {
+	var reading tempReading
+	for _, sensor := range read {
 		if sensor.Temperature <= 0 {
 			continue
 		}
 		key := strings.ToLower(sensor.SensorKey)
 		switch {
 		case isGPUSensor(key):
-			if sensor.Temperature > gpu {
-				gpu = sensor.Temperature
+			if sensor.Temperature > reading.gpu {
+				reading.gpu = sensor.Temperature
 			}
-			snap.GPUTempOK = true
+			reading.gpuOK = true
 		case isCPUSensor(key):
-			if sensor.Temperature > cpu {
-				cpu = sensor.Temperature
+			if sensor.Temperature > reading.cpu {
+				reading.cpu = sensor.Temperature
 			}
-			snap.CPUTempOK = true
-		case strings.Contains(key, "tdie"):
-			if sensor.Temperature > die {
-				die = sensor.Temperature
+			reading.cpuOK = true
+		case isDieSensor(key):
+			if sensor.Temperature > reading.soc {
+				reading.soc = sensor.Temperature
 			}
+			reading.socOK = true
 		}
 	}
-	snap.CPUTemp = cpu
-	snap.GPUTemp = gpu
-	if !snap.CPUTempOK && !snap.GPUTempOK && die > 0 {
-		snap.SoCTemp = die
-		snap.SoCTempOK = true
+	if reading.cpuOK || reading.gpuOK {
+		reading.soc, reading.socOK = 0, false
 	}
+	return reading
 }
 
 func isGPUSensor(key string) bool {
 	return strings.Contains(key, "gpu") ||
 		strings.Contains(key, "tg0") ||
 		strings.Contains(key, "nvidia") ||
-		strings.Contains(key, "radeon")
+		strings.Contains(key, "radeon") ||
+		strings.Contains(key, "nouveau")
 }
 
 func isCPUSensor(key string) bool {
@@ -218,7 +262,18 @@ func isCPUSensor(key string) bool {
 		strings.Contains(key, "tc0") ||
 		strings.Contains(key, "coretemp") ||
 		strings.Contains(key, "k10temp") ||
-		strings.Contains(key, "package")
+		strings.Contains(key, "zenpower") ||
+		strings.Contains(key, "package") ||
+		strings.Contains(key, "pkg") ||
+		strings.Contains(key, "tctl") ||
+		strings.Contains(key, "tccd")
+}
+
+// isDieSensor matches the whole-chip readings a machine reports when it
+// draws no CPU/GPU line: Apple Silicon's per-chiplet dies and the SoC
+// thermal zones on ARM boards.
+func isDieSensor(key string) bool {
+	return strings.Contains(key, "tdie") || strings.Contains(key, "soc")
 }
 
 // LogicalCPUs is the number of logical processors used as the denominator

--- a/internal/sysstat/sysstat_test.go
+++ b/internal/sysstat/sysstat_test.go
@@ -161,6 +161,23 @@ func TestClassifyTemps(t *testing.T) {
 			want: tempReading{},
 		},
 		{
+			name: "a sensor reporting its own absence is not a reading",
+			read: []sensors.TemperatureStat{
+				{SensorKey: "coretemp_core_0", Temperature: math.NaN()},
+				{SensorKey: "amdgpu_edge", Temperature: math.Inf(1)},
+				{SensorKey: "k10temp_tctl", Temperature: 3276.7},
+			},
+			want: tempReading{},
+		},
+		{
+			name: "a live sensor outlives its broken neighbours",
+			read: []sensors.TemperatureStat{
+				{SensorKey: "coretemp_core_0", Temperature: math.NaN()},
+				{SensorKey: "coretemp_package_id_0", Temperature: 58},
+			},
+			want: tempReading{cpu: 58, cpuOK: true},
+		},
+		{
 			name: "no sensors at all",
 			read: nil,
 			want: tempReading{},

--- a/internal/sysstat/sysstat_test.go
+++ b/internal/sysstat/sysstat_test.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"runtime"
 	"testing"
+
+	"github.com/shirou/gopsutil/v4/sensors"
 )
 
 func TestSample(t *testing.T) {
@@ -79,6 +81,97 @@ func TestSensorCategories(t *testing.T) {
 		if isCPUSensor(key) || isGPUSensor(key) {
 			t.Fatalf("apple silicon die key %q should be neither cpu nor gpu", key)
 		}
+	}
+}
+
+// TestClassifyTemps walks the sensor names each platform actually reports:
+// Apple Silicon dies, Intel Mac SMC keys, and the hwmon and thermal-zone
+// names Linux builds from its drivers.
+func TestClassifyTemps(t *testing.T) {
+	cases := []struct {
+		name string
+		read []sensors.TemperatureStat
+		want tempReading
+	}{
+		{
+			name: "apple silicon dies fold into one soc reading",
+			read: []sensors.TemperatureStat{
+				{SensorKey: "PMU tdie1", Temperature: 60.4},
+				{SensorKey: "PMU2 tdie8", Temperature: 50.7},
+				{SensorKey: "gas gauge battery", Temperature: 27.8},
+				{SensorKey: "NAND CH0 temp", Temperature: 42},
+			},
+			want: tempReading{soc: 60.4, socOK: true},
+		},
+		{
+			name: "intel mac smc keys split cpu and gpu",
+			read: []sensors.TemperatureStat{
+				{SensorKey: "TC0D", Temperature: 61},
+				{SensorKey: "TG0D", Temperature: 55},
+			},
+			want: tempReading{cpu: 61, cpuOK: true, gpu: 55, gpuOK: true},
+		},
+		{
+			name: "intel linux keeps the package over its cores",
+			read: []sensors.TemperatureStat{
+				{SensorKey: "coretemp_package_id_0", Temperature: 58},
+				{SensorKey: "coretemp_core_0", Temperature: 54},
+				{SensorKey: "nvme_composite", Temperature: 47},
+				{SensorKey: "iwlwifi_1", Temperature: 40},
+			},
+			want: tempReading{cpu: 58, cpuOK: true},
+		},
+		{
+			name: "amd names the cpu tctl and the gpu amdgpu",
+			read: []sensors.TemperatureStat{
+				{SensorKey: "k10temp_tctl", Temperature: 64},
+				{SensorKey: "k10temp_tccd1", Temperature: 59},
+				{SensorKey: "amdgpu_edge", Temperature: 49},
+			},
+			want: tempReading{cpu: 64, cpuOK: true, gpu: 49, gpuOK: true},
+		},
+		{
+			name: "zenpower tdie is a cpu, not a bare die",
+			read: []sensors.TemperatureStat{
+				{SensorKey: "zenpower_tdie", Temperature: 66},
+			},
+			want: tempReading{cpu: 66, cpuOK: true},
+		},
+		{
+			name: "thermal zones name the chip by type",
+			read: []sensors.TemperatureStat{
+				{SensorKey: "cpu-thermal", Temperature: 52},
+				{SensorKey: "x86_pkg_temp", Temperature: 57},
+			},
+			want: tempReading{cpu: 57, cpuOK: true},
+		},
+		{
+			name: "an soc thermal zone alone reads as the soc",
+			read: []sensors.TemperatureStat{
+				{SensorKey: "soc-thermal", Temperature: 48},
+			},
+			want: tempReading{soc: 48, socOK: true},
+		},
+		{
+			name: "zeroed and unknown sensors report nothing",
+			read: []sensors.TemperatureStat{
+				{SensorKey: "coretemp_core_0", Temperature: 0},
+				{SensorKey: "acpitz", Temperature: 27.8},
+			},
+			want: tempReading{},
+		},
+		{
+			name: "no sensors at all",
+			read: nil,
+			want: tempReading{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyTemps(tc.read); got != tc.want {
+				t.Fatalf("classifyTemps() = %+v, want %+v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/sysstat/temps_linux_test.go
+++ b/internal/sysstat/temps_linux_test.go
@@ -1,0 +1,121 @@
+//go:build linux
+
+package sysstat
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/sensors"
+)
+
+// TestReadTempsFromSysfs runs the real Linux sensor reader over a sysfs tree
+// we lay out ourselves, so the hwmon and thermal-zone shapes a machine can
+// present are checked end to end rather than from their names alone.
+func TestReadTempsFromSysfs(t *testing.T) {
+	cases := []struct {
+		name  string
+		hwmon []hwmonChip
+		zones []thermalZone
+		want  tempReading
+	}{
+		{
+			name: "intel laptop with a coretemp package and an nvme",
+			hwmon: []hwmonChip{
+				{driver: "coretemp", sensors: []hwmonSensor{
+					{label: "Package id 0", milliC: 58000},
+					{label: "Core 0", milliC: 54000},
+				}},
+				{driver: "nvme", sensors: []hwmonSensor{{label: "Composite", milliC: 47000}}},
+			},
+			want: tempReading{cpu: 58, cpuOK: true},
+		},
+		{
+			name: "amd desktop with a discrete radeon",
+			hwmon: []hwmonChip{
+				{driver: "k10temp", sensors: []hwmonSensor{
+					{label: "Tctl", milliC: 64000},
+					{label: "Tccd1", milliC: 59000},
+				}},
+				{driver: "amdgpu", sensors: []hwmonSensor{{label: "edge", milliC: 49000}}},
+			},
+			want: tempReading{cpu: 64, cpuOK: true, gpu: 49, gpuOK: true},
+		},
+		{
+			name:  "a board with no hwmon falls back to its thermal zones",
+			zones: []thermalZone{{kind: "cpu-thermal", milliC: 52000}},
+			want:  tempReading{cpu: 52, cpuOK: true},
+		},
+		{
+			name:  "an soc thermal zone reads as the whole chip",
+			zones: []thermalZone{{kind: "soc-thermal", milliC: 48000}},
+			want:  tempReading{soc: 48, socOK: true},
+		},
+		{
+			name: "a kernel with no sensor files reports nothing",
+			want: tempReading{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOST_SYS", writeSysfs(t, tc.hwmon, tc.zones))
+			read, err := sensors.SensorsTemperatures()
+			if err != nil && len(read) == 0 && (len(tc.hwmon) > 0 || len(tc.zones) > 0) {
+				t.Fatalf("reading sensors: %v", err)
+			}
+			if got := classifyTemps(read); got != tc.want {
+				t.Fatalf("classifyTemps() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+type hwmonSensor struct {
+	label  string
+	milliC int
+}
+
+type hwmonChip struct {
+	driver  string
+	sensors []hwmonSensor
+}
+
+type thermalZone struct {
+	kind   string
+	milliC int
+}
+
+func writeSysfs(t *testing.T, chips []hwmonChip, zones []thermalZone) string {
+	t.Helper()
+	root := t.TempDir()
+	for i, chip := range chips {
+		dir := filepath.Join(root, "class", "hwmon", "hwmon"+strconv.Itoa(i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("creating hwmon dir: %v", err)
+		}
+		writeSysfsFile(t, filepath.Join(dir, "name"), chip.driver)
+		for j, sensor := range chip.sensors {
+			prefix := filepath.Join(dir, "temp"+strconv.Itoa(j+1))
+			writeSysfsFile(t, prefix+"_label", sensor.label)
+			writeSysfsFile(t, prefix+"_input", strconv.Itoa(sensor.milliC))
+		}
+	}
+	for i, zone := range zones {
+		dir := filepath.Join(root, "class", "thermal", "thermal_zone"+strconv.Itoa(i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("creating thermal zone dir: %v", err)
+		}
+		writeSysfsFile(t, filepath.Join(dir, "type"), zone.kind)
+		writeSysfsFile(t, filepath.Join(dir, "temp"), strconv.Itoa(zone.milliC))
+	}
+	return root
+}
+
+func writeSysfsFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content+"\n"), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/sysstat"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -387,12 +388,35 @@ func (m *Model) computerLines(width int) []string {
 	} else {
 		lines = append(lines, meter("disk", 0, false, ""))
 	}
+	if temps := tempReadings(snap); temps != "" {
+		lines = append(lines, pad+labelStyle.Width(5).Render("temp")+temps)
+	}
 	if m.netRates {
 		lines = append(lines, pad+labelStyle.Width(5).Render("net")+
 			valueStyle.Render("↓ "+humanBytes(m.netDown)+"/s")+
 			subtleStyle.Render("  ↑ "+humanBytes(m.netUp)+"/s"))
 	}
 	return append(lines, "")
+}
+
+// tempReadings writes whichever chip temperatures the machine exposes:
+// a cpu/gpu pair where the hardware draws that line, one soc figure where
+// it reports the whole chip, and nothing where it reports neither.
+func tempReadings(snap sysstat.Snapshot) string {
+	var parts []string
+	if snap.CPUTempOK {
+		parts = append(parts, fmt.Sprintf("cpu %.0f°C", snap.CPUTemp))
+	}
+	if snap.GPUTempOK {
+		parts = append(parts, fmt.Sprintf("gpu %.0f°C", snap.GPUTemp))
+	}
+	if snap.SoCTempOK {
+		parts = append(parts, fmt.Sprintf("soc %.0f°C", snap.SoCTemp))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return valueStyle.Render(strings.Join(parts, subtleStyle.Render("  ")))
 }
 
 // contentLines is the right column: what the cursor is on, then its live

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -405,18 +405,15 @@ func (m *Model) computerLines(width int) []string {
 func tempReadings(snap sysstat.Snapshot) string {
 	var parts []string
 	if snap.CPUTempOK {
-		parts = append(parts, fmt.Sprintf("cpu %.0f°C", snap.CPUTemp))
+		parts = append(parts, valueStyle.Render(fmt.Sprintf("cpu %.0f°C", snap.CPUTemp)))
 	}
 	if snap.GPUTempOK {
-		parts = append(parts, fmt.Sprintf("gpu %.0f°C", snap.GPUTemp))
+		parts = append(parts, valueStyle.Render(fmt.Sprintf("gpu %.0f°C", snap.GPUTemp)))
 	}
 	if snap.SoCTempOK {
-		parts = append(parts, fmt.Sprintf("soc %.0f°C", snap.SoCTemp))
+		parts = append(parts, valueStyle.Render(fmt.Sprintf("soc %.0f°C", snap.SoCTemp)))
 	}
-	if len(parts) == 0 {
-		return ""
-	}
-	return valueStyle.Render(strings.Join(parts, subtleStyle.Render("  ")))
+	return strings.Join(parts, subtleStyle.Render("  "))
 }
 
 // contentLines is the right column: what the cursor is on, then its live

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/sysstat"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The computer block reports whichever temperatures the machine exposes:
+// a cpu/gpu pair where the hardware draws that line, a single soc figure
+// on a chip that does not, and no temp row at all where nothing is read.
+func TestComputerLinesTemperatures(t *testing.T) {
+	cases := []struct {
+		name string
+		snap sysstat.Snapshot
+		want string
+	}{
+		{
+			name: "cpu and gpu",
+			snap: sysstat.Snapshot{CPUTempOK: true, CPUTemp: 61, GPUTempOK: true, GPUTemp: 55},
+			want: "temp cpu 61°C gpu 55°C",
+		},
+		{
+			name: "soc alone",
+			snap: sysstat.Snapshot{SoCTempOK: true, SoCTemp: 60.4},
+			want: "temp soc 60°C",
+		},
+		{
+			name: "no sensors",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Model{width: 120, height: 34, snap: tc.snap}
+			var temp string
+			for _, line := range m.computerLines(40) {
+				plain := strings.TrimSpace(ansi.Strip(line))
+				if strings.HasPrefix(plain, "temp") {
+					temp = strings.Join(strings.Fields(plain), " ")
+				}
+			}
+			if tc.want == "" {
+				if temp != "" {
+					t.Fatalf("expected no temp row, got %q", temp)
+				}
+				return
+			}
+			if temp != tc.want {
+				t.Fatalf("temp row = %q, want %q", temp, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -54,3 +54,30 @@ func TestComputerLinesTemperatures(t *testing.T) {
 		})
 	}
 }
+
+// A reading after the first sits behind the separator's own reset, so each
+// one carries its color rather than inheriting one from the reading before.
+func TestTemperatureReadingsEachKeepTheirColor(t *testing.T) {
+	forceANSI256(t)
+
+	row := tempReadings(sysstat.Snapshot{CPUTempOK: true, CPUTemp: 61, GPUTempOK: true, GPUTemp: 55})
+	want := sgrOf(valueStyle.Render("x"))
+	for _, reading := range []string{"cpu 61°C", "gpu 55°C"} {
+		before, _, found := strings.Cut(row, reading)
+		if !found {
+			t.Fatalf("row %q is missing %q", row, reading)
+		}
+		if got := lastSGR(before); got != want {
+			t.Fatalf("%q renders under %q, want %q", reading, got, want)
+		}
+	}
+}
+
+func lastSGR(s string) string {
+	idx := strings.LastIndex(s, "\x1b[")
+	if idx < 0 {
+		return ""
+	}
+	code, _, _ := strings.Cut(s[idx+2:], "m")
+	return code
+}


### PR DESCRIPTION
The rail's machine block ends with a temp row again: `cpu 61°C  gpu 55°C` where the hardware draws that line, `soc 67°C` where the chip reports itself whole. A machine with no readable sensor keeps the block exactly as it is today.

## What changed

- **Render.** `computerLines` writes the temp row under disk, in the same shape as the net row.
- **Naming coverage.** The classifier now reads AMD's `tctl`/`tccd`, `zenpower_tdie` as a CPU rather than a bare die, `x86_pkg_temp`, the `cpu-thermal` and `soc-thermal` zones an ARM board exposes, and `nouveau` beside the existing `amdgpu`/`nvidia` keys. Storage, wireless and battery sensors stay out, so a warm NVMe is never printed as a warm CPU.
- **Linux partial reads.** Linux returns the sensors it could read alongside a warning for the ones it could not. Those readings are now kept.
- **Cadence.** Each read builds an IOKit HID client on Apple Silicon and costs ~57ms, so a reading is reused for 5s. With gauges sampling every 4s that lands on a sensor read every 8s, measured from a running build: `21:34:39.520`, `:47.531`, `:55.553`, `21:35:03.531`, `:11.537`. Roughly 0.7% of one core, and the read already ran on every gauge sample before this change.

## Verification

- Live on Apple Silicon (macOS, `CGO_ENABLED` off): `temp soc 54°C` in the rail.
- The reading tracks real heat. Sampled every 3s across idle → load → idle: 52.5°C idle, rising to 78.3°C after 24s of full load, back to 55.1°C once the load stopped. The heatsink-side `tdev` sensors peak three seconds behind the dies, as they should.
- Hottest die is the figure shown. At idle the 16 dies span 52.6–60.9°C, so it reads ~4°C above their mean — worst case is what throttles.
- The Linux reader runs for real in `TestReadTempsFromSysfs` over a sysfs tree the test lays out: Intel `coretemp` beside an NVMe, AMD `k10temp` with a discrete GPU, a thermal-zone-only board, an SoC zone, and a kernel with no sensor files at all. It is linux-tagged, so CI exercises it on every push.
- `TestClassifyTemps` covers the names each platform reports, including the Apple Silicon dies read off this machine.
- `go test ./...` green.

Intel Macs are covered by code path only — gopsutil polls a fixed SMC key list (`TC0D`/`TC0H`/`TC0P`, `TG0D`/`TG0H`/`TG0P`) with no cgo, and the matchers cover those keys — but there was no Intel machine here to run it on. Same for WSL, which takes the Linux path and shows a reading only where that kernel exposes thermal zones.