### PR TITLE
docs(badge): record that the card package has no importer

### DIFF
--- a/internal/badge/badge.go
+++ b/internal/badge/badge.go
@@ -1,6 +1,10 @@
 // Package badge renders the README's stat card as SVG the repo owns, so its
 // type, palette and spacing match the TUI instead of a badge host's house
 // style.
+//
+// Nothing imports it today: the README header reads its counts live from
+// shields.io, which a committed SVG cannot do. Kept because the card is the
+// only rendering of these stats in the project's own type and palette.
 package badge
 
 import "strings"


### PR DESCRIPTION
`internal/badge` renders the stat card, and nothing imports it since the README header moved to live shields.io chips. A reader opening the package has no way to tell whether that is deliberate or a mistake.

The package doc now says so, and why it was kept rather than deleted.