### PR TITLE
docs(readme): fix mobile header layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+<p align="center">
+  <a href="#install"><b>Install</b></a> ·
+  <a href="#usage"><b>Usage</b></a> ·
+  <a href="docs/usage.md#keys"><b>Keys</b></a> ·
+  <a href="docs/usage.md#diff-review"><b>Diff review</b></a> ·
+  <a href="docs/configuration.md"><b>Configuration</b></a>
+</p>
+
 <h1 align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/brand/wordmark-dark.svg">
@@ -7,17 +15,20 @@
 
 <p align="center"><b>The fastest workflow for every AI coding agent.</b></p>
 
-<p align="center"><!-- trendshift:start --><a href="https://trendshift.io/repositories/89312?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-89312" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/89312/daily?language=Go" alt="agent-manager on Trendshift" width="250" height="55"></a><!-- trendshift:end --></p>
+<div align="center">
+<!-- trendshift:start --><a href="https://trendshift.io/repositories/89312?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-89312" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/89312/daily?language=Go" alt="agent-manager on Trendshift" width="250" height="55"></a><!-- trendshift:end -->
+</div>
 
-<p align="center">
-  <a href="https://github.com/YoanWai/agent-manager/stargazers"><img src="https://img.shields.io/github/stars/YoanWai/agent-manager?style=for-the-badge&label=stars&labelColor=1f2328&color=96591f" alt="stars"></a>
-  <a href="https://github.com/YoanWai/agent-manager"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FYoanWai%2Fagent-manager%2Fbadges%2Fclones.json&style=for-the-badge&labelColor=1f2328" alt="clones in the last 14 days"></a>
-  <a href="https://github.com/YoanWai/agent-manager/releases/latest"><img src="https://img.shields.io/github/v/release/YoanWai/agent-manager?style=for-the-badge&label=release&labelColor=1f2328&color=2f5f8f" alt="latest release"></a>
+<div align="center">
+  <a href="https://github.com/YoanWai/agent-manager/stargazers"><img src="https://img.shields.io/github/stars/YoanWai/agent-manager?style=flat-square&label=stars&labelColor=1f2328&color=96591f" alt="stars"></a>
+  <a href="https://github.com/YoanWai/agent-manager"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FYoanWai%2Fagent-manager%2Fbadges%2Fclones.json&style=flat-square&labelColor=1f2328" alt="clones in the last 14 days"></a>
   <br>
-  <a href="https://github.com/YoanWai/agent-manager/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/YoanWai/agent-manager/ci.yml?branch=main&style=for-the-badge&label=build&labelColor=1f2328&color=2f7f62" alt="CI status"></a>
-  <a href="https://pkg.go.dev/github.com/YoanWai/agent-manager"><img src="https://img.shields.io/badge/go.dev-reference-007d9c?style=for-the-badge&logo=go&logoColor=white" alt="Go package reference"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/YoanWai/agent-manager?style=for-the-badge&label=license&labelColor=1f2328&color=59636e" alt="licence"></a>
-</p>
+  <a href="https://github.com/YoanWai/agent-manager/releases/latest"><img src="https://img.shields.io/github/v/release/YoanWai/agent-manager?style=flat-square&label=release&labelColor=1f2328&color=2f5f8f" alt="latest release"></a>
+  <a href="https://github.com/YoanWai/agent-manager/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/YoanWai/agent-manager/ci.yml?branch=main&style=flat-square&label=build&labelColor=1f2328&color=2f7f62" alt="CI status"></a>
+  <br>
+  <a href="https://pkg.go.dev/github.com/YoanWai/agent-manager"><img src="https://img.shields.io/badge/go-reference-007d9c?style=flat-square&logo=go&logoColor=white" alt="Go package reference"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/YoanWai/agent-manager?style=flat-square&label=license&labelColor=1f2328&color=59636e" alt="licence"></a>
+</div>
 
 ![five prompts to five fresh agents without moving the cursor, one per CLI, then the blocked one answered and its diff opened](docs/demo.gif)
 
@@ -28,8 +39,6 @@ agent-manager is a thin layer over the CLIs you already have. Each session launc
 Instead of hunting through terminal tabs to see which agent is done and which is stuck, every session shows up in one list with live status, grouped into a project tree you can fold and reorder. You answer any of them without attaching: `space` sends a prompt straight into a session's pane, or spawns a new agent in the selected group. A dead session revives on its own conversation with `v`. And `ctrl+r` opens a full-file diff of what an agent changed, syntax-highlighted, where the comments you leave on lines go back to the agent's pane as one review prompt when you press `C`.
 
 Not here yet: cost tracking, mouse-driven navigation, and agents that can talk to each other.
-
-**Jump to:** [Install](#install) · [Usage](#usage) · [Keys](docs/usage.md#keys) · [Diff review](docs/usage.md#diff-review) · [Configuration](docs/configuration.md)
 
 ## Supported tools
 


### PR DESCRIPTION
## What changed

- moved the compact README navigation ahead of the brand block so GitHub's sticky mobile README bar no longer covers the wordmark
- gave the Trendshift badge its own centered block
- replaced the large, unpredictably wrapping status badges with three explicit two-chip rows using compact badges
- kept install, usage, keys, diff review, and configuration links visible at the top of the README

## Why

On narrow GitHub viewports, the sticky README tab bar covered the first header element, while the large status badges wrapped differently at each width. The result hid the wordmark, pushed useful links down the page, and made the badge header look off-center.

## Validation

- verified the rendered branch on GitHub at 320 px and 390 px
- confirmed the wordmark remains visible when the sticky README bar is active
- confirmed the Trendshift badge and all three badge rows share the README centerline with no horizontal overflow
- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `git diff --check`