### PR TITLE
feat(focus): ctrl+\ unfocus alias and feed message for group worktree defaults

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -1,11 +1,24 @@
 [
   {
+    "id": "group-worktree-defaults",
+    "banner": "new: worktree defaults per group",
+    "title": "Groups now carry their own worktree default",
+    "body": [
+      "Each group can choose inherit, on, or off for spawning sessions in",
+      "their own git worktree, set when creating a group (g) or editing one (r);",
+      "children inherit from their parents, and the global setting stays the",
+      "root fallback. The quick-prompt toggle moved to shift+tab, which every",
+      "terminal delivers, and ctrl+\\ now leaves a focused session, same as ctrl+q."
+    ],
+    "url": "https://github.com/YoanWai/agent-manager/releases"
+  },
+  {
     "id": "worktree-sessions",
     "banner": "new: worktree sessions",
     "title": "Sessions can now spawn in their own git worktree",
     "body": [
       "Parallel agents on one repo never edit the same checkout again.",
-      "Toggle it on the new-session form (n), with alt+w on the quick prompt,",
+      "Toggle it on the new-session form (n), with shift+tab on the quick prompt,",
       "or set the default for both in settings (s).",
       "Deleting a session cleans up its worktree and branch when they are clean."
     ],

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -178,13 +178,14 @@ func (d *Driver) styleStatusBar(name string) error {
 	return nil
 }
 
-// EnsureBindings installs the server-global Ctrl+Q detach and Ctrl+R review
-// bindings. Both only act inside am_* sessions; elsewhere the key passes
-// through to the pane. Idempotent, so it is safe to re-run for sessions that
-// predate a binding.
+// EnsureBindings installs the server-global Ctrl+Q / Ctrl+\ detach and
+// Ctrl+R review bindings. All only act inside am_* sessions; elsewhere the
+// key passes through to the pane. Idempotent, so it is safe to re-run for
+// sessions that predate a binding.
 func (d *Driver) EnsureBindings() error {
 	binds := [][]string{
 		{"bind-key", "-n", "C-q", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "detach-client", "send-keys C-q"},
+		{"bind-key", "-n", `C-\`, "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "detach-client", `send-keys C-\\`},
 		{"bind-key", "-n", "C-r", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "set-option -g " + reviewOption + " 1 ; detach-client", "send-keys C-r"},
 	}
 	for _, args := range binds {

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -155,11 +155,12 @@ func (m *Model) leaveFocus() tea.Cmd {
 	})
 }
 
-// handleFocusKey forwards every key into the focused pane. Ctrl+Q is the
-// one reserved key: it returns to the list, mirroring detach from a real
-// attach, and every plain character - q included - reaches the agent.
+// handleFocusKey forwards every key into the focused pane. Ctrl+Q and
+// ctrl+\ are the reserved keys: they return to the list, mirroring detach
+// from a real attach, and every plain character - q included - reaches
+// the agent.
 func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if msg.String() == "ctrl+q" {
+	if msg.String() == "ctrl+q" || msg.String() == `ctrl+\` {
 		return m, m.leaveFocus()
 	}
 	sess, ok := m.selected()

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -422,3 +422,21 @@ func TestDetachNoMouseReArm(t *testing.T) {
 		t.Fatalf("detach should not re-arm mouse, got %T", cmd)
 	}
 }
+
+// Ctrl+\ mirrors ctrl+q: it leaves focus without touching the pane.
+func TestFocusModeCtrlBackslashUnfocuses(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "focusme", t.TempDir(), "")
+	m.selectSessionRow(t, "focusme")
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+	if m.mode != modeFocus {
+		t.Fatalf("after enter, mode = %v, err = %q", m.mode, m.errBar.text)
+	}
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlBackslash})
+	*m = *updated.(*Model)
+	if m.mode != modeList {
+		t.Fatalf("ctrl+\\ left mode = %v", m.mode)
+	}
+}

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -265,7 +265,7 @@ func (m *Model) viewHelp() string {
 	rows := [][2]string{
 		{"n", "new session"},
 		{"↵", "attach session / fold group"},
-		{"ctrl+q", "inside a session: back to manager"},
+		{"ctrl+q", "inside a session: back to manager (ctrl+\\ also works)"},
 		{"ctrl+r", "inside a session: review its diff, esc returns"},
 		{"m", "move session to another group"},
 		{"g", "new group (name, parent, default path, worktree)"},

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -134,7 +134,7 @@ func (m *Model) viewStatus() string {
 			subtleStyle.Render(fmt.Sprintf("%d chars to clipboard", m.copied))
 	case m.mode == modeFocus:
 		return "  " + keyStyle.Render("focus ") +
-			subtleStyle.Render("typing goes to the agent · drag/double/triple click to copy · ctrl+q back")
+			subtleStyle.Render("typing goes to the agent · drag/double/triple click to copy · ctrl+q or ctrl+\\ back")
 	case m.mode == modeConfirmDelete:
 		return "  " + errStyle.Render("⚠ "+m.confirm.label) + subtleStyle.Render("  y/n")
 	case m.split.resizeMode:


### PR DESCRIPTION
## What

- **ctrl+\** now leaves a focused session, alongside ctrl+q: added to the focus-mode key handler and as a server-global tmux detach binding for real attaches (verified the `C-\` bind syntax against a live tmux on an isolated socket). Shift+enter was considered and is impossible on bubbletea v1: plain terminals send the same byte for enter and shift+enter.
- Help modal and focus footer name the new key.
- **Message feed**: announces the per-group worktree defaults, the shift+tab quick-prompt toggle, and ctrl+\; the older worktree card now names shift+tab instead of the dead alt+w binding.

## Tests

New focus-mode test drives ctrl+\ and asserts it returns to the list. ui and tmux packages green on an isolated socket.