### PR TITLE
feat(ui): drop the preview label and give the pane every row below the detail seam

### DIFF
--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -512,10 +512,15 @@ func (m *Model) contentLines(width, height int) []contentLine {
 	body := ours(splitLines(m.viewDetail(inner)))
 	rest := height - len(body) - len(bar) - 1
 	if rest >= 3 {
-		body = append(body, contentLine{rule: true})
 		if group, ok := m.selectedGroup(); ok {
+			body = append(body, contentLine{rule: true})
 			body = append(body, ours(splitLines(m.viewGroupAgents(group, inner, rest)))...)
 		} else {
+			separator := contentLine{rule: true}
+			if m.mode == modeFocus {
+				separator = contentLine{text: focusTopRule(width), raw: true}
+			}
+			body = append(body, separator)
 			m.previewBodyOffset = len(body)
 			body = append(body, m.previewLines(width, rest, gutter)...)
 		}
@@ -538,22 +543,14 @@ func focusTopRule(width int) string {
 	return rule
 }
 
-// previewLines is the captured pane under its label. The captured rows are
-// marked raw and drawn without the column's gutters: painting our backdrop
-// behind an agent's own CLI colors would replace the background it drew
-// itself, and insetting its output would put a margin around a terminal
-// that has its own. Only the label, which is ours, keeps the gutter.
+// previewLines is the captured pane, filling every row under the detail
+// separator. The captured rows are marked raw and drawn without the
+// column's gutters: painting our backdrop behind an agent's own CLI colors
+// would replace the background it drew itself, and insetting its output
+// would put a margin around a terminal that has its own.
 func (m *Model) previewLines(width, height int, gutter string) []contentLine {
-	rule := contentLine{raw: true}
-	if m.mode == modeFocus {
-		rule = contentLine{text: focusTopRule(width), raw: true}
-	}
-	lines := []contentLine{{text: gutter + subtleStyle.Render("preview")}, rule}
-	rows := height - len(lines)
-	if rows < 1 {
-		return lines
-	}
-	pane := paneExact(m.preview, rows)
+	var lines []contentLine
+	pane := paneExact(m.preview, height)
 	if len(pane) == 0 {
 		// No rows painted means nothing to hit-test: a box left over from
 		// the previous session would catch clicks on empty space.
@@ -564,7 +561,7 @@ func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 	// geometry the paint used.
 	m.pane.box = paneBox{
 		x:      m.paneOriginX(),
-		y:      m.listChromeRows() + m.previewBodyOffset + len(lines),
+		y:      m.listChromeRows() + m.previewBodyOffset,
 		width:  width,
 		height: len(pane),
 		ok:     true,

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -106,18 +106,14 @@ func (m *Model) previewPaneHeight() int {
 	if m.quick.active {
 		avail -= lipgloss.Height(m.viewQuickBar(inner)) + 1
 	}
-	// Mirrors contentLines: the detail head, the seam, then the preview
-	// under its label and the blank line beneath it.
+	// Mirrors contentLines: the detail head, the seam, then the pane
+	// filling everything below.
 	rest := avail - lipgloss.Height(m.viewDetail(inner)) - 1
 	if rest < 3 {
 		// Preview section is hidden; keep a tiny pane for create/attach paths.
 		return 3
 	}
-	h := rest - 2
-	if h < 1 {
-		return 1
-	}
-	return h
+	return rest
 }
 
 // viewStatus is the transient message line: prompts, search, and


### PR DESCRIPTION
The captured pane now starts directly under the session-details separator and fills the content column to the bottom. In focus mode the separator row itself carries the focused title rule. previewPaneHeight mirrors the new layout so tmux windows stay sized 1:1 with the painted box.

Verified with the full test suite on an isolated tmux socket and a live smoke run: list view shows the pane flush under the seam at full height, focus mode shows the titled rule as the seam.