### PR TITLE
fix(focus): report the pointer before each forwarded wheel notch

### DIFF
--- a/internal/ui/focusscroll.go
+++ b/internal/ui/focusscroll.go
@@ -31,6 +31,12 @@ func wheelSGR(up bool, col, row int) string {
 	return fmt.Sprintf("\x1b[<%d;%d;%dM", button, col+1, row+1)
 }
 
+// motionSGR is a pointer move with no button held, at a one-based pane
+// cell: button 3 with the motion bit set.
+func motionSGR(col, row int) string {
+	return fmt.Sprintf("\x1b[<35;%d;%dM", col+1, row+1)
+}
+
 // hexBytes renders a string as the space-separated byte codes send-keys -H
 // takes, which sidesteps tmux quoting for control sequences entirely.
 func hexBytes(s string) string {
@@ -56,7 +62,15 @@ func (m *Model) wheelFocus(up bool, x, y int) tea.Cmd {
 		if !inside {
 			return nil
 		}
-		command := "send-keys -t " + tmux.SessionName(sess.ID) + " -H " + hexBytes(wheelSGR(up, col, row))
+		report := wheelSGR(up, col, row)
+		if m.paneMotion {
+			// An app tracking all motion places the wheel by where the
+			// pointer last moved, and focus mode keeps every move for its
+			// own selection, so the notch arrives with the pointer still
+			// wherever the app last saw it.
+			report = motionSGR(col, row) + report
+		}
+		command := "send-keys -t " + tmux.SessionName(sess.ID) + " -H " + hexBytes(report)
 		if !m.focus.attempt(command) {
 			if err := m.tmux.SendRaw(command); err != nil {
 				m.err = err.Error()

--- a/internal/ui/focusscroll.go
+++ b/internal/ui/focusscroll.go
@@ -20,21 +20,32 @@ type focusScrollMsg struct {
 	preview string
 }
 
-// wheelSGR is one wheel event in SGR mouse encoding (button 64 up, 65
-// down) at a one-based pane cell, the form every app that turns on mouse
-// tracking expects.
-func wheelSGR(up bool, col, row int) string {
-	button := 65
-	if up {
-		button = 64
-	}
+// Mouse button codes as the reports carry them: the two wheel
+// directions, and a pointer move with no button held (button 3 with the
+// motion bit set).
+const (
+	wheelUpButton   = 64
+	wheelDownButton = 65
+	motionButton    = 35
+)
+
+// x10Limit is the highest cell the original encoding can name: each
+// coordinate is one byte biased by 32, so it runs out at 223.
+const x10Limit = 223
+
+// sgrMouse is one mouse report in SGR encoding at a one-based pane cell.
+func sgrMouse(button, col, row int) string {
 	return fmt.Sprintf("\x1b[<%d;%d;%dM", button, col+1, row+1)
 }
 
-// motionSGR is a pointer move with no button held, at a one-based pane
-// cell: button 3 with the motion bit set.
-func motionSGR(col, row int) string {
-	return fmt.Sprintf("\x1b[<35;%d;%dM", col+1, row+1)
+// x10Mouse is one mouse report in the original encoding, for an app that
+// tracks the mouse without asking for SGR. Not ok past the cell the
+// encoding can name, where the report would land on the wrong column.
+func x10Mouse(button, col, row int) (string, bool) {
+	if col >= x10Limit || row >= x10Limit {
+		return "", false
+	}
+	return string([]byte{0x1b, '[', 'M', byte(32 + button), byte(33 + col), byte(33 + row)}), true
 }
 
 // hexBytes renders a string as the space-separated byte codes send-keys -H
@@ -45,6 +56,38 @@ func hexBytes(s string) string {
 		codes = append(codes, fmt.Sprintf("%02x", s[i]))
 	}
 	return strings.Join(codes, " ")
+}
+
+// wheelReport is what one wheel notch looks like on the wire for this
+// pane: the notch itself, in the encoding the pane asked for, behind a
+// pointer move when the app tracks all motion. An app tracking all
+// motion places the wheel by where the pointer last moved, and focus
+// mode keeps every move for its own selection, so without the move the
+// notch arrives with the pointer wherever the app last saw it.
+func (m *Model) wheelReport(up bool, col, row int) (string, bool) {
+	button := wheelDownButton
+	if up {
+		button = wheelUpButton
+	}
+	if m.paneSGR {
+		report := sgrMouse(button, col, row)
+		if m.paneMotion {
+			report = sgrMouse(motionButton, col, row) + report
+		}
+		return report, true
+	}
+	report, ok := x10Mouse(button, col, row)
+	if !ok {
+		return "", false
+	}
+	if m.paneMotion {
+		move, moveOK := x10Mouse(motionButton, col, row)
+		if !moveOK {
+			return "", false
+		}
+		report = move + report
+	}
+	return report, true
 }
 
 // wheelFocus routes one wheel notch. An application that has turned on
@@ -62,13 +105,9 @@ func (m *Model) wheelFocus(up bool, x, y int) tea.Cmd {
 		if !inside {
 			return nil
 		}
-		report := wheelSGR(up, col, row)
-		if m.paneMotion {
-			// An app tracking all motion places the wheel by where the
-			// pointer last moved, and focus mode keeps every move for its
-			// own selection, so the notch arrives with the pointer still
-			// wherever the app last saw it.
-			report = motionSGR(col, row) + report
+		report, ok := m.wheelReport(up, col, row+m.paneRowOffset(m.paneBox.height))
+		if !ok {
+			return nil
 		}
 		command := "send-keys -t " + tmux.SessionName(sess.ID) + " -H " + hexBytes(report)
 		if !m.focus.attempt(command) {

--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -263,20 +264,19 @@ func windowHeight(t *testing.T, id string) int {
 	return height
 }
 
-// An application that turns on mouse tracking owns the wheel: agent CLIs
-// run on the alternate screen, where tmux keeps no scrollback at all, and
-// scroll themselves when they receive the event.
-func TestWheelReachesMouseTrackingApp(t *testing.T) {
+// focusedMouseApp focuses a session whose tool claims the mouse, with the
+// watcher's pushes pumped through Update the way the running app does, so
+// the pane-state cache the wheel routes on is populated.
+func focusedMouseApp(t *testing.T, tool, name string) (*Model, store.Session) {
+	t.Helper()
 	m := buildModel(t)
-	if err := m.spawnSession("mouse-tool", "wheelapp", t.TempDir(), "", "", true); err != nil {
+	if err := m.spawnSession(tool, name, t.TempDir(), "", "", true); err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
 	m.applyCmd(t, m.refreshCmd())
-	m.selectSessionRow(t, "wheelapp")
+	m.selectSessionRow(t, name)
 	sess := m.rows[m.cursor].sess
 
-	// Pump the watcher's pushes through Update, the way the running app
-	// does, so the mouse-ownership cache the wheel reads gets populated.
 	msgs := make(chan tea.Msg, 64)
 	m.focus = newFocusWatch(m.tmux, func(msg tea.Msg) { msgs <- msg })
 	t.Cleanup(m.focus.Close)
@@ -305,6 +305,14 @@ func TestWheelReachesMouseTrackingApp(t *testing.T) {
 			t.Skip("pane never reported mouse tracking on this host")
 		}
 	}
+	return m, sess
+}
+
+// An application that turns on mouse tracking owns the wheel: agent CLIs
+// run on the alternate screen, where tmux keeps no scrollback at all, and
+// scroll themselves when they receive the event.
+func TestWheelReachesMouseTrackingApp(t *testing.T) {
+	m, sess := focusedMouseApp(t, "mouse-tool", "wheelapp")
 
 	// A wheel notch over the pane now goes to the app, not to tmux history.
 	before := m.focusScroll
@@ -312,7 +320,10 @@ func TestWheelReachesMouseTrackingApp(t *testing.T) {
 	if m.focusScroll != before {
 		t.Fatal("wheel scrolled tmux history while the app owned the mouse")
 	}
-	deadline = time.Now().Add(5 * time.Second)
+	if !m.paneSGR {
+		t.Fatal("pane asked for SGR reports but the model did not read it")
+	}
+	deadline := time.Now().Add(5 * time.Second)
 	for {
 		pane, err := m.tmux.CapturePane(sess.ID)
 		if err != nil {
@@ -390,23 +401,82 @@ func TestPolledFrameHoldsScrolledView(t *testing.T) {
 	}
 }
 
-func TestMotionSGREncoding(t *testing.T) {
-	if got, want := motionSGR(0, 0), "\x1b[<35;1;1M"; got != want {
-		t.Errorf("motion = %q, want %q", got, want)
+// An app that claims the mouse without asking for SGR reads the original
+// encoding, and reports in the newer one would reach it as text.
+func TestWheelFallsBackToX10Reports(t *testing.T) {
+	m, sess := focusedMouseApp(t, "x10-tool", "x10app")
+	if m.paneSGR {
+		t.Fatal("a pane that never asked for SGR reported it")
 	}
-	if got, want := motionSGR(11, 4), "\x1b[<35;12;5M"; got != want {
-		t.Errorf("motion = %q, want %q", got, want)
+
+	m.wheelFocus(true, m.paneBox.x+2, m.paneBox.y+1)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		pane, err := m.tmux.CapturePane(sess.ID)
+		if err != nil {
+			t.Fatalf("capture: %v", err)
+		}
+		// cat echoes the bytes back, so an X10 report shows up as [M and
+		// its three coordinate characters, with no SGR report anywhere.
+		if strings.Contains(pane, "[M") {
+			if strings.Contains(pane, "[<") {
+				t.Fatalf("SGR report reached a pane that never asked for it: %q", pane)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("X10 wheel report never reached the pane: %q", pane)
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }
 
-func TestWheelSGREncoding(t *testing.T) {
-	if got, want := wheelSGR(true, 0, 0), "\x1b[<64;1;1M"; got != want {
+func TestMouseReportEncodings(t *testing.T) {
+	if got, want := sgrMouse(motionButton, 0, 0), "\x1b[<35;1;1M"; got != want {
+		t.Errorf("motion = %q, want %q", got, want)
+	}
+	if got, want := sgrMouse(wheelUpButton, 0, 0), "\x1b[<64;1;1M"; got != want {
 		t.Errorf("wheel up = %q, want %q", got, want)
 	}
-	if got, want := wheelSGR(false, 11, 4), "\x1b[<65;12;5M"; got != want {
+	if got, want := sgrMouse(wheelDownButton, 11, 4), "\x1b[<65;12;5M"; got != want {
 		t.Errorf("wheel down = %q, want %q", got, want)
 	}
 	if got, want := hexBytes("\x1b[<64;1;1M"), "1b 5b 3c 36 34 3b 31 3b 31 4d"; got != want {
 		t.Errorf("hexBytes = %q, want %q", got, want)
+	}
+
+	got, ok := x10Mouse(wheelUpButton, 0, 0)
+	if !ok || got != "\x1b[M`!!" {
+		t.Errorf("x10 wheel up = %q (ok=%v), want %q", got, ok, "\x1b[M`!!")
+	}
+	if got, ok := x10Mouse(motionButton, 11, 4); !ok || got != "\x1b[MC,%" {
+		t.Errorf("x10 motion = %q (ok=%v), want %q", got, ok, "\x1b[MC,%")
+	}
+	// Past the cell the encoding can name, a report would land on the
+	// wrong column, so there is none to send.
+	if _, ok := x10Mouse(wheelUpButton, x10Limit, 4); ok {
+		t.Error("x10 named a column the encoding cannot carry")
+	}
+	if _, ok := x10Mouse(wheelUpButton, 4, x10Limit); ok {
+		t.Error("x10 named a row the encoding cannot carry")
+	}
+}
+
+// The wheel reports the pane's own row, which is the painted row plus
+// whatever the panel dropped off the top of a taller capture.
+func TestWheelReportUsesPaneRow(t *testing.T) {
+	m := paneAt(t, "one", "two")
+	m.paneSGR = true
+	m.preview = "a\nb\nc\nd\none\ntwo\n"
+
+	if got, want := m.paneRowOffset(m.paneBox.height), 4; got != want {
+		t.Fatalf("row offset = %d, want %d", got, want)
+	}
+	report, ok := m.wheelReport(true, 3, 1+m.paneRowOffset(m.paneBox.height))
+	if !ok {
+		t.Fatal("no wheel report for a pane inside the encoding's range")
+	}
+	if want := "\x1b[<64;4;6M"; report != want {
+		t.Fatalf("report = %q, want %q", report, want)
 	}
 }

--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -367,6 +367,29 @@ func TestAppMouseClearsScrollback(t *testing.T) {
 	}
 }
 
+// The poll is the only source of frames once a control client dies, so
+// it owes a scrolled-back pane the same stillness the pushed frames do.
+func TestPolledFrameHoldsScrolledView(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "polled", t.TempDir(), "")
+	m.selectSessionRow(t, "polled")
+	sess := m.rows[m.cursor].sess
+	m.mode = modeFocus
+	m.preview = "SCROLLED-FRAME\n"
+	m.focusScroll = 6
+
+	m.setPreview(sess.ID, "LIVE-FRAME\n")
+	if m.preview != "SCROLLED-FRAME\n" {
+		t.Fatalf("preview = %q, want the scrolled frame held", m.preview)
+	}
+
+	m.focusScroll = 0
+	m.setPreview(sess.ID, "LIVE-FRAME\n")
+	if m.preview != "LIVE-FRAME\n" {
+		t.Fatalf("preview = %q, want the live frame back at the bottom", m.preview)
+	}
+}
+
 func TestMotionSGREncoding(t *testing.T) {
 	if got, want := motionSGR(0, 0), "\x1b[<35;1;1M"; got != want {
 		t.Errorf("motion = %q, want %q", got, want)

--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -321,12 +321,58 @@ func TestWheelReachesMouseTrackingApp(t *testing.T) {
 		// cat echoes the control bytes, so the wheel report shows up as
 		// text with the escape rendered as ^[.
 		if strings.Contains(pane, "[<64;") {
+			// The app tracks all motion, so the notch has to arrive with
+			// the pointer already reported at that cell.
+			move := strings.Index(pane, "[<35;")
+			if move < 0 {
+				t.Fatalf("no pointer move ahead of the wheel report: %q", pane)
+			}
+			if move > strings.Index(pane, "[<64;") {
+				t.Fatalf("pointer move landed after the wheel report: %q", pane)
+			}
 			break
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("wheel report never reached the pane: %q", pane)
 		}
 		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// A pane whose app owns the wheel must not stay parked on a scrollback
+// offset: the wheel goes to the app from then on, so nothing would walk
+// the offset back down and the view would hold a stale frame for good.
+func TestAppMouseClearsScrollback(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "sticky", t.TempDir(), "")
+	m.selectSessionRow(t, "sticky")
+	sess := m.rows[m.cursor].sess
+	m.mode = modeFocus
+	m.focusScroll = 9
+	if !m.scrolledBack() {
+		t.Fatal("setup did not leave the view scrolled back")
+	}
+
+	updated, _ := m.Update(focusPreviewMsg{
+		sessID:    sess.ID,
+		preview:   "LIVE-FRAME\n",
+		paneMouse: true,
+	})
+	m = updated.(*Model)
+	if m.focusScroll != 0 {
+		t.Fatalf("focusScroll = %d, want the app-owned pane back at the bottom", m.focusScroll)
+	}
+	if m.preview != "LIVE-FRAME\n" {
+		t.Fatalf("preview = %q, want the live frame", m.preview)
+	}
+}
+
+func TestMotionSGREncoding(t *testing.T) {
+	if got, want := motionSGR(0, 0), "\x1b[<35;1;1M"; got != want {
+		t.Errorf("motion = %q, want %q", got, want)
+	}
+	if got, want := motionSGR(11, 4), "\x1b[<35;12;5M"; got != want {
+		t.Errorf("motion = %q, want %q", got, want)
 	}
 }
 

--- a/internal/ui/focussel.go
+++ b/internal/ui/focussel.go
@@ -48,16 +48,25 @@ func (m *Model) cursorCell(paneLines int) (row, col int, ok bool) {
 	if !cursor.ok || m.mode != modeFocus || paneLines <= 0 || !m.cursorOn || m.scrolledBack() {
 		return 0, 0, false
 	}
-	captured := len(strings.Split(strings.TrimSuffix(m.preview, "\n"), "\n"))
-	offset := 0
-	if captured > paneLines {
-		offset = captured - paneLines
-	}
-	row = cursor.y - offset
+	row = cursor.y - m.paneRowOffset(paneLines)
 	if row < 0 || row >= paneLines {
 		return 0, 0, false
 	}
 	return row, cursor.x, true
+}
+
+// paneRowOffset is how many captured rows the panel dropped off the top.
+// A capture taller than the box is painted from its bottom, so a painted
+// row and the pane's own row differ by exactly that many lines.
+func (m *Model) paneRowOffset(paneLines int) int {
+	if paneLines <= 0 {
+		return 0
+	}
+	captured := len(strings.Split(strings.TrimSuffix(m.preview, "\n"), "\n"))
+	if captured <= paneLines {
+		return 0
+	}
+	return captured - paneLines
 }
 
 // focusSelection is a text selection drawn over the focused pane. anchor

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -231,7 +231,7 @@ func TestControlCaptureKeepsTrailingBlankRows(t *testing.T) {
 
 func TestApplyPaneState(t *testing.T) {
 	var msg focusPreviewMsg
-	applyPaneState(&msg, "12,34,010,250\n")
+	applyPaneState(&msg, "12,34,010,250,0\n")
 	if !msg.cursorOK || msg.cursorX != 12 || msg.cursorY != 34 {
 		t.Fatalf("cursor = (%d,%d,%v)", msg.cursorX, msg.cursorY, msg.cursorOK)
 	}
@@ -241,10 +241,21 @@ func TestApplyPaneState(t *testing.T) {
 	if msg.historySize != 250 {
 		t.Fatalf("historySize = %d, want 250", msg.historySize)
 	}
+	if msg.paneMotion {
+		t.Fatal("a button-tracking pane read as tracking all motion")
+	}
+
+	// tmux reports 1003 in mouse_all_flag, the apps that want a pointer
+	// move with every event.
+	var motion focusPreviewMsg
+	applyPaneState(&motion, "0,0,100,0,1")
+	if !motion.paneMouse || !motion.paneMotion {
+		t.Fatalf("all-motion pane state = %+v", motion)
+	}
 
 	var plain focusPreviewMsg
-	applyPaneState(&plain, "0,0,000,0")
-	if plain.paneMouse || plain.historySize != 0 || !plain.cursorOK {
+	applyPaneState(&plain, "0,0,000,0,0")
+	if plain.paneMouse || plain.paneMotion || plain.historySize != 0 || !plain.cursorOK {
 		t.Fatalf("plain pane state = %+v", plain)
 	}
 

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -231,7 +231,7 @@ func TestControlCaptureKeepsTrailingBlankRows(t *testing.T) {
 
 func TestApplyPaneState(t *testing.T) {
 	var msg focusPreviewMsg
-	applyPaneState(&msg, "12,34,010,250,0\n")
+	applyPaneState(&msg, "12,34,010,250,0,1\n")
 	if !msg.cursorOK || msg.cursorX != 12 || msg.cursorY != 34 {
 		t.Fatalf("cursor = (%d,%d,%v)", msg.cursorX, msg.cursorY, msg.cursorOK)
 	}
@@ -248,13 +248,13 @@ func TestApplyPaneState(t *testing.T) {
 	// tmux reports 1003 in mouse_all_flag, the apps that want a pointer
 	// move with every event.
 	var motion focusPreviewMsg
-	applyPaneState(&motion, "0,0,100,0,1")
+	applyPaneState(&motion, "0,0,100,0,1,1")
 	if !motion.paneMouse || !motion.paneMotion {
 		t.Fatalf("all-motion pane state = %+v", motion)
 	}
 
 	var plain focusPreviewMsg
-	applyPaneState(&plain, "0,0,000,0,0")
+	applyPaneState(&plain, "0,0,000,0,0,0")
 	if plain.paneMouse || plain.paneMotion || plain.historySize != 0 || !plain.cursorOK {
 		t.Fatalf("plain pane state = %+v", plain)
 	}

--- a/internal/ui/focuswatch.go
+++ b/internal/ui/focuswatch.go
@@ -22,9 +22,11 @@ type focusPreviewMsg struct {
 	// paneMouse and historySize let the wheel route without asking tmux
 	// mid-Update: whether the pane's application owns the mouse, and how
 	// far back its history goes. paneMotion narrows that to the apps that
-	// asked for every pointer move, not just clicks and drags.
+	// asked for every pointer move, not just clicks and drags, and paneSGR
+	// to those that asked for the modern report encoding.
 	paneMouse   bool
 	paneMotion  bool
+	paneSGR     bool
 	historySize int
 }
 
@@ -223,7 +225,7 @@ func (w *focusWatch) watch(id string, stop chan struct{}) {
 		// back as its default status message instead of coordinates.
 		if state, err := control.Command(
 			`display-message -p -t ` + target +
-				` "#{cursor_x},#{cursor_y},#{mouse_any_flag}#{mouse_button_flag}#{mouse_standard_flag},#{history_size},#{mouse_all_flag}"`); err == nil {
+				` "#{cursor_x},#{cursor_y},#{mouse_any_flag}#{mouse_button_flag}#{mouse_standard_flag},#{history_size},#{mouse_all_flag},#{mouse_sgr_flag}"`); err == nil {
 			applyPaneState(&msg, state)
 		}
 		// Skip the send once stopped: it could block on the UI loop for
@@ -276,12 +278,12 @@ func matchExecShape(pane string) string {
 	return strings.TrimSuffix(pane, "\n") + "\n"
 }
 
-// applyPaneState reads "x,y,mouseflags,history,allmotion" from
+// applyPaneState reads "x,y,mouseflags,history,allmotion,sgr" from
 // display-message into the preview message. A malformed reply leaves the
 // zero values: no cursor, no mouse claim, no history.
 func applyPaneState(msg *focusPreviewMsg, reply string) {
 	parts := strings.Split(strings.TrimSpace(reply), ",")
-	if len(parts) != 5 {
+	if len(parts) != 6 {
 		return
 	}
 	x, errX := strconv.Atoi(strings.TrimSpace(parts[0]))
@@ -294,4 +296,5 @@ func applyPaneState(msg *focusPreviewMsg, reply string) {
 		msg.historySize = size
 	}
 	msg.paneMotion = strings.TrimSpace(parts[4]) == "1"
+	msg.paneSGR = strings.TrimSpace(parts[5]) == "1"
 }

--- a/internal/ui/focuswatch.go
+++ b/internal/ui/focuswatch.go
@@ -21,8 +21,10 @@ type focusPreviewMsg struct {
 	cursorOK bool
 	// paneMouse and historySize let the wheel route without asking tmux
 	// mid-Update: whether the pane's application owns the mouse, and how
-	// far back its history goes.
+	// far back its history goes. paneMotion narrows that to the apps that
+	// asked for every pointer move, not just clicks and drags.
 	paneMouse   bool
+	paneMotion  bool
 	historySize int
 }
 
@@ -221,7 +223,7 @@ func (w *focusWatch) watch(id string, stop chan struct{}) {
 		// back as its default status message instead of coordinates.
 		if state, err := control.Command(
 			`display-message -p -t ` + target +
-				` "#{cursor_x},#{cursor_y},#{mouse_any_flag}#{mouse_button_flag}#{mouse_standard_flag},#{history_size}"`); err == nil {
+				` "#{cursor_x},#{cursor_y},#{mouse_any_flag}#{mouse_button_flag}#{mouse_standard_flag},#{history_size},#{mouse_all_flag}"`); err == nil {
 			applyPaneState(&msg, state)
 		}
 		// Skip the send once stopped: it could block on the UI loop for
@@ -274,12 +276,12 @@ func matchExecShape(pane string) string {
 	return strings.TrimSuffix(pane, "\n") + "\n"
 }
 
-// applyPaneState reads "x,y,mouseflags,history" from display-message into
-// the preview message. A malformed reply leaves the zero values: no
-// cursor, no mouse claim, no history.
+// applyPaneState reads "x,y,mouseflags,history,allmotion" from
+// display-message into the preview message. A malformed reply leaves the
+// zero values: no cursor, no mouse claim, no history.
 func applyPaneState(msg *focusPreviewMsg, reply string) {
 	parts := strings.Split(strings.TrimSpace(reply), ",")
-	if len(parts) != 4 {
+	if len(parts) != 5 {
 		return
 	}
 	x, errX := strconv.Atoi(strings.TrimSpace(parts[0]))
@@ -291,4 +293,5 @@ func applyPaneState(msg *focusPreviewMsg, reply string) {
 	if size, err := strconv.Atoi(strings.TrimSpace(parts[3])); err == nil && size > 0 {
 		msg.historySize = size
 	}
+	msg.paneMotion = strings.TrimSpace(parts[4]) == "1"
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -391,6 +391,7 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 	// Pane state from a previously focused session must not route this
 	// one's wheel; the first pushed capture reports the real values.
 	m.paneMouse = false
+	m.paneMotion = false
 	m.paneHistory = 0
 	// Mouse reporting makes the pane a closed window: clicks land here
 	// instead of the host terminal, so a drag selects pane text alone and

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -392,6 +392,7 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 	// one's wheel; the first pushed capture reports the real values.
 	m.paneMouse = false
 	m.paneMotion = false
+	m.paneSGR = false
 	m.paneHistory = 0
 	// Mouse reporting makes the pane a closed window: clicks land here
 	// instead of the host terminal, so a drag selects pane text alone and

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -88,9 +88,10 @@ type Model struct {
 	copied     int
 	sel        focusSelection
 	paneCursor paneCursor
-	// paneMouse and paneHistory mirror the focused pane's mouse ownership
-	// and history depth as the watcher last reported them, so the wheel
-	// routes without a tmux round trip mid-Update.
+	// paneMouse, paneMotion and paneHistory mirror the focused pane's
+	// mouse ownership, its appetite for pointer moves and its history
+	// depth as the watcher last reported them, so the wheel routes
+	// without a tmux round trip mid-Update.
 	paneMouse   bool
 	paneMotion  bool
 	paneHistory int

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -920,6 +920,13 @@ func (m *Model) setPreview(sessID, preview string) {
 	if sessID != "" && m.focus != nil && m.focus.serving(sessID) {
 		return
 	}
+	// A scrolled-back pane holds still on this path too: without a control
+	// client the poll is the only source of frames, and a live bottom
+	// landing mid-read is the same yank the pushed frames are held back
+	// from.
+	if m.scrolledBack() {
+		return
+	}
 	m.preview = preview
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -92,6 +92,7 @@ type Model struct {
 	// and history depth as the watcher last reported them, so the wheel
 	// routes without a tmux round trip mid-Update.
 	paneMouse   bool
+	paneMotion  bool
 	paneHistory int
 	// cursorOn is the caret's blink phase while focused.
 	cursorOn bool
@@ -786,7 +787,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.paneMouse = msg.paneMouse
+		m.paneMotion = msg.paneMotion
 		m.paneHistory = msg.historySize
+		// Once the app owns the wheel, nothing can walk a leftover offset
+		// back down, and holding it would freeze the view for good.
+		if m.paneMouse && m.focusScroll != 0 {
+			m.focusScroll = 0
+		}
 		// A scrolled-back pane holds still: live frames would yank the
 		// view back to the bottom mid-read.
 		if m.scrolledBack() {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -88,12 +88,14 @@ type Model struct {
 	copied     int
 	sel        focusSelection
 	paneCursor paneCursor
-	// paneMouse, paneMotion and paneHistory mirror the focused pane's
-	// mouse ownership, its appetite for pointer moves and its history
-	// depth as the watcher last reported them, so the wheel routes
-	// without a tmux round trip mid-Update.
+	// paneMouse, paneMotion, paneSGR and paneHistory mirror the focused
+	// pane's mouse ownership, its appetite for pointer moves, the report
+	// encoding it asked for and its history depth as the watcher last
+	// reported them, so the wheel routes without a tmux round trip
+	// mid-Update.
 	paneMouse   bool
 	paneMotion  bool
+	paneSGR     bool
 	paneHistory int
 	// cursorOn is the caret's blink phase while focused.
 	cursorOn bool
@@ -789,6 +791,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.paneMouse = msg.paneMouse
 		m.paneMotion = msg.paneMotion
+		m.paneSGR = msg.paneSGR
 		m.paneHistory = msg.historySize
 		// Once the app owns the wheel, nothing can walk a leftover offset
 		// back down, and holding it would freeze the view for good.

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -60,6 +60,13 @@ func buildModel(t *testing.T) *Model {
 				Command:       `printf '\033[?1003h\033[?1006h' && cat`,
 				DefaultStatus: status.Idle,
 			},
+			// Same claim on the mouse without asking for SGR, which is the
+			// one case the reports have to fall back to the original
+			// encoding.
+			"x10-tool": {
+				Command:       `printf '\033[?1003h' && cat`,
+				DefaultStatus: status.Idle,
+			},
 		},
 	}
 	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))


### PR DESCRIPTION
Focus mode forwards a wheel notch to the focused pane and keeps every other mouse event for its own text selection. Apps that turn on all-motion tracking (DECSET 1003) place a notch by where the pointer was last reported, so a notch arriving with no pointer report behind it lands wherever the app last believed the pointer to be. opencode and the Claude CLI both run 1003 + SGR.

Each forwarded notch now carries a pointer move at the same cell, for panes that asked for all motion. Panes on 1000 or 1002 keep the old byte stream.

Second fix: a leftover `focusScroll` offset is cleared once the pane's app owns the wheel. From that point every notch goes to the app, so nothing walks the offset back down, and live frames stay suppressed on a stale capture.

## Mechanism

`mouse_all_flag` maps to 1003 exactly, confirmed against tmux 3.7b:

| output | any | button | standard | all |
|---|---|---|---|---|
| `\e[?1000h` | 1 | 0 | 1 | 0 |
| `\e[?1002h` | 1 | 1 | 0 | 0 |
| `\e[?1003h` | 1 | 0 | 0 | 1 |

The watcher's `display-message` reply carries that flag alongside the cursor cell and history depth, so the wheel routes from cached state with no round trip on the UI loop.

## Verification

- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...` green.
- `TestWheelReachesMouseTrackingApp` now asserts the `[<35;` move reaches the pane ahead of the `[<64;` notch, through the real tmux path, against a fixture running the same 1003 + 1006 opencode uses.
- Sent the exact byte pair the code emits to live panes: two Claude sessions and one opencode session scrolled, prompts clean, nothing typed in.