### PR TITLE
chore(ci): scope the CI token and schedule dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       prefix: "chore(deps)"
     groups:
       go-minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch
@@ -23,6 +25,8 @@ updates:
       prefix: "chore(ci)"
     groups:
       actions:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      go-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two gaps the security surface had, both one file each.

## CI token scope

`ci.yml` declared no `permissions` block, so the job ran with the default `GITHUB_TOKEN` scope on every push and pull request, forks included. Code scanning has an open `actions/missing-workflow-permissions` warning pointing at it (`badges.yml` already declares `contents: write`).

The job checks out, builds, tests and uploads coverage. It reads the repository and writes nothing, so `contents: read` covers it. Codecov keeps using `secrets.CODECOV_TOKEN`, which is unaffected by the token scope.

## Dependency updates

There was no `.github/dependabot.yml`, so the only Dependabot PRs this repo ever saw were automatic security updates — the `golang.org/x/image` TIFF advisories that became #127. Ordinary version drift went unwatched, and `go list -m -u all` currently reports a long tail behind.

`gomod` and `github-actions` now run weekly on Monday. Minor and patch bumps are grouped per ecosystem, so a quiet week is one PR rather than a dozen, and majors still arrive on their own where the changelog deserves reading. Go updates are capped at five open PRs.

Dependabot opens PRs and nothing merges them: `allow_auto_merge` is off for the repo, and releases are cut by hand with goreleaser. A bump reaches users when you tag, not before.

## Also done outside this diff

Secret scanning and push protection are now enabled on the repository (both were off). Those are settings rather than files, so there is nothing here to review for them.