### PR TITLE
fix(ui): contain RTL pane text in preview

### DIFF
--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -53,6 +53,7 @@ func TestFocusKeyCommand(t *testing.T) {
 // bgRun returns, for each column, whether a background color is active,
 // by walking the row's SGR sequences the way a terminal would.
 func bgRun(row string, width int) []bool {
+	row = strings.NewReplacer("\u2066", "", "\u2069", "").Replace(row)
 	out := make([]bool, 0, width)
 	bg := false
 	i := 0

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -154,7 +154,7 @@ func TestTripleClickOnRealFrameTakesPaneRowOnly(t *testing.T) {
 // plainCells is a painted frame row as visible cells, escape sequences
 // removed, so a column index in the frame is a column on screen.
 func plainCells(row string) []rune {
-	return []rune(ansi.Strip(row))
+	return []rune(strings.NewReplacer("\u2066", "", "\u2069", "").Replace(ansi.Strip(row)))
 }
 
 // A capture taken by the slower poll path must not repaint over a frame
@@ -311,7 +311,7 @@ func TestCursorPaintedOnItsRow(t *testing.T) {
 	if !strings.Contains(withCursor, "\x1b[") {
 		t.Fatalf("cursor row carries no styling: %q", withCursor)
 	}
-	if ansi.Strip(withCursor) != "abc" {
+	if string(plainCells(withCursor)) != "abc" {
 		t.Fatalf("cursor changed the row text: %q", ansi.Strip(withCursor))
 	}
 	if other := m.renderPaneRow(1, "def", 20); other != previewLine("def", 20) {
@@ -355,7 +355,7 @@ func TestCursorPastEndOfLine(t *testing.T) {
 	if !strings.Contains(row, "\x1b[") {
 		t.Fatalf("no cursor drawn past end of line: %q", row)
 	}
-	if plain := strings.TrimRight(ansi.Strip(row), " "); plain != "ab" {
+	if plain := strings.TrimRight(string(plainCells(row)), " "); plain != "ab" {
 		t.Fatalf("cursor changed the line text: %q", plain)
 	}
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -338,7 +338,8 @@ func previewLine(line string, width int) string {
 	if strings.ContainsRune(line, 0x1b) {
 		line += "\x1b[0m"
 	}
-	return line
+	// Keep a leading RTL run inside the preview instead of the terminal's full row.
+	return "\u2066" + line + "\u2069"
 }
 
 // paneExact returns up to n lines of pane text as captured, preserving

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -82,21 +82,21 @@ func TestPreviewLine(t *testing.T) {
 	if !strings.Contains(got, "\x1b[38;5;42m") {
 		t.Fatalf("color escapes should survive: %q", got)
 	}
-	if !strings.HasSuffix(got, "\x1b[0m") {
+	if !strings.HasSuffix(got, "\x1b[0m\u2069") {
 		t.Fatalf("line with ANSI must end in SGR reset: %q", got)
 	}
 
 	erased := "abc\x1b[K\x1b[2Jdef"
-	if got := previewLine(erased, 80); got != "abcdef" {
+	if got := previewLine(erased, 80); ansi.Strip(got) != "\u2066abcdef\u2069" {
 		t.Fatalf("erase sequences should be stripped: %q", got)
 	}
 	scrolled := "a\x1b[1Sb\x1bMc\x1b[2Td"
-	if got := previewLine(scrolled, 80); got != "abcd" {
+	if got := previewLine(scrolled, 80); ansi.Strip(got) != "\u2066abcd\u2069" {
 		t.Fatalf("scroll sequences should be stripped: %q", got)
 	}
 
 	control := "a\rb\bc"
-	if got := previewLine(control, 80); got != "abc" {
+	if got := previewLine(control, 80); ansi.Strip(got) != "\u2066abc\u2069" {
 		t.Fatalf("control chars should be dropped: %q", got)
 	}
 
@@ -109,6 +109,12 @@ func TestPreviewLine(t *testing.T) {
 	plain := previewLine("plain", 80)
 	if strings.Contains(plain, "\x1b") {
 		t.Fatalf("plain line should gain no escapes: %q", plain)
+	}
+	if !strings.HasPrefix(plain, "\u2066") || !strings.HasSuffix(plain, "\u2069") {
+		t.Fatalf("pane row should be directionally isolated: %q", plain)
+	}
+	if got := ansi.Strip(previewLine("קודינג\",\"slowly\":false", 80)); got != "\u2066קודינג\",\"slowly\":false\u2069" {
+		t.Fatalf("mixed-direction pane row lost its isolation: %q", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- wrap captured pane rows in Unicode left-to-right isolation markers
- keep mixed RTL/LTR output inside the preview column
- add a regression covering a Hebrew continuation followed by JSON text
- update focus rendering test helpers to ignore the zero-width framing marks

## Why

A captured Codex tool-call line that wrapped before Hebrew text could be reordered by the host terminal across the entire Agent Manager row. The leading Hebrew run then appeared at column zero, over the left rail, while the remaining JSON stayed in the preview.

Directional isolation gives each captured pane row an LTR boundary while preserving the pane's ANSI styling and cell width.

## Validation

- `gofmt -l .`
- `go vet ./...`
- `env -u TMUX TMUX_TMPDIR=/tmp/amd050 go test -count=1 ./...`