### PR TITLE
Pin root to the rail and tighten the frame's chrome

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -213,6 +213,10 @@ func (m *Model) reorderSelected(delta int) (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
+	if entry.isRoot() {
+		m.err = "root stays at the top of the list"
+		return m, nil
+	}
 	target, ok := m.visibleReorderTarget(entry, delta)
 	if !ok {
 		edge := "top"
@@ -262,6 +266,11 @@ func (m *Model) visibleReorderTarget(entry treeRow, delta int) (treeRow, bool) {
 	}
 	for i := m.cursor + step; i >= 0 && i < len(m.rows); i += step {
 		candidate := m.rows[i]
+		if candidate.isRoot() {
+			// parentGroup("") is "" too, so root would match a top-level
+			// group as its own sibling.
+			continue
+		}
 		if entry.isGroup {
 			if candidate.isGroup && parentGroup(candidate.group) == parentGroup(entry.group) {
 				return candidate, true
@@ -903,6 +912,10 @@ func (m *Model) prepareDelete() {
 	if !ok {
 		return
 	}
+	if entry.isRoot() {
+		m.err = "root is the top level; delete the sessions under it instead"
+		return
+	}
 	if !entry.isGroup {
 		m.confirm = confirmTarget{
 			label:    "delete " + entry.sess.Name + "? kills its tmux session.",
@@ -1061,6 +1074,10 @@ func (m *Model) deleteConfirmedGroups() ([]string, error) {
 func (m *Model) openRename() {
 	entry, ok := m.selectedRow()
 	if !ok {
+		return
+	}
+	if entry.isRoot() {
+		m.err = "root is the top level, not a group to rename"
 		return
 	}
 	input := textinput.New()

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -53,16 +53,14 @@ func (m *Model) viewListFrame() string {
 	seam := make([]string, bodyHeight)
 	edge := make([]string, bodyHeight)
 	for i := range seam {
-		leftRule := i < len(railRows) && railRows[i].rule
-		rightRule := i < len(contentRows) && contentRows[i].rule
-		seam[i] = m.seamCell(leftRule, rightRule)
+		seam[i] = m.seamCell(i < len(railRows) && railRows[i].rule)
 		tone := panelHex()
 		if i < len(railRows) && railRows[i].tone != "" {
 			tone = railRows[i].tone
 		}
 		edge[i] = railEdgeCell(tone)
 	}
-	frame = append(frame, m.boundedRuleRow(leftWidth+1, m.width, "▀"))
+	frame = append(frame, m.railTopRow(leftWidth+1, m.width))
 	frame = append(frame, joinColumns(
 		edge,
 		paintContent(railRows, railWidth, bodyHeight, panelHex()),
@@ -93,15 +91,10 @@ func (m *Model) railLines(width, height int) []contentLine {
 		listHeight, meters = height, nil
 	}
 	var rows []contentLine
-	// A populated list keeps a breath of air at the top; the empty state
+	// The list starts straight under the pane's top edge; the empty state
 	// centers itself in the full list area instead.
-	if len(m.rows) > 0 {
-		rows = append(rows, contentLine{})
-	}
 	if m.showArchived {
-		if len(rows) == 0 {
-			rows = append(rows, contentLine{})
-		}
+		rows = append(rows, contentLine{})
 		rows = append(rows,
 			contentLine{text: strings.Repeat(" ", railInset) + scopeBadgeStyle.Render("ARCHIVED") +
 				subtleStyle.Render("  ") + keyCap("t", "back to active")},
@@ -125,9 +118,16 @@ func (m *Model) railLines(width, height int) []contentLine {
 // tall, so the window is measured in lines rather than rows. Each line
 // carries the tone its entry painted, which the edge column matches.
 func (m *Model) entryLines(width, height int) []contentLine {
-	if len(m.rows) == 0 {
+	// Root alone is still an empty list: it says what the rail holds, not
+	// what to do about it being empty.
+	if rest := m.rowsBelowRoot(); len(rest) == 0 {
 		var lines []contentLine
-		for _, line := range m.emptyRailLines(width, height) {
+		for _, entry := range m.rows {
+			for _, line := range splitLines(m.renderTreeRow(entry, m.cursor == 0, width, 0, panelHex())) {
+				lines = append(lines, contentLine{text: line})
+			}
+		}
+		for _, line := range m.emptyRailLines(width, height-len(lines)) {
 			lines = append(lines, contentLine{text: line})
 		}
 		return lines
@@ -342,7 +342,15 @@ func (m *Model) renderGroupEntry(entry treeRow, selected bool, width int, pad, g
 	if selected {
 		nameStyle = nameStyle.Foreground(colorBright)
 	}
-	head := pad + guides + subtleStyle.Render(marker) + " " + nameStyle.Render(baseName(entry.group))
+	name := baseName(entry.group)
+	if entry.isRoot() {
+		// Nothing nests under root, so the marker is a blank that holds the column.
+		marker, name = " ", "root"
+		if !selected {
+			nameStyle = nameStyle.Foreground(lipgloss.Color(mix(current.Accent2, current.Subtle, 0.5)))
+		}
+	}
+	head := pad + guides + subtleStyle.Render(marker) + " " + nameStyle.Render(name)
 
 	// What the group is doing rides on the same line as its name, so a
 	// folded group still reports its subtree without being opened. It is

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1020,6 +1020,21 @@ func hashString(s string) uint64 {
 	return h.Sum64()
 }
 
+// rootGroup is the path every ungrouped session already carries.
+const rootGroup = ""
+
+// isRoot marks the pinned top-level row, which is not a stored group.
+func (e treeRow) isRoot() bool { return e.isGroup && e.group == rootGroup }
+
+// rowsBelowRoot is the tree without its pinned row: empty means the rail
+// has nothing to list, however many rows it paints.
+func (m *Model) rowsBelowRoot() []treeRow {
+	if len(m.rows) > 0 && m.rows[0].isRoot() {
+		return m.rows[1:]
+	}
+	return m.rows
+}
+
 func rowKey(entry treeRow) string {
 	if entry.isGroup {
 		return "g:" + entry.group
@@ -1084,7 +1099,9 @@ func (m *Model) rebuildRows() {
 	// there would hide the very sessions the user came to act on.
 	honorFolds := query == "" && !m.showArchived
 
-	rows := make([]treeRow, 0, len(m.sessions)+len(paths))
+	// Root is a standing move and spawn target; its sessions stay flat.
+	rows := make([]treeRow, 0, len(m.sessions)+len(paths)+1)
+	rows = append(rows, treeRow{isGroup: true, group: rootGroup})
 	for _, sess := range sessionsByGroup[""] {
 		rows = append(rows, treeRow{sess: sess})
 	}
@@ -1113,6 +1130,9 @@ func (m *Model) rebuildRows() {
 				break
 			}
 		}
+	} else if m.cursor == 0 && len(rows) > 1 && rows[0].isRoot() {
+		// A launch opens on a session, not on root's rollup.
+		m.cursor = 1
 	}
 	if m.cursor >= len(rows) {
 		m.cursor = len(rows) - 1

--- a/internal/ui/pathcomplete_test.go
+++ b/internal/ui/pathcomplete_test.go
@@ -189,6 +189,8 @@ func TestGroupFormInheritsParentPath(t *testing.T) {
 	}
 	m.applyCmd(t, m.refreshCmd())
 
+	// The cursor starts on root, which has no stored path to inherit.
+	m.selectGroupRow(t, "projects")
 	m.openGroupForm()
 	if m.groupForm.path.Value() != parentPath {
 		t.Fatalf("cursor on group should inherit its path, got %q want %q", m.groupForm.path.Value(), parentPath)

--- a/internal/ui/root_row_test.go
+++ b/internal/ui/root_row_test.go
@@ -1,0 +1,177 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+)
+
+func TestRootRowLeadsTheList(t *testing.T) {
+	m := shotModel()
+	m.rebuildRows()
+	if len(m.rows) == 0 {
+		t.Fatal("no rows, want root")
+	}
+	if !m.rows[0].isRoot() {
+		t.Fatalf("first row is %+v, want root", m.rows[0])
+	}
+	// Its sessions stay flat rather than nesting under it.
+	for _, row := range m.rows[1:] {
+		if !row.isGroup && row.sess.Group == "" && row.depth != 0 {
+			t.Fatalf("ungrouped session %q nested at depth %d", row.sess.Name, row.depth)
+		}
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "root") {
+		t.Fatal("root row is not painted")
+	}
+}
+
+// Root is not a stored group, so group edits refuse it rather than running
+// against an empty path.
+func TestRootRowRefusesGroupEdits(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(*Model)
+	}{
+		{"rename", func(m *Model) { m.openRename() }},
+		{"delete", func(m *Model) { m.prepareDelete() }},
+		{"reorder", func(m *Model) { m.reorderSelected(1) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := shotModel()
+			m.rebuildRows()
+			m.cursor = 0
+			tc.run(m)
+			if m.err == "" {
+				t.Fatal("no message explaining the refusal")
+			}
+			if m.mode != modeList {
+				t.Fatalf("mode changed to %v", m.mode)
+			}
+			if m.confirm.label != "" {
+				t.Fatalf("a confirmation was staged: %q", m.confirm.label)
+			}
+		})
+	}
+}
+
+// Root's rollup counts top-level sessions, not the whole tree.
+func TestRootRollupCountsUngroupedOnly(t *testing.T) {
+	m := shotModel()
+	counts := m.groupStatusCounts(rootGroup)
+	total := 0
+	for _, n := range counts {
+		total += n
+	}
+	ungrouped := 0
+	for _, sess := range m.sessions {
+		if sess.Group == "" {
+			ungrouped++
+		}
+	}
+	if total != ungrouped {
+		t.Fatalf("root rollup counts %d sessions, want %d ungrouped", total, ungrouped)
+	}
+}
+
+// A launch opens on a session, not on root's rollup.
+func TestCursorSkipsRootOnFirstBuild(t *testing.T) {
+	m := shotModel()
+	m.cursor = 0
+	m.rebuildRows()
+	if len(m.rows) < 2 {
+		t.Fatalf("want root and a row below it, got %d rows", len(m.rows))
+	}
+	if m.rows[m.cursor].isRoot() {
+		t.Fatal("cursor parked on root with rows available below it")
+	}
+	// With nothing but root to land on, it is the selection.
+	bare := shotModel()
+	bare.sessions, bare.rows, bare.cursor = nil, nil, 0
+	bare.rebuildRows()
+	if len(bare.rows) != 1 || !bare.rows[0].isRoot() || bare.cursor != 0 {
+		t.Fatalf("empty list should rest on root, got %d rows cursor %d", len(bare.rows), bare.cursor)
+	}
+}
+
+// Root reads quieter than the groups the user named.
+func TestRootRowIsDimmerThanNamedGroups(t *testing.T) {
+	// The suite's default Ascii profile strips every color sequence.
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	m := shotModel()
+	m.rebuildRows()
+	if len(m.rows) == 0 {
+		t.Fatal("no rows, want root")
+	}
+	root := m.renderTreeRow(m.rows[0], false, 40, 0, panelHex())
+	dimmed := strings.TrimPrefix(fgSeq(mix(current.Accent2, current.Subtle, 0.5)), "\x1b[")
+	if !strings.Contains(root, dimmed) {
+		t.Fatalf("root is not painted in the dimmed tone: %q", root)
+	}
+	if accent := strings.TrimPrefix(fgSeq(current.Accent2), "\x1b["); strings.Contains(root, accent) {
+		t.Fatalf("root still carries the group accent: %q", root)
+	}
+}
+
+// Root pins a row at the top, which must not stand in for having sessions:
+// an empty list still says so.
+func TestEmptyListKeepsItsGuidance(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		setup    func(*Model)
+		wantText string
+	}{
+		{"no sessions", func(m *Model) {}, "no sessions yet"},
+		{"no matches", func(m *Model) { m.search = "nothing-matches-this" }, "no matches"},
+		{"nothing archived", func(m *Model) { m.showArchived = true }, "nothing archived"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := shotModel()
+			m.sessions, m.rows = nil, nil
+			tc.setup(m)
+			m.rebuildRows()
+			rail := ansi.Strip(strings.Join(splitLines(joinContentText(m.railLines(40, 20))), "\n"))
+			if !strings.Contains(rail, tc.wantText) {
+				t.Fatalf("rail is missing %q:\n%s", tc.wantText, rail)
+			}
+			if !strings.Contains(rail, "root") {
+				t.Fatalf("root row should still lead the rail:\n%s", rail)
+			}
+		})
+	}
+}
+
+func joinContentText(lines []contentLine) string {
+	var out []string
+	for _, line := range lines {
+		out = append(out, line.text)
+	}
+	return strings.Join(out, "\n")
+}
+
+// Root is pinned first, so it can never be the sibling a top-level group
+// swaps with; parentGroup("") is "" too, which would otherwise match.
+func TestReorderSkipsRootAsSibling(t *testing.T) {
+	m := shotModel()
+	m.rebuildRows()
+	var groupRow, index = treeRow{}, -1
+	for i, row := range m.rows {
+		if row.isGroup && !row.isRoot() && parentGroup(row.group) == "" {
+			groupRow, index = row, i
+			break
+		}
+	}
+	if index < 0 {
+		t.Fatal("no top-level group row to test with")
+	}
+	m.cursor = index
+	if target, ok := m.visibleReorderTarget(groupRow, -1); ok && target.isRoot() {
+		t.Fatalf("root matched as a reorder sibling of %q", groupRow.group)
+	}
+}

--- a/internal/ui/screenshot_test.go
+++ b/internal/ui/screenshot_test.go
@@ -140,12 +140,14 @@ func TestFrameFitsTerminal(t *testing.T) {
 	}
 }
 
-// The pane's soft edges: the opening row bleeds down, the closing row up,
-// and every body row ends with the ▐ half-block edge one column past the
-// seam. The end cells of the edge rows are the corners: the first is a
-// foreground half block so the window margin cannot inherit pane tone and
-// smear past the corner, and the last is a quadrant so the bleed's
-// half-cell fill closes at the corner instead of jutting right.
+// The pane's soft edges: the opening row is drawn in sextants and stops a
+// third of a cell under the wordmark, the closing row bleeds up by half, and
+// every body row ends with the ▐ half-block edge one column past the seam.
+// The end cells of the edge rows are the corners: the first is a foreground
+// block so the window margin cannot inherit pane tone and smear past the
+// corner, and the last is narrowed to the bleed's half width so the fill
+// closes at the corner instead of jutting right. The top row's corner is
+// also a sextant, which is what keeps its edge level with the run beside it.
 func TestPaneSoftEdges(t *testing.T) {
 	m := shotModel()
 	rows := strings.Split(m.View(), "\n")
@@ -153,23 +155,23 @@ func TestPaneSoftEdges(t *testing.T) {
 
 	top := []rune(ansi.Strip(rows[m.headerRows()]))
 	bottom := []rune(ansi.Strip(rows[m.headerRows()+1+m.listBodyHeight()]))
-	if top[0] != '▄' || bottom[0] != '▀' {
-		t.Fatalf("edge rows should open with foreground half blocks, got %q and %q",
+	if top[0] != '🬹' || bottom[0] != '▀' {
+		t.Fatalf("edge rows should open with foreground blocks, got %q and %q",
 			string(top[0]), string(bottom[0]))
 	}
 	for col := 1; col <= leftWidth; col++ {
-		if top[col] != '▀' {
-			t.Fatalf("top edge col %d is %q, want ▀:\n%s", col, string(top[col]), string(top))
+		if top[col] != '🬂' {
+			t.Fatalf("top edge col %d is %q, want 🬂:\n%s", col, string(top[col]), string(top))
 		}
 		if bottom[col] != '▄' {
 			t.Fatalf("bottom edge col %d is %q, want ▄:\n%s", col, string(bottom[col]), string(bottom))
 		}
 	}
-	if top[leftWidth+1] != '▜' || bottom[leftWidth+1] != '▟' {
-		t.Fatalf("edge rows should close with corner quadrants, got %q and %q",
+	if top[leftWidth+1] != '🬨' || bottom[leftWidth+1] != '▟' {
+		t.Fatalf("edge rows should close on the bleed's half width, got %q and %q",
 			string(top[leftWidth+1]), string(bottom[leftWidth+1]))
 	}
-	if top[leftWidth+2] == '▀' || bottom[leftWidth+2] == '▄' {
+	if top[leftWidth+2] == '🬂' || bottom[leftWidth+2] == '▄' {
 		t.Fatalf("the bleed should stop after the seam's edge column")
 	}
 	for i := m.headerRows() + 1; i < m.headerRows()+1+m.listBodyHeight(); i++ {

--- a/internal/ui/seam_rule_test.go
+++ b/internal/ui/seam_rule_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// A content separator stops at the pane's edge instead of crossing the seam.
+func TestContentRuleStopsAtSeam(t *testing.T) {
+	m := shotModel()
+	leftWidth, _ := m.splitWidths()
+	rows := strings.Split(m.View(), "\n")
+	start, end := m.bodyYRange()
+
+	crossings := 0
+	for i := start; i < end; i++ {
+		row := []rune(ansi.Strip(rows[i]))
+		contentRule := row[leftWidth+2] == '─'
+		railRule := row[leftWidth-2] == '─'
+		if contentRule && !railRule && row[leftWidth] == '─' {
+			t.Fatalf("row %d: content rule crosses the seam:\n%s", i, string(row))
+		}
+		if railRule && row[leftWidth] == '─' {
+			crossings++
+		}
+	}
+	// The rail's own rule still runs the width of its pane, seam included.
+	if crossings == 0 {
+		t.Fatal("no rail rule crossed the seam; the pane's own rules should")
+	}
+}

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -41,11 +41,25 @@ func hrule(width int) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(ruleHex())).Render(strings.Repeat("─", width))
 }
 
-// boundedRuleRow is the row that opens or closes the body. Over the pane
-// it draws half blocks in the pane's own tone — the fill bleeding half a
-// cell past its box, which is as far as a character cell can be divided —
-// and across the content it draws the thin rule, whose center line meets
-// the half blocks' edge at the same height.
+// railTopRow opens the body a third of a cell under the wordmark. Sextants,
+// not half blocks: no half block fits the corner over the half-width bleed
+// column at the height of the run beside it, so that cell always stepped.
+func (m *Model) railTopRow(paneWidth, width int) string {
+	if paneWidth < 2 || paneWidth >= width {
+		return paint(hrule(width), width, backdropHex())
+	}
+	fill := lipgloss.NewStyle().Foreground(lipgloss.Color(panelHex()))
+	first := plain(fill.Render("🬹"), 1)
+	interior := lipgloss.NewStyle().Foreground(colorBg).Render(strings.Repeat("🬂", paneWidth-1))
+	last := lipgloss.NewStyle().Foreground(colorBg).Render("🬨")
+	return first + paint(interior, paneWidth-1, panelHex()) + paint(last, 1, panelHex()) +
+		paint(hrule(width-paneWidth-1), width-paneWidth-1, backdropHex())
+}
+
+// boundedRuleRow closes the body. Over the pane it draws half blocks in the
+// pane's own tone — the fill bleeding half a cell past its box — and across
+// the content it draws the thin rule, whose center line meets the half
+// blocks' edge at the same height.
 // The run's interior is drawn inverted — the cell background carries the
 // pane tone and the glyph paints the backdrop half in the theme's backdrop
 // color — but both end cells are not. The terminal extends a row's edge
@@ -84,7 +98,7 @@ func railEdgeCell(tone string) string {
 func (m *Model) vruleColumn(height int) []string {
 	lines := make([]string, height)
 	for i := range lines {
-		lines[i] = m.seamCell(false, false)
+		lines[i] = m.seamCell(false)
 	}
 	return lines
 }
@@ -131,11 +145,10 @@ func (m *Model) focusBottomRule(paneWidth, width int) string {
 		paint(focusEdgeStyle.Render(strings.Repeat("─", tail)), tail, backdropHex())
 }
 
-// seamCell is one row of the vertical seam. A rule arriving from either
-// side turns the cell into the matching junction, so crossing lines meet
-// instead of butting against each other; while the divider is being moved
-// the whole seam becomes the grip and junctions give way to it.
-func (m *Model) seamCell(leftRule, rightRule bool) string {
+// seamCell is one row of the vertical seam. The column is the pane's own
+// fill, so only the pane's rules cross it: a content rule carried across
+// reads as the content's separator running into the sessions list.
+func (m *Model) seamCell(railRule bool) string {
 	// While the divider is being moved the seam becomes the grip.
 	if m.splitDragging || m.resizeMode {
 		color := colorAccent
@@ -144,10 +157,7 @@ func (m *Model) seamCell(leftRule, rightRule bool) string {
 		}
 		return paint(lipgloss.NewStyle().Foreground(color).Render("║"), 1, panelHex())
 	}
-	// Otherwise the seam is the pane's own fill — its edge is drawn by the
-	// bleed column beside it, not by a line — and a rule arriving from
-	// either side crosses it as a rule cell on that fill.
-	if leftRule || rightRule {
+	if railRule {
 		return paint(hrule(1), 1, panelHex())
 	}
 	return paint("", 1, panelHex())

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -142,10 +142,11 @@ func (m *Model) selectGroupRow(t *testing.T, path string) {
 	t.Fatalf("no group row for %q", path)
 }
 
+// groupRowPaths lists the stored groups the tree paints, skipping root.
 func (m *Model) groupRowPaths() []string {
 	var paths []string
 	for _, r := range m.rows {
-		if r.isGroup {
+		if r.isGroup && !r.isRoot() {
 			paths = append(paths, r.group)
 		}
 	}
@@ -353,12 +354,7 @@ func TestNestedGroupsTree(t *testing.T) {
 	createSession(t, m, "deep", dir, "backend/api/auth")
 	createSession(t, m, "top", dir, "")
 
-	var groupPaths []string
-	for _, r := range m.rows {
-		if r.isGroup {
-			groupPaths = append(groupPaths, r.group)
-		}
-	}
+	groupPaths := m.groupRowPaths()
 	want := []string{"backend", "backend/api", "backend/api/auth"}
 	if len(groupPaths) != len(want) {
 		t.Fatalf("group rows = %v want %v", groupPaths, want)
@@ -369,8 +365,11 @@ func TestNestedGroupsTree(t *testing.T) {
 		}
 	}
 
-	if m.rows[0].isGroup || m.rows[0].sess.Name != "top" {
-		t.Fatalf("root session should render first, rows[0] = %+v", m.rows[0])
+	if !m.rows[0].isRoot() {
+		t.Fatalf("root row should lead the list, rows[0] = %+v", m.rows[0])
+	}
+	if m.rows[1].isGroup || m.rows[1].sess.Name != "top" {
+		t.Fatalf("the top-level session should follow root, rows[1] = %+v", m.rows[1])
 	}
 
 	deep := m.sessionRows()[1]


### PR DESCRIPTION
The sessions list gains a standing top-level row, and the frame around it loses three seams that were reading as gaps.

## Root row

Root leads the list as a target you can act on: a session moves onto it and an agent spawns there without a group having to exist first. The sessions that belong to it stay flat, so the tree looks as it did.

```
  root                ◆ 1  ○ 1
◆ db-migrations       waiting · opencode
○ notes               idle · grok · 12m
▾ backend             ◐ 2  ● 1
```

It carries no fold marker, since nothing nests under it, and sits a step quieter than the groups you named. Its rollup counts only the sessions actually at the top level: `inGroupSubtree(g, "")` matches `""` or a `/` prefix, so real groups are excluded.

Rename, delete and reorder refuse it with a message rather than running against an empty path — for delete that would have been a subtree query over every session. A launch opens on the first real row, so the sidebar shows a session rather than the top level's rollup.

## Pane top edge

Drawn in sextants. Half blocks divide a cell in two, and the cell over the bleed column is half a cell wide already, so at eighths it could only be half height or full — either way it stepped against the run beside it, as a tab or a notch. Sextants land the whole row on the same third: `🬹` for the pane's first column, `🬂` across it, `🬓` for the corner at the bleed's half width. The wordmark gets a third of a row of air and the edge stays flat to the corner.

All three glyphs measure one column wide, so the frame math is unchanged.

## Seam and list top

The seam column is the pane's own fill, so only a rule arriving from the pane crosses it now. A separator in the content column used to stop one cell inside the sessions list, which read as the preview's rule running into it.

The list opens straight under the top edge; the blank row it used to lead with is gone.

## Tests

- `TestRootRowLeadsTheList`, `TestRootRowRefusesGroupEdits`, `TestRootRollupCountsUngroupedOnly`, `TestCursorSkipsRootOnFirstBuild`, `TestRootRowIsDimmerThanNamedGroups`
- `TestContentRuleStopsAtSeam` — the content rule stops at the seam while the rail's own still crosses it
- `TestPaneSoftEdges` updated to the sextant edge
- `groupRowPaths` skips root; `TestGroupFormInheritsParentPath` selects a group row, since the cursor now starts on root

Full suite and `go vet` green.