### PR TITLE
fix(hooks): subscribe Notification by matcher instead of grepping its text

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -63,13 +63,11 @@ func statusCommand(state string) string {
 	return `[ -z "$` + EnvStatusFile + `" ] || printf ` + state + ` > "$` + EnvStatusFile + `"`
 }
 
-// notificationCommand filters the payload on stdin: Claude Code fires
-// Notification both for permission prompts and for the 60-second idle
-// "waiting for your input" reminder, and only the former means the agent
-// is blocked.
-func notificationCommand() string {
-	return `[ -z "$` + EnvStatusFile + `" ] || grep -q "waiting for your input" || printf ` + status.Waiting + ` > "$` + EnvStatusFile + `"`
-}
+// blockingNotifications are the Notification types that leave the turn
+// stuck on the user. The event also fires for the idle reminder, for
+// authentication and for background agents finishing, none of which
+// block, so the matcher names the two that do.
+const blockingNotifications = "permission_prompt|elicitation_dialog"
 
 func settingsContent() ([]byte, error) {
 	report := func(matcher, state string) []hookMatcher {
@@ -79,7 +77,7 @@ func settingsContent() ([]byte, error) {
 		"UserPromptSubmit": report("", status.Working),
 		"PreToolUse":       report("*", status.Working),
 		"PostToolUse":      report("*", status.Working),
-		"Notification":     {{Hooks: []hookCommand{{Type: "command", Command: notificationCommand()}}}},
+		"Notification":     report(blockingNotifications, status.Waiting),
 		"Stop":             report("", status.Finished),
 		// compact fires SessionStart in the middle of an active turn
 		"SessionStart": report("startup|resume|clear", status.Idle),

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -58,6 +58,23 @@ func TestEnsureSettingsWritesValidHookJSON(t *testing.T) {
 			t.Fatalf("%s matcher = %q, want *", event, got)
 		}
 	}
+	notification := parsed.Hooks["Notification"][0]
+	if notification.Matcher != blockingNotifications {
+		t.Fatalf("Notification matcher = %q, want %q", notification.Matcher, blockingNotifications)
+	}
+	// the idle reminder, auth success and background agents finishing all
+	// arrive as Notification too, and the matcher is what keeps them out
+	for _, unwanted := range []string{"idle_prompt", "auth_success", "agent_completed"} {
+		if strings.Contains(notification.Matcher, unwanted) {
+			t.Fatalf("Notification matcher %q subscribes to %s", notification.Matcher, unwanted)
+		}
+	}
+	if command := notification.Hooks[0].Command; !strings.Contains(command, "printf "+status.Waiting) || strings.Contains(command, "grep") {
+		t.Fatalf("Notification command = %q, want a plain %s write", command, status.Waiting)
+	}
+	if got := parsed.Hooks["SessionStart"][0].Matcher; got != "startup|resume|clear" {
+		t.Fatalf("SessionStart matcher = %q, want startup|resume|clear", got)
+	}
 }
 
 func TestEnsureSettingsIdempotent(t *testing.T) {


### PR DESCRIPTION
`Notification` fires for several unrelated reasons: a permission prompt, the 60-second idle reminder, authentication succeeding, an MCP elicitation, a background agent finishing. The hook told them apart by grepping the payload for the words "waiting for your input", so every type except the idle reminder wrote `waiting`.

That word sticks. `applyHookStatus` reconciles `finished` and `working` against the pane and lets a hook-reported `waiting` through untouched, so a wrong `waiting` stays on the row until the next hook event.

The event takes a matcher, so the settings file now names the two types that actually block the turn and writes `waiting` with the same plain command every other event uses.

```json
"Notification": [{ "matcher": "permission_prompt|elicitation_dialog", "hooks": [ … ] }]
```

`elicitation_dialog` is in the list because an MCP server asking for input blocks the turn exactly like a permission ask, and the grep already reported it as blocked. `agent_needs_input` is left out: it covers background `claude agents` sessions, and the main loop can still be working while one of them waits.

## What changes in practice

`auth_success`, `agent_completed`, `elicitation_complete` and `elicitation_response` stop writing `waiting`. The idle reminder was already filtered, and its live payload still carries the matched phrase, so that case is unchanged today and stops depending on the wording:

```json
{"hook_event_name":"Notification","notification_type":"idle_prompt","message":"Claude is waiting for your input"}
{"hook_event_name":"Notification","notification_type":"permission_prompt","message":"Claude needs your permission"}
```

Both captured from Claude Code 2.1.220 by a hook dumping stdin.

## Verification

Run against the settings file this branch's binary generates, with instrumented copies logging one hook per matcher value, on an isolated tmux socket:

```
20:22:48 permission_prompt     status file: waiting
20:23:09 Stop                  status file: finished
20:24:11 idle_prompt           status file: finished
```

The permission prompt reports blocked. The idle nudge, 62 seconds after a completed turn, leaves the status file alone. `permission_prompt` matching inside the alternation also confirms the matcher is treated as a pattern rather than an exact string. An earlier run on a hand-built settings file gave the same three results.

A session created through the TUI wrote the expected file:

```
matcher: permission_prompt|elicitation_dialog
command: [ -z "$AGENT_MANAGER_STATUS_FILE" ] || printf waiting > "$AGENT_MANAGER_STATUS_FILE"
```

`go test ./...` passes. The test now pins the matcher, fails if it ever subscribes to `idle_prompt`, `auth_success` or `agent_completed`, and fails if a grep comes back.

## Scope

Only tools with `status_source = "claude-hooks"`, which the default config sets on `[tools.claude]` alone. `EnsureSettings` rewrites the generated file when its bytes change, so existing installs pick this up on their next claude session with no config edit.