### PR TITLE
revert: focus mode forwards q again, ctrl+q returns to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `g` | New group (name, parent, default path) |
 | `enter` | Focus session in place (keys go to the agent, list stays) / fold group |
 | `A` | Attach session full screen (Settings can swap it with `enter`) |
-| `ctrl+q` | Inside a session: back to the manager; in the list: quit |
-| `q` | Focused session: back to the list |
+| `ctrl+q` | Inside a session: back to the manager |
 | `K` / `J` (or `shift+↑` / `shift+↓`) | Reorder session or group among its visible siblings |
 | `m` | Move session to another group |
 | `r` | Rename session / edit tool; edit group name and default path |

--- a/internal/ui/focuskeyswap_test.go
+++ b/internal/ui/focuskeyswap_test.go
@@ -35,7 +35,7 @@ func TestCursorBlinks(t *testing.T) {
 		t.Fatal("typing left the caret hidden")
 	}
 
-	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
 	*m = *updated.(*Model)
 	if _, cmd := m.Update(cursorBlinkMsg{}); cmd != nil {
 		t.Fatal("blink timer kept running after focus ended")
@@ -81,7 +81,7 @@ func TestSwappedKeysRouteActions(t *testing.T) {
 	if m.mode != modeFocus {
 		t.Fatalf("enter did not focus by default, mode = %v", m.mode)
 	}
-	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
 	*m = *updated.(*Model)
 
 	// Swap through the settings screen, the same path a user takes.

--- a/internal/ui/focusmode_test.go
+++ b/internal/ui/focusmode_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// Enter on a live session row focuses it; typed keys land in its pane, q
-// returns to the list, and ctrl+q quits the manager entirely.
+// Enter on a live session row focuses it; typed keys land in its pane and
+// ctrl+q returns to the list without touching the pane.
 func TestFocusModeForwardsKeys(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "focusme", t.TempDir(), "")
@@ -49,21 +49,10 @@ func TestFocusModeForwardsKeys(t *testing.T) {
 		time.Sleep(30 * time.Millisecond)
 	}
 
-	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
 	*m = *updated.(*Model)
 	if m.mode != modeList {
-		t.Fatalf("q left mode = %v", m.mode)
-	}
-
-	// ctrl+q while focused quits the whole manager, not just the focus.
-	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
-	*m = *updated.(*Model)
-	if m.mode != modeFocus {
-		t.Fatalf("re-focus failed, mode = %v", m.mode)
-	}
-	_, quitCmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
-	if quitCmd == nil || !batchContains(quitCmd(), tea.Quit()) {
-		t.Fatal("ctrl+q while focused did not quit the manager")
+		t.Fatalf("ctrl+q left mode = %v", m.mode)
 	}
 }
 
@@ -109,7 +98,7 @@ func TestFocusExitReleasesMouse(t *testing.T) {
 		t.Fatalf("entering focus never enabled mouse reporting: %T", enterCmd())
 	}
 
-	updated, exitCmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	updated, exitCmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
 	*m = *updated.(*Model)
 	if exitCmd == nil {
 		t.Fatal("leaving focus issued no mouse command")

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -76,7 +76,7 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg.String() {
-	case "q", "ctrl+c", "ctrl+q":
+	case "q", "ctrl+c":
 		return m, tea.Quit
 	case "up", "k":
 		return m, m.moveCursor(-1)
@@ -410,17 +410,12 @@ func (m *Model) leaveFocus() tea.Cmd {
 	})
 }
 
-// handleFocusKey forwards every key into the focused pane, with two
-// reserved: q returns to the list, and Ctrl+Q quits the manager the same
-// way it does everywhere else. The agent never sees either.
+// handleFocusKey forwards every key into the focused pane. Ctrl+Q is the
+// one reserved key: it returns to the list, mirroring detach from a real
+// attach, and every plain character - q included - reaches the agent.
 func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "q":
+	if msg.String() == "ctrl+q" {
 		return m, m.leaveFocus()
-	case "ctrl+q":
-		// Straight quit: bubbletea restores the terminal, mouse included,
-		// on shutdown.
-		return m, tea.Quit
 	}
 	sess, ok := m.selected()
 	if !ok {

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -461,7 +461,7 @@ func (m *Model) contentLines(width, height int) []contentLine {
 // focusTopRule is the hairline that caps the focused pane, titled so the
 // mode names itself where the eye already is.
 func focusTopRule(width int) string {
-	title := " focused · q back "
+	title := " focused · ctrl+q back "
 	rule := annotationStyle.Render(title)
 	rest := width - lipgloss.Width(title)
 	if rest > 0 {

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -219,7 +219,6 @@ func (m *Model) viewHelp() string {
 		{"n", "new session"},
 		{"↵", "attach session / fold group"},
 		{"ctrl+q", "inside a session: back to manager"},
-		{"q", "focused: back to the list"},
 		{"ctrl+r", "inside a session: review its diff, esc returns"},
 		{"m", "move session to another group"},
 		{"g", "new group (name, parent, default path)"},

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -136,7 +136,7 @@ func (m *Model) viewStatus() string {
 			subtleStyle.Render(fmt.Sprintf("%d chars to clipboard", m.copied))
 	case m.mode == modeFocus:
 		return "  " + keyStyle.Render("focus ") +
-			subtleStyle.Render("typing goes to the agent · drag/double/triple click to copy · q back · ctrl+q quit")
+			subtleStyle.Render("typing goes to the agent · drag/double/triple click to copy · ctrl+q back")
 	case m.mode == modeConfirmDelete:
 		return "  " + errStyle.Render("⚠ "+m.confirm.label) + subtleStyle.Render("  y/n")
 	case m.resizeMode:


### PR DESCRIPTION
Reserving `q` in focus mode broke typing `q` into the focused agent (vim, less, any CLI that reads it). `ctrl+q` is the single reserved key again and every plain character reaches the agent. Hints, help card and README follow.