### PR TITLE
fix(focus): scrolling dead after an agent finishes — keep cached pane state on focus entry

### DIFF
--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -127,11 +127,11 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 	m.focusScroll = 0
 	// Pane state from a previously watched session must not route this
 	// one's wheel; a fresh watcher's first pushed capture reports the real
-	// values. When the watcher is already streaming this session the cache
-	// is this pane's own and stays: a quiet pane pushes nothing, so a
-	// reset here would leave the wheel routed as a plain pane with no
-	// history until the agent next paints.
-	if m.focus == nil || !m.focus.serving(sess.ID) {
+	// values. When the watcher is already streaming this session and the
+	// cache came from its own capture, it stays: a quiet pane pushes
+	// nothing, so a reset here would leave the wheel routed as a plain
+	// pane with no history until the agent next paints.
+	if m.focus == nil || !m.focus.serving(sess.ID) || m.pane.forID != sess.ID {
 		m.pane.mouse = false
 		m.pane.motion = false
 		m.pane.sgr = false

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -125,12 +125,18 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 	m.copied = 0
 	m.cursorOn = true
 	m.focusScroll = 0
-	// Pane state from a previously focused session must not route this
-	// one's wheel; the first pushed capture reports the real values.
-	m.pane.mouse = false
-	m.pane.motion = false
-	m.pane.sgr = false
-	m.pane.history = 0
+	// Pane state from a previously watched session must not route this
+	// one's wheel; a fresh watcher's first pushed capture reports the real
+	// values. When the watcher is already streaming this session the cache
+	// is this pane's own and stays: a quiet pane pushes nothing, so a
+	// reset here would leave the wheel routed as a plain pane with no
+	// history until the agent next paints.
+	if m.focus == nil || !m.focus.serving(sess.ID) {
+		m.pane.mouse = false
+		m.pane.motion = false
+		m.pane.sgr = false
+		m.pane.history = 0
+	}
 	// Mouse reporting makes the pane a closed window: clicks land here
 	// instead of the host terminal, so a drag selects pane text alone and
 	// never the rail beside it.

--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -462,6 +462,49 @@ func TestMouseReportEncodings(t *testing.T) {
 	}
 }
 
+// Entering focus on a pane that has gone quiet keeps the cached pane
+// state. The watcher is already streaming this session and a quiet pane
+// pushes no fresh capture, so a reset on entry would route the wheel as
+// a plain pane with no history — dead until the agent next paints,
+// which is exactly the shape of scrolling a finished agent's pane.
+func TestFocusReentryKeepsPaneStateOnQuietPane(t *testing.T) {
+	m, sess := focusedMouseApp(t, "mouse-tool", "quietapp")
+
+	// Out to the list and back in, with the pane painting nothing in
+	// between — checking on an agent whose turn has ended.
+	m.leaveFocus()
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+	if m.mode != modeFocus {
+		t.Fatalf("did not re-enter focus: %q", m.errBar.text)
+	}
+
+	if !m.pane.mouse {
+		t.Fatal("re-entering focus dropped the pane's mouse claim")
+	}
+	if !m.pane.sgr {
+		t.Fatal("re-entering focus dropped the pane's SGR encoding")
+	}
+	m.View()
+
+	// The wheel still reaches the app, with no pushed capture in between.
+	m.wheelFocus(true, m.pane.box.x+2, m.pane.box.y+1)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		pane, err := m.tmux.CapturePane(sess.ID)
+		if err != nil {
+			t.Fatalf("capture: %v", err)
+		}
+		if strings.Contains(pane, "[<64;") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("wheel report never reached the quiet pane: %q", pane)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
 // The wheel reports the pane's own row, which is the painted row plus
 // whatever the panel dropped off the top of a taller capture.
 func TestWheelReportUsesPaneRow(t *testing.T) {

--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -503,6 +503,16 @@ func TestFocusReentryKeepsPaneStateOnQuietPane(t *testing.T) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+
+	// A cache stamped by another session's capture still resets, serving
+	// client or not: this session's first capture may not have landed.
+	m.leaveFocus()
+	m.pane.forID = "someone-else"
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+	if m.pane.mouse {
+		t.Fatal("another session's cached flags survived focus entry")
+	}
 }
 
 // The wheel reports the pane's own row, which is the painted row plus

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -158,6 +158,10 @@ type netStats struct {
 // is the last width×height told to tmux per session id, skipping no-op
 // resize-window calls that otherwise stall the UI.
 type paneMirror struct {
+	// forID is the session whose pushed capture wrote the fields below;
+	// a serving watcher alone does not prove them current, since its
+	// first capture may still be in flight.
+	forID   string
 	mouse   bool
 	motion  bool
 	sgr     bool
@@ -850,6 +854,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !ok || sess.ID != msg.sessID {
 			return m, nil
 		}
+		m.pane.forID = msg.sessID
 		m.pane.mouse = msg.paneMouse
 		m.pane.motion = msg.paneMotion
 		m.pane.sgr = msg.paneSGR


### PR DESCRIPTION
## Bug

Focus-mode scrolling (not attached) sometimes went dead right when an agent finished its turn: the wheel did nothing until the agent painted again.

## Root cause

`focusSelected` wipes the cached pane state (`pane.mouse`, `pane.motion`, `pane.sgr`, `pane.history`) on every focus entry and relies on the focus watcher's next pushed capture to restore the real values. Two facts break that together:

1. The watcher follows the *selection*, so it is usually already streaming the session before focus is entered; `setFocus` is then a no-op and never re-captures.
2. A finished agent's pane is completely quiet (verified: an idle Claude pane produces zero repaints), so no `%output` event ever arrives to trigger the restoring capture.

Result: after entering (or re-entering) focus on a quiet pane, the wheel routes as "plain pane, no mouse, zero history", `scrollFocus` clamps every notch to offset 0, and scrolling is dead. While the agent is still working, pushes flow constantly and repair the state within milliseconds — which is why it only bit after a turn ended.

## Fix

Keep the cached state when the watcher is already serving this session: the cache is this pane's own, and any terminal-state change repaints the pane, which pushes a fresh capture. A fresh watcher still starts from a clean reset, so another session's flags can never route this pane's wheel.

## Verification

New test `TestFocusReentryKeepsPaneStateOnQuietPane` reproduces the exact flow against a real tmux server and control client: focus a mouse-tracking pane, leave, let it sit quiet, re-enter, wheel — asserts the state survives and the SGR wheel report reaches the pane. Failed before the fix, passes after. Full suite green.