### PR TITLE
feat(ui): let settings hide CLIs from new sessions

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -234,8 +234,29 @@ func sortedToolNames(cfg config.Config) []string {
 	return names
 }
 
+// enabledToolNames is the create-session picker: configured tools minus any
+// the user hid in settings. Existing sessions keep their tool even when hidden.
+func (m *Model) enabledToolNames() []string {
+	all := sortedToolNames(m.cfg)
+	hidden := m.hiddenTools()
+	if len(hidden) == 0 {
+		return all
+	}
+	out := make([]string, 0, len(all))
+	for _, name := range all {
+		if !hidden[name] {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
 func (m *Model) openForm() {
-	tools := sortedToolNames(m.cfg)
+	tools := m.enabledToolNames()
+	if len(tools) == 0 {
+		m.errBar.text = "no CLIs enabled: open settings (s), then CLIs, to turn some on"
+		return
+	}
 
 	name := textField("my-session", 60)
 	name.Focus()

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -387,6 +387,10 @@ const quickCloseSetting = "quick_prompt_close"
 
 const worktreeSetting = "worktree_default"
 
+// hiddenToolsSetting lists CLI tools omitted from new-session pickers
+// (comma-separated names). Empty means every configured tool is shown.
+const hiddenToolsSetting = "hidden_tools"
+
 func (m *Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "enter", "esc":

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -23,6 +23,34 @@ func (m *Model) card(title, body, hint string) string {
 	return m.cardSized(m.cardWidth(), title, body, hint)
 }
 
+// cardFlex is card, but the panel grows with its content up to the terminal
+// width so long settings rows are not clipped.
+func (m *Model) cardFlex(title, body, hint string) string {
+	return m.cardSized(m.flexCardWidth(title, body, hint), title, body, hint)
+}
+
+// flexCardWidth picks a width that fits every content line, never under the
+// default card width and never past the terminal edge.
+func (m *Model) flexCardWidth(title, body, hint string) int {
+	head := lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render(title)
+	content := head + "\n\n" + body
+	if m.errBar.text != "" {
+		content += "\n" + errStyle.Render("✕ "+m.errBar.text)
+	}
+	content += "\n\n" + subtleStyle.Render(hint)
+
+	need := m.cardWidth()
+	for _, line := range strings.Split(content, "\n") {
+		if w := lipgloss.Width(line) + 2*cardPaddingX; w > need {
+			need = w
+		}
+	}
+	if m.width >= 28 && need > m.width-4 {
+		need = m.width - 4
+	}
+	return need
+}
+
 // cardSized is card at an explicit width, for the key map, whose lines are
 // too long to read inside the default column.
 func (m *Model) cardSized(width int, title, body, hint string) string {
@@ -189,6 +217,9 @@ func (m *Model) viewGroupForm() string {
 }
 
 func (m *Model) viewSettings() string {
+	if m.settings.cliPicker {
+		return m.viewCLIPicker()
+	}
 	layout := "unified"
 	if m.settings.layoutSplit {
 		layout = "split"
@@ -209,6 +240,10 @@ func (m *Model) viewSettings() string {
 	if m.settings.worktreeDefault {
 		worktreeDefault = "on"
 	}
+	toolValue := ""
+	if len(m.settings.toolNames) > 0 {
+		toolValue = m.settings.toolNames[m.settings.toolIndex]
+	}
 	lead := func(field int, name string) string {
 		marker := "  "
 		labelStyle := valueStyle
@@ -225,7 +260,7 @@ func (m *Model) viewSettings() string {
 	actionRow := func(field int, name, action string) string {
 		return lead(field, name) + keyStyle.Render("↵") + mutedStyle.Render(" "+action)
 	}
-	body := row(settingsFieldTool, "quick spawn tool", m.settings.toolNames[m.settings.toolIndex]) + "\n" +
+	body := row(settingsFieldTool, "quick spawn tool", toolValue) + "\n" +
 		row(settingsFieldTheme, "theme", themes[m.settings.themeIndex].Name) + "  " +
 		themeSwatch(themes[m.settings.themeIndex]) + "\n" +
 		row(settingsFieldDensity, "list density", density) + "\n" +
@@ -233,13 +268,58 @@ func (m *Model) viewSettings() string {
 		row(settingsFieldQuickClose, "after quick send", quickClose) + "\n" +
 		row(settingsFieldFocusKey, "session keys", focusKey) + "\n" +
 		row(settingsFieldWorktree, "spawn in worktree", worktreeDefault) + "\n" +
+		actionRow(settingsFieldCLIs, "CLIs", "show or hide for new sessions") + "\n" +
 		actionRow(settingsFieldBugReport, "report a bug", "open a prefilled GitHub issue") + "\n\n" +
 		subtleStyle.Render("  version ") + valueStyle.Render(m.update.version) + m.versionStatus()
 	hint := "↑↓ field · ←→ change · ↵/esc save"
-	if m.settings.field == settingsFieldBugReport {
+	switch m.settings.field {
+	case settingsFieldBugReport:
 		hint = "↑↓ field · ↵ open issue · esc save"
+	case settingsFieldCLIs:
+		hint = "↑↓ field · ↵ manage CLIs · esc save"
 	}
-	return m.card("⚙ Settings", body, hint)
+	return m.cardFlex("⚙ Settings", body, hint)
+}
+
+func (m *Model) viewCLIPicker() string {
+	var b strings.Builder
+	for i, name := range m.settings.cliNames {
+		marker := "  "
+		labelStyle := valueStyle
+		if m.settings.cliCursor == i {
+			marker = lipgloss.NewStyle().Foreground(colorAccent).Render("❯ ")
+			labelStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+		}
+		box := "[x]"
+		if m.settings.cliHidden[name] {
+			box = "[ ]"
+		}
+		b.WriteString(marker)
+		b.WriteString(labelStyle.Render(box + " " + name))
+		b.WriteByte('\n')
+	}
+	// Request row matches other settings actions; the note below is not focusable.
+	reqFocused := m.settings.cliCursor >= len(m.settings.cliNames)
+	reqMarker := "  "
+	reqLabel := mutedStyle.Render("request CLI support")
+	if reqFocused {
+		reqMarker = lipgloss.NewStyle().Foreground(colorAccent).Render("❯ ")
+		reqLabel = lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("request CLI support")
+	}
+	b.WriteByte('\n')
+	b.WriteString(reqMarker)
+	b.WriteString(keyStyle.Render("↵"))
+	b.WriteString(" ")
+	b.WriteString(reqLabel)
+	b.WriteString(mutedStyle.Render("  open a GitHub issue"))
+	b.WriteByte('\n')
+	b.WriteString(subtleStyle.Render("  * more will be supported soon!"))
+	hint := "↑↓ move · space/↵ toggle · esc back"
+	if reqFocused {
+		hint = "↑↓ move · ↵ open request issue · esc back"
+	}
+	// Fixed card width: short checkbox rows must not stretch a wide empty panel.
+	return m.card("⚙ CLIs", strings.TrimRight(b.String(), "\n"), hint)
 }
 
 // themeSwatch previews a palette as a run of blocks, so a theme can be
@@ -294,7 +374,7 @@ func (m *Model) viewHelp() string {
 		{"b", "in review: pick the branch from the repo's worktrees"},
 		{"B", "in review: pick the target (merge-into branch) the branch diff compares against"},
 		{"F", "fold / unfold all groups"},
-		{"s", "settings (quick spawn tool, review layout, after quick send)"},
+		{"s", "settings (CLIs, theme, quick spawn, review layout)"},
 		{"|", "resize split (←→ / drag, enter commits, esc cancels)"},
 		{"t", "toggle archived view"},
 		{"M", "messages (updates, tips, bug reporting; x dismisses)"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -322,6 +322,11 @@ type settingsState struct {
 	enterFocuses    bool
 	comfortableRows bool
 	worktreeDefault bool
+	// cliPicker is the sub-panel for which CLIs appear when creating sessions.
+	cliPicker bool
+	cliNames  []string
+	cliHidden map[string]bool
+	cliCursor int
 }
 
 const (
@@ -332,6 +337,7 @@ const (
 	settingsFieldQuickClose
 	settingsFieldFocusKey
 	settingsFieldWorktree
+	settingsFieldCLIs
 	settingsFieldBugReport
 	settingsFieldCount
 )

--- a/internal/ui/quick.go
+++ b/internal/ui/quick.go
@@ -89,6 +89,11 @@ func (m *Model) quickMessage() string {
 }
 
 func (m *Model) openQuickMode() {
+	names, index := m.defaultToolSelection()
+	if len(names) == 0 {
+		m.errBar.text = "no CLIs enabled: open settings (s), then CLIs, to turn some on"
+		return
+	}
 	input := textarea.New()
 	input.CharLimit = 2000
 	input.Placeholder = "type and press enter"
@@ -104,7 +109,6 @@ func (m *Model) openQuickMode() {
 	input.Focus()
 	m.errBar.text = ""
 	m.forgetWorktreeCapability()
-	names, index := m.defaultToolSelection()
 	m.quick = quickState{
 		active:         true,
 		input:          input,
@@ -115,10 +119,10 @@ func (m *Model) openQuickMode() {
 	}
 }
 
-// defaultToolSelection returns the sorted tool names with the index of
+// defaultToolSelection returns enabled tool names with the index of
 // the configured default, ready to seed a tool picker.
 func (m *Model) defaultToolSelection() ([]string, int) {
-	names := sortedToolNames(m.cfg)
+	names := m.enabledToolNames()
 	current := m.defaultTool()
 	index := 0
 	for i, name := range names {

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -1,6 +1,9 @@
 package ui
 
 import (
+	"net/url"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/YoanWai/agent-manager/internal/store"
@@ -8,10 +11,10 @@ import (
 )
 
 // defaultTool is the CLI quick spawn launches: the settings choice when it
-// still exists in the config, else the first tool alphabetically. A store
-// error still yields the fallback but is surfaced, never swallowed.
+// is still enabled, else the first enabled tool. A store error still yields
+// the fallback but is surfaced, never swallowed.
 func (m *Model) defaultTool() string {
-	names := sortedToolNames(m.cfg)
+	names := m.enabledToolNames()
 	if len(names) == 0 {
 		return ""
 	}
@@ -21,11 +24,54 @@ func (m *Model) defaultTool() string {
 		return names[0]
 	}
 	if chosen != "" {
-		if _, ok := m.cfg.Tools[chosen]; ok {
-			return chosen
+		for _, name := range names {
+			if name == chosen {
+				return chosen
+			}
 		}
 	}
 	return names[0]
+}
+
+// hiddenTools returns the set of CLI names the user turned off for new sessions.
+func (m *Model) hiddenTools() map[string]bool {
+	raw, err := m.store.Setting(hiddenToolsSetting)
+	if err != nil {
+		m.errBar.text = "reading hidden tools setting: " + err.Error()
+		return nil
+	}
+	return parseHiddenTools(raw)
+}
+
+func parseHiddenTools(raw string) map[string]bool {
+	if raw == "" {
+		return nil
+	}
+	hidden := make(map[string]bool)
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(part)
+		if name != "" {
+			hidden[name] = true
+		}
+	}
+	if len(hidden) == 0 {
+		return nil
+	}
+	return hidden
+}
+
+func formatHiddenTools(hidden map[string]bool) string {
+	if len(hidden) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(hidden))
+	for name, on := range hidden {
+		if on {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return strings.Join(names, ",")
 }
 
 func (m *Model) defaultWorktree() bool {
@@ -148,6 +194,9 @@ func (m *Model) openSettings() {
 }
 
 func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.settings.cliPicker {
+		return m.handleCLIPickerKey(msg)
+	}
 	switch msg.String() {
 	case "up", "k":
 		m.settings.field = (m.settings.field + settingsFieldCount - 1) % settingsFieldCount
@@ -157,60 +206,158 @@ func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.cycleSetting(-1)
 	case "right", "l":
 		m.cycleSetting(1)
-	case "enter", "esc":
-		// Enter on the bug-report row is the action itself, not save-and-close.
-		if msg.String() == "enter" && m.settings.field == settingsFieldBugReport {
+	case "enter":
+		switch m.settings.field {
+		case settingsFieldBugReport:
 			if err := openBrowser(bugReportURL(m.update.version)); err != nil {
 				m.errBar.text = err.Error()
 			}
 			return m, nil
+		case settingsFieldCLIs:
+			m.openCLIPicker()
+			return m, nil
 		}
+		return m.saveAndCloseSettings()
+	case "esc":
+		return m.saveAndCloseSettings()
+	}
+	return m, nil
+}
+
+func (m *Model) saveAndCloseSettings() (tea.Model, tea.Cmd) {
+	if len(m.settings.toolNames) > 0 {
 		if err := m.store.SetSetting("default_tool", m.settings.toolNames[m.settings.toolIndex]); err != nil {
 			m.errBar.text = err.Error()
 		}
-		if err := m.store.SetSetting(themeSetting, themes[m.settings.themeIndex].Name); err != nil {
+	}
+	if err := m.store.SetSetting(themeSetting, themes[m.settings.themeIndex].Name); err != nil {
+		m.errBar.text = err.Error()
+	}
+	layout := "split"
+	if !m.settings.layoutSplit {
+		layout = "unified"
+	}
+	if err := m.store.SetSetting(diffLayoutSetting, layout); err != nil {
+		m.errBar.text = err.Error()
+	}
+	quickClose := "stay"
+	if m.settings.quickCloseSend {
+		quickClose = "close"
+	}
+	if err := m.store.SetSetting(quickCloseSetting, quickClose); err != nil {
+		m.errBar.text = err.Error()
+	}
+	focusKey := "focus"
+	if !m.settings.enterFocuses {
+		focusKey = "attach"
+	}
+	if err := m.store.SetSetting(focusKeySetting, focusKey); err != nil {
+		m.errBar.text = err.Error()
+	}
+	density := "compact"
+	if m.settings.comfortableRows {
+		density = "comfortable"
+	}
+	if err := m.store.SetSetting(listDensitySetting, density); err != nil {
+		m.errBar.text = err.Error()
+	}
+	worktreeChoice := "off"
+	if m.settings.worktreeDefault {
+		worktreeChoice = "on"
+	}
+	if err := m.store.SetSetting(worktreeSetting, worktreeChoice); err != nil {
+		m.errBar.text = err.Error()
+	}
+	m.focusOnEnter = m.settings.enterFocuses
+	m.comfortableRows = m.settings.comfortableRows
+	m.mode = modeList
+	return m, nil
+}
+
+func (m *Model) openCLIPicker() {
+	names := sortedToolNames(m.cfg)
+	hidden := make(map[string]bool)
+	for name, on := range m.hiddenTools() {
+		if on {
+			if _, ok := m.cfg.Tools[name]; ok {
+				hidden[name] = true
+			}
+		}
+	}
+	m.settings.cliPicker = true
+	m.settings.cliNames = names
+	m.settings.cliHidden = hidden
+	m.settings.cliCursor = 0
+}
+
+func (m *Model) handleCLIPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// cursor 0..len(names)-1 = tools; len(names) = request-support action.
+	count := len(m.settings.cliNames) + 1
+	if count < 1 {
+		count = 1
+	}
+	switch msg.String() {
+	case "up", "k":
+		m.settings.cliCursor = (m.settings.cliCursor + count - 1) % count
+	case "down", "j":
+		m.settings.cliCursor = (m.settings.cliCursor + 1) % count
+	case " ", "space":
+		if m.settings.cliCursor < len(m.settings.cliNames) {
+			m.toggleCLIHidden(m.settings.cliNames[m.settings.cliCursor])
+		}
+	case "enter":
+		if m.settings.cliCursor >= len(m.settings.cliNames) {
+			if err := openBrowser(requestCLISupportURL()); err != nil {
+				m.errBar.text = err.Error()
+			}
+			return m, nil
+		}
+		m.toggleCLIHidden(m.settings.cliNames[m.settings.cliCursor])
+	case "esc":
+		if err := m.store.SetSetting(hiddenToolsSetting, formatHiddenTools(m.settings.cliHidden)); err != nil {
 			m.errBar.text = err.Error()
 		}
-		layout := "split"
-		if !m.settings.layoutSplit {
-			layout = "unified"
-		}
-		if err := m.store.SetSetting(diffLayoutSetting, layout); err != nil {
-			m.errBar.text = err.Error()
-		}
-		quickClose := "stay"
-		if m.settings.quickCloseSend {
-			quickClose = "close"
-		}
-		if err := m.store.SetSetting(quickCloseSetting, quickClose); err != nil {
-			m.errBar.text = err.Error()
-		}
-		focusKey := "focus"
-		if !m.settings.enterFocuses {
-			focusKey = "attach"
-		}
-		if err := m.store.SetSetting(focusKeySetting, focusKey); err != nil {
-			m.errBar.text = err.Error()
-		}
-		density := "compact"
-		if m.settings.comfortableRows {
-			density = "comfortable"
-		}
-		if err := m.store.SetSetting(listDensitySetting, density); err != nil {
-			m.errBar.text = err.Error()
-		}
-		worktreeChoice := "off"
-		if m.settings.worktreeDefault {
-			worktreeChoice = "on"
-		}
-		if err := m.store.SetSetting(worktreeSetting, worktreeChoice); err != nil {
-			m.errBar.text = err.Error()
-		}
-		m.focusOnEnter = m.settings.enterFocuses
-		m.comfortableRows = m.settings.comfortableRows
-		m.mode = modeList
+		m.settings.cliPicker = false
+		// Refresh the quick-spawn tool list so it matches the new filter.
+		names, index := m.defaultToolSelection()
+		m.settings.toolNames = names
+		m.settings.toolIndex = index
 	}
 	return m, nil
+}
+
+// toggleCLIHidden flips visibility for one tool. At least one CLI must stay
+// enabled so new sessions still have something to launch.
+func (m *Model) toggleCLIHidden(name string) {
+	if m.settings.cliHidden == nil {
+		m.settings.cliHidden = map[string]bool{}
+	}
+	if m.settings.cliHidden[name] {
+		delete(m.settings.cliHidden, name)
+		return
+	}
+	enabled := 0
+	for _, toolName := range m.settings.cliNames {
+		if !m.settings.cliHidden[toolName] {
+			enabled++
+		}
+	}
+	if enabled <= 1 {
+		m.errBar.text = "keep at least one CLI enabled"
+		return
+	}
+	m.settings.cliHidden[name] = true
+	m.errBar.text = ""
+}
+
+// requestCLISupportURL opens a prefilled feature request for another CLI.
+func requestCLISupportURL() string {
+	body := "**What are you trying to do**\n\n" +
+		"I want agent-manager to support another coding CLI.\n\n" +
+		"**What you have in mind**\n\n" +
+		"CLI name:\nHow to launch it:\nResume / session flags (if any):\n\n" +
+		"**Area**\nConfig and tool support\n"
+	return repoURL + "/issues/new?labels=enhancement&body=" + url.QueryEscape(body)
 }
 
 // cycleSetting steps the focused setting by one. The theme applies as it
@@ -219,6 +366,9 @@ func (m *Model) cycleSetting(step int) {
 	switch m.settings.field {
 	case settingsFieldTool:
 		count := len(m.settings.toolNames)
+		if count == 0 {
+			return
+		}
 		m.settings.toolIndex = (m.settings.toolIndex + step + count) % count
 	case settingsFieldTheme:
 		m.settings.themeIndex = (m.settings.themeIndex + step + len(themes)) % len(themes)

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -334,6 +334,7 @@ func (m *Model) toggleCLIHidden(name string) {
 	}
 	if m.settings.cliHidden[name] {
 		delete(m.settings.cliHidden, name)
+		m.errBar.text = ""
 		return
 	}
 	enabled := 0

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -136,3 +136,137 @@ func TestSettingsBugReportRowOpensIssue(t *testing.T) {
 		t.Fatal("esc should still save and close")
 	}
 }
+
+func TestSettingsCLIPickerHidesFromNewSessions(t *testing.T) {
+	m := buildModel(t)
+	m.cfg = config.Config{Tools: map[string]config.Tool{
+		"claude": {Command: "cat"},
+		"codex":  {Command: "cat"},
+		"grok":   {Command: "cat"},
+	}}
+	m.openSettings()
+	m.settings.field = settingsFieldCLIs
+	m.handleSettingsKey(key("enter"))
+	if !m.settings.cliPicker {
+		t.Fatal("enter on CLIs should open the picker")
+	}
+	out := m.viewSettings()
+	for _, name := range []string{"claude", "codex", "grok"} {
+		if !strings.Contains(out, name) {
+			t.Fatalf("picker missing %q: %s", name, out)
+		}
+	}
+	if !strings.Contains(out, "more will be supported soon") {
+		t.Fatalf("picker missing support note: %s", out)
+	}
+
+	// Hide codex (index 1 in display order: claude, codex, grok).
+	m.settings.cliCursor = 1
+	m.handleSettingsKey(key(" "))
+	if !m.settings.cliHidden["codex"] {
+		t.Fatal("space should hide the focused CLI")
+	}
+	m.handleSettingsKey(key("esc"))
+	if m.settings.cliPicker {
+		t.Fatal("esc should leave the picker")
+	}
+	raw, err := m.store.Setting(hiddenToolsSetting)
+	if err != nil || raw != "codex" {
+		t.Fatalf("stored hidden_tools = %q err %v, want codex", raw, err)
+	}
+
+	enabled := m.enabledToolNames()
+	for _, name := range enabled {
+		if name == "codex" {
+			t.Fatalf("codex should be omitted from create pickers: %v", enabled)
+		}
+	}
+	m.openForm()
+	if m.mode != modeForm {
+		t.Fatalf("form should open with remaining CLIs, mode=%v err=%q", m.mode, m.errBar.text)
+	}
+	for _, name := range m.form.toolNames {
+		if name == "codex" {
+			t.Fatal("new-session form must not list a hidden CLI")
+		}
+	}
+}
+
+func TestSettingsCLIPickerKeepsOneEnabled(t *testing.T) {
+	m := buildModel(t)
+	m.cfg = config.Config{Tools: map[string]config.Tool{
+		"claude": {Command: "cat"},
+		"codex":  {Command: "cat"},
+	}}
+	m.openSettings()
+	m.openCLIPicker()
+	m.settings.cliCursor = 0
+	m.handleSettingsKey(key("enter"))
+	if !m.settings.cliHidden["claude"] {
+		t.Fatal("first hide should succeed")
+	}
+	// Only codex left; refusing further hides.
+	m.settings.cliCursor = 1
+	m.handleSettingsKey(key("enter"))
+	if m.settings.cliHidden["codex"] {
+		t.Fatal("must not hide the last enabled CLI")
+	}
+	if !strings.Contains(m.errBar.text, "at least one") {
+		t.Fatalf("want keep-one message, got %q", m.errBar.text)
+	}
+}
+
+func TestSettingsCLIRequestSupportOpensIssue(t *testing.T) {
+	m := buildModel(t)
+	m.cfg = config.Config{Tools: map[string]config.Tool{"claude": {Command: "cat"}}}
+	var opened string
+	openBrowser = func(url string) error {
+		opened = url
+		return nil
+	}
+	t.Cleanup(func() { openBrowser = defaultOpenBrowser })
+
+	m.openSettings()
+	m.openCLIPicker()
+	m.settings.cliCursor = len(m.settings.cliNames)
+	m.handleSettingsKey(key("enter"))
+	if !strings.Contains(opened, "issues/new") || !strings.Contains(opened, "enhancement") {
+		t.Fatalf("request row should open a feature-request issue, got %q", opened)
+	}
+	if !m.settings.cliPicker {
+		t.Fatal("opening the issue must leave the picker open")
+	}
+}
+
+func TestCLIPickerShowsSupportAction(t *testing.T) {
+	m := buildModel(t)
+	m.cfg = config.Config{Tools: map[string]config.Tool{
+		"claude": {Command: "cat"},
+		"codex":  {Command: "cat"},
+	}}
+	m.width = 80
+	m.height = 40
+	m.openSettings()
+	m.openCLIPicker()
+	m.settings.cliCursor = len(m.settings.cliNames)
+	out := m.viewSettings()
+	if !strings.Contains(out, "request CLI support") {
+		t.Fatalf("missing request action:\n%s", out)
+	}
+	if !strings.Contains(out, "more will be supported soon") {
+		t.Fatalf("missing support note:\n%s", out)
+	}
+}
+
+func TestParseFormatHiddenTools(t *testing.T) {
+	if got := parseHiddenTools(""); got != nil {
+		t.Fatalf("empty parse = %v", got)
+	}
+	got := parseHiddenTools("codex, grok")
+	if !got["codex"] || !got["grok"] || len(got) != 2 {
+		t.Fatalf("parse = %v", got)
+	}
+	if formatHiddenTools(map[string]bool{"grok": true, "codex": true}) != "codex,grok" {
+		t.Fatalf("format should sort: %q", formatHiddenTools(map[string]bool{"grok": true, "codex": true}))
+	}
+}


### PR DESCRIPTION
## What changed

Settings gains a **CLIs** row that opens a checklist of every configured tool. Unchecked tools no longer appear when creating a session (new form and quick spawn). Existing sessions keep their tool, and rename can still select it. At least one CLI must stay enabled. The panel includes a **request CLI support** action that opens a prefilled GitHub issue, plus a short note that more tools are coming.

## Why

People who only use one or two agent CLIs still see the full list when spawning sessions. Hiding the rest keeps the picker short without removing tools from config.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test` for the UI settings/CLI suite passes
- [x] Built `agent-manager-dev` and drove settings → CLIs (toggle, keep-one, support row layout)