### PR TITLE
docs(readme): say up front that Windows runs it inside WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Status detection currently supports **Claude Code**, **OpenCode**, **Codex**, **
 
 ## Install
 
+Runs on macOS and Linux, and on Windows inside [WSL2](docs/install.md#windows).
+
 ### Homebrew (macOS / Linux)
 
 ```bash


### PR DESCRIPTION
The install section now opens with the supported platforms, pointing Windows readers at the WSL2 path in docs/install.md before the per-manager subsections.