### PR TITLE
feat(notices): update in place from the update notice

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -203,11 +203,22 @@ type splitState struct {
 }
 
 // updateInfo is this build's release tag plus a newer release found on
-// GitHub, so the header can badge it.
+// GitHub, so the header can badge it. applying marks an in-flight
+// self-update; restartPath, once set, tells main to exec the freshly
+// swapped binary after the program exits.
 type updateInfo struct {
-	version string
-	latest  string
-	url     string
+	version     string
+	latest      string
+	url         string
+	applying    bool
+	restartPath string
+}
+
+// updateAppliedMsg reports the self-update download-and-swap: on success
+// path is the binary to restart into.
+type updateAppliedMsg struct {
+	path string
+	err  error
 }
 
 // confirmTarget.action values; the zero value means delete.
@@ -856,6 +867,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.update.url = msg.url
 		})
 		return m, nil
+
+	case updateAppliedMsg:
+		m.update.applying = false
+		if msg.err != nil {
+			m.errBar.text = "update failed: " + msg.err.Error()
+			return m, nil
+		}
+		m.update.restartPath = msg.path
+		return m, tea.Quit
 
 	case updateTickMsg:
 		return m, tea.Batch(m.checkForUpdate, m.checkFeed, m.updateTick())

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -1,9 +1,11 @@
 package ui
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"sort"
@@ -14,6 +16,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/update"
 )
 
 const (
@@ -58,6 +61,7 @@ func (m *Model) activeNotices() []notice {
 			title:  "Update available",
 			body: []string{
 				"Release " + m.update.latest + " is out; this build is " + m.update.version + ".",
+				"u updates in place and restarts; sessions keep running.",
 				"Enter opens the release page with the changelog and install notes.",
 			},
 			url: m.update.url,
@@ -74,7 +78,7 @@ func (m *Model) activeNotices() []notice {
 				"This machine now runs " + m.update.version + ".",
 				"Enter opens the release notes for everything that changed.",
 			},
-			url: repoURL + "/releases/tag/" + m.update.version,
+			url: repoURL + "/releases/tag/v" + strings.TrimPrefix(m.update.version, "v"),
 		})
 	}
 	for _, msg := range m.feedMessages {
@@ -334,9 +338,48 @@ func (m *Model) keepNoticeSelection(apply func()) {
 	}
 }
 
