### PR TITLE
Block in-place self-update for Homebrew installs

### DIFF
--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -21,12 +21,41 @@ import (
 // local server.
 var downloadBase = "https://github.com/YoanWai/agent-manager/releases/download"
 
+var buildSource string
+
+func SetBuildSource(source string) {
+	buildSource = source
+}
+
 const applyBudget = 2 * time.Minute
 
 // binaryLimit caps how much of the archive is read into the new binary,
 // so a corrupt or hostile archive cannot fill the disk. Real builds are
 // under 20MB.
 const binaryLimit = 200 << 20
+
+var errHomebrewManaged = errors.New("installed via Homebrew; upgrade with: brew upgrade yoanwai/tap/agent-manager")
+
+func homebrewManaged(source, execPath string) bool {
+	if source == "Homebrew" {
+		return true
+	}
+	path := execPath
+	if resolved, err := filepath.EvalSymlinks(execPath); err == nil {
+		path = resolved
+	}
+	parts := strings.Split(filepath.ToSlash(path), "/")
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i+1] != "agent-manager" {
+			continue
+		}
+		switch parts[i] {
+		case "Cellar", "Caskroom", "opt":
+			return true
+		}
+	}
+	return false
+}
 
 // Apply downloads the release named by tag, verifies the archive for this
 // OS and architecture against the release's checksums.txt, and atomically
@@ -35,6 +64,10 @@ const binaryLimit = 200 << 20
 // build under a fresh inode, which also sidesteps macOS's per-inode
 // signature cache.
 func Apply(ctx context.Context, tag, execPath string) error {
+	if homebrewManaged(buildSource, execPath) {
+		return errHomebrewManaged
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, applyBudget)
 	defer cancel()
 

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -54,6 +55,78 @@ func serveRelease(t *testing.T, tag string, archive []byte, sum string) {
 	orig := downloadBase
 	downloadBase = server.URL
 	t.Cleanup(func() { downloadBase = orig })
+}
+
+func TestHomebrewManaged(t *testing.T) {
+	cases := []struct {
+		label  string
+		source string
+		path   string
+		want   bool
+	}{
+		{"buildSource Homebrew", "Homebrew", "/usr/local/bin/agent-manager", true},
+		{"other buildSource", "binaryBuild", "/usr/local/bin/agent-manager", false},
+		{"cellar path", "", "/opt/homebrew/Cellar/agent-manager/0.18.0/bin/agent-manager", true},
+		{"caskroom path", "", "/opt/homebrew/Caskroom/agent-manager/0.18.0/agent-manager", true},
+		{"opt path", "", "/opt/homebrew/opt/agent-manager/bin/agent-manager", true},
+		{"linuxbrew cellar", "", "/home/linuxbrew/.linuxbrew/Cellar/agent-manager/0.18.0/bin/agent-manager", true},
+		{"local bin", "", "/home/user/.local/bin/agent-manager", false},
+		{"gopath bin", "", "/home/user/go/bin/agent-manager", false},
+		{"caskroom name only", "", "/Users/me/notes/Caskroom-guide/agent-manager", false},
+		{"caskroom other package", "", "/opt/homebrew/Caskroom/other-app/1.0.0/other-app", false},
+		{"empty source ordinary path", "", "/usr/local/bin/agent-manager", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			if got := homebrewManaged(tc.source, tc.path); got != tc.want {
+				t.Fatalf("homebrewManaged(%q, %q) = %v, want %v", tc.source, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHomebrewManagedFollowsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	cellar := filepath.Join(dir, "Cellar", "agent-manager", "0.18.0", "bin")
+	if err := os.MkdirAll(cellar, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realBinary := filepath.Join(cellar, "agent-manager")
+	if err := os.WriteFile(realBinary, []byte("brew build"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "bin", "agent-manager")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realBinary, link); err != nil {
+		t.Fatal(err)
+	}
+	if !homebrewManaged("", link) {
+		t.Fatal("symlink into Cellar/agent-manager should be managed")
+	}
+}
+
+func TestApplyRejectsHomebrew(t *testing.T) {
+	orig := buildSource
+	buildSource = "Homebrew"
+	t.Cleanup(func() { buildSource = orig })
+
+	target := filepath.Join(t.TempDir(), "agent-manager")
+	if err := os.WriteFile(target, []byte("old build"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := Apply(context.Background(), "v9.9.9", target)
+	if !errors.Is(err, errHomebrewManaged) {
+		t.Fatalf("want errHomebrewManaged, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "brew upgrade yoanwai/tap/agent-manager") {
+		t.Fatalf("error should name the brew upgrade command, got %v", err)
+	}
+	untouched, readErr := os.ReadFile(target)
+	if readErr != nil || string(untouched) != "old build" {
+		t.Fatalf("binary must stay untouched, got %q err %v", untouched, readErr)
+	}
 }
 
 func TestApplySwapsBinary(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -17,12 +17,16 @@ import (
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
 	"github.com/YoanWai/agent-manager/internal/ui"
+	"github.com/YoanWai/agent-manager/internal/update"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 const devVersion = "dev"
 
 var version = devVersion
+
+// packagers set this via -X main.buildSource=...
+var buildSource = ""
 
 // resolveVersion falls back to the module version so `go install` builds, which
 // carry no ldflags, report the tag they came from. Pseudo-versions stay "dev":
@@ -50,6 +54,7 @@ func resolveVersion(embedded string, info *debug.BuildInfo, ok bool) string {
 func main() {
 	info, hasInfo := debug.ReadBuildInfo()
 	version = resolveVersion(version, info, hasInfo)
+	update.SetBuildSource(buildSource)
 
 	if len(os.Args) > 1 {
 		if os.Args[1] == "--version" || os.Args[1] == "-v" {


### PR DESCRIPTION
## Summary
- Refuse `update.Apply` when the binary is Homebrew-managed (Cellar, Caskroom, or `opt/agent-manager`, or `buildSource=Homebrew`).
- Point users at `brew upgrade yoanwai/tap/agent-manager` instead of overwriting the brew binary.
- install.sh / go install / manual binaries keep self-update.

## Test plan
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./internal/update/...`
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...`
- [x] `gofmt -l .` clean, `go vet` clean
- [ ] CI green