### PR TITLE
docs: rebuild the README badge row on the app's own palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 <p align="center"><b>Run every AI coding agent from one terminal.</b></p>
 
 <p align="center">
-  <a href="https://github.com/YoanWai/agent-manager/stargazers"><img src="https://img.shields.io/github/stars/YoanWai/agent-manager?style=flat-square&logo=github&logoColor=c6ccd6&label=stars&color=d08442&labelColor=0f1115" alt="GitHub stars"></a>
-  <a href="https://github.com/YoanWai/agent-manager/releases"><img src="https://img.shields.io/github/downloads/YoanWai/agent-manager/total?style=flat-square&logo=github&logoColor=c6ccd6&label=downloads&color=6cb6a4&labelColor=0f1115" alt="Release downloads"></a>
-  <a href="https://github.com/YoanWai/agent-manager/releases/latest"><img src="https://img.shields.io/github/v/release/YoanWai/agent-manager?style=flat-square&label=release&color=6f9fd0&labelColor=0f1115" alt="Latest release"></a>
+  <a href="https://github.com/YoanWai/agent-manager/stargazers"><img src="https://img.shields.io/github/stars/YoanWai/agent-manager?style=flat-square&logo=github&logoColor=white&color=d08442" alt="GitHub stars"></a>
+  <a href="https://github.com/YoanWai/agent-manager/releases"><img src="https://img.shields.io/github/downloads/YoanWai/agent-manager/total?style=flat-square&logo=github&logoColor=white&label=downloads&color=6cb6a4" alt="Release downloads"></a>
+  <a href="https://github.com/YoanWai/agent-manager/releases/latest"><img src="https://img.shields.io/github/v/release/YoanWai/agent-manager?style=flat-square&logo=github&logoColor=white&label=release&color=6f9fd0" alt="Latest release"></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/YoanWai/agent-manager/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/YoanWai/agent-manager/ci.yml?branch=main&style=flat-square&label=ci&color=85b26f&labelColor=0f1115" alt="CI status"></a>
-  <a href="go.mod"><img src="https://img.shields.io/github/go-mod/go-version/YoanWai/agent-manager?style=flat-square&logo=go&logoColor=c6ccd6&label=go&color=a78bd0&labelColor=0f1115" alt="Go version"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/YoanWai/agent-manager?style=flat-square&label=license&color=646c78&labelColor=0f1115" alt="License"></a>
-  <a href="#install"><img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20WSL2-646c78?style=flat-square&labelColor=0f1115" alt="Platforms"></a>
+  <a href="https://github.com/YoanWai/agent-manager/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/YoanWai/agent-manager/ci.yml?branch=main&style=flat-square&label=ci&color=85b26f" alt="CI status"></a>
+  <a href="go.mod"><img src="https://img.shields.io/github/go-mod/go-version/YoanWai/agent-manager?style=flat-square&logo=go&logoColor=white&label=go&color=a78bd0" alt="Go version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/YoanWai/agent-manager?style=flat-square&color=646c78" alt="License"></a>
+  <a href="#install"><img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20WSL2-646c78?style=flat-square" alt="Platforms"></a>
 </p>
 
 ![agent-manager demo](docs/demo.gif)
@@ -52,6 +52,8 @@ Downloads the latest release for your platform, verifies it against the publishe
 ```bash
 yay -S agent-manager-bin
 ```
