### PR TITLE
feat: per-group worktree default and a working quick-prompt toggle

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -115,6 +115,7 @@ CREATE TABLE IF NOT EXISTS settings (
 		)`,
 		`ALTER TABLE sessions ADD COLUMN worktree_repo TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN worktree_branch TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE groups ADD COLUMN worktree TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, migration := range migrations {
 		if _, err := s.db.Exec(migration); err != nil {
@@ -638,10 +639,14 @@ type Group struct {
 	Name     string
 	Path     string
 	Archived bool
+	// Worktree is the group's spawn-in-worktree choice: "on", "off", or
+	// "" to inherit from the nearest ancestor with a choice, else the
+	// global setting.
+	Worktree string
 }
 
 func (s *Store) Groups() ([]Group, error) {
-	rows, err := s.db.Query(`SELECT name, path, archived FROM groups ORDER BY sort_order, name`)
+	rows, err := s.db.Query(`SELECT name, path, archived, worktree FROM groups ORDER BY sort_order, name`)
 	if err != nil {
 		return nil, err
 	}
@@ -650,13 +655,20 @@ func (s *Store) Groups() ([]Group, error) {
 	for rows.Next() {
 		var g Group
 		var archived int
-		if err := rows.Scan(&g.Name, &g.Path, &archived); err != nil {
+		if err := rows.Scan(&g.Name, &g.Path, &archived, &g.Worktree); err != nil {
 			return nil, err
 		}
 		g.Archived = archived != 0
 		groups = append(groups, g)
 	}
 	return groups, rows.Err()
+}
+
+// SetGroupWorktree stores a group's spawn-in-worktree choice: "on",
+// "off", or "" to inherit.
+func (s *Store) SetGroupWorktree(name, worktree string) error {
+	_, err := s.db.Exec(`UPDATE groups SET worktree = ? WHERE name = ?`, worktree, name)
+	return err
 }
 
 // SetGroupArchived flips the archived flag on a group, every descendant

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -704,3 +704,37 @@ func TestSessionWorktreeColumnsRoundTrip(t *testing.T) {
 		t.Fatalf("list dropped worktree fields: %+v", list[0])
 	}
 }
+
+func TestGroupWorktreeRoundtrip(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.CreateGroup("backend", ""); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	groups, err := st.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Worktree != "" {
+		t.Fatalf("new group should inherit worktree, got %+v", groups)
+	}
+	if err := st.SetGroupWorktree("backend", "on"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	groups, err = st.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	if groups[0].Worktree != "on" {
+		t.Fatalf("worktree choice lost: %+v", groups[0])
+	}
+	if err := st.SetGroupWorktree("backend", ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	groups, err = st.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	if groups[0].Worktree != "" {
+		t.Fatalf("worktree choice should clear back to inherit: %+v", groups[0])
+	}
+}

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -32,8 +32,33 @@ const (
 	gfName = iota
 	gfParent
 	gfPath
+	gfWorktree
 	gfCount
 )
+
+// groupWorktreeOptions are the picker states for a group's spawn-in-worktree
+// choice; index 0 stores as "" so the group keeps inheriting.
+var groupWorktreeOptions = []string{"inherit", "on", "off"}
+
+func groupWorktreeValue(index int) string {
+	switch index {
+	case 1:
+		return "on"
+	case 2:
+		return "off"
+	}
+	return ""
+}
+
+func groupWorktreeIndex(value string) int {
+	switch value {
+	case "on":
+		return 1
+	case "off":
+		return 2
+	}
+	return 0
+}
 
 type groupOption struct {
 	path  string
@@ -41,23 +66,25 @@ type groupOption struct {
 }
 
 type form struct {
-	name       textinput.Model
-	dir        textinput.Model
-	prompt     textinput.Model
-	dirAuto    bool
-	toolNames  []string
-	toolIndex  int
-	groups     []groupOption
-	groupIndex int
-	worktree   bool
-	focus      int
+	name         textinput.Model
+	dir          textinput.Model
+	prompt       textinput.Model
+	dirAuto      bool
+	toolNames    []string
+	toolIndex    int
+	groups       []groupOption
+	groupIndex   int
+	worktree     bool
+	worktreeAuto bool
+	focus        int
 }
 
 type groupForm struct {
-	name     textinput.Model
-	path     textinput.Model
-	pathAuto bool
-	focus    int
+	name          textinput.Model
+	path          textinput.Model
+	pathAuto      bool
+	worktreeIndex int
+	focus         int
 }
 
 // sessionLabel renders a session's identity for the tmux status bar.
@@ -173,7 +200,8 @@ func (m *Model) openForm() {
 	m.errBar.text = ""
 	m.rebuildGroupOptions(m.contextGroup())
 	m.form.dir.SetValue(m.groupDefaultDir(m.selectedGroupPath()))
-	m.form.worktree = m.defaultWorktree()
+	m.form.worktree = m.groupWorktree(m.selectedGroupPath())
+	m.form.worktreeAuto = true
 	m.pathSugg.reset()
 	m.mode = modeForm
 }
@@ -266,6 +294,7 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if m.form.focus == fieldWorktree {
 			m.form.worktree = !m.form.worktree
+			m.form.worktreeAuto = false
 			return m, nil
 		}
 	case "right":
@@ -275,6 +304,7 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if m.form.focus == fieldWorktree {
 			m.form.worktree = !m.form.worktree
+			m.form.worktreeAuto = false
 			return m, nil
 		}
 	case "enter":
@@ -309,6 +339,9 @@ func (m *Model) moveGroupCursor(delta int) bool {
 	m.form.groupIndex = next
 	if m.mode == modeForm && m.form.dirAuto {
 		m.form.dir.SetValue(m.groupDefaultDir(m.selectedGroupPath()))
+	}
+	if m.mode == modeForm && m.form.worktreeAuto {
+		m.form.worktree = m.groupWorktree(m.selectedGroupPath())
 	}
 	if m.mode == modeGroupForm && m.groupForm.pathAuto {
 		m.groupForm.path.SetValue(m.ancestorGroupDir(m.selectedGroupPath()))
@@ -604,6 +637,17 @@ func (m *Model) handleGroupFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.groupFormFocus(1)
 		}
 		return m, nil
+	case "left":
+		if m.groupForm.focus == gfWorktree {
+			count := len(groupWorktreeOptions)
+			m.groupForm.worktreeIndex = (m.groupForm.worktreeIndex + count - 1) % count
+			return m, nil
+		}
+	case "right":
+		if m.groupForm.focus == gfWorktree {
+			m.groupForm.worktreeIndex = (m.groupForm.worktreeIndex + 1) % len(groupWorktreeOptions)
+			return m, nil
+		}
 	case "enter":
 		if pathSuggesting && m.pathSugg.chosen {
 			m.applyPathSuggestion()
@@ -655,6 +699,10 @@ func (m *Model) submitGroupForm() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if err := m.store.CreateGroup(full, path); err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	if err := m.store.SetGroupWorktree(full, groupWorktreeValue(m.groupForm.worktreeIndex)); err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
 	}

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestNewSessionPreselectsContextGroup(t *testing.T) {
@@ -346,5 +347,44 @@ func TestSpawnWorktreeRollsBackWhenLaunchBuildFails(t *testing.T) {
 	worktreePath := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-worktrees", "wt-launchfail")
 	if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
 		t.Fatal("worktree must be rolled back when the launch command cannot be built")
+	}
+}
+
+func TestFormWorktreeSeedsFromGroupDefault(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("grp", t.TempDir()); err != nil {
+		t.Fatalf("group: %v", err)
+	}
+	if err := m.store.SetGroupWorktree("grp", "on"); err != nil {
+		t.Fatalf("set worktree: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "grp")
+	m.openForm()
+	if !m.form.worktree {
+		t.Fatal("form should seed worktree on from the group default")
+	}
+	pickGroup(t, m, "")
+	m.moveGroupCursor(0)
+	if m.form.worktree {
+		t.Fatal("moving to root should follow its default off")
+	}
+}
+
+func TestGroupFormStoresWorktreeChoice(t *testing.T) {
+	m := buildModel(t)
+	m.openGroupForm()
+	m.groupForm.name.SetValue("wtgrp")
+	m.groupForm.path.SetValue(t.TempDir())
+	m.groupForm.focus = gfWorktree
+	m.handleGroupFormKey(tea.KeyMsg{Type: tea.KeyRight})
+	_, cmd := m.handleGroupFormKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m.applyCmd(t, cmd)
+	groups, err := m.store.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Worktree != "on" {
+		t.Fatalf("group form should store the worktree choice, got %+v", groups)
 	}
 }

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -621,17 +621,23 @@ func (m *Model) viewGroupDetail(group string, width int) string {
 	head := rowColumns(title, subtleStyle.Render(countLabel), width)
 
 	if m.renamingGroup(group) {
-		label := labelStyle
+		pathLabel := labelStyle
 		if m.rename.focus == 1 {
-			label = lipgloss.NewStyle().Foreground(colorAccent)
+			pathLabel = lipgloss.NewStyle().Foreground(colorAccent)
 		}
-		if fieldWidth := width - 8; fieldWidth >= 10 {
+		worktreeLabel := labelStyle
+		if m.rename.focus == 2 {
+			worktreeLabel = lipgloss.NewStyle().Foreground(colorAccent)
+		}
+		if fieldWidth := width - 12; fieldWidth >= 10 {
 			m.rename.dir.Width = fieldWidth
 		}
-		out := head + "\n" + label.Width(6).Render("path") + m.rename.dir.View()
+		out := head + "\n" + pathLabel.Width(10).Render("path") + m.rename.dir.View()
 		if m.rename.focus == 1 && m.pathSugg.active() {
 			out += "\n" + m.viewPathSuggestions()
 		}
+		out += "\n" + worktreeLabel.Width(10).Render("worktree") +
+			subtleStyle.Render("◂ ") + valueStyle.Render(groupWorktreeOptions[m.rename.worktreeIndex]) + subtleStyle.Render(" ▸")
 		return out
 	}
 

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -164,12 +164,17 @@ func (m *Model) viewGroupForm() string {
 	if m.groupForm.focus == gfPath && m.pathSugg.active() {
 		b.WriteString(m.viewPathSuggestions() + "\n")
 	}
+	worktreeVal := subtleStyle.Render("◂ ") + valueStyle.Render(groupWorktreeOptions[m.groupForm.worktreeIndex]) + subtleStyle.Render(" ▸")
+	b.WriteString(formField("worktree", worktreeVal, m.groupForm.focus == gfWorktree))
 	if m.groupForm.focus == gfParent {
 		b.WriteString("\n" + m.viewGroupPicker())
 	}
 	hint := "tab/↑↓ move · ↵ create · esc cancel"
 	if m.groupForm.focus == gfParent {
 		hint = "↑↓ pick parent · tab next field · ↵ create · esc cancel"
+	}
+	if m.groupForm.focus == gfWorktree {
+		hint = "tab/↑↓ move · ←→ change · ↵ create · esc cancel"
 	}
 	if m.groupForm.focus == gfPath && m.pathSugg.active() {
 		hint = pathSuggestHint(m.pathSugg.chosen)
@@ -221,7 +226,7 @@ func (m *Model) viewSettings() string {
 		row(settingsFieldLayout, "review layout", layout) + "\n" +
 		row(settingsFieldQuickClose, "after quick send", quickClose) + "\n" +
 		row(settingsFieldFocusKey, "session keys", focusKey) + "\n" +
-		row(settingsFieldWorktree, "worktree sessions", worktreeDefault) + "\n" +
+		row(settingsFieldWorktree, "spawn in worktree", worktreeDefault) + "\n" +
 		actionRow(settingsFieldBugReport, "report a bug", "open a prefilled GitHub issue") + "\n\n" +
 		subtleStyle.Render("  version ") + valueStyle.Render(m.update.version) + m.versionStatus()
 	hint := "↑↓ field · ←→ change · ↵/esc save"
@@ -263,8 +268,8 @@ func (m *Model) viewHelp() string {
 		{"ctrl+q", "inside a session: back to manager"},
 		{"ctrl+r", "inside a session: review its diff, esc returns"},
 		{"m", "move session to another group"},
-		{"g", "new group (name, parent, default path)"},
-		{"r", "rename session / edit group (name + default path)"},
+		{"g", "new group (name, parent, default path, worktree)"},
+		{"r", "rename session / edit group (name, default path, worktree)"},
 		{"x", "kill session, or every live session in a group (frees their RAM)"},
 		{"X", "kill every live session"},
 		{"v", "revive killed session, or every dead session in a group (resumes the agent)"},
@@ -274,7 +279,7 @@ func (m *Model) viewHelp() string {
 		{"K / J", "reorder row up / down (shift+↑↓ also works)"},
 		{"space", "quick prompt: answer session / spawn agent in group"},
 		{"⇥", "in quick prompt: switch spawn tool"},
-		{"⌥w", "in quick prompt: toggle worktree for the spawned agent"},
+		{"⇤", "in quick prompt: toggle worktree for the spawned agent"},
 		{"^v", "in quick prompt: paste image as a chip at the cursor"},
 		{"⌫", "in quick prompt: next to a chip, delete the whole chip"},
 		{"ctrl+r", "review changes: whole-file diffs, comment lines, send to agent"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -67,6 +67,7 @@ type Model struct {
 	rows           []treeRow
 	groups         []string
 	groupPaths     map[string]string
+	groupWorktrees map[string]string
 	archivedGroups map[string]bool
 	snap           sysstat.Snapshot
 	proc           sysstat.ProcStat
@@ -229,14 +230,15 @@ type confirmTarget struct {
 }
 
 type renameTarget struct {
-	isGroup   bool
-	path      string
-	sessID    string
-	input     textinput.Model
-	dir       textinput.Model
-	focus     int
-	toolNames []string
-	toolIndex int
+	isGroup       bool
+	path          string
+	sessID        string
+	input         textinput.Model
+	dir           textinput.Model
+	worktreeIndex int
+	focus         int
+	toolNames     []string
+	toolIndex     int
 }
 
 // quickState is the inline prompt bar docked under the preview: active
@@ -253,6 +255,9 @@ type quickState struct {
 	lastImageID    int
 	closeAfterSend bool
 	worktree       bool
+	// worktreeTouched marks an explicit toggle this run; until then the
+	// hint and spawn follow the target group's default.
+	worktreeTouched bool
 }
 
 // quickAttachment is one pasted image: the id its token carries, and the
@@ -312,6 +317,7 @@ type refreshMsg struct {
 	sessions       []store.Session
 	groups         []string
 	groupPaths     map[string]string
+	groupWorktrees map[string]string
 	archivedGroups map[string]bool
 	snap           sysstat.Snapshot
 	snapOK         bool
@@ -800,6 +806,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.sessions = msg.sessions
 		m.groups = msg.groups
 		m.groupPaths = msg.groupPaths
+		m.groupWorktrees = msg.groupWorktrees
 		m.archivedGroups = msg.archivedGroups
 		m.agents = msg.agents
 		if msg.snapOK {

--- a/internal/ui/pathcomplete_test.go
+++ b/internal/ui/pathcomplete_test.go
@@ -176,8 +176,12 @@ func TestRenamePathSuggestionsExitToName(t *testing.T) {
 	m.pathSugg.index = len(m.pathSugg.suggestions) - 1
 
 	m.handleRenameKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.rename.focus != 2 {
+		t.Fatalf("down past last suggestion should move to worktree, focus=%d", m.rename.focus)
+	}
+	m.handleRenameKey(tea.KeyMsg{Type: tea.KeyDown})
 	if m.rename.focus != 0 {
-		t.Fatalf("down past last suggestion should wrap to name, focus=%d", m.rename.focus)
+		t.Fatalf("down past worktree should wrap to name, focus=%d", m.rename.focus)
 	}
 }
 

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -363,10 +363,14 @@ func (p *poller) refreshOnce() tea.Msg {
 	}
 	names := make([]string, len(groups))
 	paths := make(map[string]string, len(groups))
+	worktrees := make(map[string]string, len(groups))
 	archivedGroups := make(map[string]bool, len(groups))
 	for i, g := range groups {
 		names[i] = g.Name
 		paths[g.Name] = g.Path
+		if g.Worktree != "" {
+			worktrees[g.Name] = g.Worktree
+		}
 		if g.Archived {
 			archivedGroups[g.Name] = true
 		}
@@ -387,6 +391,7 @@ func (p *poller) refreshOnce() tea.Msg {
 		sessions:       sessions,
 		groups:         names,
 		groupPaths:     paths,
+		groupWorktrees: worktrees,
 		archivedGroups: archivedGroups,
 		proc:           proc,
 		procFor:        selectedID,

--- a/internal/ui/quick.go
+++ b/internal/ui/quick.go
@@ -148,8 +148,9 @@ func (m *Model) handleQuickKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.quick.toolIndex = (m.quick.toolIndex + 1) % len(m.quick.toolNames)
 		}
 		return m, nil
-	case "alt+w":
-		m.quick.worktree = !m.quick.worktree
+	case "shift+tab", "alt+w":
+		m.quick.worktree = !m.quickWorktreeOn()
+		m.quick.worktreeTouched = true
 		return m, nil
 	case "ctrl+v":
 		if m.quickPasting() {
@@ -260,8 +261,12 @@ func (m *Model) quickSpawn(group, prompt string) (tea.Model, tea.Cmd) {
 		m.errBar.text = "group has no valid default path: " + dir
 		return m, nil
 	}
+	worktree := m.quick.worktree
+	if !m.quick.worktreeTouched {
+		worktree = m.groupWorktree(group)
+	}
 	name := toolName + "-" + newID()[:4]
-	if err := m.spawnSession(toolName, name, dir, group, prompt, true, m.quick.worktree); err != nil {
+	if err := m.spawnSession(toolName, name, dir, group, prompt, true, worktree); err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
@@ -278,6 +283,23 @@ func (m *Model) clearQuickAfterSend() {
 	if m.quick.closeAfterSend {
 		m.quick.active = false
 	}
+}
+
+// quickWorktreeOn is the worktree state the quick bar shows and spawns
+// with: the target group's default until shift+tab overrides it.
+func (m *Model) quickWorktreeOn() bool {
+	if m.quick.worktreeTouched {
+		return m.quick.worktree
+	}
+	group := ""
+	if entry, ok := m.selectedRow(); ok {
+		if entry.isGroup {
+			group = entry.group
+		} else {
+			group = entry.sess.Group
+		}
+	}
+	return m.groupWorktree(group)
 }
 
 // quickTool is the spawn CLI for the current quick-mode run: the settings

--- a/internal/ui/quick_test.go
+++ b/internal/ui/quick_test.go
@@ -606,7 +606,10 @@ func TestQuickSpawnRespectsWorktreeToggleInNonRepo(t *testing.T) {
 	m.applyCmd(t, m.refreshCmd())
 	m.selectGroupRow(t, "grp")
 	m.openQuickMode()
-	m.quick.worktree = true
+	m.handleQuickKey(tea.KeyMsg{Type: tea.KeyShiftTab})
+	if !m.quick.worktree {
+		t.Fatal("shift+tab should toggle worktree on")
+	}
 	m.quick.input.SetValue("do a thing")
 	m.submitQuick()
 	if m.errBar.text == "" {
@@ -618,5 +621,57 @@ func TestQuickSpawnRespectsWorktreeToggleInNonRepo(t *testing.T) {
 	}
 	if len(sessions) != 0 {
 		t.Fatal("blocked spawn must not create a session")
+	}
+}
+
+func TestQuickSpawnUsesGroupWorktreeDefault(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("grp", dir); err != nil {
+		t.Fatalf("group: %v", err)
+	}
+	if err := m.store.SetGroupWorktree("grp", "on"); err != nil {
+		t.Fatalf("set worktree: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "grp")
+	m.openQuickMode()
+	if !m.quickWorktreeOn() {
+		t.Fatal("quick bar should show the group's worktree default on")
+	}
+	m.quick.input.SetValue("do a thing")
+	m.submitQuick()
+	if m.errBar.text == "" {
+		t.Fatal("group-default worktree spawn into a non-repo dir must surface an error")
+	}
+	sessions, err := m.store.ListSessions(true)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatal("blocked spawn must not create a session")
+	}
+}
+
+func TestQuickWorktreeToggleOverridesGroupDefault(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("grp", dir); err != nil {
+		t.Fatalf("group: %v", err)
+	}
+	if err := m.store.SetGroupWorktree("grp", "on"); err != nil {
+		t.Fatalf("set worktree: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "grp")
+	m.openQuickMode()
+	m.handleQuickKey(tea.KeyMsg{Type: tea.KeyShiftTab})
+	if m.quickWorktreeOn() {
+		t.Fatal("shift+tab should override the group default off")
+	}
+	m.quick.input.SetValue("do a thing")
+	m.submitQuick()
+	if m.errBar.text != "" {
+		t.Fatalf("plain spawn should succeed: %q", m.errBar.text)
 	}
 }

--- a/internal/ui/rename.go
+++ b/internal/ui/rename.go
@@ -30,7 +30,13 @@ func (m *Model) openRename() {
 		}
 		dir.SetValue(dirValue)
 		m.pathSugg.reset()
-		m.rename = renameTarget{isGroup: true, path: entry.group, input: input, dir: dir}
+		m.rename = renameTarget{
+			isGroup:       true,
+			path:          entry.group,
+			input:         input,
+			dir:           dir,
+			worktreeIndex: groupWorktreeIndex(m.groupWorktrees[entry.group]),
+		}
 	} else {
 		input.SetValue(entry.sess.Name)
 		tools := sortedToolNames(m.cfg)
@@ -60,12 +66,17 @@ func (m *Model) openRename() {
 
 func (m *Model) renameFocus(delta int) {
 	m.pathSugg.reset()
-	m.rename.focus = (m.rename.focus + delta + 2) % 2
+	fields := 2
+	if m.rename.isGroup {
+		fields = 3
+	}
+	m.rename.focus = (m.rename.focus + delta + fields) % fields
 	m.rename.input.Blur()
 	m.rename.dir.Blur()
-	if m.rename.focus == 0 {
+	switch m.rename.focus {
+	case 0:
 		m.rename.input.Focus()
-	} else {
+	case 1:
 		m.rename.dir.Focus()
 	}
 }
@@ -123,6 +134,16 @@ func (m *Model) handleRenameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.renameFocus(1)
 		}
 		return m, nil
+	case "left", "right":
+		if m.rename.isGroup && m.rename.focus == 2 {
+			delta := 1
+			if msg.String() == "left" {
+				delta = -1
+			}
+			count := len(groupWorktreeOptions)
+			m.rename.worktreeIndex = (m.rename.worktreeIndex + delta + count) % count
+			return m, nil
+		}
 	case "enter":
 		if pathSuggesting && m.pathSugg.chosen {
 			m.applyPathSuggestion()
@@ -131,9 +152,10 @@ func (m *Model) handleRenameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.applyRename()
 	}
 	var cmd tea.Cmd
-	if m.rename.focus == 0 {
+	switch m.rename.focus {
+	case 0:
 		m.rename.input, cmd = m.rename.input.Update(msg)
-	} else {
+	case 1:
 		m.rename.dir, cmd = m.rename.dir.Update(msg)
 		m.pathSugg.recompute(m.rename.dir.Value())
 	}
@@ -182,7 +204,12 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 			m.errBar.text = err.Error()
 			return m, nil
 		}
-		m.renameGroupLocally(m.rename.path, newPath, dir)
+		worktree := groupWorktreeValue(m.rename.worktreeIndex)
+		if err := m.store.SetGroupWorktree(newPath, worktree); err != nil {
+			m.errBar.text = err.Error()
+			return m, nil
+		}
+		m.renameGroupLocally(m.rename.path, newPath, dir, worktree)
 		m.relabelSubtree(newPath)
 	} else {
 		if err := m.store.RenameSession(m.rename.sessID, name); err != nil {
@@ -224,7 +251,7 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 // renameGroupLocally rewrites the in-memory tree right away, so the
 // frames between saving and the poller's next refresh already show the
 // new name and path instead of flashing the stale ones.
-func (m *Model) renameGroupLocally(old, newPath, dir string) {
+func (m *Model) renameGroupLocally(old, newPath, dir, worktree string) {
 	moved := func(group string) (string, bool) {
 		if group == old || strings.HasPrefix(group, old+"/") {
 			return newPath + group[len(old):], true
@@ -244,6 +271,17 @@ func (m *Model) renameGroupLocally(old, newPath, dir string) {
 	}
 	groupPaths[newPath] = dir
 	m.groupPaths = groupPaths
+	groupWorktrees := make(map[string]string, len(m.groupWorktrees))
+	for group, choice := range m.groupWorktrees {
+		group, _ = moved(group)
+		groupWorktrees[group] = choice
+	}
+	if worktree == "" {
+		delete(groupWorktrees, newPath)
+	} else {
+		groupWorktrees[newPath] = worktree
+	}
+	m.groupWorktrees = groupWorktrees
 	for group, folded := range m.collapsed {
 		if renamed, ok := moved(group); ok {
 			delete(m.collapsed, group)

--- a/internal/ui/rename_test.go
+++ b/internal/ui/rename_test.go
@@ -213,3 +213,34 @@ func TestGroupPathNeverEmpty(t *testing.T) {
 		t.Fatal("edited group should keep a resolved path when cleared")
 	}
 }
+
+func TestGroupEditPersistsWorktreeChoice(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("grp", t.TempDir()); err != nil {
+		t.Fatalf("group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "grp")
+	m.openRename()
+	m.handleRenameKey(tea.KeyMsg{Type: tea.KeyDown})
+	m.handleRenameKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.rename.focus != 2 {
+		t.Fatalf("focus should reach the worktree field, got %d", m.rename.focus)
+	}
+	m.handleRenameKey(tea.KeyMsg{Type: tea.KeyRight})
+	_, cmd := m.handleRenameKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m.applyCmd(t, cmd)
+	groups, err := m.store.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Worktree != "on" {
+		t.Fatalf("worktree choice should persist, got %+v", groups)
+	}
+	if !m.groupWorktree("grp") {
+		t.Fatal("group worktree should resolve on")
+	}
+	if !m.groupWorktree("grp/child") {
+		t.Fatal("child group should inherit the parent's worktree choice")
+	}
+}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -35,6 +35,20 @@ func (m *Model) defaultWorktree() bool {
 	return chosen == "on"
 }
 
+// groupWorktree resolves a group's spawn-in-worktree default: the nearest
+// ancestor with an explicit choice wins, else the global setting.
+func (m *Model) groupWorktree(group string) bool {
+	for g := group; g != ""; g = parentGroup(g) {
+		switch m.groupWorktrees[g] {
+		case "on":
+			return true
+		case "off":
+			return false
+		}
+	}
+	return m.defaultWorktree()
+}
+
 // defaultSplitLayout reports whether review mode should open in split
 // (side-by-side) layout. Split is the default; a stored "unified" choice
 // opts out. A store error is surfaced but still yields the split default.

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -383,12 +383,12 @@ func (m *Model) viewFooter() string {
 	}
 	if m.quick.active {
 		worktreeHint := "off"
-		if m.quick.worktree {
+		if m.quickWorktreeOn() {
 			worktreeHint = "on"
 		}
 		pairs = [][2]string{
 			{"↵", "send"}, {"↑↓", "switch target"}, {"⇥", "tool: " + m.quickTool()},
-			{"⌥w", "worktree: " + worktreeHint}, {"esc", "close"},
+			{"⇤", "worktree: " + worktreeHint}, {"esc", "close"},
 		}
 	}
 	if m.split.resizeMode {


### PR DESCRIPTION
## What

- Quick prompt: worktree toggle is now **shift+tab** (`⇤`). The old `alt+w` binding never fired on macOS terminals (Option composes a character unless remapped to Meta), so the toggle was unreachable; `alt+w` remains as an alias where terminals send it. Footer and help updated.
- Groups: new **worktree** choice (`inherit` / `on` / `off`) on each group, set in the group form (`g`) and the edit view (`r`). Resolution walks up the group tree to the nearest explicit choice, with the global setting as the root fallback.
- Quick spawn and the new-session form seed their worktree state from the target group's default and keep following it until the user touches the toggle.
- Settings row relabeled **spawn in worktree**.

## Storage

`groups.worktree TEXT NOT NULL DEFAULT ''` via the additive migration list; `''` means inherit, so existing groups keep today's behavior.

## Tests

Store roundtrip, group inheritance resolution, quick spawn group default + shift+tab override, form seeding on group change, group form and edit persistence. Full suite green on an isolated tmux socket.