### PR TITLE
fix(form): arrows move focus only, group picking moves to left/right

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -309,11 +309,7 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.formFocus(-1)
 		return m, nil
 	case "up":
-		if m.form.focus == fieldGroup {
-			if !m.moveGroupCursor(-1) {
-				m.formFocus(-1)
-			}
-		} else if dirSuggesting {
+		if dirSuggesting {
 			if !m.pathSugg.move(-1) {
 				m.formFocus(-1)
 			}
@@ -322,11 +318,7 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "down":
-		if m.form.focus == fieldGroup {
-			if !m.moveGroupCursor(1) {
-				m.formFocus(1)
-			}
-		} else if dirSuggesting {
+		if dirSuggesting {
 			if !m.pathSugg.move(1) {
 				m.formFocus(1)
 			}
@@ -344,6 +336,10 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.form.worktreeAuto = false
 			return m, nil
 		}
+		if m.form.focus == fieldGroup {
+			m.moveGroupCursor(-1)
+			return m, nil
+		}
 	case "right":
 		if m.form.focus == fieldTool {
 			m.cycleTool(1)
@@ -352,6 +348,10 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.form.focus == fieldWorktree {
 			m.form.worktree = !m.form.worktree
 			m.form.worktreeAuto = false
+			return m, nil
+		}
+		if m.form.focus == fieldGroup {
+			m.moveGroupCursor(1)
 			return m, nil
 		}
 	case "enter":
@@ -663,11 +663,7 @@ func (m *Model) handleGroupFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.groupFormFocus(-1)
 		return m, nil
 	case "up":
-		if m.groupForm.focus == gfParent {
-			if !m.moveGroupCursor(-1) {
-				m.groupFormFocus(-1)
-			}
-		} else if pathSuggesting {
+		if pathSuggesting {
 			if !m.pathSugg.move(-1) {
 				m.groupFormFocus(-1)
 			}
@@ -676,11 +672,7 @@ func (m *Model) handleGroupFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "down":
-		if m.groupForm.focus == gfParent {
-			if !m.moveGroupCursor(1) {
-				m.groupFormFocus(1)
-			}
-		} else if pathSuggesting {
+		if pathSuggesting {
 			if !m.pathSugg.move(1) {
 				m.groupFormFocus(1)
 			}
@@ -694,9 +686,17 @@ func (m *Model) handleGroupFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.groupForm.worktreeIndex = (m.groupForm.worktreeIndex + count - 1) % count
 			return m, nil
 		}
+		if m.groupForm.focus == gfParent {
+			m.moveGroupCursor(-1)
+			return m, nil
+		}
 	case "right":
 		if m.groupForm.focus == gfWorktree {
 			m.groupForm.worktreeIndex = (m.groupForm.worktreeIndex + 1) % len(groupWorktreeOptions)
+			return m, nil
+		}
+		if m.groupForm.focus == gfParent {
+			m.moveGroupCursor(1)
 			return m, nil
 		}
 	case "enter":

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -381,7 +381,7 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // moveGroupCursor moves within the expanded group picker without wrapping.
-// A false result lets the form move focus to the adjacent field.
+// A false result reports the cursor was already at that edge.
 func (m *Model) moveGroupCursor(delta int) bool {
 	next := m.form.groupIndex + delta
 	if next < 0 || next >= len(m.form.groups) {

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -380,14 +380,14 @@ func (m *Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-// moveGroupCursor moves within the expanded group picker without wrapping.
-// A false result reports the cursor was already at that edge.
-func (m *Model) moveGroupCursor(delta int) bool {
-	next := m.form.groupIndex + delta
-	if next < 0 || next >= len(m.form.groups) {
-		return false
+// moveGroupCursor moves within the expanded group picker, wrapping at the
+// ends; a delta of 0 re-resolves the dependent defaults in place.
+func (m *Model) moveGroupCursor(delta int) {
+	count := len(m.form.groups)
+	if count == 0 {
+		return
 	}
-	m.form.groupIndex = next
+	m.form.groupIndex = (m.form.groupIndex + delta + count) % count
 	if m.mode == modeForm && m.form.dirAuto {
 		m.form.dir.SetValue(m.groupDefaultDir(m.selectedGroupPath()))
 	}
@@ -397,7 +397,6 @@ func (m *Model) moveGroupCursor(delta int) bool {
 	if m.mode == modeGroupForm && m.groupForm.pathAuto {
 		m.groupForm.path.SetValue(m.ancestorGroupDir(m.selectedGroupPath()))
 	}
-	return true
 }
 
 func (m *Model) formFocus(delta int) {

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -173,6 +173,14 @@ func TestFormGroupArrowsMoveFocusNotSelection(t *testing.T) {
 	if m.form.groupIndex != 0 {
 		t.Fatalf("left should cycle back, index = %d", m.form.groupIndex)
 	}
+	m.handleFormKey(tea.KeyMsg{Type: tea.KeyLeft})
+	if m.form.groupIndex != len(m.form.groups)-1 {
+		t.Fatalf("left at the first group should wrap to the last, index = %d", m.form.groupIndex)
+	}
+	m.handleFormKey(tea.KeyMsg{Type: tea.KeyRight})
+	if m.form.groupIndex != 0 {
+		t.Fatalf("right at the last group should wrap to the first, index = %d", m.form.groupIndex)
+	}
 }
 
 func TestGroupFormParentArrowsMoveFocusNotSelection(t *testing.T) {

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -142,6 +142,65 @@ func TestTextareaRowsCountsExactMultipleWrap(t *testing.T) {
 	}
 }
 
+func TestFormGroupArrowsMoveFocusNotSelection(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("alpha", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.openForm()
+	m.formFocus(-1) // wrap from name to group
+	if m.form.focus != fieldGroup {
+		t.Fatalf("focus = %v, want fieldGroup", m.form.focus)
+	}
+
+	initial := m.form.groupIndex
+	m.handleFormKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.form.groupIndex != initial {
+		t.Fatalf("down must not change the group selection, index = %d, want %d", m.form.groupIndex, initial)
+	}
+	if m.form.focus == fieldGroup {
+		t.Fatal("down should move focus off the group field")
+	}
+
+	m.form.focus = fieldGroup
+	m.form.groupIndex = 0
+	m.handleFormKey(tea.KeyMsg{Type: tea.KeyRight})
+	if m.form.groupIndex != 1 {
+		t.Fatalf("right should cycle the group selection, index = %d", m.form.groupIndex)
+	}
+	m.handleFormKey(tea.KeyMsg{Type: tea.KeyLeft})
+	if m.form.groupIndex != 0 {
+		t.Fatalf("left should cycle back, index = %d", m.form.groupIndex)
+	}
+}
+
+func TestGroupFormParentArrowsMoveFocusNotSelection(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("alpha", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.openGroupForm()
+	m.groupForm.focus = gfParent
+
+	initial := m.form.groupIndex
+	m.handleGroupFormKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.form.groupIndex != initial {
+		t.Fatalf("down must not change the parent selection, index = %d, want %d", m.form.groupIndex, initial)
+	}
+	if m.groupForm.focus == gfParent {
+		t.Fatal("down should move focus off the parent field")
+	}
+
+	m.groupForm.focus = gfParent
+	m.form.groupIndex = 0
+	m.handleGroupFormKey(tea.KeyMsg{Type: tea.KeyRight})
+	if m.form.groupIndex != 1 {
+		t.Fatalf("right should cycle the parent selection, index = %d", m.form.groupIndex)
+	}
+}
+
 func TestFormRejectsDashLeadingPrompt(t *testing.T) {
 	m := buildModel(t)
 	m.openForm()

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -102,7 +102,7 @@ func (m *Model) viewForm() string {
 
 	hint := "tab/↑↓ move · ←→ change · ↵ create · esc cancel"
 	if m.form.focus == fieldGroup {
-		hint = "↑↓ pick group · tab next field · ↵ create · esc cancel"
+		hint = "←→ pick group · tab/↑↓ move · ↵ create · esc cancel"
 	}
 	if m.form.focus == fieldDir && m.pathSugg.active() {
 		hint = pathSuggestHint(m.pathSugg.chosen)
@@ -173,7 +173,7 @@ func (m *Model) viewGroupForm() string {
 	}
 	hint := "tab/↑↓ move · ↵ create · esc cancel"
 	if m.groupForm.focus == gfParent {
-		hint = "↑↓ pick parent · tab next field · ↵ create · esc cancel"
+		hint = "←→ pick parent · tab/↑↓ move · ↵ create · esc cancel"
 	}
 	if m.groupForm.focus == gfWorktree {
 		hint = "tab/↑↓ move · ←→ change · ↵ create · esc cancel"

--- a/internal/ui/move.go
+++ b/internal/ui/move.go
@@ -19,14 +19,10 @@ func (m *Model) handleMoveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.mode = modeList
 		return m, nil
 	case "up":
-		if !m.moveGroupCursor(-1) && len(m.form.groups) > 0 {
-			m.form.groupIndex = len(m.form.groups) - 1
-		}
+		m.moveGroupCursor(-1)
 		return m, nil
 	case "down":
-		if !m.moveGroupCursor(1) && len(m.form.groups) > 0 {
-			m.form.groupIndex = 0
-		}
+		m.moveGroupCursor(1)
 		return m, nil
 	case "enter":
 		group := m.selectedGroupPath()


### PR DESCRIPTION
Part 2 of #180, completing it (part 1 was #182).

Scrolling the new-session or new-group card with ↑/↓ used to fall into the group/parent picker: further presses silently changed the selection, and through the group's default path also overwrote the dir field mid-edit.

- ↑/↓ (and tab) now always move between fields, in both cards.
- The group/parent selection cycles with ←/→, matching the tool and worktree fields; the expanded picker stays visible under the field with its highlight following.
- The dir default still follows a deliberate group change while the field is untouched; a hand-edited dir is never overwritten.
- Hints updated: "←→ pick group · tab/↑↓ move".

Verified live in an isolated tmux run: ↓ cycles focus straight through the group field and wraps, selection only moves on ←/→. `go test ./...` green.