### PR TITLE
fix(focus): keep pasted prompts in the composer instead of auto-submitting

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -219,11 +219,28 @@ func (d *Driver) SendText(id, text string) error {
 	return d.pasteAndEnter(sessionName(id), text)
 }
 
+// Paste delivers text into the session's pane without submitting it. The
+// focus path uses this for clipboard pastes: sending the bytes as raw
+// keystrokes would turn every newline into an Enter press and submit the
+// agent's prompt mid-paste.
+func (d *Driver) Paste(id, text string) error {
+	return d.paste(sessionName(id), text)
+}
+
 var pasteSeq atomic.Uint64
 
 // pasteAndEnter pastes text of any length into a pane and submits it.
-// tmux send-keys silently stops around 1024 bytes; load-buffer does not.
 func (d *Driver) pasteAndEnter(target, text string) error {
+	if err := d.paste(target, text); err != nil {
+		return err
+	}
+	_, err := d.run("send-keys", "-t", target, "Enter")
+	return err
+}
+
+// paste loads text into a tmux buffer and pastes it into the pane.
+// tmux send-keys silently stops around 1024 bytes; load-buffer does not.
+func (d *Driver) paste(target, text string) error {
 	file, err := os.CreateTemp("", "am-paste-*")
 	if err != nil {
 		return fmt.Errorf("paste temp file: %w", err)
@@ -249,8 +266,7 @@ func (d *Driver) pasteAndEnter(target, text string) error {
 		_, _ = d.run("delete-buffer", "-b", buf)
 		return err
 	}
-	_, err = d.run("send-keys", "-t", target, "Enter")
-	return err
+	return nil
 }
 
 // SendRaw runs one pre-assembled tmux command line. The focus path builds

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -203,6 +203,49 @@ func TestSendTextKeepsEnterOutsideBracketedPaste(t *testing.T) {
 	t.Fatalf("pane input = %q, want bracketed paste followed by Enter %q", got, want)
 }
 
+// A clipboard paste forwarded into a focused pane must arrive inside the
+// pane's bracketed-paste markers with no Enter after it, so agent composers
+// keep multi-line text instead of submitting on the first newline.
+func TestPasteDeliversWithoutSubmitting(t *testing.T) {
+	driver := requireTmux(t)
+	id := "paste" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	marker := "/tmp/am-paste-nosubmit-" + id
+	t.Cleanup(func() { os.Remove(marker) })
+
+	text := "first line\nsecond line\n"
+	// paste-buffer converts newlines to carriage returns, the same bytes a
+	// terminal emits when pasting; composers read them as line breaks.
+	want := "\x1b[200~first line\rsecond line\r\x1b[201~"
+	command := "stty raw -echo; printf '\\033[?2004h'; dd bs=1 count=" +
+		strconv.Itoa(len(want)+1) + " of=" + ShellQuote(marker) + " 2>/dev/null"
+	if err := driver.Create(id, "/tmp", command, nil, 0, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+
+	time.Sleep(100 * time.Millisecond)
+	if err := driver.Paste(id, text); err != nil {
+		t.Fatalf("Paste: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := os.ReadFile(marker)
+		if err == nil && string(got) == want {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if got, _ := os.ReadFile(marker); string(got) != want {
+		t.Fatalf("pane input = %q, want bracketed paste %q", got, want)
+	}
+	// dd is still waiting for one more byte; a stray Enter would land now.
+	time.Sleep(300 * time.Millisecond)
+	if got, _ := os.ReadFile(marker); string(got) != want {
+		t.Fatalf("pane received extra input after the paste: %q", got)
+	}
+}
+
 // Create used to type the launch line with send-keys, which silently
 // truncates around 1024 bytes and left long first prompts as a broken
 // shell command. paste-buffer must deliver the full line.

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -63,6 +63,11 @@ func init() {
 // tmux command-line quoting entirely; special keys go by tmux key name.
 // ok is false for keys tmux cannot represent, which are dropped.
 func focusKeyCommand(target string, msg tea.KeyMsg) (string, bool) {
+	// Pastes go through the tmux buffer path: as raw bytes their newlines
+	// would land as Enter presses and submit the agent's prompt.
+	if msg.Paste {
+		return "", false
+	}
 	if msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace {
 		runes := msg.Runes
 		if msg.Type == tea.KeySpace {

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -27,6 +27,9 @@ func TestFocusKeyCommand(t *testing.T) {
 		{"alt-up", tea.KeyMsg{Type: tea.KeyUp, Alt: true}, "send-keys -t am_x M-Up", true},
 		{"pgup", tea.KeyMsg{Type: tea.KeyPgUp}, "send-keys -t am_x PPage", true},
 		{"backspace", tea.KeyMsg{Type: tea.KeyBackspace}, "send-keys -t am_x BSpace", true},
+		// A bracketed paste never rides the raw-bytes path: its newlines
+		// would reach the agent as bare Enter presses and submit the prompt.
+		{"paste", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do it\n"), Paste: true}, "", false},
 	}
 	for _, c := range cases {
 		got, ok := focusKeyCommand("am_x", c.msg)

--- a/internal/ui/focuspaste_test.go
+++ b/internal/ui/focuspaste_test.go
@@ -3,8 +3,8 @@ package ui
 import (
 	"testing"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/YoanWai/agent-manager/internal/tmux"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // A paste while focused goes through the tmux paste path as one block, so

--- a/internal/ui/focuspaste_test.go
+++ b/internal/ui/focuspaste_test.go
@@ -1,0 +1,46 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/YoanWai/agent-manager/internal/tmux"
+)
+
+// A paste while focused goes through the tmux paste path as one block, so
+// the agent's composer receives the newlines instead of Enter presses that
+// submit the prompt mid-paste.
+func TestFocusPasteKeepsPromptInComposer(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "paster", t.TempDir(), "")
+	m.selectSessionRow(t, "paster")
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+	if m.mode != modeFocus {
+		t.Fatalf("enter did not focus, mode = %v", m.mode)
+	}
+
+	var pastedID, pastedText string
+	calls := 0
+	restore := pasteFocused
+	pasteFocused = func(d *tmux.Driver, id, text string) error {
+		calls++
+		pastedID, pastedText = id, text
+		return nil
+	}
+	t.Cleanup(func() { pasteFocused = restore })
+
+	text := "line one\nline two\n"
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(text), Paste: true})
+	*m = *updated.(*Model)
+
+	if calls != 1 {
+		t.Fatalf("paste path called %d times, want 1 (err=%q)", calls, m.err)
+	}
+	if pastedText != text {
+		t.Fatalf("pasted text = %q, want %q", pastedText, text)
+	}
+	if wantID := m.sessionRows()[0].ID; pastedID != wantID {
+		t.Fatalf("pasted into %q, want %q", pastedID, wantID)
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -421,6 +421,11 @@ func (m *Model) leaveFocus() tea.Cmd {
 	})
 }
 
+// pasteFocused is the seam tests swap to observe pastes into the pane.
+var pasteFocused = func(driver *tmux.Driver, id, text string) error {
+	return driver.Paste(id, text)
+}
+
 // handleFocusKey forwards every key into the focused pane. Ctrl+Q is the
 // one reserved key: it returns to the list, mirroring detach from a real
 // attach, and every plain character - q included - reaches the agent.
@@ -440,6 +445,12 @@ func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.scrolledBack() {
 		m.focusScroll = 0
 		resume = m.focusRegionCmd(sess.ID, 0)
+	}
+	if msg.Paste {
+		if err := pasteFocused(m.tmux, sess.ID, string(msg.Runes)); err != nil {
+			m.err = err.Error()
+		}
+		return m, resume
 	}
 	command, ok := focusKeyCommand(tmux.SessionName(sess.ID), msg)
 	if !ok {


### PR DESCRIPTION
## Problem

Pasting into a focused session (Cmd+V) auto-submitted the prompt the moment the clipboard contained a newline. Focus mode forwarded the paste byte-by-byte via `send-keys -H`, so each newline reached the agent as a bare Enter keystroke. This hit every provider (Claude, Codex, Gemini) since the forwarding path is provider-agnostic.

## Fix

Bracketed-paste events from the terminal now route through `load-buffer` + `paste-buffer -p`: tmux re-wraps the text in bracketed-paste markers when the pane application requests them, and no Enter is sent. Agents keep the full multi-line text in their composer; the user submits when ready.

- `Driver.Paste` delivers text without submitting (shares the buffer path with `SendText`)
- `handleFocusKey` routes `Paste` key messages to it
- `focusKeyCommand` refuses paste messages so they can never ride the raw-bytes path

## Tests

- `TestPasteDeliversWithoutSubmitting`: real tmux pane with bracketed paste on receives exactly `ESC[200~text ESC[201~` and nothing after
- `TestFocusPasteKeepsPromptInComposer`: focus mode routes the paste as one block
- `TestFocusKeyCommand`: paste messages are rejected by the raw-key encoder
