### PR TITLE
feat(ui): add a comfortable list density

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
 | `ctrl+r` | Review the selected session's changes: full-screen whole-file diffs, with `c` to comment a line and `C` to send the comments to the agent |
 | `F` | Fold / unfold every group |
-| `s` | Settings (quick-spawn tool, theme, review layout, after quick send) |
+| `s` | Settings (quick-spawn tool, theme, list density, review layout, after quick send) |
 | `\|` | Resize the split: `←→` nudge the divider, `enter` commits, `esc` cancels |
 | `t` | Toggle archived view |
 | `e` | Hide / show empty groups |

--- a/internal/ui/focuskeyswap_test.go
+++ b/internal/ui/focuskeyswap_test.go
@@ -53,11 +53,11 @@ func TestSettingsSwapsFocusKey(t *testing.T) {
 	if !strings.Contains(card, "session keys") {
 		t.Fatalf("settings card has no session keys row:\n%s", card)
 	}
-	for i := 0; i < 4; i++ {
+	for i := 0; i < settingsFieldFocusKey; i++ {
 		m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyDown})
 	}
 	if m.settings.field != settingsFieldFocusKey {
-		t.Fatalf("fourth down should focus the session keys field, got %d", m.settings.field)
+		t.Fatalf("stepping down should reach the session keys field, got %d", m.settings.field)
 	}
 	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyRight})
 	if !strings.Contains(ansi.Strip(m.viewSettings()), "attach") {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -1612,6 +1612,18 @@ func (m *Model) defaultSplitLayout() bool {
 	return chosen != "unified"
 }
 
+const listDensitySetting = "list_density"
+
+// storedComfortableRows reads the persisted list density. Compact is the
+// default; a stored "comfortable" choice gives every entry a second line.
+func storedComfortableRows(st *store.Store) bool {
+	chosen, err := st.Setting(listDensitySetting)
+	if err != nil {
+		return false
+	}
+	return chosen == "comfortable"
+}
+
 const focusKeySetting = "focus_key"
 
 // enterFocuses reports which key opens a session where. Enter focuses the
@@ -1660,6 +1672,8 @@ func (m *Model) openSettings() {
 		layoutSplit:    m.defaultSplitLayout(),
 		quickCloseSend: m.quickCloseAfterSend(),
 		enterFocuses:   m.enterFocuses(),
+
+		comfortableRows: m.comfortableRows,
 	}
 	m.mode = modeSettings
 }
@@ -1702,7 +1716,15 @@ func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if err := m.store.SetSetting(focusKeySetting, focusKey); err != nil {
 			m.err = err.Error()
 		}
+		density := "compact"
+		if m.settings.comfortableRows {
+			density = "comfortable"
+		}
+		if err := m.store.SetSetting(listDensitySetting, density); err != nil {
+			m.err = err.Error()
+		}
 		m.focusOnEnter = m.settings.enterFocuses
+		m.comfortableRows = m.settings.comfortableRows
 		m.mode = modeList
 	}
 	return m, nil
