### PR TITLE
refactor: name the mcp add command directly in registration errors

### DIFF
--- a/internal/mcpreg/mcpreg.go
+++ b/internal/mcpreg/mcpreg.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/tmux"
@@ -146,7 +145,7 @@ func ensureGrokRegistered(exe, hooksDir string) error {
 		"--scope", "user",
 		"-e", hooks.EnvSessionID+"=${"+hooks.EnvSessionID+"}",
 		serverName, "--", exe, "mcp")
-	return ensureRegisteredOnce("mcp-grok-registered", exe, hooksDir, cmd)
+	return ensureRegisteredOnce("grok", exe, hooksDir, cmd)
 }
 
 // ensureGeminiRegistered adds the server to gemini's user-scope
@@ -158,7 +157,7 @@ func ensureGeminiRegistered(exe, hooksDir string) error {
 		"--scope", "user",
 		"-e", hooks.EnvSessionID+"=${"+hooks.EnvSessionID+"}",
 		serverName, exe, "mcp")
-	return ensureRegisteredOnce("mcp-gemini-registered", exe, hooksDir, cmd)
+	return ensureRegisteredOnce("gemini", exe, hooksDir, cmd)
 }
 
 // ensureRegisteredOnce runs a tool's own mcp-add command once per binary
@@ -166,13 +165,13 @@ func ensureGeminiRegistered(exe, hooksDir string) error {
 // the binary re-register. The check-then-add window is benign: the add
 // commands update in place, so two racing managers just write the same
 // entry twice.
-func ensureRegisteredOnce(markerName, exe, hooksDir string, cmd *exec.Cmd) error {
-	marker := filepath.Join(hooksDir, markerName)
+func ensureRegisteredOnce(tool, exe, hooksDir string, cmd *exec.Cmd) error {
+	marker := filepath.Join(hooksDir, "mcp-"+tool+"-registered")
 	if content, err := os.ReadFile(marker); err == nil && string(content) == exe {
 		return nil
 	}
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("%s: %v: %s", strings.Join(cmd.Args[:3], " "), err, out)
+		return fmt.Errorf("%s mcp add: %v: %s", tool, err, out)
 	}
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 		return err

--- a/internal/mcpreg/mcpreg_test.go
+++ b/internal/mcpreg/mcpreg_test.go
@@ -3,6 +3,7 @@ package mcpreg
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -132,6 +133,17 @@ func TestApplyGeminiSkipsWhenMarkerMatches(t *testing.T) {
 	}
 	if command != "gemini" {
 		t.Fatalf("command = %q", command)
+	}
+}
+
+func TestEnsureRegisteredOnceNamesFailedCommand(t *testing.T) {
+	err := ensureRegisteredOnce("gemini", "/opt/bin/agent-manager", t.TempDir(),
+		exec.Command("agent-manager-no-such-binary"))
+	if err == nil {
+		t.Fatal("expected an error when the add command cannot run")
+	}
+	if !strings.HasPrefix(err.Error(), "gemini mcp add: ") {
+		t.Fatalf("error = %q, want it to name the tool's add command", err)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #132.

`ensureRegisteredOnce` built its error label by slicing the command's own arguments:

```go
return fmt.Errorf("%s: %v: %s", strings.Join(cmd.Args[:3], " "), err, out)
```

`cmd.Args[:3]` slices without a length check, so a caller passing a command shorter than three words panics instead of returning an error. Both current callers pass longer commands, so this never fires today; it is a trap for the next tool added.

The helper now takes the tool name and derives both the marker filename and the error label from it, so the slice is gone and the two strings share one source.

Marker filenames stay byte-identical (`mcp-grok-registered`, `mcp-gemini-registered`), so existing registrations still skip and no one re-registers on upgrade. The two skip tests write those literal names and still pass, which is what pins the derivation.

Added `TestEnsureRegisteredOnceNamesFailedCommand`, which calls the helper with a one-word command that cannot run. It covers both halves of the change: the old code panicked on that input, and the assertion checks the error still names the tool's add command.

`go test ./...` passes, `go vet` and `gofmt` clean.