### PR TITLE
feat(worktree): renaming a session moves its worktree and branch

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,6 +60,8 @@ The worktree lives at `<repo>-worktrees/<name>` next to the repo, on a new branc
 
 A directory that is not a git repo cannot hold a worktree, so the field and the quick prompt's footer read `unavailable (not a git repo)` in place of on/off, the toggle says why when pressed, and the session spawns in that directory as a plain session. This is what a group path sitting above several repos does: the umbrella itself is not a repo, so its sessions launch in it directly.
 
+Renaming a session (`r`, or the agent's own `agent-manager rename`) carries its worktree along: the directory becomes `<repo>-worktrees/<new name>` and the branch becomes `am/<new name>`, so an agent that names itself after the work it picked up is reviewed and merged under that name. A destination directory or branch that already exists reports that and keeps the session where it is, so the name, the directory and the branch always agree. A worktree you have renamed or removed by hand is left alone and the session still takes the new name.
+
 Deleting (`d`) a session that holds a worktree removes the worktree and its branch when it is clean: no uncommitted changes and no commits ahead of its base. A dirty worktree is left in place and its path shown, so nothing is lost. Note that "clean" is judged by `git status`, so gitignored files inside the worktree (a `.env`, local config, build output) are removed along with the directory. Killing, archiving, and reviving a session never touch its worktree.
 
 ## Killing and reviving sessions

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -687,16 +687,21 @@ func (d *Driver) worktreeBase(root string) string {
 	return ""
 }
 
+// worktreePlacement is where a session of this name keeps its worktree:
+// a directory beside the repo and the am/ branch checked out in it.
+func worktreePlacement(root, name string) (string, string) {
+	return filepath.Join(filepath.Dir(root), filepath.Base(root)+"-worktrees", name), "am/" + name
+}
+
 func (d *Driver) AddWorktree(root, sessionName string) (string, string, error) {
 	name := sanitizeWorktreeName(sessionName)
 	if name == "" {
 		return "", "", fmt.Errorf("session name %q leaves nothing usable for a worktree directory", sessionName)
 	}
-	path := filepath.Join(filepath.Dir(root), filepath.Base(root)+"-worktrees", name)
+	path, branch := worktreePlacement(root, name)
 	if _, err := os.Stat(path); err == nil {
 		return "", "", fmt.Errorf("worktree path already exists: %s", path)
 	}
-	branch := "am/" + name
 	base := d.worktreeBase(root)
 	if base == "" {
 		return "", "", fmt.Errorf("no base ref for a worktree in %s: repository has no commits", root)
@@ -705,6 +710,45 @@ func (d *Driver) AddWorktree(root, sessionName string) (string, string, error) {
 		return "", "", err
 	}
 	return path, branch, nil
+}
+
+// MoveWorktree renames a session's worktree and its branch to the ones a
+// session of newName would have been given at spawn, and reports where
+// they ended up. The recorded pair is returned untouched when there is
+// nothing to do: a name that lands on the same directory, or a worktree
+// git no longer has under the recorded path and branch, which is what a
+// worktree renamed or deleted by hand looks like. A destination already
+// taken is an error, so a session's name, directory and branch never
+// drift apart.
+func (d *Driver) MoveWorktree(root, path, branch, newName string) (string, string, error) {
+	name := sanitizeWorktreeName(newName)
+	if name == "" {
+		return "", "", fmt.Errorf("session name %q leaves nothing usable for a worktree directory", newName)
+	}
+	newPath, newBranch := worktreePlacement(root, name)
+	if newPath == path && newBranch == branch {
+		return path, branch, nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		return path, branch, nil
+	}
+	if _, err := d.run(root, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
+		return path, branch, nil
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		return "", "", fmt.Errorf("worktree path already exists: %s", newPath)
+	}
+	if _, err := d.run(root, "rev-parse", "--verify", "--quiet", "refs/heads/"+newBranch); err == nil {
+		return "", "", fmt.Errorf("branch already exists: %s", newBranch)
+	}
+	if _, err := d.run(root, "worktree", "move", path, newPath); err != nil {
+		return "", "", err
+	}
+	if _, err := d.run(root, "branch", "-m", branch, newBranch); err != nil {
+		_, _ = d.run(root, "worktree", "move", newPath, path)
+		return "", "", err
+	}
+	return newPath, newBranch, nil
 }
 
 // RemoveWorktreeIfClean removes a session's worktree and its am/ branch

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -730,6 +730,9 @@ func (d *Driver) MoveWorktree(root, path, branch, newName string) (string, strin
 		return path, branch, nil
 	}
 	if _, err := os.Stat(path); err != nil {
+		if !os.IsNotExist(err) {
+			return "", "", err
+		}
 		return path, branch, nil
 	}
 	if _, err := d.run(root, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch); err != nil {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -648,6 +648,141 @@ func TestRemoveWorktreeIfClean(t *testing.T) {
 	}
 }
 
+func TestMoveWorktree(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "a.txt", "x")
+	commit(t, dir, "seed")
+	path, branch, err := driver.AddWorktree(dir, "claude-7a72")
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	write(t, path, "wip.txt", "uncommitted work")
+
+	newPath, newBranch, err := driver.MoveWorktree(dir, path, branch, "release the version")
+	if err != nil {
+		t.Fatalf("move: %v", err)
+	}
+	wantPath := filepath.Join(filepath.Dir(dir), filepath.Base(dir)+"-worktrees", "release-the-version")
+	if newPath != wantPath {
+		t.Fatalf("path = %q, want %q", newPath, wantPath)
+	}
+	if newBranch != "am/release-the-version" {
+		t.Fatalf("branch = %q", newBranch)
+	}
+	if _, err := os.Stat(filepath.Join(newPath, "wip.txt")); err != nil {
+		t.Fatalf("moved worktree lost uncommitted work: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("old worktree directory still on disk")
+	}
+	if _, err := driver.run(dir, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch); err == nil {
+		t.Fatal("old branch should be gone")
+	}
+	head, err := driver.run(newPath, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil || head != newBranch {
+		t.Fatalf("moved worktree HEAD = %q err=%v, want %q", head, err, newBranch)
+	}
+	// The move has to leave a worktree the rest of the driver still owns.
+	if removed, err := driver.RemoveWorktreeIfClean(dir, newPath, newBranch); err != nil || removed {
+		t.Fatalf("moved worktree still holds work: removed=%v err=%v", removed, err)
+	}
+}
+
+func TestMoveWorktreeSameNameKeepsEverything(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "a.txt", "x")
+	commit(t, dir, "seed")
+	path, branch, err := driver.AddWorktree(dir, "steady")
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	// Both names sanitize to "steady", so there is nothing to move.
+	newPath, newBranch, err := driver.MoveWorktree(dir, path, branch, "steady/")
+	if err != nil {
+		t.Fatalf("same name should be a no-op: %v", err)
+	}
+	if newPath != path || newBranch != branch {
+		t.Fatalf("no-op returned %q %q, want %q %q", newPath, newBranch, path, branch)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("worktree directory should survive a no-op: %v", err)
+	}
+}
+
+func TestMoveWorktreeRefusesTakenNames(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "a.txt", "x")
+	commit(t, dir, "seed")
+	path, branch, err := driver.AddWorktree(dir, "mover")
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, _, err := driver.AddWorktree(dir, "taken"); err != nil {
+		t.Fatalf("add taken: %v", err)
+	}
+
+	if _, _, err := driver.MoveWorktree(dir, path, branch, "taken"); err == nil {
+		t.Fatal("an occupied path and branch should fail the move")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("refused move should leave the worktree in place: %v", err)
+	}
+	if head, err := driver.run(path, "rev-parse", "--abbrev-ref", "HEAD"); err != nil || head != branch {
+		t.Fatalf("refused move changed the branch: %q err=%v", head, err)
+	}
+
+	// A free directory whose branch is already taken is refused just the same.
+	if _, err := driver.run(dir, "branch", "am/reserved"); err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	if _, _, err := driver.MoveWorktree(dir, path, branch, "reserved"); err == nil {
+		t.Fatal("an occupied branch should fail the move")
+	}
+}
+
+func TestMoveWorktreeLeavesUnrecognizedWorktreeAlone(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "a.txt", "x")
+	commit(t, dir, "seed")
+	path, branch, err := driver.AddWorktree(dir, "handed-over")
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	// The branch was renamed by hand, so the worktree is no longer the
+	// manager's to move.
+	if _, err := driver.run(dir, "branch", "-m", branch, "feat/mine"); err != nil {
+		t.Fatalf("rename branch: %v", err)
+	}
+	newPath, newBranch, err := driver.MoveWorktree(dir, path, branch, "renamed")
+	if err != nil {
+		t.Fatalf("a branch git no longer has should be left alone: %v", err)
+	}
+	if newPath != path || newBranch != branch {
+		t.Fatalf("returned %q %q, want the recorded %q %q", newPath, newBranch, path, branch)
+	}
+	if head, _ := driver.run(path, "rev-parse", "--abbrev-ref", "HEAD"); head != "feat/mine" {
+		t.Fatalf("hand-renamed branch was disturbed: %q", head)
+	}
+
+	gone := filepath.Join(filepath.Dir(dir), "nowhere")
+	if p, b, err := driver.MoveWorktree(dir, gone, branch, "renamed"); err != nil || p != gone || b != branch {
+		t.Fatalf("a missing directory should be left alone: %q %q %v", p, b, err)
+	}
+}
+
+func TestMoveWorktreeEmptyNameFails(t *testing.T) {
+	driver, dir := testRepo(t)
+	write(t, dir, "a.txt", "x")
+	commit(t, dir, "seed")
+	path, branch, err := driver.AddWorktree(dir, "named")
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, _, err := driver.MoveWorktree(dir, path, branch, "///"); err == nil {
+		t.Fatal("a name with nothing usable should fail")
+	}
+}
+
 func TestRemoveWorktreeKeepsDirtyAndAhead(t *testing.T) {
 	driver, dir := testRepo(t)
 	write(t, dir, "a.txt", "x")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -770,6 +770,30 @@ func TestMoveWorktreeLeavesUnrecognizedWorktreeAlone(t *testing.T) {
 	}
 }
 
+func TestMoveWorktreeUnreadableDirFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads through a stripped directory")
+	}
+	driver, dir := testRepo(t)
+	write(t, dir, "a.txt", "x")
+	commit(t, dir, "seed")
+	path, branch, err := driver.AddWorktree(dir, "unreadable")
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	// A worktree the manager cannot even look at is not a worktree that
+	// has been removed, so it must not pass for one.
+	parent := filepath.Dir(path)
+	if err := os.Chmod(parent, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(parent, 0o755) })
+
+	if _, _, err := driver.MoveWorktree(dir, path, branch, "renamed"); err == nil {
+		t.Fatal("a directory that cannot be read should fail the move, not pass as removed")
+	}
+}
+
 func TestMoveWorktreeEmptyNameFails(t *testing.T) {
 	driver, dir := testRepo(t)
 	write(t, dir, "a.txt", "x")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -508,6 +508,17 @@ func (s *Store) RenameSession(id, name string) error {
 	return requireRow(res, id)
 }
 
+// MoveSessionWorktree records a worktree that followed its session's new
+// name: the directory the session now runs in and the branch checked out
+// there. The repo root the worktree hangs off stays as it was.
+func (s *Store) MoveSessionWorktree(id, cwd, branch string) error {
+	res, err := s.db.Exec(`UPDATE sessions SET cwd = ?, worktree_branch = ? WHERE id = ?`, cwd, branch, id)
+	if err != nil {
+		return err
+	}
+	return requireRow(res, id)
+}
+
 // UpdateTool changes which tool status rules and revive use for a session.
 // Clears the captured agent conversation id: that id only makes sense for
 // the tool that minted it, and a manual tool swap means the user swapped

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -705,6 +705,33 @@ func TestSessionWorktreeColumnsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMoveSessionWorktree(t *testing.T) {
+	s := newTestStore(t)
+	sess := Session{
+		ID: "wt2", Name: "claude-7a72", Tool: "claude", Cwd: "/tmp/repo-worktrees/claude-7a72",
+		WorktreeRepo: "/tmp/repo", WorktreeBranch: "am/claude-7a72",
+	}
+	if err := s.CreateSession(sess); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := s.MoveSessionWorktree("wt2", "/tmp/repo-worktrees/renamed", "am/renamed"); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+	got, err := s.Get("wt2")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Cwd != "/tmp/repo-worktrees/renamed" || got.WorktreeBranch != "am/renamed" {
+		t.Fatalf("move did not land: %+v", got)
+	}
+	if got.WorktreeRepo != "/tmp/repo" {
+		t.Fatalf("move disturbed the repo root: %q", got.WorktreeRepo)
+	}
+	if err := s.MoveSessionWorktree("ghost", "/tmp/x", "am/x"); err == nil {
+		t.Fatal("moving an unknown session should error")
+	}
+}
+
 func TestGroupWorktreeRoundtrip(t *testing.T) {
 	st := newTestStore(t)
 	if err := st.CreateGroup("backend", ""); err != nil {

--- a/internal/ui/helpers_test.go
+++ b/internal/ui/helpers_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -204,6 +205,62 @@ func createSession(t *testing.T, m *Model, name, dir, group string) {
 		t.Fatalf("after submit, mode = %v, err = %q", m.mode, m.errBar.text)
 	}
 	m.applyCmd(t, cmd)
+}
+
+// seedRepo builds a committed repo the worktree tests can branch from.
+// It sits one level inside the temp directory so the sibling
+// "<name>-worktrees" tree is cleaned up with it.
+func seedRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init", "-b", "main"},
+		{"config", "user.email", "test@test"},
+		{"config", "user.name", "test"},
+		{"add", "."},
+		{"commit", "-m", "seed"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	return dir
+}
+
+func createWorktreeSession(t *testing.T, m *Model, name, repo string) store.Session {
+	t.Helper()
+	m.openForm()
+	m.form.name.SetValue(name)
+	m.form.dir.SetValue(repo)
+	m.form.toolIndex = 0
+	m.form.worktree = true
+	pickGroup(t, m, "")
+	_, cmd := m.submitForm()
+	if m.mode != modeList {
+		t.Fatalf("after submit, mode = %v, err = %q", m.mode, m.errBar.text)
+	}
+	m.applyCmd(t, cmd)
+	for _, sess := range m.sessions {
+		if sess.Name == name {
+			if sess.WorktreeBranch == "" {
+				t.Fatalf("session %q did not spawn in a worktree: %+v", name, sess)
+			}
+			return sess
+		}
+	}
+	t.Fatalf("session %q missing after spawn", name)
+	return store.Session{}
 }
 
 func windowWidth(t *testing.T, id string) int {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -435,7 +435,7 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 		hooks:           hookManager,
 		gitDrv:          gitDriver,
 		setSnapshot:     st.SetSnapshot,
-		poller:          newPoller(st, driver, engine, hookManager, statusSources, sessionStores, cfg.PollInterval.Duration),
+		poller:          newPoller(st, driver, engine, hookManager, gitDriver, statusSources, sessionStores, cfg.PollInterval.Duration),
 		collapsed:       loadCollapsed(st),
 		split:           splitState{ratio: loadSplitRatio(st)},
 		focusOnEnter:    storedFocusOnEnter(st),

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/YoanWai/agent-manager/internal/agentsession"
+	"github.com/YoanWai/agent-manager/internal/git"
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
@@ -27,6 +29,7 @@ type poller struct {
 	tmux          *tmux.Driver
 	engine        *status.Engine
 	hooks         *hooks.Manager
+	gitDrv        *git.Driver
 	statusSources map[string]string
 	sessionStores map[string]string
 	interval      time.Duration
@@ -77,12 +80,13 @@ func paneBooted(pane string) bool {
 	return strings.TrimSpace(ansi.Strip(pane)) != ""
 }
 
-func newPoller(st *store.Store, driver *tmux.Driver, engine *status.Engine, hookManager *hooks.Manager, statusSources, sessionStores map[string]string, interval time.Duration) *poller {
+func newPoller(st *store.Store, driver *tmux.Driver, engine *status.Engine, hookManager *hooks.Manager, gitDriver *git.Driver, statusSources, sessionStores map[string]string, interval time.Duration) *poller {
 	return &poller{
 		store:            st,
 		tmux:             driver,
 		engine:           engine,
 		hooks:            hookManager,
+		gitDrv:           gitDriver,
 		statusSources:    statusSources,
 		sessionStores:    sessionStores,
 		interval:         interval,
@@ -506,13 +510,20 @@ func (p *poller) maybeSendDirective(sess store.Session, pane string, agentAlive 
 // keeping the manager the sole database writer. The file is consumed
 // even when the name is unchanged so it never lingers. A dead tmux
 // session cannot take a label, which is fine; the label is rewritten on
-// revive.
+// revive. A worktree session's directory and branch follow the new name,
+// and a name git cannot give them keeps the session on the one it has:
+// the file is consumed either way, so the reason is reported once rather
+// than on every poll from here on.
 func (p *poller) applyPendingRename(sess *store.Session) error {
 	name, found := p.hooks.ReadName(sess.ID)
 	if !found {
 		return nil
 	}
 	if name != "" && name != sess.Name {
+		if err := renameSessionWorktree(p.gitDrv, p.store, sess, name); err != nil {
+			_ = p.hooks.RemoveName(sess.ID)
+			return fmt.Errorf("worktree rename: %w", err)
+		}
 		if err := ignoreDeletedSession(p.store.RenameSession(sess.ID, name)); err != nil {
 			return err
 		}

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -159,6 +159,78 @@ func TestPendingRenameForADeletedSessionDoesNotFailThePoll(t *testing.T) {
 	}
 }
 
+func TestPendingRenameMovesTheWorktree(t *testing.T) {
+	m := buildModel(t)
+	repo := seedRepo(t)
+	spawned := createWorktreeSession(t, m, "claude-7a72", repo)
+	writeName(t, m, spawned.ID, "audit the poller")
+
+	sess := spawned
+	if err := m.poller.applyPendingRename(&sess); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	wantDir := filepath.Join(filepath.Dir(spawned.Cwd), "audit-the-poller")
+	if sess.Cwd != wantDir || sess.WorktreeBranch != "am/audit-the-poller" {
+		t.Fatalf("session did not follow the name: %+v", sess)
+	}
+	if sess.Name != "audit the poller" {
+		t.Fatalf("name = %q", sess.Name)
+	}
+	stored, err := m.store.Get(spawned.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if stored.Cwd != wantDir || stored.WorktreeBranch != "am/audit-the-poller" || stored.Name != "audit the poller" {
+		t.Fatalf("store did not follow the name: %+v", stored)
+	}
+	if _, err := os.Stat(wantDir); err != nil {
+		t.Fatalf("worktree directory did not follow: %v", err)
+	}
+	if _, found := m.hooks.ReadName(spawned.ID); found {
+		t.Fatal("the name file should be consumed")
+	}
+}
+
+func TestPendingRenameOnATakenWorktreeNameStopsAfterOneReport(t *testing.T) {
+	m := buildModel(t)
+	repo := seedRepo(t)
+	spawned := createWorktreeSession(t, m, "mover", repo)
+	createWorktreeSession(t, m, "taken", repo)
+	writeName(t, m, spawned.ID, "taken")
+
+	sess := spawned
+	if err := m.poller.applyPendingRename(&sess); err == nil {
+		t.Fatal("a taken worktree name should report why")
+	}
+	if _, found := m.hooks.ReadName(spawned.ID); found {
+		t.Fatal("the name file must be consumed so later polls are not stuck on it")
+	}
+	stored, err := m.store.Get(spawned.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if stored.Name != "mover" || stored.Cwd != spawned.Cwd || stored.WorktreeBranch != spawned.WorktreeBranch {
+		t.Fatalf("refused rename still moved something: %+v", stored)
+	}
+
+	// The next poll runs clean, so one bad name does not stall the loop.
+	if err := m.poller.applyPendingRename(&sess); err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+}
+
+func writeName(t *testing.T, m *Model, id, name string) {
+	t.Helper()
+	path := m.hooks.NameFile(id)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("hooks dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(name), 0o644); err != nil {
+		t.Fatalf("write name file: %v", err)
+	}
+}
+
 func writeHookStatus(t *testing.T, m *Model, id, state string) {
 	t.Helper()
 	path := m.hooks.StatusFile(id)

--- a/internal/ui/rename.go
+++ b/internal/ui/rename.go
@@ -3,9 +3,34 @@ package ui
 import (
 	"strings"
 
+	"github.com/YoanWai/agent-manager/internal/git"
+	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+// renameSessionWorktree moves a session's worktree and branch onto its new
+// name, so a session named after the work it ended up doing is reviewed
+// under that name too. Sessions running in a shared directory have nothing
+// to move. The session's own fields are updated in place, leaving the
+// caller a session that already knows where it runs.
+func renameSessionWorktree(gitDrv *git.Driver, st *store.Store, sess *store.Session, name string) error {
+	if gitDrv == nil || sess.WorktreeRepo == "" || sess.WorktreeBranch == "" {
+		return nil
+	}
+	path, branch, err := gitDrv.MoveWorktree(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch, name)
+	if err != nil {
+		return err
+	}
+	if path == sess.Cwd && branch == sess.WorktreeBranch {
+		return nil
+	}
+	if err := st.MoveSessionWorktree(sess.ID, path, branch); err != nil {
+		return err
+	}
+	sess.Cwd, sess.WorktreeBranch = path, branch
+	return nil
+}
 
 func (m *Model) openRename() {
 	entry, ok := m.selectedRow()
@@ -212,17 +237,30 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 		m.renameGroupLocally(m.rename.path, newPath, dir, worktree)
 		m.relabelSubtree(newPath)
 	} else {
+		index := -1
+		for i := range m.sessions {
+			if m.sessions[i].ID == m.rename.sessID {
+				index = i
+				break
+			}
+		}
+		// The worktree moves before the name is stored, so a directory or
+		// branch the new name cannot have leaves the rename card open with
+		// the reason instead of splitting the two apart.
+		if index >= 0 {
+			if err := renameSessionWorktree(m.gitDrv, m.store, &m.sessions[index], name); err != nil {
+				m.errBar.text = "worktree rename: " + err.Error()
+				return m, nil
+			}
+		}
 		if err := m.store.RenameSession(m.rename.sessID, name); err != nil {
 			m.errBar.text = err.Error()
 			return m, nil
 		}
 		tool := m.renameTool()
-		var prevTool string
-		for i := range m.sessions {
-			if m.sessions[i].ID == m.rename.sessID {
-				prevTool = m.sessions[i].Tool
-				break
-			}
+		prevTool := ""
+		if index >= 0 {
+			prevTool = m.sessions[index].Tool
 		}
 		toolChanged := tool != "" && tool != prevTool
 		if toolChanged {
@@ -231,13 +269,11 @@ func (m *Model) applyRename() (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		}
-		for i := range m.sessions {
-			if m.sessions[i].ID == m.rename.sessID {
-				m.sessions[i].Name = name
-				if toolChanged {
-					m.sessions[i].Tool = tool
-					m.sessions[i].AgentSessionID = ""
-				}
+		if index >= 0 {
+			m.sessions[index].Name = name
+			if toolChanged {
+				m.sessions[index].Tool = tool
+				m.sessions[index].AgentSessionID = ""
 			}
 		}
 		m.relabelSession(m.rename.sessID)

--- a/internal/ui/rename.go
+++ b/internal/ui/rename.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/git"
@@ -26,6 +27,11 @@ func renameSessionWorktree(gitDrv *git.Driver, st *store.Store, sess *store.Sess
 		return nil
 	}
 	if err := st.MoveSessionWorktree(sess.ID, path, branch); err != nil {
+		// The directory already moved, so put it back rather than leave the
+		// store pointing at one that is no longer there. The old directory
+		// is named for the session it held, which is the name that rebuilds
+		// the pair it was moved from.
+		_, _, _ = gitDrv.MoveWorktree(sess.WorktreeRepo, path, branch, filepath.Base(sess.Cwd))
 		return err
 	}
 	sess.Cwd, sess.WorktreeBranch = path, branch

--- a/internal/ui/rename_test.go
+++ b/internal/ui/rename_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -150,6 +151,38 @@ func TestRenameSessionRefusesAWorktreeNameAlreadyTaken(t *testing.T) {
 	}
 	if _, err := os.Stat(spawned.Cwd); err != nil {
 		t.Fatalf("worktree should stay put: %v", err)
+	}
+}
+
+func TestRenameSessionWorktreePutsItBackWhenTheStoreRefuses(t *testing.T) {
+	m := buildModel(t)
+	repo := seedRepo(t)
+	spawned := createWorktreeSession(t, m, "claude-7a72", repo)
+
+	// A store that cannot take the new location must not leave the session
+	// recorded in a directory that has already moved away.
+	m.store.Close()
+
+	sess := spawned
+	if err := renameSessionWorktree(m.gitDrv, m.store, &sess, "renamed"); err == nil {
+		t.Fatal("a store that cannot record the move should report it")
+	}
+	if sess.Cwd != spawned.Cwd || sess.WorktreeBranch != spawned.WorktreeBranch {
+		t.Fatalf("session moved anyway: %+v", sess)
+	}
+	if _, err := os.Stat(spawned.Cwd); err != nil {
+		t.Fatalf("worktree was not put back: %v", err)
+	}
+	moved := filepath.Join(filepath.Dir(spawned.Cwd), "renamed")
+	if _, err := os.Stat(moved); !os.IsNotExist(err) {
+		t.Fatalf("worktree left behind at the new path: %v", err)
+	}
+	branches, err := exec.Command("git", "-C", repo, "branch", "--format=%(refname:short)").Output()
+	if err != nil {
+		t.Fatalf("branch: %v", err)
+	}
+	if !strings.Contains(string(branches), spawned.WorktreeBranch) {
+		t.Fatalf("branch was not put back, have: %s", branches)
 	}
 }
 

--- a/internal/ui/rename_test.go
+++ b/internal/ui/rename_test.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -78,6 +80,96 @@ func TestRenameSession(t *testing.T) {
 	}
 	if stored.Tool != "claude" {
 		t.Fatalf("name-only rename changed tool: %q", stored.Tool)
+	}
+}
+
+func TestRenameSessionMovesItsWorktree(t *testing.T) {
+	m := buildModel(t)
+	repo := seedRepo(t)
+	spawned := createWorktreeSession(t, m, "claude-7a72", repo)
+
+	m.selectSessionRow(t, "claude-7a72")
+	m.openRename()
+	m.rename.input.SetValue("release the version")
+	_, cmd := m.handleRenameKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m.applyCmd(t, cmd)
+	if m.errBar.text != "" {
+		t.Fatalf("rename reported: %s", m.errBar.text)
+	}
+
+	// The spawn path is the one git resolved, which on macOS differs from
+	// the temp path by the /private prefix.
+	wantDir := filepath.Join(filepath.Dir(spawned.Cwd), "release-the-version")
+	stored, err := m.store.Get(spawned.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if stored.Cwd != wantDir {
+		t.Fatalf("stored cwd = %q, want %q", stored.Cwd, wantDir)
+	}
+	if stored.WorktreeBranch != "am/release-the-version" {
+		t.Fatalf("stored branch = %q", stored.WorktreeBranch)
+	}
+	if stored.WorktreeRepo != spawned.WorktreeRepo {
+		t.Fatalf("repo root moved: %q want %q", stored.WorktreeRepo, spawned.WorktreeRepo)
+	}
+	if _, err := os.Stat(wantDir); err != nil {
+		t.Fatalf("worktree directory did not follow the name: %v", err)
+	}
+	if _, err := os.Stat(spawned.Cwd); !os.IsNotExist(err) {
+		t.Fatalf("old worktree directory survived: %v", err)
+	}
+	if row := m.sessionRows()[0]; row.Cwd != wantDir || row.WorktreeBranch != "am/release-the-version" {
+		t.Fatalf("row still points at the old worktree: %+v", row)
+	}
+}
+
+func TestRenameSessionRefusesAWorktreeNameAlreadyTaken(t *testing.T) {
+	m := buildModel(t)
+	repo := seedRepo(t)
+	spawned := createWorktreeSession(t, m, "mover", repo)
+	createWorktreeSession(t, m, "taken", repo)
+
+	m.selectSessionRow(t, "mover")
+	m.openRename()
+	m.rename.input.SetValue("taken")
+	m.handleRenameKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.errBar.text == "" {
+		t.Fatal("a taken worktree name should report why")
+	}
+	if m.mode != modeRename {
+		t.Fatalf("mode = %v, want the rename card still open to fix the name", m.mode)
+	}
+	stored, err := m.store.Get(spawned.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if stored.Name != "mover" || stored.Cwd != spawned.Cwd || stored.WorktreeBranch != spawned.WorktreeBranch {
+		t.Fatalf("refused rename still moved something: %+v", stored)
+	}
+	if _, err := os.Stat(spawned.Cwd); err != nil {
+		t.Fatalf("worktree should stay put: %v", err)
+	}
+}
+
+func TestRenameSessionWithoutAWorktreeIsUnchanged(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "plain", t.TempDir(), "")
+	m.selectSessionRow(t, "plain")
+	spawned := m.sessionRows()[0]
+
+	m.openRename()
+	m.rename.input.SetValue("still-plain")
+	_, cmd := m.handleRenameKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m.applyCmd(t, cmd)
+
+	stored, err := m.store.Get(spawned.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if stored.Name != "still-plain" || stored.Cwd != spawned.Cwd {
+		t.Fatalf("shared-directory session should rename in place: %+v", stored)
 	}
 }
 

--- a/internal/ui/rename_test.go
+++ b/internal/ui/rename_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -177,12 +178,16 @@ func TestRenameSessionWorktreePutsItBackWhenTheStoreRefuses(t *testing.T) {
 	if _, err := os.Stat(moved); !os.IsNotExist(err) {
 		t.Fatalf("worktree left behind at the new path: %v", err)
 	}
-	branches, err := exec.Command("git", "-C", repo, "branch", "--format=%(refname:short)").Output()
+	out, err := exec.Command("git", "-C", repo, "branch", "--format=%(refname:short)").Output()
 	if err != nil {
 		t.Fatalf("branch: %v", err)
 	}
-	if !strings.Contains(string(branches), spawned.WorktreeBranch) {
-		t.Fatalf("branch was not put back, have: %s", branches)
+	branches := strings.Fields(string(out))
+	if !slices.Contains(branches, spawned.WorktreeBranch) {
+		t.Fatalf("branch was not put back, have: %v", branches)
+	}
+	if slices.Contains(branches, "am/renamed") {
+		t.Fatalf("rollback left the new branch behind, have: %v", branches)
 	}
 }
 


### PR DESCRIPTION
Closes #189.

A session that spawns into its own git worktree was named at spawn time, and `RenameSession` only ever wrote the name column, so the directory and the branch kept the generated name for good. The auto-rename case could never come out right: agents are told to run `agent-manager rename` as their first action, which is after the worktree already exists, so every quick-prompt spawn was reviewed and merged under `am/claude-<4 hex>`.

Both rename paths now carry the worktree along, to `<repo>-worktrees/<name>` on `am/<name>`, the same shapes `AddWorktree` builds at spawn.

- `MoveWorktree` moves the directory and renames the branch as one step, rolling the directory back if the branch rename fails.
- A destination directory or branch that already exists reports that and keeps the session where it is, so the name, the directory and the branch stay in agreement.
- A worktree whose recorded directory or branch git no longer has is left alone, which is what a worktree renamed or removed by hand looks like, and the session still takes the new name.
- The agent's rename directive is consumed even when the move is refused, so a name git cannot give is reported once instead of on every poll from then on.

`am/` stays the prefix: it is the namespace that lets `worktree add -b` cut a branch without colliding with one you already have, and it marks which branches the manager created.

## Verified

Unit tests cover the driver, the store column, and both rename paths, including the taken-name refusal and the hand-renamed worktree.

Run end to end against the built binary on an isolated tmux socket and config directory:

- Spawned a worktree session named `claude-7a72`, landing on `demo-worktrees/claude-7a72` and `am/claude-7a72`.
- Ran the real `agent-manager rename "audit worktree rename"` directive. The directory became `demo-worktrees/audit-worktree-rename`, the branch `am/audit-worktree-rename`, the store row followed, and the running pane's `pane_current_path` tracked the move with its shell alive.
- Renamed a second session onto a name already taken: `✕ worktree rename: worktree path already exists: .../demo-worktrees/taken`, the card stayed open, and nothing on disk moved.

## Note

The agent CLI resolves its transcript location from the working directory at launch, so a session renamed mid-flight keeps writing its transcript under the spawn-time path. Hooks, status detection, MCP registration and the rename directive are keyed by session id under the manager's config directory, so they follow the move as they are.