### PR TITLE
Add Trendshift, build, and Go reference badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
   <a href="https://github.com/YoanWai/agent-manager/stargazers"><img src="https://img.shields.io/github/stars/YoanWai/agent-manager?style=for-the-badge&label=stars&labelColor=1f2328&color=96591f" alt="stars"></a>
   <a href="https://github.com/YoanWai/agent-manager"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FYoanWai%2Fagent-manager%2Fbadges%2Fclones.json&style=for-the-badge&labelColor=1f2328" alt="clones in the last 14 days"></a>
   <a href="https://github.com/YoanWai/agent-manager/releases/latest"><img src="https://img.shields.io/github/v/release/YoanWai/agent-manager?style=for-the-badge&label=release&labelColor=1f2328&color=2f5f8f" alt="latest release"></a>
+  <a href="https://github.com/YoanWai/agent-manager/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/YoanWai/agent-manager/ci.yml?branch=main&style=for-the-badge&label=build&labelColor=1f2328&color=2f7f62" alt="CI status"></a>
+  <a href="https://pkg.go.dev/github.com/YoanWai/agent-manager"><img src="https://img.shields.io/badge/go.dev-reference-007d9c?style=for-the-badge&logo=go&logoColor=white" alt="Go package reference"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/YoanWai/agent-manager?style=for-the-badge&label=license&labelColor=1f2328&color=59636e" alt="licence"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><b>The fastest workflow for every AI coding agent.</b></p>
 
-<p align="center"><!-- trendshift:start --><!-- trendshift:end --></p>
+<p align="center"><!-- trendshift:start --><a href="https://trendshift.io/repositories/89312?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-89312" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/89312/daily?language=Go" alt="agent-manager on Trendshift" width="250" height="55"></a><!-- trendshift:end --></p>
 
 <p align="center">
   <a href="https://github.com/YoanWai/agent-manager/stargazers"><img src="https://img.shields.io/github/stars/YoanWai/agent-manager?style=for-the-badge&label=stars&labelColor=1f2328&color=96591f" alt="stars"></a>

--- a/tools/badges/main.go
+++ b/tools/badges/main.go
@@ -112,12 +112,11 @@ func get(url string, into any) error {
 }
 
 // trendshiftBadge is the banner Trendshift mints once a repository reaches
-// GitHub Trending. Ours has a profile but no badge yet: the endpoint answers
-// 500 until the day it trends, so the region in the README stays empty and
-// fills itself on the first run after that happens.
+// GitHub Trending.
 func trendshiftBadge() string {
 	const id = "89312"
-	resp, err := http.Get("https://trendshift.io/api/badge/repositories/" + id)
+	const badgeURL = "https://trendshift.io/api/badge/trendshift/repositories/" + id + "/daily?language=Go"
+	resp, err := http.Get(badgeURL)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "badges: trendshift unreachable:", err)
 		return ""
@@ -127,8 +126,8 @@ func trendshiftBadge() string {
 		return ""
 	}
 	return fmt.Sprintf(
-		`<a href="https://trendshift.io/repositories/%s"><img src="https://trendshift.io/api/badge/repositories/%s" alt="agent-manager on Trendshift" width="250" height="55"></a>`,
-		id, id)
+		`<a href="https://trendshift.io/repositories/%s?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-%s" target="_blank" rel="noopener noreferrer"><img src="%s" alt="agent-manager on Trendshift" width="250" height="55"></a>`,
+		id, id, badgeURL)
 }
 
 // fillTrendshift keeps the README's trendshift region in step with whether the


### PR DESCRIPTION
## What changed

- embed the newly minted Trendshift badge beneath the README tagline
- point the badge automation at Trendshift's current daily Go endpoint
- add matching live build-status and Go package-reference badges
- preserve Trendshift attribution parameters and safe external-link attributes

## Why

The repository has now earned its Trendshift badge, but the README region was empty and the automation still probed an obsolete endpoint. The header also lacked direct signals for the passing CI workflow and published Go module.

## Impact

Visitors now see the centered Trendshift badge plus consistent build and Go reference chips in the project header. Scheduled badge refreshes will continue using the live Trendshift endpoint.

## Validation

- Trendshift badge endpoint returns HTTP 200
- build badge renders `BUILD: PASSING`
- Go package badge renders `GO.DEV: REFERENCE`
- `test -z "$(gofmt -l .)"`
- `go vet ./...`
- `env -u TMUX TMUX_TMPDIR=/tmp/am7171 go test ./...`