+
+[![AUR version](https://img.shields.io/aur/version/agent-manager-bin?style=flat-square&logo=archlinux&logoColor=white&label=aur&color=6f9fd0)](https://aur.archlinux.org/packages/agent-manager-bin)
 
 [agent-manager-bin](https://aur.archlinux.org/packages/agent-manager-bin) in the AUR installs the released binary and pulls in tmux and git.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,16 @@
 <p align="center"><b>Run every AI coding agent from one terminal.</b></p>
 
 <p align="center">
-  <a href="https://github.com/YoanWai/agent-manager/actions/workflows/ci.yml"><img src="https://github.com/YoanWai/agent-manager/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/YoanWai/agent-manager/releases/latest"><img src="https://img.shields.io/github/v/release/YoanWai/agent-manager?label=release" alt="Release"></a>
-  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux-blue" alt="Platforms">
-  <a href="go.mod"><img src="https://img.shields.io/github/go-mod/go-version/YoanWai/agent-manager" alt="Go version"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/YoanWai/agent-manager" alt="License"></a>
+  <a href="https://github.com/YoanWai/agent-manager/stargazers"><img src="https://img.shields.io/github/stars/YoanWai/agent-manager?style=flat-square&logo=github&logoColor=c6ccd6&label=stars&color=d08442&labelColor=0f1115" alt="GitHub stars"></a>
+  <a href="https://github.com/YoanWai/agent-manager/releases"><img src="https://img.shields.io/github/downloads/YoanWai/agent-manager/total?style=flat-square&logo=github&logoColor=c6ccd6&label=downloads&color=6cb6a4&labelColor=0f1115" alt="Release downloads"></a>
+  <a href="https://github.com/YoanWai/agent-manager/releases/latest"><img src="https://img.shields.io/github/v/release/YoanWai/agent-manager?style=flat-square&label=release&color=6f9fd0&labelColor=0f1115" alt="Latest release"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/YoanWai/agent-manager/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/YoanWai/agent-manager/ci.yml?branch=main&style=flat-square&label=ci&color=85b26f&labelColor=0f1115" alt="CI status"></a>
+  <a href="go.mod"><img src="https://img.shields.io/github/go-mod/go-version/YoanWai/agent-manager?style=flat-square&logo=go&logoColor=c6ccd6&label=go&color=a78bd0&labelColor=0f1115" alt="Go version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/YoanWai/agent-manager?style=flat-square&label=license&color=646c78&labelColor=0f1115" alt="License"></a>
+  <a href="#install"><img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20WSL2-646c78?style=flat-square&labelColor=0f1115" alt="Platforms"></a>
 </p>
 
 ![agent-manager demo](docs/demo.gif)


### PR DESCRIPTION
## What changed

The badge row becomes two grouped rows of chips.

**Row one, the numbers a visitor reads first:** stars, total release downloads, latest release.
**Row two, project facts:** CI status, Go version, license, platforms.

The style follows what the neighbouring terminal tools already do: `flat-square`, a brand logo where one exists, `logoColor=white`, and one distinct colour per chip. Colours come from the app's own `classic` theme, so the header matches what you see on launch: amber `#d08442` for stars, teal `#6cb6a4` for downloads, blue `#6f9fd0` for release, green `#85b26f` for CI, purple `#a78bd0` for Go, and the theme's `subtle` grey `#646c78` for license and platform. Keeping CI green carries meaning the colour would otherwise waste.

Two chips are new: **stars** and **downloads**. The download count is a fair proxy for installs, since Homebrew, the install script, the AUR package, and mise all pull the release asset from GitHub; only `go install` builds from source.

Two are more correct than before: CI now reads through shields with a `branch=main` filter, so it reports main rather than whatever ran last and it matches the row's height; platform now names WSL2, which the Windows install section already documents.

The Arch section gains an AUR version chip, so an Arch reader can see at a glance that the package tracks the current release rather than trusting the install line.

Every chip links somewhere useful: stars to stargazers, downloads and release to the releases pages, CI to the workflow, Go to `go.mod`, license to `LICENSE`, platform to the install section, AUR to the package page.

## Why

The old row was five default-grey shields in mixed styles, one of them GitHub's own workflow SVG, which renders at a different height than the rest. It carried no stars and no downloads, the two numbers a visitor reads first.

## How it was verified

Surveyed how the closest projects style their headers (lazygit, gitui, k9s, zellij, atuin, bubbletea, bat, zoxide) and followed the majority idiom: `flat-square` with per-badge logos and colours.

Fetched every shields URL in the file and read the value out of each SVG:

```
stars      160
downloads  176
release    v0.11.1
ci         passing
go         v1.26.5
license    MIT
platform   macOS | Linux | WSL2
aur        v0.11.1-1
```

Rendered four candidate header styles in a browser against `#ffffff` and `#0d1117`, GitHub's light and dark page backgrounds, and screenshotted both to compare contrast and check that no two adjacent chips share a hue.

Repology and Go Report Card chips were considered and left out: Repology tracks only the AUR entry and lags a release behind, and Go Report Card is retired.

- [x] `gofmt -l .` prints nothing (no Go changed)
- [x] `go vet ./...` passes (no Go changed)
- [x] `go test -race ./...` passes (no Go changed)
- [ ] Ran it against real sessions (docs-only change)