@@ -1719,6 +1741,8 @@ func (m *Model) cycleSetting(step int) {
 		m.settings.themeIndex = (m.settings.themeIndex + step + len(themes)) % len(themes)
 		applyTheme(themes[m.settings.themeIndex])
 		SyncTerminalBackground()
+	case settingsFieldDensity:
+		m.settings.comfortableRows = !m.settings.comfortableRows
 	case settingsFieldLayout:
 		m.settings.layoutSplit = !m.settings.layoutSplit
 	case settingsFieldQuickClose:

--- a/internal/ui/listdensity_test.go
+++ b/internal/ui/listdensity_test.go
@@ -1,0 +1,110 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func railText(t *testing.T, m *Model) []string {
+	t.Helper()
+	var out []string
+	for _, line := range m.entryLines(60, 20) {
+		out = append(out, strings.TrimRight(ansi.Strip(line.text), " "))
+	}
+	return out
+}
+
+func lineWith(t *testing.T, lines []string, want string) int {
+	t.Helper()
+	for i, line := range lines {
+		if strings.Contains(line, want) {
+			return i
+		}
+	}
+	t.Fatalf("no rail line carrying %q:\n%s", want, strings.Join(lines, "\n"))
+	return -1
+}
+
+// Compact keeps a session on one line; comfortable moves its meta to a
+// second line under the name, and the choice persists.
+func TestSettingsTogglesListDensity(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "alpha", t.TempDir(), "")
+	m.selectSessionRow(t, "alpha")
+
+	lines := railText(t, m)
+	head := lineWith(t, lines, "alpha")
+	if !strings.Contains(lines[head], "claude") {
+		t.Fatalf("compact row should carry its meta inline: %q", lines[head])
+	}
+	if got := m.entryHeight(m.rows[0]); got != 1 {
+		t.Fatalf("compact entry height = %d want 1", got)
+	}
+
+	m.openSettings()
+	if m.settings.comfortableRows {
+		t.Fatal("settings should open on compact by default")
+	}
+	for i := 0; i < settingsFieldDensity; i++ {
+		m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if m.settings.field != settingsFieldDensity {
+		t.Fatalf("stepping down should reach the density field, got %d", m.settings.field)
+	}
+	if card := ansi.Strip(m.viewSettings()); !strings.Contains(card, "list density") {
+		t.Fatalf("settings card has no density row:\n%s", card)
+	}
+	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyRight})
+	if card := ansi.Strip(m.viewSettings()); !strings.Contains(card, "comfortable") {
+		t.Fatalf("toggled card does not read comfortable:\n%s", card)
+	}
+	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !m.comfortableRows {
+		t.Fatal("model did not pick up the comfortable density")
+	}
+	if !storedComfortableRows(m.store) {
+		t.Fatal("comfortable density did not persist")
+	}
+	if got := m.entryHeight(m.rows[0]); got != 2 {
+		t.Fatalf("comfortable entry height = %d want 2", got)
+	}
+
+	lines = railText(t, m)
+	head = lineWith(t, lines, "alpha")
+	if strings.Contains(lines[head], "claude") {
+		t.Fatalf("comfortable name line should not carry meta: %q", lines[head])
+	}
+	if head+1 >= len(lines) {
+		t.Fatalf("comfortable row has no meta line:\n%s", strings.Join(lines, "\n"))
+	}
+	meta := lines[head+1]
+	if !strings.Contains(meta, "claude") || !strings.Contains(meta, statusLabel(m.rows[0].sess.Status)) {
+		t.Fatalf("meta line = %q", meta)
+	}
+	if indent := len(meta) - len(strings.TrimLeft(meta, " ")); indent < railInset+2 {
+		t.Fatalf("meta line should sit under the name, indent = %d: %q", indent, meta)
+	}
+}
+
+// Groups follow the same density so the list keeps one rhythm.
+func TestComfortableGroupRowStacks(t *testing.T) {
+	m := buildModel(t)
+	m.comfortableRows = true
+	m.openGroupForm()
+	m.groupForm.name.SetValue("fleet")
+	if _, _ = m.submitGroupForm(); m.err != "" {
+		t.Fatalf("create group: %q", m.err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "beta", t.TempDir(), "fleet")
+
+	lines := railText(t, m)
+	head := lineWith(t, lines, "fleet")
+	if head+1 >= len(lines) || strings.TrimSpace(lines[head+1]) == "" {
+		t.Fatalf("group row has no meta line:\n%s", strings.Join(lines, "\n"))
+	}
+}

--- a/internal/ui/listdensity_test.go
+++ b/internal/ui/listdensity_test.go
@@ -132,3 +132,43 @@ func TestComfortableRowSurvivesShortRail(t *testing.T) {
 		t.Fatalf("selected entry lost its meta line: %q", meta)
 	}
 }
