### PR TITLE
fix(groups): make group creation immediate and reliable

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -15,7 +15,6 @@ import (
 // listed a moment earlier can tell that race apart from a real failure.
 var ErrSessionGone = errors.New("session no longer exists")
 
-// ErrGroupExists reports an add that would replace an existing group.
 var ErrGroupExists = errors.New("group already exists")
 
 type Session struct {
@@ -272,8 +271,6 @@ func (s *Store) CreateGroup(name, path string) error {
 	return err
 }
 
-// AddGroup inserts a new group and its worktree choice in one statement.
-// Unlike CreateGroup, it refuses to overwrite an existing group.
 func (s *Store) AddGroup(name, path, worktree string) error {
 	if name == "" {
 		return errors.New("group name cannot be empty")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -15,6 +15,9 @@ import (
 // listed a moment earlier can tell that race apart from a real failure.
 var ErrSessionGone = errors.New("session no longer exists")
 
+// ErrGroupExists reports an add that would replace an existing group.
+var ErrGroupExists = errors.New("group already exists")
+
 type Session struct {
 	ID           string
 	Name         string
@@ -267,6 +270,29 @@ func (s *Store) CreateGroup(name, path string) error {
 		 VALUES (?, ?, (SELECT COALESCE(MAX(sort_order)+1, 0) FROM groups))
 		 ON CONFLICT(name) DO UPDATE SET path = excluded.path`, name, path)
 	return err
+}
+
+// AddGroup inserts a new group and its worktree choice in one statement.
+// Unlike CreateGroup, it refuses to overwrite an existing group.
+func (s *Store) AddGroup(name, path, worktree string) error {
+	if name == "" {
+		return errors.New("group name cannot be empty")
+	}
+	res, err := s.db.Exec(
+		`INSERT INTO groups (name, path, worktree, sort_order)
+		 VALUES (?, ?, ?, (SELECT COALESCE(MAX(sort_order)+1, 0) FROM groups))
+		 ON CONFLICT(name) DO NOTHING`, name, path, worktree)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return fmt.Errorf("group %q: %w", name, ErrGroupExists)
+	}
+	return nil
 }
 
 func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -765,3 +765,21 @@ func TestGroupWorktreeRoundtrip(t *testing.T) {
 		t.Fatalf("worktree choice should clear back to inherit: %+v", groups[0])
 	}
 }
+
+func TestAddGroupStoresSettingsWithoutReplacingExistingGroup(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.AddGroup("backend", "/first", "off"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := st.AddGroup("backend", "/second", "on"); !errors.Is(err, ErrGroupExists) {
+		t.Fatalf("duplicate add error = %v, want ErrGroupExists", err)
+	}
+
+	groups, err := st.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Path != "/first" || groups[0].Worktree != "off" {
+		t.Fatalf("duplicate add changed group: %+v", groups)
+	}
+}

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -163,6 +163,14 @@ func (m *Model) syncFormFieldWidths() {
 	m.form.prompt.SetWidth(inner)
 }
 
+func (m *Model) syncGroupFormFieldWidths() {
+	width := m.formValueWidth() - 3
+	m.groupForm.name.Width = width
+	m.groupForm.path.Width = width
+	m.groupForm.name.SetCursor(m.groupForm.name.Position())
+	m.groupForm.path.SetCursor(m.groupForm.path.Position())
+}
+
 // contextGroup is the group the cursor currently sits in: a highlighted
 // group row itself, or the group holding a highlighted session.
 func (m *Model) contextGroup() string {
@@ -265,6 +273,11 @@ func (m *Model) selectedGroupPath() string {
 // Index 0 is always the root; selectPath moves the highlight when given.
 func (m *Model) rebuildGroupOptions(selectPath string) {
 	paths := groupClosure(m.groups, m.sessions)
+	for path := range paths {
+		if m.groupEffectivelyArchived(path) {
+			delete(paths, path)
+		}
+	}
 	children := childIndex(paths, m.groups)
 
 	options := []groupOption{{path: "", depth: 0}}
@@ -662,6 +675,7 @@ func (m *Model) openGroupForm() {
 	}
 	m.rebuildGroupOptions(m.contextGroup())
 	m.groupForm.path.SetValue(m.groupDefaultDir(m.selectedGroupPath()))
+	m.syncGroupFormFieldWidths()
 	m.pathSugg.reset()
 	m.mode = modeGroupForm
 	m.errBar.text = ""
@@ -774,14 +788,40 @@ func (m *Model) submitGroupForm() (tea.Model, tea.Cmd) {
 		m.errBar.text = "default path does not exist: " + path
 		return m, nil
 	}
-	if err := m.store.CreateGroup(full, path); err != nil {
+	worktree := groupWorktreeValue(m.groupForm.worktreeIndex)
+	if err := m.store.AddGroup(full, path, worktree); err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
-	if err := m.store.SetGroupWorktree(full, groupWorktreeValue(m.groupForm.worktreeIndex)); err != nil {
-		m.errBar.text = err.Error()
-		return m, nil
+	m.materializeGroupsLocal([]string{full})
+	if m.groupPaths == nil {
+		m.groupPaths = map[string]string{}
 	}
+	m.groupPaths[full] = path
+	if m.groupWorktrees == nil {
+		m.groupWorktrees = map[string]string{}
+	}
+	if worktree == "" {
+		delete(m.groupWorktrees, full)
+	} else {
+		m.groupWorktrees[full] = worktree
+	}
+	for group := parent; group != ""; group = parentGroup(group) {
+		delete(m.collapsed, group)
+	}
+	m.persistCollapsed()
+	m.search = ""
+	m.searching = false
+	m.showArchived = false
+	m.hideEmptyGroups = false
+	m.errBar.text = ""
 	m.mode = modeList
+	m.rebuildRows()
+	for i, row := range m.rows {
+		if row.isGroup && row.group == full {
+			m.cursor = i
+			break
+		}
+	}
 	return m, m.refreshCmd()
 }

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -73,6 +73,127 @@ func TestGroupFormCreatesUnderParent(t *testing.T) {
 	}
 }
 
+func TestGroupFormShowsNewEmptyGroupWithWorktreeOff(t *testing.T) {
+	m := buildModel(t)
+	m.hideEmptyGroups = true
+	m.search = "does-not-match"
+	m.showArchived = true
+	m.openGroupForm()
+	m.groupForm.name.SetValue("manual")
+	m.groupForm.path.SetValue(t.TempDir())
+	m.groupForm.worktreeIndex = groupWorktreeIndex("off")
+
+	_, cmd := m.submitGroupForm()
+	if m.hideEmptyGroups {
+		t.Fatal("creating a group should reveal it when empty groups were hidden")
+	}
+	if m.search != "" || m.showArchived {
+		t.Fatalf("creation left list filters active: search=%q archived=%v", m.search, m.showArchived)
+	}
+	if got := m.groupRowPaths(); !reflect.DeepEqual(got, []string{"manual"}) {
+		t.Fatalf("group rows before refresh = %v, want [manual]", got)
+	}
+	if row, ok := m.selectedRow(); !ok || !row.isGroup || row.group != "manual" {
+		t.Fatalf("new group is not selected: %+v", row)
+	}
+
+	m.applyCmd(t, cmd)
+	if got := m.groupRowPaths(); !reflect.DeepEqual(got, []string{"manual"}) {
+		t.Fatalf("group rows after refresh = %v, want [manual]", got)
+	}
+	if got := m.groupWorktrees["manual"]; got != "off" {
+		t.Fatalf("local worktree choice = %q, want off", got)
+	}
+}
+
+func TestGroupFormExpandsParentToShowNewChild(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("projects", t.TempDir()); err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "projects")
+	m.collapsed["projects"] = true
+	m.openGroupForm()
+	m.groupForm.name.SetValue("api")
+
+	_, _ = m.submitGroupForm()
+	if m.collapsed["projects"] {
+		t.Fatal("parent remained collapsed after creating a child")
+	}
+	if got := m.groupRowPaths(); !reflect.DeepEqual(got, []string{"projects", "projects/api"}) {
+		t.Fatalf("group rows = %v, want parent and child", got)
+	}
+	if row, ok := m.selectedRow(); !ok || row.group != "projects/api" {
+		t.Fatalf("new child is not selected: %+v", row)
+	}
+}
+
+func TestGroupFormRejectsDuplicateWithoutChangingIt(t *testing.T) {
+	m := buildModel(t)
+	first := t.TempDir()
+	second := t.TempDir()
+	if err := m.store.AddGroup("backend", first, "on"); err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+
+	m.openGroupForm()
+	pickGroup(t, m, "")
+	m.groupForm.name.SetValue("backend")
+	m.groupForm.path.SetValue(second)
+	m.groupForm.worktreeIndex = groupWorktreeIndex("off")
+	_, cmd := m.submitGroupForm()
+	if cmd != nil || m.mode != modeGroupForm || !strings.Contains(m.errBar.text, "already exists") {
+		t.Fatalf("duplicate submission succeeded: mode=%v err=%q", m.mode, m.errBar.text)
+	}
+
+	groups, err := m.store.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Path != first || groups[0].Worktree != "on" {
+		t.Fatalf("duplicate submission changed group: %+v", groups)
+	}
+}
+
+func TestGroupParentPickerExcludesArchivedGroups(t *testing.T) {
+	m := buildModel(t)
+	for _, group := range []string{"active", "archived", "archived/child"} {
+		if err := m.store.CreateGroup(group, t.TempDir()); err != nil {
+			t.Fatalf("create %s: %v", group, err)
+		}
+	}
+	if err := m.store.SetGroupArchived("archived", true); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+
+	m.openGroupForm()
+	var options []string
+	for _, option := range m.form.groups {
+		options = append(options, option.path)
+	}
+	if !reflect.DeepEqual(options, []string{"", "active"}) {
+		t.Fatalf("parent options = %v, want root and active", options)
+	}
+}
+
+func TestGroupFormFieldsTrackCardWidth(t *testing.T) {
+	m := buildModel(t)
+	m.openGroupForm()
+	want := m.formValueWidth() - 3
+	if m.groupForm.name.Width != want || m.groupForm.path.Width != want {
+		t.Fatalf("initial widths = name %d path %d, want %d", m.groupForm.name.Width, m.groupForm.path.Width, want)
+	}
+
+	m.Update(tea.WindowSizeMsg{Width: 72, Height: m.height})
+	want = m.formValueWidth() - 3
+	if m.groupForm.name.Width != want || m.groupForm.path.Width != want {
+		t.Fatalf("resized widths = name %d path %d, want %d", m.groupForm.name.Width, m.groupForm.path.Width, want)
+	}
+}
+
 func TestGroupDefaultPathFillsSessionDir(t *testing.T) {
 	m := buildModel(t)
 	groupDir := t.TempDir()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -796,6 +796,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resizeSessions()
 		if m.mode == modeForm {
 			m.syncFormFieldWidths()
+		} else if m.mode == modeGroupForm {
+			m.syncGroupFormFieldWidths()
 		}
 		return m, nil
 


### PR DESCRIPTION
## What changed

- update the in-memory group tree immediately after creation and select the new group
- reveal new groups through search, archived, empty-group, and collapsed-parent states
- store the path and worktree choice atomically and reject duplicate group creation
- exclude archived groups from destination pickers
- keep group-form fields sized to the modal
- add regression coverage for the full creation flow

## Why

A newly created group could remain invisible until the TUI restarted because the list depended on a later refresh and could still be filtered. Group creation also used an upsert followed by a separate worktree update, allowing duplicate submissions to overwrite existing settings and leaving persistence split across two writes.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./...` passes
- [x] `go build ./...` passes