### PR TITLE
fix(form): scroll long name/dir inputs and wrap the prompt field

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -13,8 +13,10 @@ import (
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
+	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/google/uuid"
 )
 
@@ -68,7 +70,7 @@ type groupOption struct {
 type form struct {
 	name         textinput.Model
 	dir          textinput.Model
-	prompt       textinput.Model
+	prompt       textarea.Model
 	dirAuto      bool
 	toolNames    []string
 	toolIndex    int
@@ -115,6 +117,45 @@ func textField(placeholder string, limit int) textinput.Model {
 	in.Placeholder = placeholder
 	in.CharLimit = limit
 	return in
+}
+
+const (
+	// formLabelColumn is the columns before a field value: marker (2),
+	// label (9), separator space (1).
+	formLabelColumn   = 12
+	formPromptMaxRows = 4
+)
+
+func promptField() textarea.Model {
+	in := textarea.New()
+	in.CharLimit = 2000
+	in.Placeholder = "first task (optional)"
+	in.ShowLineNumbers = false
+	in.SetPromptFunc(2, func(lineIndex int) string {
+		if lineIndex == 0 {
+			return "> "
+		}
+		return "  "
+	})
+	in.FocusedStyle.CursorLine = lipgloss.NewStyle()
+	in.SetHeight(1)
+	return in
+}
+
+// formValueWidth is the columns a field value can occupy inside the card.
+func (m *Model) formValueWidth() int {
+	return m.cardWidth() - 2*cardPaddingX - formLabelColumn
+}
+
+// syncFormFieldWidths fits the field widgets to the card so long values
+// scroll (inputs) or wrap (prompt) instead of clipping at the card edge.
+// Inputs reserve 3 columns: their "> " prompt plus the cursor cell that
+// renders past the last character.
+func (m *Model) syncFormFieldWidths() {
+	inner := m.formValueWidth()
+	m.form.name.Width = inner - 3
+	m.form.dir.Width = inner - 3
+	m.form.prompt.SetWidth(inner)
 }
 
 // contextGroup is the group the cursor currently sits in: a highlighted
@@ -187,7 +228,7 @@ func (m *Model) openForm() {
 	name.Focus()
 
 	dir := textField("", 400)
-	prompt := textField("first task (optional)", 2000)
+	prompt := promptField()
 
 	m.form = form{
 		name:      name,
@@ -198,6 +239,7 @@ func (m *Model) openForm() {
 		focus:     fieldName,
 	}
 	m.errBar.text = ""
+	m.syncFormFieldWidths()
 	m.rebuildGroupOptions(m.contextGroup())
 	m.form.dir.SetValue(m.groupDefaultDir(m.selectedGroupPath()))
 	m.form.worktree = m.groupWorktree(m.selectedGroupPath())
@@ -324,6 +366,10 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.form.dirAuto = false
 		m.pathSugg.recompute(m.form.dir.Value())
 	case fieldPrompt:
+		// Update repositions the viewport against the height set at the
+		// last render; full cap height here keeps the first row from
+		// scrolling away when a keystroke adds a wrapped row.
+		m.form.prompt.SetHeight(formPromptMaxRows)
 		m.form.prompt, cmd = m.form.prompt.Update(msg)
 	}
 	return m, cmd

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -155,6 +155,11 @@ func (m *Model) syncFormFieldWidths() {
 	inner := m.formValueWidth()
 	m.form.name.Width = inner - 3
 	m.form.dir.Width = inner - 3
+	// textinput recomputes its scroll window only inside Update/SetValue/
+	// SetCursor, so a width change alone would render a stale window until
+	// the next keystroke.
+	m.form.name.SetCursor(m.form.name.Position())
+	m.form.dir.SetCursor(m.form.dir.Position())
 	m.form.prompt.SetWidth(inner)
 }
 

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -133,6 +133,15 @@ func TestFormLongPromptWrapsAcrossRows(t *testing.T) {
 	}
 }
 
+func TestTextareaRowsCountsExactMultipleWrap(t *testing.T) {
+	in := promptField()
+	in.SetWidth(12) // content width 10
+	in.SetValue("1234567890\nx")
+	if rows := textareaRows(in, 10, 5); rows != 3 {
+		t.Fatalf("a line filling its row exactly adds a wrap row: want 3, got %d", rows)
+	}
+}
+
 func TestFormRejectsDashLeadingPrompt(t *testing.T) {
 	m := buildModel(t)
 	m.openForm()

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestNewSessionPreselectsContextGroup(t *testing.T) {
@@ -106,6 +107,29 @@ func TestFormPromptComposesWithSettings(t *testing.T) {
 	}
 	if got := withPrompt(tool, tool.Command, ""); got != "cat" {
 		t.Fatalf("empty prompt should leave the command untouched, got %q", got)
+	}
+}
+
+func TestFormLongDirKeepsCursorEndVisible(t *testing.T) {
+	m := buildModel(t)
+	m.openForm()
+	m.formFocus(2) // name -> tool -> dir
+	m.form.dir.SetValue("/very/long/" + strings.Repeat("a", 80) + "/tail-end")
+	m.form.dir.CursorEnd()
+	view := ansi.Strip(m.viewForm())
+	if !strings.Contains(view, "tail-end") {
+		t.Fatal("dir field should scroll so the end of a long value stays visible")
+	}
+}
+
+func TestFormLongPromptWrapsAcrossRows(t *testing.T) {
+	m := buildModel(t)
+	m.openForm()
+	m.formFocus(-2) // name -> group -> prompt
+	m.form.prompt.SetValue(strings.Repeat("word ", 25) + "finale")
+	view := ansi.Strip(m.viewForm())
+	if !strings.Contains(view, "finale") {
+		t.Fatal("long prompt should wrap onto more rows instead of being clipped")
 	}
 }
 

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -74,6 +74,8 @@ func maxLineWidth(lines []string) int {
 }
 
 func (m *Model) viewForm() string {
+	m.form.prompt.SetHeight(textareaRows(m.form.prompt, m.formValueWidth()-2, formPromptMaxRows))
+
 	var b strings.Builder
 	b.WriteString(formField("name", m.form.name.View(), m.form.focus == fieldName))
 
@@ -315,5 +317,11 @@ func formField(label, value string, focused bool) string {
 		marker = lipgloss.NewStyle().Foreground(colorAccent).Render("❯ ")
 		style = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 	}
-	return fmt.Sprintf("%s%s %s\n", marker, style.Width(9).Render(label), value)
+	lines := strings.Split(value, "\n")
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s%s %s\n", marker, style.Width(9).Render(label), lines[0]))
+	for _, line := range lines[1:] {
+		b.WriteString(strings.Repeat(" ", formLabelColumn) + line + "\n")
+	}
+	return b.String()
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -783,6 +783,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Geometry cache is stale for every session after a real resize.
 		m.pane.geom = nil
 		m.resizeSessions()
+		if m.mode == modeForm {
+			m.syncFormFieldWidths()
+		}
 		return m, nil
 
 	case bannerTickMsg:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -244,8 +244,9 @@ func textareaRows(input textarea.Model, textWidth, maxRows int) int {
 		if textWidth < 1 {
 			textWidth = 1
 		}
+		// A line filling its last row exactly wraps onto one more empty row.
 		for _, line := range strings.Split(input.Value(), "\n") {
-			rows += 1 + (max(lipgloss.Width(line), 1)-1)/textWidth
+			rows += 1 + max(lipgloss.Width(line), 1)/textWidth
 		}
 	}
 	if rows > maxRows {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -232,19 +233,23 @@ const quickBarMaxRows = 5
 // normal case) count exact soft-wrap rows; pasted multi-line values are
 // estimated, with the textarea scrolling to keep the cursor visible.
 func (m *Model) quickBarRows(textWidth int) int {
+	return textareaRows(m.quick.input, textWidth, quickBarMaxRows)
+}
+
+func textareaRows(input textarea.Model, textWidth, maxRows int) int {
 	rows := 0
-	if m.quick.input.LineCount() == 1 {
-		rows = m.quick.input.LineInfo().Height
+	if input.LineCount() == 1 {
+		rows = input.LineInfo().Height
 	} else {
 		if textWidth < 1 {
 			textWidth = 1
 		}
-		for _, line := range strings.Split(m.quick.input.Value(), "\n") {
+		for _, line := range strings.Split(input.Value(), "\n") {
 			rows += 1 + (max(lipgloss.Width(line), 1)-1)/textWidth
 		}
 	}
-	if rows > quickBarMaxRows {
-		rows = quickBarMaxRows
+	if rows > maxRows {
+		rows = maxRows
 	}
 	if rows < 1 {
 		rows = 1


### PR DESCRIPTION
Part 1 of #180.

The new-session card clipped every field at the card edge, so a long prompt (or a long directory) disappeared behind an ellipsis while typing.

- `name` and `dir` now set the textinput width to the card's value column, so long values scroll horizontally and the cursor stays visible.
- `prompt` is now a textarea (same widget as the quick prompt bar): text soft-wraps and the field grows up to 4 rows, with the viewport following the cursor beyond that.
- `formField` renders multi-line values by indenting continuation rows under the value column.
- Field widths re-sync on terminal resize.

Verified live in an isolated tmux run: long prompt wraps across rows, long dir shows its tail with the cursor. `go test ./...` green.

The keyboard-navigation half of #180 (arrow keys dropping into the group picker and resetting the dir override) comes in a second PR.