### PR TITLE
fix(badges): check out main so the refresh commit has a branch to push

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod


### PR DESCRIPTION
`badges.yml` runs on `release: published` as well as on a schedule. On a release event `actions/checkout` lands on the tagged commit, which is a detached HEAD, so the job commits onto nothing and `git push` fails. Run 30591117651 on 2026-07-30 died exactly that way with `exit code 128` after printing `[detached HEAD 8fd3ec6] chore(badges)`.

It is invisible today because the job has nothing to commit, and it would start failing on every release the moment it did.

Pinning the checkout to `main` gives the commit a branch to land on.