### PR TITLE
feat: support Gemini CLI as a built-in tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ![agent-manager demo](docs/demo.gif)
 
-Claude Code, Codex, OpenCode, and Grok run side by side, each in its own tmux session, so they keep working after you quit the manager.
+Claude Code, Codex, OpenCode, Grok, and Gemini CLI run side by side, each in its own tmux session, so they keep working after you quit the manager.
 
 Instead of hunting through terminal tabs to see which agent is done and which is stuck, every session shows up in one list with live status, grouped into a project tree you can fold and reorder. You answer any of them without attaching: `space` sends a prompt straight into a session's pane, or spawns a new agent in the selected group. A dead session revives on its own conversation with `v`. And `ctrl+r` opens a full-file diff of what an agent changed, syntax-highlighted, where the comments you leave on lines go back to the agent's pane as one review prompt when you press `C`.
 
@@ -22,7 +22,7 @@ Not here yet: worktree creation, cost tracking, mouse-driven navigation, and age
 
 ## Supported tools
 
-Status detection currently supports **Claude Code**, **OpenCode**, **Codex**, and **Grok Build** out of the box. Any other CLI tool can run as a session; add a `[tools.<name>]` block with status rules to get live status for it (see [Configuration](#configuration)).
+Status detection currently supports **Claude Code**, **OpenCode**, **Codex**, **Grok Build**, and **Gemini CLI** out of the box. Any other CLI tool can run as a session; add a `[tools.<name>]` block with status rules to get live status for it (see [Configuration](#configuration)).
 
 ## Install
 
@@ -139,7 +139,7 @@ Press `space` to dock a prompt bar at the bottom of the sidebar. The target foll
 
 `x` ends a session that is holding RAM you want back, and on a group row it ends every live session under it; `X` ends every live session in view. Each asks to confirm first, and what it ends is the tmux session, not the record: the row stays in the tree, marked `dead`, with its name, group, and conversation id intact.
 
-`v` relaunches a dead session under its old id, keeping its name, group, and history. When the manager holds that session's own conversation id, revive resumes **that exact conversation** through the tool's `resume_by_id_command`: `claude --resume {id}`, `codex resume {id}`, `opencode --session {id}`, `grok --resume {id}`.
+`v` relaunches a dead session under its old id, keeping its name, group, and history. When the manager holds that session's own conversation id, revive resumes **that exact conversation** through the tool's `resume_by_id_command`: `claude --resume {id}`, `codex resume {id}`, `opencode --session {id}`, `grok --resume {id}`, `gemini --resume {id}`.
 
 The id arrives one of two ways: tools with a `session_id_flag` launch under an id the manager mints, and tools that mint their own are read back by a `session_store` capturer (`codex`, `opencode`). Without an id, revive falls back to `revive_command` (`claude --continue`), which resumes the working directory's most recent conversation, and the manager says so in the status line, since sessions sharing a directory would otherwise land on the wrong one. On a group row `v` revives every dead session under it, and `V` revives every dead session in view; both revive what they can and name the first failure rather than stopping.
 
@@ -161,7 +161,7 @@ Agents usually work in git worktrees, one branch per worktree, and those worktre
 
 Every session the manager spawns or revives carries the agent-manager MCP server, so MCP-capable agents see `rename`, `review_repo`, `review_base` and `review_mode` (which sets the diff scope review opens on) as native tools with descriptions telling them when to call each: no prompt injection, no per-project setup. The server lives in the same binary (`agent-manager mcp`, stdio) and identifies the calling session through its environment.
 
-Registration is per tool. The built-in claude, codex, opencode and grok tools register automatically: claude gets a generated `--mcp-config` file, codex gets `-c mcp_servers...` overrides, opencode gets an `OPENCODE_CONFIG` merge file, and grok gets a one-time `grok mcp add --scope user` entry on its first launch. A custom tool opts in with `mcp = "<style>"` in its config section, or out with `mcp = "none"`. The `rename`, `review-repo` and `review-base` CLI subcommands keep working everywhere, MCP or not.
+Registration is per tool. The built-in claude, codex, opencode, grok and gemini tools register automatically: claude gets a generated `--mcp-config` file, codex gets `-c mcp_servers...` overrides, opencode gets an `OPENCODE_CONFIG` merge file, and grok and gemini each get a one-time `mcp add --scope user` entry on their first launch. A custom tool opts in with `mcp = "<style>"` in its config section, or out with `mcp = "none"`. The `rename`, `review-repo` and `review-base` CLI subcommands keep working everywhere, MCP or not.
 
 ### Diff review
 
@@ -263,7 +263,7 @@ Rules match top-down against the visible pane text; first match wins, and `defau
 
 **Prompts.** `prompt_flag` controls how the new-session form's optional prompt is embedded into the launch command. Tools that take the prompt as a positional argument (Claude Code: `claude 'the prompt'`) leave it empty; tools whose positional argument means something else declare the flag (OpenCode: `prompt_flag = "--prompt"`, since its positional argument is the project path). The prompt only shapes the launch command; revive (`v`) uses the revive commands untouched.
 
-**MCP.** `mcp = "claude" | "codex" | "opencode" | "grok" | "none"` picks how the agent-manager MCP server is registered into the tool's sessions (see [MCP](#mcp-how-agents-discover-these-commands)). An empty value uses the tool's config key when it names a known style.
+**MCP.** `mcp = "claude" | "codex" | "opencode" | "grok" | "gemini" | "none"` picks how the agent-manager MCP server is registered into the tool's sessions (see [MCP](#mcp-how-agents-discover-these-commands)). An empty value uses the tool's config key when it names a known style.
 
 State is stored next to the config in `state.db` (SQLite).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,7 +30,8 @@ type Tool struct {
 	// minted itself when it has no SessionIDFlag ("codex" or "opencode").
 	SessionStore string `toml:"session_store"`
 	// MCP picks how the agent-manager MCP server is registered into this
-	// tool's sessions: "claude", "codex", "opencode", "grok" or "none".
+	// tool's sessions: "claude", "codex", "opencode", "grok", "gemini" or
+	// "none".
 	// Empty uses the tool's config key when it names a known style.
 	MCP            string `toml:"mcp"`
 	StatusSource   string `toml:"status_source"`
@@ -317,5 +318,34 @@ rules = [
   # ("⠹ Delete file… 2.5s"). A pending approval freezes it to a ◆ glyph.
   { state = "working", pattern = "(?m)[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] .*… \\d" },
   { state = "errored", pattern = "(?im)^\\s*error:" },
+]
+
+[tools.gemini]
+command = "gemini"
+# revive (v) launches a new session with this id, so it can later resume
+# that exact conversation regardless of what else ran in the directory
+session_id_flag = "--session-id"
+resume_by_id_command = "gemini --resume {id}"
+# fallback when a session predates id tracking: resumes the project's most
+# recent session
+revive_command = "gemini --resume latest"
+default_status = "idle"
+# the composer line: "> " normally, "! " in shell mode, "* " in yolo mode
+activity_cutoff = "(?m)^\\s*[>!*] "
+# box borders, the composer's ▄/▀ background rows, the right-aligned
+# "? for shortcuts" hint (its ? must not read as a question) and the
+# approval-mode banner ("Shift+Tab to accept edits", "auto-accept edits
+# shift+tab to manual", ...) are all chrome above the composer
+chrome_line = "^\\s*[╭╮╰╯│─▄▀█]*\\s*$|^\\s*\\? for shortcuts\\s*$|^\\s*press tab twice for more\\s*$|^\\s*Press Ctrl\\+O to show more lines.*$|(?i)^\\s*(auto-accept edits |plan |yolo )?\\S*tab\\S* to (accept edits|manual|plan|auto-accept edits)\\s*$"
+rules = [
+  # selected row of an approval/trust dialog, inside its bordered box:
+  # "│ ● 1. Allow once"
+  { state = "waiting", pattern = "(?m)^[\\s│]*●\\s*\\d+\\." },
+  # loading-line tip while a tool call blocks on the user's answer
+  { state = "waiting", pattern = "Waiting for user confirmation" },
+  # active turn status line: "(esc to cancel, 12s)"
+  { state = "working", pattern = "esc to cancel" },
+  # error messages render with a "✕ " prefix
+  { state = "errored", pattern = "(?m)^✕ " },
 ]
 `

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,6 +52,18 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if got := cfg.Tools["grok"].PromptFlag; got != "" {
 		t.Fatalf("grok prompt_flag = %q want empty (positional prompt)", got)
 	}
+	if _, ok := cfg.Tools["gemini"]; !ok {
+		t.Fatal("expected gemini tool in default config")
+	}
+	if cfg.Tools["gemini"].Command != "gemini" {
+		t.Fatalf("gemini command = %q", cfg.Tools["gemini"].Command)
+	}
+	if got := cfg.Tools["gemini"].ReviveCommand; got != "gemini --resume latest" {
+		t.Fatalf("gemini revive_command = %q want \"gemini --resume latest\"", got)
+	}
+	if got := cfg.Tools["gemini"].PromptFlag; got != "" {
+		t.Fatalf("gemini prompt_flag = %q want empty (positional prompt)", got)
+	}
 	if cfg.Tools["claude"].Command != "claude" {
 		t.Fatalf("claude command = %q", cfg.Tools["claude"].Command)
 	}
@@ -98,7 +110,7 @@ func TestDefaultResumeByIDFields(t *testing.T) {
 		t.Fatalf("Default: %v", err)
 	}
 	// Tools that accept a chosen id launch with it and resume by it.
-	for _, name := range []string{"claude", "grok"} {
+	for _, name := range []string{"claude", "grok", "gemini"} {
 		tool := cfg.Tools[name]
 		if tool.SessionIDFlag != "--session-id" {
 			t.Fatalf("%s session_id_flag = %q want --session-id", name, tool.SessionIDFlag)

--- a/internal/mcpreg/mcpreg.go
+++ b/internal/mcpreg/mcpreg.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/tmux"
@@ -24,6 +25,7 @@ var knownStyles = map[string]bool{
 	"codex":    true,
 	"opencode": true,
 	"grok":     true,
+	"gemini":   true,
 	"none":     true,
 }
 
@@ -74,6 +76,11 @@ func Apply(style, exe, hooksDir, command string, env map[string]string) (string,
 		return command, nil
 	case "grok":
 		if err := ensureGrokRegistered(exe, hooksDir); err != nil {
+			return "", err
+		}
+		return command, nil
+	case "gemini":
+		if err := ensureGeminiRegistered(exe, hooksDir); err != nil {
 			return "", err
 		}
 		return command, nil
@@ -133,21 +140,39 @@ func writeConfig(dir, name string, content []byte) (string, error) {
 }
 
 // ensureGrokRegistered adds the server to grok's user-scope config once
-// per binary path, via grok's own config writer. The marker file records
-// the registered path so upgrades that move the binary re-register.
-// The check-then-add window is benign: grok mcp add updates in place, so
-// two racing managers just write the same entry twice.
+// per binary path, via grok's own config writer.
 func ensureGrokRegistered(exe, hooksDir string) error {
-	marker := filepath.Join(hooksDir, "mcp-grok-registered")
-	if content, err := os.ReadFile(marker); err == nil && string(content) == exe {
-		return nil
-	}
 	cmd := exec.Command("grok", "mcp", "add",
 		"--scope", "user",
 		"-e", hooks.EnvSessionID+"=${"+hooks.EnvSessionID+"}",
 		serverName, "--", exe, "mcp")
+	return ensureRegisteredOnce("mcp-grok-registered", exe, hooksDir, cmd)
+}
+
+// ensureGeminiRegistered adds the server to gemini's user-scope
+// settings.json once per binary path, via gemini's own config writer.
+// Gemini expands ${VAR} in a server's env block at launch, so the entry
+// forwards the per-session id env var.
+func ensureGeminiRegistered(exe, hooksDir string) error {
+	cmd := exec.Command("gemini", "mcp", "add",
+		"--scope", "user",
+		"-e", hooks.EnvSessionID+"=${"+hooks.EnvSessionID+"}",
+		serverName, exe, "mcp")
+	return ensureRegisteredOnce("mcp-gemini-registered", exe, hooksDir, cmd)
+}
+
+// ensureRegisteredOnce runs a tool's own mcp-add command once per binary
+// path. The marker file records the registered path so upgrades that move
+// the binary re-register. The check-then-add window is benign: the add
+// commands update in place, so two racing managers just write the same
+// entry twice.
+func ensureRegisteredOnce(markerName, exe, hooksDir string, cmd *exec.Cmd) error {
+	marker := filepath.Join(hooksDir, markerName)
+	if content, err := os.ReadFile(marker); err == nil && string(content) == exe {
+		return nil
+	}
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("grok mcp add: %v: %s", err, out)
+		return fmt.Errorf("%s: %v: %s", strings.Join(cmd.Args[:3], " "), err, out)
 	}
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 		return err

--- a/internal/mcpreg/mcpreg_test.go
+++ b/internal/mcpreg/mcpreg_test.go
@@ -16,6 +16,7 @@ func TestStyleResolution(t *testing.T) {
 		{"codex", "", "codex"},
 		{"opencode", "", "opencode"},
 		{"grok", "", "grok"},
+		{"gemini", "", "gemini"},
 		{"aider", "", "none"},
 		{"my-claude", "claude", "claude"},
 		{"claude", "none", "none"},
@@ -116,6 +117,20 @@ func TestApplyGrokSkipsWhenMarkerMatches(t *testing.T) {
 		t.Fatal(err)
 	}
 	if command != "grok" {
+		t.Fatalf("command = %q", command)
+	}
+}
+
+func TestApplyGeminiSkipsWhenMarkerMatches(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "mcp-gemini-registered"), []byte("/opt/bin/agent-manager"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	command, err := Apply("gemini", "/opt/bin/agent-manager", dir, "gemini", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command != "gemini" {
 		t.Fatalf("command = %q", command)
 	}
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -224,6 +224,60 @@ func TestCodexRealPanes(t *testing.T) {
 	}
 }
 
+// Gemini fixtures: idle, the auth dialog, the usage-limit dialog and the
+// API-error frame are captured from real gemini v0.53.0 panes (2026-07-31);
+// the working spinner and tool-confirmation frames reconstruct that
+// version's rendering source ("(esc to cancel, Ns)" loading suffix,
+// "Waiting for user confirmation..." tip, RadioButtonSelect's "● N."
+// selected row).
+func TestGeminiPanes(t *testing.T) {
+	engine := defaultEngine(t)
+	cases := []struct {
+		name string
+		tool string
+		pane string
+		want string
+	}{
+		{"gemini idle at prompt", "gemini",
+			" Gemini CLI v0.53.0\nTips for getting started:\n1. Create GEMINI.md files to customize your interactions\n──────────────────────────────\n Shift+Tab to accept edits\n▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n >   Type your message or @path/to/file\n▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀\n workspace (/directory)   branch   sandbox   /model\n /Users/dev/proj          main     no sandbox     gemini-2.5-flash", Idle},
+		{"gemini active turn", "gemini",
+			" Press Ctrl+O to show more lines of the last response\n ⠧ Thinking... (esc to cancel, 4s)                        ? for shortcuts\n──────────────────────────────\n Shift+Tab to accept edits\n▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n >   Type your message or @path/to/file\n▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀", Working},
+		{"gemini tool confirmation dialog", "gemini",
+			"╭──────────────────────────────────────╮\n│ Edit example.txt                     │\n│ Apply this change?                   │\n│ ● 1. Allow once                      │\n│   2. Allow always                    │\n│   3. No, suggest changes (esc)       │\n╰──────────────────────────────────────╯\n⡏ Waiting for user confirmation...", Waiting},
+		{"gemini confirmation tip without dialog rows", "gemini",
+			"⡏ Waiting for user confirmation...\n\n >   Type your message or @path/to/file", Waiting},
+		{"gemini errored", "gemini",
+			" > Count from 1 to 5, one number per line, then stop.\n▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀\n✕ [API Error: An unknown error occurred.]\nℹ This request failed. Press F12 for diagnostics, or run /settings and change \"Error Verbosity\" to full for\n  full details.\n▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n >   Type your message or @path/to/file", Errored},
+		{"gemini first-run auth dialog", "gemini",
+			"╭──────────────────────────────╮\n│ ? Get started                │\n│                              │\n│   How would you like to authenticate for this project?  │\n│                              │\n│   ● 1. Sign in with Google   │\n│     2. Use Gemini API Key    │\n│     3. Vertex AI             │\n│                              │\n│   (Use Enter to select)      │\n╰──────────────────────────────╯", Waiting},
+		{"gemini usage-limit dialog", "gemini",
+			"╭──────────────────────────────────────╮\n│                                      │\n│ Usage limit reached for gemini-3.5-flash.  │\n│ /stats model for usage details       │\n│ /model to switch models.             │\n│                                      │\n│ ● 1. Keep trying                     │\n│   2. Stop                            │\n│                                      │\n╰──────────────────────────────────────╯", Waiting},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, _ := engine.Match(tc.tool, tc.pane); got != tc.want {
+				t.Fatalf("Match(%s) = %q want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// Gemini closes turns without a summary line, so resting status comes from
+// TurnEndedState over the quiet region. The "? for shortcuts" hint and the
+// approval-mode banner sit above the composer; both must count as chrome
+// or the hint's "?" would read every finished turn as a question.
+func TestGeminiTurnEndedState(t *testing.T) {
+	engine := defaultEngine(t)
+	finishedRegion := "✦ Dark screen glows with text\n  Commands flow, stories unfold\n  Prompt waits, ready now\n Press Ctrl+O to show more lines of the last response\n                    ? for shortcuts\n──────────────────────────────\n Shift+Tab to accept edits\n▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n"
+	if got := engine.TurnEndedState("gemini", finishedRegion); got != Finished {
+		t.Fatalf("TurnEndedState(finished region) = %q want %q", got, Finished)
+	}
+	questionRegion := "✦ Should I refactor module A or module B?\n\n                    ? for shortcuts\n Shift+Tab to accept edits\n"
+	if got := engine.TurnEndedState("gemini", questionRegion); got != Waiting {
+		t.Fatalf("TurnEndedState(question region) = %q want %q", got, Waiting)
+	}
+}
+
 func TestTurnEndedState(t *testing.T) {
 	engine := defaultEngine(t)
 	cases := []struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -26,8 +26,8 @@ type Session struct {
 	Acked        bool
 	CreatedAt    time.Time
 	LastStatusAt time.Time
-	// AgentSessionID is the agent CLI's own conversation id (claude/grok
-	// session UUID, codex rollout id, opencode session id). Revive resumes
+	// AgentSessionID is the agent CLI's own conversation id (claude/grok/
+	// gemini session UUID, codex rollout id, opencode session id). Revive resumes
 	// this exact conversation instead of the cwd's most recent one.
 	AgentSessionID string
 }

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -128,7 +128,7 @@ func (m *Model) groupDefaultDir(group string) string {
 // toolDisplayOrder fixes the order tools appear in when creating a session and
 // when cycling the quick-spawn tool. Tools outside this list follow, sorted
 // alphabetically.
-var toolDisplayOrder = []string{"claude", "opencode", "codex", "grok"}
+var toolDisplayOrder = []string{"claude", "opencode", "codex", "grok", "gemini"}
 
 func sortedToolNames(cfg config.Config) []string {
 	names := cfg.ToolNames()

--- a/internal/ui/form_order_test.go
+++ b/internal/ui/form_order_test.go
@@ -10,6 +10,7 @@ import (
 func TestSortedToolNamesOrder(t *testing.T) {
 	cfg := config.Config{Tools: map[string]config.Tool{
 		"grok":     {Command: "grok"},
+		"gemini":   {Command: "gemini"},
 		"codex":    {Command: "codex"},
 		"claude":   {Command: "claude"},
 		"opencode": {Command: "opencode"},
@@ -17,7 +18,7 @@ func TestSortedToolNamesOrder(t *testing.T) {
 		"acme":     {Command: "acme"},
 	}}
 	got := sortedToolNames(cfg)
-	want := []string{"claude", "opencode", "codex", "grok", "acme", "zephyr"}
+	want := []string{"claude", "opencode", "codex", "grok", "gemini", "acme", "zephyr"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sortedToolNames = %v want %v", got, want)
 	}


### PR DESCRIPTION
Adds Gemini CLI to the built-in tools, alongside claude, codex, opencode and grok.

## What

- **Config**: a default `[tools.gemini]` block. Sessions launch with `--session-id <uuid>` and revive resumes the exact conversation with `gemini --resume {id}`; `gemini --resume latest` is the no-id fallback. The prompt travels as the positional argument. Existing user configs pick the tool up through the defaults backfill.
- **Status**: waiting on selection dialogs (`● 1.` rows: tool approval, auth, usage-limit) and the "Waiting for user confirmation..." tip; working on the `(esc to cancel, Ns)` loading line; errored on the `✕ ` message prefix. Gemini closes turns without a summary line, so finished/waiting resolves through the quiet-region fallback; the composer's `▄/▀` background rows, the "? for shortcuts" hint, the approval-mode banner and the "Press Ctrl+O to show more lines" notice count as chrome so the hint's `?` never reads as a question.
- **MCP**: new `gemini` registration style, a one-time `gemini mcp add --scope user` entry with the session-id env forwarded through `${VAR}` expansion. Shared `ensureRegisteredOnce` helper now backs both grok and gemini.
- **UI**: gemini in the tool display order.

## Verification

Against Gemini CLI v0.53.0:

- `--session-id` + `--resume <uuid>` round-trip ran live: a session launched under a chosen UUID was resumed by that UUID and recalled earlier conversation state.
- `gemini mcp add --scope user -e VAR='${VAR}'` ran live and wrote the expected `mcpServers` entry with the env template preserved.
- Status fixtures in `status_test.go` come from real captured panes (idle, working spinner, finished turn, auth dialog, usage-limit dialog, API error), completed from the v0.53.0 rendering source for the tool-confirmation dialog.
- `go test ./...` passes, `gofmt` clean.