+
+// A nested entry's second line carries its ancestors' branches straight
+// down, so the tree column has no gap between an entry and the next.
+func TestComfortableMetaLineKeepsTreeGuides(t *testing.T) {
+	m := buildModel(t)
+	m.comfortableRows = true
+	m.openGroupForm()
+	m.groupForm.name.SetValue("outer")
+	if _, _ = m.submitGroupForm(); m.err != "" {
+		t.Fatalf("create outer group: %q", m.err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "outer")
+	m.openGroupForm()
+	m.groupForm.name.SetValue("inner")
+	if _, _ = m.submitGroupForm(); m.err != "" {
+		t.Fatalf("create inner group: %q", m.err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "nested", t.TempDir(), "outer/inner")
+	createSession(t, m, "sibling", t.TempDir(), "outer")
+
+	lines := railText(t, m)
+	head := lineWith(t, lines, "sibling")
+	name, meta := lines[head], lines[head+1]
+	nameRunes, metaRunes := []rune(name), []rune(meta)
+	guideAt := -1
+	for i, r := range nameRunes {
+		if r == '├' {
+			guideAt = i
+			break
+		}
+	}
+	if guideAt < 0 {
+		t.Fatalf("entry has no branch connector: %q\n%s", name, strings.Join(lines, "\n"))
+	}
+	if len(metaRunes) <= guideAt || metaRunes[guideAt] != '│' {
+		t.Fatalf("meta line breaks the guide column at %d:\n%q\n%q", guideAt, name, meta)
+	}
+}

--- a/internal/ui/listdensity_test.go
+++ b/internal/ui/listdensity_test.go
@@ -108,3 +108,27 @@ func TestComfortableGroupRowStacks(t *testing.T) {
 		t.Fatalf("group row has no meta line:\n%s", strings.Join(lines, "\n"))
 	}
 }
+
+// A rail too short for the counters keeps the selected entry whole: a
+// two-line row trimmed to one reads as a compact row that lost its meta.
+func TestComfortableRowSurvivesShortRail(t *testing.T) {
+	m := buildModel(t)
+	m.comfortableRows = true
+	for _, name := range []string{"one", "two", "three", "four"} {
+		createSession(t, m, name, t.TempDir(), "")
+	}
+	m.selectSessionRow(t, "three")
+
+	lines := m.entryLines(60, 2)
+	if len(lines) != 2 {
+		t.Fatalf("entry lines = %d want 2", len(lines))
+	}
+	head := lineWith(t, []string{ansi.Strip(lines[0].text), ansi.Strip(lines[1].text)}, "three")
+	if head != 0 {
+		t.Fatalf("selected entry should start the window, got line %d", head)
+	}
+	meta := ansi.Strip(lines[1].text)
+	if !strings.Contains(meta, "claude") {
+		t.Fatalf("selected entry lost its meta line: %q", meta)
+	}
+}

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -134,7 +134,7 @@ func (m *Model) entryLines(width, height int) []contentLine {
 	}
 	heights := make([]int, len(m.rows))
 	for i := range heights {
-		heights[i] = entryHeight(m.rows[i])
+		heights[i] = m.entryHeight(m.rows[i])
 	}
 	start, end := lineWindow(heights, m.cursor, height)
 
@@ -162,10 +162,16 @@ func (m *Model) entryLines(width, height int) []contentLine {
 	return lines
 }
 
-// entryHeight is how many lines an entry paints. Every entry is one line,
-// groups included: a ragged list of one- and two-line rows reads as gaps
-// rather than as rhythm.
-func entryHeight(treeRow) int { return 1 }
+// entryHeight is how many lines an entry paints: one in the compact list,
+// two once the comfortable density unstacks the meta onto its own line.
+// Groups match sessions either way, since a ragged list of one- and
+// two-line rows reads as gaps rather than as rhythm.
+func (m *Model) entryHeight(treeRow) int {
+	if m.comfortableRows {
+		return 2
+	}
+	return 1
+}
 
 // lineWindow keeps the cursor's entry fully visible inside a line budget,
 // scrolling by whole entries so an entry is never cut in half.
@@ -299,7 +305,11 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width, index int, bg
 
 	if m.renamingRow(entry) {
 		line := pad + guides + m.renameRowInput(entry, width-railGutter-ansi.StringWidth(guides))
-		return paint(line, width, selectedHex())
+		row := paint(line, width, selectedHex())
+		if m.comfortableRows {
+			row += "\n" + paint("", width, selectedHex())
+		}
+		return row
 	}
 
 	if entry.isGroup {
@@ -330,7 +340,21 @@ func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad,
 	meta := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusLabel(sess.Status)) +
 		metaStyle.Render(" · "+sess.Tool+" · "+relSince(lastActivity(sess)))
 
+	if m.comfortableRows {
+		return stackedRow(head, metaIndent(pad, guides)+meta, width, bg)
+	}
 	return paint(rowColumns(head, meta, width-railGutter), width, bg)
+}
+
+// metaIndent lines a second row line up under the name on the first, past
+// the entry's guides and the glyph column ahead of it.
+func metaIndent(pad, guides string) string {
+	return pad + strings.Repeat(" ", ansi.StringWidth(guides)+2)
+}
+
+// stackedRow paints an entry that carries its meta on a second line.
+func stackedRow(head, meta string, width int, bg string) string {
+	return paint(head, width, bg) + "\n" + paint(meta, width, bg)
 }
 
 func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, guides, bg string) string {
@@ -352,6 +376,9 @@ func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, g
 		meta = subtleStyle.Render("no agents yet")
 	}
 