+// RestartPath is the binary main execs into after the program exits;
+// empty when no self-update happened this run.
+func (m *Model) RestartPath() string { return m.update.restartPath }
+
+// isUpdateNotice marks the one notice that carries the in-place update
+// action.
+func isUpdateNotice(n notice) bool {
+	return strings.HasPrefix(n.id, "update-")
+}
+
+// applyUpdate is the self-update seam: tests swap it for a fake instead
+// of downloading a release.
+var applyUpdate = update.Apply
+
+// applyUpdateCmd downloads the latest release off the event loop, swaps
+// the running binary, and reports the path to restart into.
+func (m *Model) applyUpdateCmd() tea.Cmd {
+	tag := m.update.latest
+	return func() tea.Msg {
+		execPath, err := os.Executable()
+		if err != nil {
+			return updateAppliedMsg{err: err}
+		}
+		if err := applyUpdate(context.Background(), tag, execPath); err != nil {
+			return updateAppliedMsg{err: err}
+		}
+		return updateAppliedMsg{path: execPath}
+	}
+}
+
 func (m *Model) handleNoticesKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	notices := m.activeNotices()
 	switch msg.String() {
+	case "u":
+		if m.update.applying {
+			return m, nil
+		}
+		if m.noticeCursor < len(notices) && isUpdateNotice(notices[m.noticeCursor]) {
+			m.update.applying = true
+			m.errBar.text = ""
+			return m, m.applyUpdateCmd()
+		}
 	case "up", "k":
 		if m.noticeCursor > 0 {
 			m.noticeCursor--
@@ -396,14 +439,21 @@ func (m *Model) viewNotices() string {
 	if selected.url != "" {
 		rows = append(rows, subtleStyle.Render("↗ "+truncateTail(strings.TrimPrefix(selected.url, "https://"), inner-2)))
 	}
+	if m.update.applying {
+		rows = append(rows, lipgloss.NewStyle().Foreground(colorAccent).Render("↓ downloading "+m.update.latest+"…"))
+	}
 	if m.errBar.text != "" {
 		rows = append(rows, errStyle.Render("✕ "+m.errBar.text))
 	}
 	rows = append(rows, "")
 
+	hint := "↑↓ pick · ↵ open · x dismiss · esc "
+	if isUpdateNotice(selected) {
+		hint = "↑↓ pick · u update · ↵ open · x dismiss · esc "
+	}
 	frame := noticeFrame(rows, inner,
 		noticeLegend(),
-		mutedStyle.Render("↑↓ pick · ↵ open · x dismiss · esc "))
+		mutedStyle.Render(hint))
 	return m.centerOnBackdrop(frame)
 }
 

--- a/internal/ui/notices_test.go
+++ b/internal/ui/notices_test.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -482,5 +484,84 @@ func TestLateFeedKeepsModalSelection(t *testing.T) {
 	}
 	if got := m.activeNotices()[m.noticeCursor].id; got != selected {
 		t.Fatalf("selection moved from %q to %q when the feed arrived", selected, got)
+	}
+}
+
+func TestUpdateNoticeAppliesOnU(t *testing.T) {
+	m := noticeModel(noticeStore(t), "v0.2.0")
+	m.update.latest = "v0.3.0"
+	m.openNotices("update-v0.3.0")
+	if m.mode != modeNotices || m.noticeCursor != 0 {
+		t.Fatalf("update notice should open selected, mode=%v cursor=%d", m.mode, m.noticeCursor)
+	}
+
+	applied := ""
+	orig := applyUpdate
+	defer func() { applyUpdate = orig }()
+	applyUpdate = func(_ context.Context, tag, execPath string) error {
+		applied = tag + " " + execPath
+		return nil
+	}
+
+	_, cmd := m.handleNoticesKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	if cmd == nil {
+		t.Fatal("u on the update notice should start the update")
+	}
+	if !m.update.applying {
+		t.Fatal("applying should be marked while the download runs")
+	}
+	msg, ok := cmd().(updateAppliedMsg)
+	if !ok {
+		t.Fatalf("cmd returned %T", cmd())
+	}
+	if msg.err != nil {
+		t.Fatalf("apply: %v", msg.err)
+	}
+	if !strings.HasPrefix(applied, "v0.3.0 ") {
+		t.Fatalf("applyUpdate saw %q", applied)
+	}
+	updated, quit := m.Update(msg)
+	m = updated.(*Model)
+	if m.update.applying {
+		t.Fatal("applying should clear once the swap lands")
+	}
+	if m.RestartPath() == "" {
+		t.Fatal("a successful swap must set the restart path")
+	}
+	if quit == nil {
+		t.Fatal("a successful swap must quit so main can exec the new build")
+	}
+}
+
+func TestUpdateNoticeApplyFailureSurfaces(t *testing.T) {
+	m := noticeModel(noticeStore(t), "v0.2.0")
+	m.update.latest = "v0.3.0"
+	m.openNotices("update-v0.3.0")
+
+	orig := applyUpdate
+	defer func() { applyUpdate = orig }()
+	applyUpdate = func(_ context.Context, _, _ string) error {
+		return errors.New("permission denied")
+	}
+	_, cmd := m.handleNoticesKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	updated, _ := m.Update(cmd().(updateAppliedMsg))
+	m = updated.(*Model)
+	if m.update.applying {
+		t.Fatal("applying should clear on failure")
+	}
+	if m.RestartPath() != "" {
+		t.Fatal("a failed swap must not restart")
+	}
+	if !strings.Contains(m.errBar.text, "permission denied") {
+		t.Fatalf("failure should surface, err=%q", m.errBar.text)
+	}
+}
+
+func TestUOutsideUpdateNoticeDoesNothing(t *testing.T) {
+	m := noticeModel(noticeStore(t), "v0.2.0")
+	m.openNotices(noticeWelcome)
+	_, cmd := m.handleNoticesKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	if cmd != nil || m.update.applying {
+		t.Fatal("u on a plain notice must not start an update")
 	}
 }

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -1,0 +1,186 @@
+package update
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// downloadBase is a var so tests can point the release download at a
+// local server.
+var downloadBase = "https://github.com/YoanWai/agent-manager/releases/download"
+
+const applyBudget = 2 * time.Minute
+
+// binaryLimit caps how much of the archive is read into the new binary,
+// so a corrupt or hostile archive cannot fill the disk. Real builds are
+// under 20MB.
+const binaryLimit = 200 << 20
+
+// Apply downloads the release named by tag, verifies the archive for this
+// OS and architecture against the release's checksums.txt, and atomically
+// replaces the binary at execPath. The swap uses rename, so the running
+// process keeps its (now unlinked) image and the next start runs the new
+// build under a fresh inode, which also sidesteps macOS's per-inode
+// signature cache.
+func Apply(ctx context.Context, tag, execPath string) error {
+	ctx, cancel := context.WithTimeout(ctx, applyBudget)
+	defer cancel()
+
+	version := strings.TrimPrefix(tag, "v")
+	asset := fmt.Sprintf("agent-manager_%s_%s_%s.tar.gz", version, runtime.GOOS, runtime.GOARCH)
+
+	wantSum, err := fetchChecksum(ctx, tag, asset)
+	if err != nil {
+		return err
+	}
+
+	archive, err := fetchAsset(ctx, tag, asset)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(archive)
+
+	if err := verifyChecksum(archive, wantSum); err != nil {
+		return err
+	}
+
+	target, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return err
+	}
+	staged := target + ".update"
+	if err := extractBinary(archive, staged); err != nil {
+		return err
+	}
+	if err := os.Rename(staged, target); err != nil {
+		os.Remove(staged)
+		return err
+	}
+	return nil
+}
+
+func fetchChecksum(ctx context.Context, tag, asset string) (string, error) {
+	body, err := fetch(ctx, downloadBase+"/"+tag+"/checksums.txt")
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+	raw, err := io.ReadAll(io.LimitReader(body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == asset {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("update: checksums.txt has no entry for %s", asset)
+}
+
+// fetchAsset streams the release archive to a temp file and returns its path.
+func fetchAsset(ctx context.Context, tag, asset string) (string, error) {
+	body, err := fetch(ctx, downloadBase+"/"+tag+"/"+asset)
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+	tmp, err := os.CreateTemp("", "agent-manager-update-*.tar.gz")
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(tmp, io.LimitReader(body, binaryLimit)); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+func fetch(ctx context.Context, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("update: %s returned %s", url, resp.Status)
+	}
+	return resp.Body, nil
+}
+
+func verifyChecksum(path, want string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return err
+	}
+	got := hex.EncodeToString(hash.Sum(nil))
+	if got != want {
+		return fmt.Errorf("update: checksum mismatch: got %s, want %s", got, want)
+	}
+	return nil
+}
+
+// extractBinary writes the archive's agent-manager entry to staged,
+// executable, next to the target so the final rename stays on one
+// filesystem.
+func extractBinary(archive, staged string) error {
+	file, err := os.Open(archive)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	unzipped, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+	defer unzipped.Close()
+	entries := tar.NewReader(unzipped)
+	for {
+		header, err := entries.Next()
+		if errors.Is(err, io.EOF) {
+			return errors.New("update: archive holds no agent-manager binary")
+		}
+		if err != nil {
+			return err
+		}
+		if filepath.Base(header.Name) != "agent-manager" || header.Typeflag != tar.TypeReg {
+			continue
+		}
+		out, err := os.OpenFile(staged, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, io.LimitReader(entries, binaryLimit)); err != nil {
+			out.Close()
+			os.Remove(staged)
+			return err
+		}
+		return out.Close()
+	}
+}

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -1,0 +1,163 @@
+package update
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func releaseArchive(t *testing.T, binary []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zipper := gzip.NewWriter(&buf)
+	archive := tar.NewWriter(zipper)
+	if err := archive.WriteHeader(&tar.Header{Name: "agent-manager", Mode: 0o755, Size: int64(len(binary)), Typeflag: tar.TypeReg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := archive.Write(binary); err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := zipper.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func serveRelease(t *testing.T, tag string, archive []byte, sum string) {
+	t.Helper()
+	asset := fmt.Sprintf("agent-manager_%s_%s_%s.tar.gz", strings.TrimPrefix(tag, "v"), runtime.GOOS, runtime.GOARCH)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + tag + "/checksums.txt":
+			fmt.Fprintf(w, "%s  %s\n", sum, asset)
+		case "/" + tag + "/" + asset:
+			w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	orig := downloadBase
+	downloadBase = server.URL
+	t.Cleanup(func() { downloadBase = orig })
+}
+
+func TestApplySwapsBinary(t *testing.T) {
+	newBinary := []byte("new build bytes")
+	archive := releaseArchive(t, newBinary)
+	digest := sha256.Sum256(archive)
+	serveRelease(t, "v9.9.9", archive, hex.EncodeToString(digest[:]))
+
+	target := filepath.Join(t.TempDir(), "agent-manager")
+	if err := os.WriteFile(target, []byte("old build"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(context.Background(), "v9.9.9", target); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	swapped, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(swapped, newBinary) {
+		t.Fatalf("binary not swapped, got %q", swapped)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("swapped binary mode = %v", info.Mode().Perm())
+	}
+}
+
+func TestApplyFollowsSymlink(t *testing.T) {
+	newBinary := []byte("new build bytes")
+	archive := releaseArchive(t, newBinary)
+	digest := sha256.Sum256(archive)
+	serveRelease(t, "v9.9.9", archive, hex.EncodeToString(digest[:]))
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real-binary")
+	if err := os.WriteFile(target, []byte("old build"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "agent-manager")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(context.Background(), "v9.9.9", link); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	swapped, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(swapped, newBinary) {
+		t.Fatal("symlink target should hold the new build")
+	}
+	wantTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved, err := filepath.EvalSymlinks(link); err != nil || resolved != wantTarget {
+		t.Fatalf("link should survive the swap, resolved %q err %v", resolved, err)
+	}
+}
+
+func TestApplyRejectsChecksumMismatch(t *testing.T) {
+	archive := releaseArchive(t, []byte("new build bytes"))
+	serveRelease(t, "v9.9.9", archive, strings.Repeat("0", 64))
+
+	target := filepath.Join(t.TempDir(), "agent-manager")
+	if err := os.WriteFile(target, []byte("old build"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := Apply(context.Background(), "v9.9.9", target)
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("want checksum mismatch, got %v", err)
+	}
+	untouched, readErr := os.ReadFile(target)
+	if readErr != nil || string(untouched) != "old build" {
+		t.Fatalf("binary must stay untouched on mismatch, got %q err %v", untouched, readErr)
+	}
+}
+
+func TestApplyRejectsArchiveWithoutBinary(t *testing.T) {
+	var buf bytes.Buffer
+	zipper := gzip.NewWriter(&buf)
+	archive := tar.NewWriter(zipper)
+	if err := archive.WriteHeader(&tar.Header{Name: "README.md", Mode: 0o644, Size: 2, Typeflag: tar.TypeReg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := archive.Write([]byte("hi")); err != nil {
+		t.Fatal(err)
+	}
+	archive.Close()
+	zipper.Close()
+	digest := sha256.Sum256(buf.Bytes())
+	serveRelease(t, "v9.9.9", buf.Bytes(), hex.EncodeToString(digest[:]))
+
+	target := filepath.Join(t.TempDir(), "agent-manager")
+	if err := os.WriteFile(target, []byte("old build"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := Apply(context.Background(), "v9.9.9", target)
+	if err == nil || !strings.Contains(err.Error(), "no agent-manager binary") {
+		t.Fatalf("want missing-binary error, got %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
@@ -178,10 +179,18 @@ func run() error {
 	ui.EnableTerminalPassthrough()
 	ui.SyncTerminalBackground()
 	model.StartPoller(program.Send)
-	_, runErr := program.Run()
+	final, runErr := program.Run()
 	ui.ResetTerminalBackground()
 	if err := ui.DisableAlternateScroll(); err != nil && runErr == nil {
 		runErr = err
+	}
+	if runErr == nil {
+		if finished, ok := final.(*ui.Model); ok && finished.RestartPath() != "" {
+			// A self-update swapped the binary on disk; exec replaces this
+			// process with the new build so the manager comes back updated
+			// without touching the tmux sessions it manages.
+			return syscall.Exec(finished.RestartPath(), os.Args, os.Environ())
+		}
 	}
 	return runErr
 }


### PR DESCRIPTION
## What

The "Update available" notice now carries an action: pressing **u** in the messages modal downloads the latest release for this OS/arch, verifies it against the release's `checksums.txt` (sha256), atomically renames it over the running binary, and execs the new build in place. tmux sessions are untouched; the restarted manager greets with the what's-new notice.

- Rename gives the new build a fresh inode, which also sidesteps macOS's per-inode signature cache (the known `cp`-over-binary SIGKILL trap).
- Symlinked installs (Homebrew cask) are followed to the real target before the swap.
- Failures (offline, read-only install dir, checksum mismatch) surface in the modal and leave the current binary untouched.
- The what's-new link now uses the tag's `v` prefix; the bare version 404ed.

## Verified live

Sandboxed 0.15.0 build (isolated tmux socket, fake HOME) pressed u against the real v0.16.0 release: downloaded, checksum-verified, swapped (`--version` reports 0.16.0), exec-restarted, and showed "What's new in 0.16.0".

## Tests

update: swap, symlink follow, checksum mismatch leaves binary untouched, binary-less archive rejected. ui: u triggers apply and marks progress, success sets the restart path and quits, failure surfaces and never restarts, u on other notices is inert.