### PR TITLE
fix(notices): keep the frame and hints when the terminal is short

### DIFF
--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -410,11 +410,18 @@ func (m *Model) handleNoticesKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) viewNotices() string {
+	notices := m.activeNotices()
 	inner := noticeModalInner
+	for _, n := range notices {
+		for _, line := range n.body {
+			if w := lipgloss.Width(line); w > inner {
+				inner = w
+			}
+		}
+	}
 	if m.width >= 8 && inner > m.width-8 {
 		inner = m.width - 8
 	}
-	notices := m.activeNotices()
 	if len(notices) == 0 {
 		frame := noticeFrame([]string{subtleStyle.Render("nothing new")}, inner,
 			noticeLegend(), keyCap("esc", "close"))
@@ -434,7 +441,9 @@ func (m *Model) viewNotices() string {
 	selected := notices[m.noticeCursor]
 	rows = append(rows, noticeBorderStyle().Render(strings.Repeat("┄", inner)))
 	for _, line := range selected.body {
-		rows = append(rows, mutedStyle.Render(line))
+		for _, wrapped := range strings.Split(ansi.Wordwrap(line, inner, "-"), "\n") {
+			rows = append(rows, mutedStyle.Render(wrapped))
+		}
 	}
 	if selected.url != "" {
 		rows = append(rows, subtleStyle.Render("↗ "+truncateTail(strings.TrimPrefix(selected.url, "https://"), inner-2)))
@@ -457,8 +466,9 @@ func (m *Model) viewNotices() string {
 	return m.centerOnBackdrop(frame)
 }
 
-// noticeModalInner is the modal's content column, sized for the welcome
-// notice's longest body line.
+// noticeModalInner is the modal content column's floor, sized for the
+// welcome notice's longest body line; longer bodies widen it up to the
+// terminal.
 const noticeModalInner = 62
 
 func loadDismissed(st *store.Store) map[string]bool {

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -419,8 +419,8 @@ func (m *Model) viewNotices() string {
 			}
 		}
 	}
-	if m.width >= 8 && inner > m.width-8 {
-		inner = m.width - 8
+	if fit := m.width - 8; inner > fit {
+		inner = max(fit, 1)
 	}
 	if len(notices) == 0 {
 		frame := noticeFrame([]string{subtleStyle.Render("nothing new")}, inner,
@@ -440,21 +440,27 @@ func (m *Model) viewNotices() string {
 	}
 	selected := notices[m.noticeCursor]
 	rows = append(rows, noticeBorderStyle().Render(strings.Repeat("┄", inner)))
+
+	var body []string
 	for _, line := range selected.body {
 		for _, wrapped := range strings.Split(ansi.Wordwrap(line, inner, "-"), "\n") {
-			rows = append(rows, mutedStyle.Render(wrapped))
+			body = append(body, mutedStyle.Render(wrapped))
 		}
 	}
+	var tail []string
 	if selected.url != "" {
-		rows = append(rows, subtleStyle.Render("↗ "+truncateTail(strings.TrimPrefix(selected.url, "https://"), inner-2)))
+		tail = append(tail, subtleStyle.Render("↗ "+truncateTail(strings.TrimPrefix(selected.url, "https://"), inner-2)))
 	}
 	if m.update.applying {
-		rows = append(rows, lipgloss.NewStyle().Foreground(colorAccent).Render("↓ downloading "+m.update.latest+"…"))
+		tail = append(tail, lipgloss.NewStyle().Foreground(colorAccent).Render("↓ downloading "+m.update.latest+"…"))
 	}
 	if m.errBar.text != "" {
-		rows = append(rows, errStyle.Render("✕ "+m.errBar.text))
+		tail = append(tail, errStyle.Render("✕ "+m.errBar.text))
 	}
-	rows = append(rows, "")
+	tail = append(tail, "")
+
+	rows = append(rows, fitBody(body, m.height-2-len(rows)-len(tail))...)
+	rows = append(rows, tail...)
 
 	hint := "↑↓ pick · ↵ open · x dismiss · esc "
 	if isUpdateNotice(selected) {
@@ -464,6 +470,19 @@ func (m *Model) viewNotices() string {
 		noticeLegend(),
 		mutedStyle.Render(hint))
 	return m.centerOnBackdrop(frame)
+}
+
+// fitBody keeps the body inside the rows a terminal this short can hold,
+// marking the cut so a clipped message reads as clipped. Without it the
+// outer frame clamp eats the modal's own border and key hints instead.
+func fitBody(body []string, room int) []string {
+	if room >= len(body) {
+		return body
+	}
+	if room < 1 {
+		room = 1
+	}
+	return append(body[:room-1:room-1], mutedStyle.Render("…"))
 }
 
 // noticeModalInner is the modal content column's floor, sized for the

--- a/internal/ui/notices_test.go
+++ b/internal/ui/notices_test.go
@@ -409,6 +409,34 @@ func TestNoticesLongBodyWrapsFully(t *testing.T) {
 	}
 }
 
+func TestNoticesShortTerminalKeepsFrameAndHint(t *testing.T) {
+	m := modalModel(t)
+	m.width, m.height = 30, 12
+	m.feedMessages = []feed.Message{{
+		ID:     "feed-long",
+		Banner: "long banner",
+		Title:  "Long body message",
+		Body: []string{
+			"Each group can choose inherit, on, or off for spawning sessions into their own git worktree, set when creating a group or editing it later.",
+		},
+	}}
+	m.openNotices("feed-long")
+	lines := strings.Split(ansi.Strip(m.View()), "\n")
+	if len(lines) > m.height {
+		t.Fatalf("frame must fit %d rows, got %d", m.height, len(lines))
+	}
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "╰") {
+		t.Fatalf("short terminal ate the modal's bottom border:\n%s", joined)
+	}
+	if !strings.Contains(joined, "↑↓ pick") {
+		t.Fatalf("short terminal ate the key hint:\n%s", joined)
+	}
+	if !strings.Contains(joined, "…") {
+		t.Fatalf("a clipped body must say so:\n%s", joined)
+	}
+}
+
 func TestNoticesDismissAdvancesAndCloses(t *testing.T) {
 	m := modalModel(t)
 	total := len(m.activeNotices())
@@ -596,5 +624,17 @@ func TestUOutsideUpdateNoticeDoesNothing(t *testing.T) {
 	_, cmd := m.handleNoticesKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
 	if cmd != nil || m.update.applying {
 		t.Fatal("u on a plain notice must not start an update")
+	}
+}
+
+func TestNoticesTinyTerminalStaysInside(t *testing.T) {
+	m := modalModel(t)
+	for _, width := range []int{5, 12, 30} {
+		m.width, m.height = width, 10
+		for _, line := range strings.Split(ansi.Strip(m.View()), "\n") {
+			if got := lipgloss.Width(line); got > width {
+				t.Fatalf("width %d: line overflows at %d: %q", width, got, line)
+			}
+		}
 	}
 }

--- a/internal/ui/notices_test.go
+++ b/internal/ui/notices_test.go
@@ -376,6 +376,39 @@ func TestNoticesViewListsAndDetails(t *testing.T) {
 	}
 }
 
+func TestNoticesLongBodyWrapsFully(t *testing.T) {
+	m := modalModel(t)
+	m.feedMessages = []feed.Message{{
+		ID:     "feed-long",
+		Banner: "long banner",
+		Title:  "Long body message",
+		Body: []string{
+			"Each group can choose inherit, on, or off for spawning sessions into their own git worktree, set when creating a group or editing it later; children inherit from their parents, and the global setting stays the root fallback.",
+		},
+	}}
+	m.openNotices("feed-long")
+	frame := ansi.Strip(m.View())
+	for _, line := range strings.Split(frame, "\n") {
+		if !strings.Contains(line, "╭") {
+			continue
+		}
+		if got := lipgloss.Width(strings.TrimSpace(line)); got <= noticeModalInner+4 {
+			t.Fatalf("wide terminal must widen the modal past %d, got %d", noticeModalInner+4, got)
+		}
+		break
+	}
+	for _, word := range []string{"worktree,", "parents,", "fallback."} {
+		if !strings.Contains(frame, word) {
+			t.Fatalf("long body must wrap, %q missing:\n%s", word, frame)
+		}
+	}
+	for _, line := range strings.Split(frame, "\n") {
+		if got := lipgloss.Width(line); got > m.width {
+			t.Fatalf("line overflows terminal at %d: %q", got, line)
+		}
+	}
+}
+
 func TestNoticesDismissAdvancesAndCloses(t *testing.T) {
 	m := modalModel(t)
 	total := len(m.activeNotices())


### PR DESCRIPTION
The notices modal sized its column to a fixed 62 and printed every body line straight into the frame. On a short terminal the outer clamp cut the modal's own border and key hints, so a long message left the modal looking unreadable and unclosable.

The column now grows to the widest body line, capped by the terminal width; bodies word-wrap into it; and the body is trimmed to the rows the terminal can hold with an ellipsis marking the cut. The border, link, download line, error line and key hints always survive.