+	if m.comfortableRows {
+		return stackedRow(head, metaIndent(pad, guides)+meta, width, bg)
+	}
 	return paint(rowColumns(head, meta, width-railGutter), width, bg)
 }
 

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -277,16 +277,7 @@ func (m *Model) treeGuidesAt(index int) string {
 	}
 	var guides strings.Builder
 	for slot := 1; slot <= depth; slot++ {
-		continues := false
-		for j := index + 1; j < len(m.rows); j++ {
-			if m.rows[j].depth < slot {
-				break
-			}
-			if m.rows[j].depth == slot {
-				continues = true
-				break
-			}
-		}
+		continues := m.slotContinues(index, slot)
 		switch {
 		case slot < depth && continues:
 			guides.WriteString("│  ")
@@ -301,29 +292,67 @@ func (m *Model) treeGuidesAt(index int) string {
 	return subtleStyle.Render(guides.String())
 }
 
+// treeGuideTrail is the same ancestry read one line lower: every branch
+// the entry's own row connected to carries straight down past its second
+// line, so a two-line entry cannot leave a gap in the tree.
+func (m *Model) treeGuideTrail(index int) string {
+	if index < 0 || index >= len(m.rows) {
+		return ""
+	}
+	depth := m.rows[index].depth
+	if depth <= 0 {
+		return ""
+	}
+	var guides strings.Builder
+	for slot := 1; slot <= depth; slot++ {
+		if m.slotContinues(index, slot) {
+			guides.WriteString("│  ")
+			continue
+		}
+		guides.WriteString("   ")
+	}
+	return subtleStyle.Render(guides.String())
+}
+
+// slotContinues reports whether the level named by slot has another entry
+// below index. A slot goes quiet once its level has no further siblings,
+// which is what closes a branch off.
+func (m *Model) slotContinues(index, slot int) bool {
+	for j := index + 1; j < len(m.rows); j++ {
+		if m.rows[j].depth < slot {
+			return false
+		}
+		if m.rows[j].depth == slot {
+			return true
+		}
+	}
+	return false
+}
+
 // renderTreeRow paints one entry: a status dot, the name, and what the
 // entry is doing set against the row's far edge. The selected entry lifts
 // onto its own band instead of wearing a marker.
 func (m *Model) renderTreeRow(entry treeRow, selected bool, width, index int, bg string) string {
 	pad := strings.Repeat(" ", railInset)
 	guides := m.treeGuidesAt(index)
+	trail := m.treeGuideTrail(index)
 
 	if m.renamingRow(entry) {
 		line := pad + guides + m.renameRowInput(entry, width-railGutter-ansi.StringWidth(guides))
 		row := paint(line, width, selectedHex())
 		if m.comfortableRows {
-			row += "\n" + paint("", width, selectedHex())
+			row += "\n" + paint(pad+trail, width, selectedHex())
 		}
 		return row
 	}
 
 	if entry.isGroup {
-		return m.renderGroupEntry(entry, selected, width, pad, guides, bg)
+		return m.renderGroupEntry(entry, selected, width, pad, guides, trail, bg)
 	}
-	return m.renderSessionEntry(entry, selected, width, pad, guides, bg)
+	return m.renderSessionEntry(entry, selected, width, pad, guides, trail, bg)
 }
 
-func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad, guides, bg string) string {
+func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad, guides, trail, bg string) string {
 	sess := entry.sess
 	dot := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
 	nameStyle := valueStyle
@@ -346,22 +375,22 @@ func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad,
 		metaStyle.Render(" · "+sess.Tool+" · "+relSince(lastActivity(sess)))
 
 	if m.comfortableRows {
-		return stackedRow(head, metaIndent(pad, guides)+meta, width, bg)
+		return stackedRow(head, metaIndent(pad, trail)+meta, width, bg)
 	}
 	return paint(rowColumns(head, meta, width-railGutter), width, bg)
 }
 
 // metaIndent lines a second row line up under the name on the first, past
 // the entry's guides and the glyph column ahead of it.
-func metaIndent(pad, guides string) string {
-	return pad + strings.Repeat(" ", ansi.StringWidth(guides)+2)
+func metaIndent(pad, trail string) string {
+	return pad + trail + "  "
 }
 
 func stackedRow(head, meta string, width int, bg string) string {
 	return paint(head, width, bg) + "\n" + paint(meta, width, bg)
 }
 
-func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, guides, bg string) string {
+func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, guides, trail, bg string) string {
 	marker := "▾"
 	if m.collapsed[entry.group] {
 		marker = "▸"
@@ -389,7 +418,7 @@ func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, g
 	}
 
 	if m.comfortableRows {
-		return stackedRow(head, metaIndent(pad, guides)+meta, width, bg)
+		return stackedRow(head, metaIndent(pad, trail)+meta, width, bg)
 	}
 	return paint(rowColumns(head, meta, width-railGutter), width, bg)
 }

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -139,9 +139,6 @@ func (m *Model) entryLines(width, height int) []contentLine {
 	start, end := lineWindow(heights, m.cursor, height)
 
 	var lines []contentLine
-	if start > 0 {
-		lines = append(lines, contentLine{text: subtleStyle.Render(strings.Repeat(" ", railInset) + fmt.Sprintf("↑ %d more", start))})
-	}
 	for i := start; i < end; i++ {
 		selected := i == m.cursor
 		entry := m.rows[i]
@@ -153,7 +150,15 @@ func (m *Model) entryLines(width, height int) []contentLine {
 			lines = append(lines, contentLine{text: line, tone: tone})
 		}
 	}
-	if end < len(m.rows) {
+	// The counters ride in whatever room the entries leave. Claiming a line
+	// they do not have would trim an entry's last line away, and half a
+	// two-line entry reads as a whole one that lost its meta.
+	spare := height - len(lines)
+	if start > 0 && spare > 0 {
+		lines = append([]contentLine{{text: subtleStyle.Render(strings.Repeat(" ", railInset) + fmt.Sprintf("↑ %d more", start))}}, lines...)
+		spare--
+	}
+	if end < len(m.rows) && spare > 0 {
 		lines = append(lines, contentLine{text: subtleStyle.Render(strings.Repeat(" ", railInset) + fmt.Sprintf("↓ %d more", len(m.rows)-end))})
 	}
 	if len(lines) > height {
@@ -352,7 +357,6 @@ func metaIndent(pad, guides string) string {
 	return pad + strings.Repeat(" ", ansi.StringWidth(guides)+2)
 }
 
-// stackedRow paints an entry that carries its meta on a second line.
 func stackedRow(head, meta string, width int, bg string) string {
 	return paint(head, width, bg) + "\n" + paint(meta, width, bg)
 }

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -161,6 +161,10 @@ func (m *Model) viewSettings() string {
 	if m.settings.layoutSplit {
 		layout = "split"
 	}
+	density := "compact"
+	if m.settings.comfortableRows {
+		density = "comfortable"
+	}
 	quickClose := "stay open"
 	if m.settings.quickCloseSend {
 		quickClose = "close"
@@ -182,6 +186,7 @@ func (m *Model) viewSettings() string {
 	body := row(settingsFieldTool, "quick spawn tool", m.settings.toolNames[m.settings.toolIndex]) + "\n" +
 		row(settingsFieldTheme, "theme", themes[m.settings.themeIndex].Name) + "  " +
 		themeSwatch(themes[m.settings.themeIndex]) + "\n" +
+		row(settingsFieldDensity, "list density", density) + "\n" +
 		row(settingsFieldLayout, "review layout", layout) + "\n" +
 		row(settingsFieldQuickClose, "after quick send", quickClose) + "\n" +
 		row(settingsFieldFocusKey, "session keys", focusKey) + "\n\n" +

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -106,6 +106,10 @@ type Model struct {
 	// focusOnEnter mirrors the persisted focus-key setting; the footer
 	// reads it every frame, so it lives here instead of the store.
 	focusOnEnter bool
+	// comfortableRows mirrors the persisted list density: entries paint
+	// their meta on a second line instead of alongside the name. Every
+	// rail frame reads it, so it lives here instead of the store.
+	comfortableRows bool
 	// watchedGen is previewGen as of the last poll pass, so a selection
 	// that has not moved since can be recognised as at rest.
 	watchedGen        uint64
@@ -235,18 +239,20 @@ type quickImageMsg struct {
 }
 
 type settingsState struct {
-	toolNames      []string
-	toolIndex      int
-	themeIndex     int
-	field          int
-	layoutSplit    bool
-	quickCloseSend bool
-	enterFocuses   bool
+	toolNames       []string
+	toolIndex       int
+	themeIndex      int
+	field           int
+	layoutSplit     bool
+	quickCloseSend  bool
+	enterFocuses    bool
+	comfortableRows bool
 }
 
 const (
 	settingsFieldTool = iota
 	settingsFieldTheme
+	settingsFieldDensity
 	settingsFieldLayout
 	settingsFieldQuickClose
 	settingsFieldFocusKey
@@ -355,18 +361,19 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 	gitDriver, _ := git.New()
 	applyTheme(themes[themeIndex(storedTheme(st))])
 	return &Model{
-		cfg:          cfg,
-		store:        st,
-		tmux:         driver,
-		hooks:        hookManager,
-		gitDrv:       gitDriver,
-		setSnapshot:  st.SetSnapshot,
-		poller:       newPoller(st, driver, engine, hookManager, statusSources, sessionStores, cfg.PollInterval.Duration),
-		collapsed:    loadCollapsed(st),
-		splitRatio:   loadSplitRatio(st),
-		focusOnEnter: storedFocusOnEnter(st),
-		mode:         modeList,
-		version:      version,
+		cfg:             cfg,
+		store:           st,
+		tmux:            driver,
+		hooks:           hookManager,
+		gitDrv:          gitDriver,
+		setSnapshot:     st.SetSnapshot,
+		poller:          newPoller(st, driver, engine, hookManager, statusSources, sessionStores, cfg.PollInterval.Duration),
+		collapsed:       loadCollapsed(st),
+		splitRatio:      loadSplitRatio(st),
+		focusOnEnter:    storedFocusOnEnter(st),
+		comfortableRows: storedComfortableRows(st),
+		mode:            modeList,
+		version:         version,
 	}
 }
 

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	splitRatioSetting = "split_ratio"
-	defaultSplitRatio = 0.272
+	defaultSplitRatio = 0.3
 	minSplitSide      = 30
 	// How many columns on either side of the panel junction count as the
 	// divider hit target. Wide enough to grab without hunting.
@@ -21,7 +21,7 @@ type settingReader interface {
 	Setting(key string) (string, error)
 }
 
-// loadSplitRatio restores the sessions/sidebar ratio, or the 27% default
+// loadSplitRatio restores the sessions/sidebar ratio, or the 30% default
 // when nothing is stored or the value is unusable.
 func loadSplitRatio(st settingReader) float64 {
 	raw, err := st.Setting(splitRatioSetting)

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	splitRatioSetting = "split_ratio"
-	defaultSplitRatio = 0.34
+	defaultSplitRatio = 0.272
 	minSplitSide      = 30
 	// How many columns on either side of the panel junction count as the
 	// divider hit target. Wide enough to grab without hunting.
@@ -21,7 +21,7 @@ type settingReader interface {
 	Setting(key string) (string, error)
 }
 
-// loadSplitRatio restores the sessions/sidebar ratio, or the 34% default
+// loadSplitRatio restores the sessions/sidebar ratio, or the 27% default
 // when nothing is stored or the value is unusable.
 func loadSplitRatio(st settingReader) float64 {
 	raw, err := st.Setting(splitRatioSetting)

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -59,11 +59,13 @@ func TestSplitWidthsUsesRatio(t *testing.T) {
 	if left != 40 || right != 60 {
 		t.Fatalf("splitWidths = %d,%d want 40,60", left, right)
 	}
-	// Default ratio when unset.
+	// Default ratio when unset, floored by the minimum side.
 	m.splitRatio = 0
 	left, right = m.splitWidths()
-	if left != 34 || right != 66 {
-		t.Fatalf("default split = %d,%d want 34,66", left, right)
+	ratio := defaultSplitRatio
+	wantLeft := clampSplitLeft(int(ratio*100), 100)
+	if left != wantLeft || right != 100-wantLeft {
+		t.Fatalf("default split = %d,%d want %d,%d", left, right, wantLeft, 100-wantLeft)
 	}
 }
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2803,11 +2803,11 @@ func TestSettingsTogglesQuickClose(t *testing.T) {
 	if m.settings.quickCloseSend {
 		t.Fatal("settings should open on stay-open by default")
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < settingsFieldQuickClose; i++ {
 		m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyDown})
 	}
 	if m.settings.field != settingsFieldQuickClose {
-		t.Fatalf("third down should focus the quick send field, got %d", m.settings.field)
+		t.Fatalf("stepping down should reach the quick send field, got %d", m.settings.field)
 	}
 	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyRight})
 	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyEnter})
@@ -2826,9 +2826,11 @@ func TestSettingsTogglesReviewLayout(t *testing.T) {
 	if m.settings.field != settingsFieldTheme {
 		t.Fatalf("first down should focus theme field, got %d", m.settings.field)
 	}
-	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyDown})
+	for i := settingsFieldTheme; i < settingsFieldLayout; i++ {
+		m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyDown})
+	}
 	if m.settings.field != settingsFieldLayout {
-		t.Fatalf("down should focus layout field, got %d", m.settings.field)
+		t.Fatalf("stepping down should reach the layout field, got %d", m.settings.field)
 	}
 	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyLeft})
 	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyEnter})

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -56,7 +56,7 @@ func clampFrame(frame string, height int) string {
 }
 
 // splitWidths is the body's horizontal split: the sessions panel takes
