### PR TITLE
feat(update): check for releases every 4 hours

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -268,6 +268,7 @@ const previewSettle = 50 * time.Millisecond
 const (
 	previewIntervalLive = 300 * time.Millisecond
 	previewIntervalCalm = 1200 * time.Millisecond
+	updateTickInterval  = time.Hour
 )
 
 // previewTickMsg drives that timer.
@@ -393,26 +394,38 @@ func (m *Model) requestRefresh() {
 
 func (m *Model) Init() tea.Cmd {
 	m.syncPollInput()
-	return tea.Batch(m.refreshExistingSessionUX, m.checkForUpdate, m.bannerTick(), m.previewTick())
+	return tea.Batch(m.refreshExistingSessionUX, m.checkForUpdate, m.updateTick(), m.bannerTick(), m.previewTick())
 }
 
 // updateMsg carries the result of the background GitHub release check.
+// failed marks a check that never reached a verdict, which leaves any
+// badge already on screen alone instead of clearing it on a blip.
 type updateMsg struct {
 	latest string
 	url    string
+	failed bool
 }
 
-// checkForUpdate hits GitHub Releases (throttled to once a day via an
+type updateTickMsg struct{}
+
+// updateTick re-runs the release check while the manager stays open for
+// days at a time. update.Check serves most ticks from its on-disk cache,
+// so this only reaches GitHub once the cache goes stale.
+func (m *Model) updateTick() tea.Cmd {
+	return tea.Tick(updateTickInterval, func(time.Time) tea.Msg { return updateTickMsg{} })
+}
+
+// checkForUpdate hits GitHub Releases (throttled by update.Check via an
 // on-disk cache) off the event loop and reports a newer release. Any
-// failure resolves to an empty message so the TUI simply shows no badge.
+// failure resolves to a failed message so the TUI simply shows no badge.
 func (m *Model) checkForUpdate() tea.Msg {
 	dir, err := config.Dir()
 	if err != nil {
-		return updateMsg{}
+		return updateMsg{failed: true}
 	}
 	result, err := update.Check(context.Background(), dir, m.version)
 	if err != nil {
-		return updateMsg{}
+		return updateMsg{failed: true}
 	}
 	return updateMsg{latest: result.Latest, url: result.URL}
 }
@@ -627,9 +640,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.diffRefreshCmd()
 
 	case updateMsg:
+		if msg.failed {
+			return m, nil
+		}
 		m.updateLatest = msg.latest
 		m.updateURL = msg.url
 		return m, nil
+
+	case updateTickMsg:
+		return m, tea.Batch(m.checkForUpdate, m.updateTick())
 
 	case previewSettleMsg:
 		if msg.gen != m.previewGen {

--- a/internal/ui/update_badge_test.go
+++ b/internal/ui/update_badge_test.go
@@ -15,3 +15,30 @@ func TestHeaderShowsUpdateBadge(t *testing.T) {
 		t.Errorf("header should have no badge when up to date: %q", got)
 	}
 }
+
+func TestUpdateMsgSetsAndClearsBadge(t *testing.T) {
+	m := &Model{width: 120}
+	m.Update(updateMsg{latest: "v0.11.1", url: "https://example/rel"})
+	if m.updateLatest != "v0.11.1" || m.updateURL != "https://example/rel" {
+		t.Errorf("badge not set: %q %q", m.updateLatest, m.updateURL)
+	}
+	m.Update(updateMsg{})
+	if m.updateLatest != "" || m.updateURL != "" {
+		t.Errorf("an up-to-date result should clear the badge: %q %q", m.updateLatest, m.updateURL)
+	}
+}
+
+func TestFailedUpdateCheckKeepsBadge(t *testing.T) {
+	m := &Model{width: 120, updateLatest: "v0.11.1", updateURL: "https://example/rel"}
+	m.Update(updateMsg{failed: true})
+	if m.updateLatest != "v0.11.1" || m.updateURL != "https://example/rel" {
+		t.Errorf("a failed check must leave the badge alone: %q %q", m.updateLatest, m.updateURL)
+	}
+}
+
+func TestUpdateTickReArms(t *testing.T) {
+	m := &Model{width: 120}
+	if _, cmd := m.Update(updateTickMsg{}); cmd == nil {
+		t.Error("update tick should re-arm the timer and re-check")
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -17,11 +17,13 @@ import (
 )
 
 const (
-	releasesURL   = "https://api.github.com/repos/YoanWai/agent-manager/releases/latest"
 	cacheFile     = "update-check.json"
-	checkInterval = 24 * time.Hour
+	checkInterval = 4 * time.Hour
 	requestBudget = 4 * time.Second
 )
+
+// releasesURL is a var so tests can point the fetch at a local server.
+var releasesURL = "https://api.github.com/repos/YoanWai/agent-manager/releases/latest"
 
 // Result is the newest release found. Latest is empty when the current
 // build is already up to date (or the version is a dev build).

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -3,6 +3,9 @@ package update
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -84,6 +87,98 @@ func TestCheckUsesFreshCache(t *testing.T) {
 	if r.Latest != "v0.9.0" || r.URL != "https://example/rel" {
 		t.Errorf("expected cached newer release, got %+v", r)
 	}
+}
+
+// A cache older than checkInterval must go back to the network, and the
+// answer it gets must replace the stale entry on disk.
+func TestCheckStaleCacheRefetches(t *testing.T) {
+	dir := t.TempDir()
+	seed := cache{CheckedAt: time.Now().Add(-checkInterval - time.Minute), Latest: "v0.9.0", URL: "https://example/old"}
+	raw, _ := json.Marshal(seed)
+	if err := os.WriteFile(filepath.Join(dir, cacheFile), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprint(w, `{"tag_name":"v0.11.1","html_url":"https://example/new"}`)
+	}))
+	defer server.Close()
+	defer swapReleasesURL(server.URL)()
+
+	r, err := Check(context.Background(), dir, "v0.8.2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("stale cache should hit the network once, got %d calls", calls)
+	}
+	if r.Latest != "v0.11.1" || r.URL != "https://example/new" {
+		t.Errorf("expected the freshly fetched release, got %+v", r)
+	}
+	written, ok := readCache(filepath.Join(dir, cacheFile))
+	if !ok || written.Latest != "v0.11.1" {
+		t.Errorf("stale cache entry was not replaced, got %+v", written)
+	}
+	if time.Since(written.CheckedAt) > time.Minute {
+		t.Errorf("rewritten cache should carry a fresh timestamp, got %v", written.CheckedAt)
+	}
+}
+
+// A fresh cache must not reach the network at all.
+func TestCheckFreshCacheSkipsNetwork(t *testing.T) {
+	dir := t.TempDir()
+	seed := cache{CheckedAt: time.Now(), Latest: "v0.9.0", URL: "https://example/rel"}
+	raw, _ := json.Marshal(seed)
+	if err := os.WriteFile(filepath.Join(dir, cacheFile), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+	}))
+	defer server.Close()
+	defer swapReleasesURL(server.URL)()
+
+	if _, err := Check(context.Background(), dir, "v0.8.2"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("fresh cache should skip the network, got %d calls", calls)
+	}
+}
+
+// A failed fetch must surface the error and leave the stale cache in place
+// so the next start retries instead of trusting a half-written entry.
+func TestCheckFetchFailureKeepsCache(t *testing.T) {
+	dir := t.TempDir()
+	seed := cache{CheckedAt: time.Now().Add(-checkInterval - time.Minute), Latest: "v0.9.0", URL: "https://example/old"}
+	raw, _ := json.Marshal(seed)
+	if err := os.WriteFile(filepath.Join(dir, cacheFile), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusForbidden)
+	}))
+	defer server.Close()
+	defer swapReleasesURL(server.URL)()
+
+	if _, err := Check(context.Background(), dir, "v0.8.2"); err == nil {
+		t.Fatal("expected an error when GitHub rejects the request")
+	}
+	kept, ok := readCache(filepath.Join(dir, cacheFile))
+	if !ok || kept.Latest != "v0.9.0" {
+		t.Errorf("failed fetch must not overwrite the cache, got %+v", kept)
+	}
+}
+
+func swapReleasesURL(url string) func() {
+	previous := releasesURL
+	releasesURL = url
+	return func() { releasesURL = previous }
 }
 
 func TestCheckFreshCacheNoUpdate(t *testing.T) {


### PR DESCRIPTION
The release check ran once per process start and cached for 24 hours, so a manager left open for days never noticed a new release, and a restart inside the cache window still showed nothing.

The cache window is now 4 hours, and an hourly tick re-runs the check while the manager stays open. `update.Check` serves most ticks from the on-disk cache, so GitHub sees a request only once the cache goes stale. A check that fails leaves an existing badge on screen, so a transient network blip no longer drops it.

## Verification

- Live `api.github.com/repos/YoanWai/agent-manager/releases/latest` returns `tag_name` and `html_url` (`v0.11.1`), the two fields the decoder reads.
- New tests drive the cache decision against an `httptest` server: a stale entry refetches and rewrites with a fresh timestamp, a fresh entry skips the network entirely, and a rejected request keeps the old entry.
- Badge tests cover set, clear on an up-to-date result, keep on a failed check, and the tick re-arming itself.
- `go build ./...`, `gofmt -l`, and `go test ./internal/update/... ./internal/ui/...` all pass.