### PR TITLE
docs(release): name Gemini CLI and the WSL2 path in the release header

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,7 @@ changelog:
 
 release:
   header: |
-    Run every AI coding agent from one terminal. Claude Code, Codex, OpenCode, and Grok run side by side, each in its own tmux session, with live status, a project tree, quick prompts, and full-file diff review. [See it running](https://github.com/YoanWai/agent-manager#agent-manager).
+    Run every AI coding agent from one terminal. Claude Code, Codex, OpenCode, Grok, and Gemini CLI run side by side, each in its own tmux session, with live status, a project tree, quick prompts, and full-file diff review. Runs on macOS and Linux, and on Windows inside WSL2. [See it running](https://github.com/YoanWai/agent-manager#agent-manager).
 
   footer: |
     ## Install


### PR DESCRIPTION
Every release page opens with the tool list and platforms: Gemini CLI joins the header, and the supported platforms (macOS, Linux, Windows inside WSL2) are stated up front. The footer already carried the WSL2 install note.