### PR TITLE
fix: report the real version for go install builds

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
+	"strconv"
 	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/config"
@@ -17,9 +19,37 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-var version = "dev"
+const devVersion = "dev"
+
+var version = devVersion
+
+// resolveVersion falls back to the module version so `go install` builds, which
+// carry no ldflags, report the tag they came from. Pseudo-versions stay "dev":
+// they name a commit rather than a release, and the update check compares
+// against release tags.
+func resolveVersion(embedded string, info *debug.BuildInfo, ok bool) string {
+	if embedded != devVersion {
+		return embedded
+	}
+	if !ok || info == nil {
+		return devVersion
+	}
+	moduleVersion := strings.TrimPrefix(info.Main.Version, "v")
+	if strings.ContainsAny(moduleVersion, "-+") || strings.Count(moduleVersion, ".") != 2 {
+		return devVersion
+	}
+	for _, field := range strings.Split(moduleVersion, ".") {
+		if _, err := strconv.Atoi(field); err != nil {
+			return devVersion
+		}
+	}
+	return moduleVersion
+}
 
 func main() {
+	info, hasInfo := debug.ReadBuildInfo()
+	version = resolveVersion(version, info, hasInfo)
+
 	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
 		fmt.Println("agent-manager", version)
 		return

--- a/main_test.go
+++ b/main_test.go
@@ -4,11 +4,43 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 
 	"github.com/YoanWai/agent-manager/internal/hooks"
 )
+
+func TestResolveVersion(t *testing.T) {
+	cases := []struct {
+		label         string
+		embedded      string
+		moduleVersion string
+		hasInfo       bool
+		want          string
+	}{
+		{"ldflags win", "0.11.0", "v0.11.0", true, "0.11.0"},
+		{"ldflags win over missing info", "0.11.0", "", false, "0.11.0"},
+		{"go install at a tag", devVersion, "v0.11.0", true, "0.11.0"},
+		{"pseudo-version", devVersion, "v0.10.6-0.20260730153639-3b5b8a9a5649", true, devVersion},
+		{"go run", devVersion, "(devel)", true, devVersion},
+		{"empty module version", devVersion, "", true, devVersion},
+		{"no build info", devVersion, "", false, devVersion},
+		{"two components", devVersion, "v0.11", true, devVersion},
+		{"non-numeric", devVersion, "vX.Y.Z", true, devVersion},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			var info *debug.BuildInfo
+			if tc.hasInfo {
+				info = &debug.BuildInfo{Main: debug.Module{Version: tc.moduleVersion}}
+			}
+			if got := resolveVersion(tc.embedded, info, tc.hasInfo); got != tc.want {
+				t.Fatalf("resolveVersion(%q, %q) = %q, want %q", tc.embedded, tc.moduleVersion, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestRunRenameWritesNameFile(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## What

`main` now falls back to the module version recorded in the build info when no ldflags version was baked in. Pseudo-versions and `(devel)` keep reporting `dev`.

## Why

`var version = "dev"` was only ever overwritten by goreleaser's `-X main.version=`, so a `go install github.com/YoanWai/agent-manager@v0.11.0` binary reported `agent-manager dev`. That also silenced the update badge for those users: `parseVersion` needs three numeric parts, so `dev` is treated as un-comparable and never compared against a release.

Pseudo-versions like `v0.10.6-0.20260730153639-3b5b8a9a5649` name a commit rather than a release, so they stay `dev` and a source build keeps describing itself as one.

## Verification

- Before: `GOBIN=/tmp/x go install github.com/YoanWai/agent-manager@v0.11.0` then `--version` printed `agent-manager dev`, while `go version -m` on the same binary showed `mod ... v0.11.0`.
- After: the same install against a local mirror of this branch tagged `v0.99.1` prints `agent-manager 0.99.1`.
- A plain `go build` of this branch still prints `agent-manager dev`, which is the pseudo-version path running against real build info.
- `TestResolveVersion` covers ldflags precedence, a clean tag, pseudo-versions, `(devel)`, absent build info, and malformed versions. Full suite passes.