-// splitRatio of the terminal (default 27%), floored so both sides stay
+// splitRatio of the terminal (default 30%), floored so both sides stay
 // usable when the window is wide enough.
 func (m *Model) splitWidths() (int, int) {
 	if m.width <= 0 {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -56,7 +56,7 @@ func clampFrame(frame string, height int) string {
 }
 
 // splitWidths is the body's horizontal split: the sessions panel takes
-// splitRatio of the terminal (default 34%), floored so both sides stay
+// splitRatio of the terminal (default 27%), floored so both sides stay
 // usable when the window is wide enough.
 func (m *Model) splitWidths() (int, int) {
 	if m.width <= 0 {


### PR DESCRIPTION
Settings gains a `list density` picker between theme and review layout.

- `compact` (default) keeps every entry on one line, as today.
- `comfortable` gives each session and group two lines: the name on top, its `status · tool · last activity` indented underneath, with the tree's open branches carried down through the second line. Groups show their status dots below their name. Long names stop being truncated on a narrow rail.

```
├─ ○ loose-session
│    idle · claude · 0s ago
╰─ ▾ Features
     ○ 2
   ├─ ○ density-modes
   │    idle · claude · 0s ago
   ╰─ ○ footer-padding
        idle · claude · 0s ago
```

The choice persists in the store (`list_density`) and is cached on the model, since every rail frame reads it. The rail also opens at 30% of the terminal instead of 34%, giving the preview the room the second line takes back.

Verified by rendering the real frame at 100x22 and 200x26 in both densities. Covered by `internal/ui/listdensity_test.go`: the settings toggle and its persistence, session and group stacking, guide continuity through the meta line, and a short rail keeping the selected entry whole. Full suite green.