### PR TITLE
feat: fork sessions into named siblings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ agent-manager is a thin layer over the CLIs you already have. Each session launc
 
 Instead of hunting through terminal tabs to see which agent is done and which is stuck, every session shows up in one list with live status, grouped into a project tree you can fold and reorder. You answer any of them without attaching: `space` sends a prompt straight into a session's pane, or spawns a new agent in the selected group. A dead session revives on its own conversation with `v`. And `ctrl+r` opens a full-file diff of what an agent changed, syntax-highlighted, where the comments you leave on lines go back to the agent's pane as one review prompt when you press `C`.
 
+Press `f` on a session to continue its conversation in a separate named fork.
+
 Not here yet: cost tracking, mouse-driven navigation, and agents that can talk to each other.
 
 **Jump to:** [Install](#install) · [Usage](#usage) · [Keys](docs/usage.md#keys) · [Diff review](docs/usage.md#diff-review) · [Configuration](docs/configuration.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,14 @@ Rules match top-down against the visible pane text; first match wins, and `defau
 
 **Revive.** `resume_by_id_command` resumes one exact conversation, with `{id}` replaced by the session's captured agent id. That id comes either from launching under an id the manager mints (`session_id_flag`, e.g. `--session-id`) or from reading back an id the tool minted itself (`session_store = "codex" | "opencode"`). `revive_command` is what `v` falls back to when no id is available, e.g. `claude --continue`.
 
+**Forks.** `fork_command` creates a conversation from an existing session. Agent Manager replaces and shell-quotes these placeholders:
+
+- `{id}`: The source conversation ID. This placeholder is required.
+- `{new_id}`: A new UUID that Agent Manager records for exact revival.
+- `{name}`: The new Agent Manager session name.
+
+Claude Code and Codex include default fork commands. A custom tool can omit `{new_id}` when its `session_store` captures the generated ID.
+
 **Prompts.** `prompt_flag` controls how the new-session form's optional prompt is embedded into the launch command. Tools that take the prompt as a positional argument (Claude Code: `claude 'the prompt'`) leave it empty; tools whose positional argument means something else declare the flag (OpenCode: `prompt_flag = "--prompt"`, since its positional argument is the project path). The prompt only shapes the launch command; revive (`v`) uses the revive commands untouched.
 
 **MCP.** `mcp = "claude" | "codex" | "opencode" | "grok" | "gemini" | "none"` picks how the agent-manager MCP server is registered into the tool's sessions (see [MCP](usage.md#mcp-how-agents-discover-these-commands)). An empty value uses the tool's config key when it names a known style.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,6 +13,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | Key | Action |
 |-----|--------|
 | `n` | New session (name, tool, directory, worktree toggle, optional starting prompt, group picker) |
+| `f` | Fork the selected conversation into a named session in the same group and directory |
 | `g` | New group (name, parent, default path) |
 | `enter` | Focus session in place (keys go to the agent, list stays) / fold group |
 | `A` | Attach session full screen (Settings can swap it with `enter`) |
@@ -73,6 +74,18 @@ Deleting (`d`) a session that holds a worktree removes the worktree and its bran
 `v` relaunches a dead session under its old id, keeping its name, group, and history. When the manager holds that session's own conversation id, revive resumes **that exact conversation** through the tool's `resume_by_id_command`: `claude --resume {id}`, `codex resume {id}`, `opencode --session {id}`, `grok --resume {id}`, `gemini --resume {id}`.
 
 The id arrives one of two ways: tools with a `session_id_flag` launch under an id the manager mints, and tools that mint their own are read back by a `session_store` capturer (`codex`, `opencode`). Without an id, revive falls back to `revive_command` (`claude --continue`), which resumes the working directory's most recent conversation, and the manager says so in the status line, since sessions sharing a directory would otherwise land on the wrong one. On a group row `v` revives every dead session under it, and `V` revives every dead session in view; both revive what they can and name the first failure rather than stopping.
+
+## Forking sessions
+
+1. Select a session and press `f`.
+2. Enter a name.
+3. Press `enter`.
+
+The fork uses the source session's tool, group, working directory, and conversation history.
+
+Claude Code and Codex support forks by default. A custom tool needs a `fork_command` in its configuration. The source session must have a captured conversation ID.
+
+A fork shares its source session's managed worktree. Agent Manager keeps the worktree until you delete the last session that uses it. You cannot rename the worktree while another session uses it.
 
 ## Self-naming sessions
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,6 +225,7 @@ command = "claude"
 # that exact conversation regardless of what else ran in the directory
 session_id_flag = "--session-id"
 resume_by_id_command = "claude --resume {id}"
+fork_command = "claude --resume {id} --fork-session --session-id {new_id} --name {name}"
 # fallback when a session predates id tracking: resumes the last conversation there
 revive_command = "claude --continue"
 # hooks report status events directly; the pane rules below stay as fallback
@@ -277,6 +278,7 @@ command = "codex"
 # codex mints its own session id; capture it after launch and resume it
 session_store = "codex"
 resume_by_id_command = "codex resume {id}"
+fork_command = "codex fork {id}"
 # fallback: resumes the most recent session in the working directory
 revive_command = "codex resume --last"
 default_status = "idle"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,9 @@ type Tool struct {
 	// with the session's agent id. Preferred over ReviveCommand, which only
 	// resumes the working directory's most recent conversation.
 	ResumeByIDCommand string `toml:"resume_by_id_command"`
+	// ForkCommand creates a new conversation from an existing one. Templates
+	// can use {id}, {new_id}, and {name}; Agent Manager quotes each value.
+	ForkCommand string `toml:"fork_command"`
 	// SessionStore names the built-in capturer that reads back the id a tool
 	// minted itself when it has no SessionIDFlag ("codex" or "opencode").
 	SessionStore string `toml:"session_store"`
@@ -139,6 +142,7 @@ func mergeTool(user, def Tool) Tool {
 	fill(&user.PromptFlag, def.PromptFlag)
 	fill(&user.SessionIDFlag, def.SessionIDFlag)
 	fill(&user.ResumeByIDCommand, def.ResumeByIDCommand)
+	fill(&user.ForkCommand, def.ForkCommand)
 	fill(&user.SessionStore, def.SessionStore)
 	fill(&user.StatusSource, def.StatusSource)
 	fill(&user.DefaultStatus, def.DefaultStatus)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -90,6 +91,24 @@ func TestBackfillToolDefaults(t *testing.T) {
 	}
 	if _, ok := cfg.Tools["claude"]; !ok {
 		t.Fatal("expected claude tool added from built-in defaults")
+	}
+}
+
+func TestDecodeForkCommand(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := `[tools.pi]
+command = "pi"
+fork_command = "pi --fork {id} --session-id {new_id} --name {name}"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var cfg Config
+	if err := decodeInto(path, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Tools["pi"].ForkCommand; got != "pi --fork {id} --session-id {new_id} --name {name}" {
+		t.Fatalf("fork_command = %q", got)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,8 +73,8 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if got := cfg.Tools["claude"].PromptFlag; got != "" {
 		t.Fatalf("claude prompt_flag = %q want empty (positional prompt)", got)
 	}
-	if got := cfg.Tools["claude"].ForkCommand; !strings.Contains(got, "{id}") || !strings.Contains(got, "{new_id}") {
-		t.Fatalf("claude fork_command = %q want source and new ids", got)
+	if got := cfg.Tools["claude"].ForkCommand; got != "claude --resume {id} --fork-session --session-id {new_id} --name {name}" {
+		t.Fatalf("claude fork_command = %q", got)
 	}
 	if got := cfg.Tools["codex"].ForkCommand; got != "codex fork {id}" {
 		t.Fatalf("codex fork_command = %q want \"codex fork {id}\"", got)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -74,6 +73,12 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if got := cfg.Tools["claude"].PromptFlag; got != "" {
 		t.Fatalf("claude prompt_flag = %q want empty (positional prompt)", got)
 	}
+	if got := cfg.Tools["claude"].ForkCommand; !strings.Contains(got, "{id}") || !strings.Contains(got, "{new_id}") {
+		t.Fatalf("claude fork_command = %q want source and new ids", got)
+	}
+	if got := cfg.Tools["codex"].ForkCommand; got != "codex fork {id}" {
+		t.Fatalf("codex fork_command = %q want \"codex fork {id}\"", got)
+	}
 }
 
 func TestBackfillToolDefaults(t *testing.T) {
@@ -91,24 +96,6 @@ func TestBackfillToolDefaults(t *testing.T) {
 	}
 	if _, ok := cfg.Tools["claude"]; !ok {
 		t.Fatal("expected claude tool added from built-in defaults")
-	}
-}
-
-func TestDecodeForkCommand(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "config.toml")
-	content := `[tools.pi]
-command = "pi"
-fork_command = "pi --fork {id} --session-id {new_id} --name {name}"
-`
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	var cfg Config
-	if err := decodeInto(path, &cfg); err != nil {
-		t.Fatal(err)
-	}
-	if got := cfg.Tools["pi"].ForkCommand; got != "pi --fork {id} --session-id {new_id} --name {name}" {
-		t.Fatalf("fork_command = %q", got)
 	}
 }
 
@@ -166,5 +153,8 @@ func TestBackfillFillsResumeFields(t *testing.T) {
 	}
 	if tool.ResumeByIDCommand != "claude --resume {id}" {
 		t.Fatalf("claude resume_by_id_command = %q want backfilled", tool.ResumeByIDCommand)
+	}
+	if tool.ForkCommand == "" {
+		t.Fatal("claude fork_command was not backfilled")
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,9 +32,9 @@ type Session struct {
 	// gemini session UUID, codex rollout id, opencode session id). Revive resumes
 	// this exact conversation instead of the cwd's most recent one.
 	AgentSessionID string
-	// WorktreeRepo and WorktreeBranch are set only for sessions running in
-	// their own git worktree: the main repo root and the am/ branch recorded
-	// at creation, so delete-time cleanup survives later renames.
+	// WorktreeRepo and WorktreeBranch are set for sessions running in a
+	// worktree Agent Manager created. Forks share these values so the last
+	// session to leave can clean up the worktree and its am/ branch.
 	WorktreeRepo   string
 	WorktreeBranch string
 }

--- a/internal/ui/fork.go
+++ b/internal/ui/fork.go
@@ -110,6 +110,8 @@ func (m *Model) submitFork() (tea.Model, tea.Cmd) {
 		Group:          source.Group,
 		Status:         status.Starting,
 		AgentSessionID: agentID,
+		WorktreeRepo:   source.WorktreeRepo,
+		WorktreeBranch: source.WorktreeBranch,
 	}
 	if err := m.launchNewSession(forked, baseCommand, false); err != nil {
 		m.errBar.text = err.Error()

--- a/internal/ui/fork.go
+++ b/internal/ui/fork.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
@@ -32,16 +33,8 @@ func (m *Model) openFork() {
 		m.errBar.text = fmt.Sprintf("tool %s is no longer configured", entry.sess.Tool)
 		return
 	}
-	if tool.ForkCommand == "" {
-		m.errBar.text = fmt.Sprintf("tool %s has no fork_command", entry.sess.Tool)
-		return
-	}
-	if !strings.Contains(tool.ForkCommand, "{id}") {
-		m.errBar.text = fmt.Sprintf("tool %s fork_command must contain {id}", entry.sess.Tool)
-		return
-	}
-	if entry.sess.AgentSessionID == "" {
-		m.errBar.text = fmt.Sprintf("%s has no captured conversation id", entry.sess.Name)
+	if err := validateForkSource(entry.sess.Tool, tool, entry.sess); err != nil {
+		m.errBar.text = err.Error()
 		return
 	}
 	name := textField("fork name", 60)
@@ -83,12 +76,8 @@ func (m *Model) submitFork() (tea.Model, tea.Cmd) {
 		m.errBar.text = fmt.Sprintf("tool %s is no longer configured", source.Tool)
 		return m, nil
 	}
-	if tool.ForkCommand == "" || !strings.Contains(tool.ForkCommand, "{id}") {
-		m.errBar.text = fmt.Sprintf("tool %s has no valid fork_command", source.Tool)
-		return m, nil
-	}
-	if source.AgentSessionID == "" {
-		m.errBar.text = fmt.Sprintf("%s has no captured conversation id", source.Name)
+	if err := validateForkSource(source.Tool, tool, source); err != nil {
+		m.errBar.text = err.Error()
 		return m, nil
 	}
 	if info, err := os.Stat(source.Cwd); err != nil || !info.IsDir() {
@@ -113,7 +102,7 @@ func (m *Model) submitFork() (tea.Model, tea.Cmd) {
 		WorktreeRepo:   source.WorktreeRepo,
 		WorktreeBranch: source.WorktreeBranch,
 	}
-	if err := m.launchNewSession(forked, baseCommand, false); err != nil {
+	if err := m.launchNewSession(forked, tool, baseCommand, launchOptions{}); err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
@@ -126,6 +115,19 @@ func (m *Model) submitFork() (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, m.refreshCmd()
+}
+
+func validateForkSource(toolName string, tool config.Tool, source store.Session) error {
+	if tool.ForkCommand == "" {
+		return fmt.Errorf("tool %s has no fork_command", toolName)
+	}
+	if !strings.Contains(tool.ForkCommand, "{id}") {
+		return fmt.Errorf("tool %s fork_command must contain {id}", toolName)
+	}
+	if source.AgentSessionID == "" {
+		return fmt.Errorf("%s has no captured conversation id", source.Name)
+	}
+	return nil
 }
 
 func expandForkCommand(template, sourceID, newID, name string) string {

--- a/internal/ui/fork.go
+++ b/internal/ui/fork.go
@@ -1,0 +1,142 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/tmux"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
+)
+
+type forkState struct {
+	source store.Session
+	name   textinput.Model
+}
+
+func (m *Model) openFork() {
+	entry, ok := m.selectedRow()
+	if !ok {
+		return
+	}
+	if entry.isGroup {
+		m.errBar.text = "select a session to fork"
+		return
+	}
+	tool, ok := m.cfg.Tools[entry.sess.Tool]
+	if !ok {
+		m.errBar.text = fmt.Sprintf("tool %s is no longer configured", entry.sess.Tool)
+		return
+	}
+	if tool.ForkCommand == "" {
+		m.errBar.text = fmt.Sprintf("tool %s has no fork_command", entry.sess.Tool)
+		return
+	}
+	if !strings.Contains(tool.ForkCommand, "{id}") {
+		m.errBar.text = fmt.Sprintf("tool %s fork_command must contain {id}", entry.sess.Tool)
+		return
+	}
+	if entry.sess.AgentSessionID == "" {
+		m.errBar.text = fmt.Sprintf("%s has no captured conversation id", entry.sess.Name)
+		return
+	}
+	name := textField("fork name", 60)
+	name.SetValue(entry.sess.Name + "-fork")
+	name.CursorEnd()
+	name.Focus()
+	m.fork = forkState{source: entry.sess, name: name}
+	m.errBar.text = ""
+	m.mode = modeFork
+}
+
+func (m *Model) handleForkKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.mode = modeList
+		m.errBar.text = ""
+		return m, nil
+	case "enter":
+		return m.submitFork()
+	}
+	var cmd tea.Cmd
+	m.fork.name, cmd = m.fork.name.Update(msg)
+	return m, cmd
+}
+
+func (m *Model) submitFork() (tea.Model, tea.Cmd) {
+	name := strings.ReplaceAll(strings.TrimSpace(m.fork.name.Value()), "/", "-")
+	if name == "" {
+		m.errBar.text = "name cannot be empty"
+		return m, nil
+	}
+	source, err := m.store.Get(m.fork.source.ID)
+	if err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	tool, ok := m.cfg.Tools[source.Tool]
+	if !ok {
+		m.errBar.text = fmt.Sprintf("tool %s is no longer configured", source.Tool)
+		return m, nil
+	}
+	if tool.ForkCommand == "" || !strings.Contains(tool.ForkCommand, "{id}") {
+		m.errBar.text = fmt.Sprintf("tool %s has no valid fork_command", source.Tool)
+		return m, nil
+	}
+	if source.AgentSessionID == "" {
+		m.errBar.text = fmt.Sprintf("%s has no captured conversation id", source.Name)
+		return m, nil
+	}
+	if info, err := os.Stat(source.Cwd); err != nil || !info.IsDir() {
+		m.errBar.text = "working directory no longer exists: " + source.Cwd
+		return m, nil
+	}
+
+	managerID := newID()
+	agentID := ""
+	if strings.Contains(tool.ForkCommand, "{new_id}") {
+		agentID = uuid.NewString()
+	}
+	baseCommand := expandForkCommand(tool.ForkCommand, source.AgentSessionID, agentID, name)
+	forked := store.Session{
+		ID:             managerID,
+		Name:           name,
+		Tool:           source.Tool,
+		Cwd:            source.Cwd,
+		Group:          source.Group,
+		Status:         status.Starting,
+		AgentSessionID: agentID,
+	}
+	if err := m.launchNewSession(forked, baseCommand, false); err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	m.mode = modeList
+	m.errBar.text = ""
+	for i, row := range m.rows {
+		if !row.isGroup && row.sess.ID == managerID {
+			m.cursor = i
+			break
+		}
+	}
+	return m, m.refreshCmd()
+}
+
+func expandForkCommand(template, sourceID, newID, name string) string {
+	return strings.NewReplacer(
+		"{id}", tmux.ShellQuote(sourceID),
+		"{new_id}", tmux.ShellQuote(newID),
+		"{name}", tmux.ShellQuote(name),
+	).Replace(template)
+}
+
+func (m *Model) viewFork() string {
+	body := "  source  " + valueStyle.Render(m.fork.source.Name) + "\n" +
+		"  group   " + groupBadge(displayGroup(m.fork.source.Group)) + "\n" +
+		formField("name", m.fork.name.View(), true)
+	return m.card("⑂ Fork Session", body, "↵ create · esc cancel")
+}

--- a/internal/ui/fork_test.go
+++ b/internal/ui/fork_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -100,6 +102,49 @@ func TestForkSelectedSessionCreatesNamedSibling(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("fork args = %v, want %v", got, want)
 		}
+	}
+}
+
+func TestForkCopiesManagedWorktreeReference(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	source := store.Session{
+		ID:             "managed-source",
+		Name:           "source",
+		Tool:           "claude",
+		Cwd:            dir,
+		Status:         status.Idle,
+		AgentSessionID: "source-conversation",
+		WorktreeRepo:   filepath.Dir(dir),
+		WorktreeBranch: "am/source",
+	}
+	if err := m.store.CreateSession(source); err != nil {
+		t.Fatal(err)
+	}
+	loadStoredRows(t, m)
+	m.selectSessionRow(t, "source")
+	tool := m.cfg.Tools[source.Tool]
+	tool.ForkCommand = "true {id}; cat"
+	m.cfg.Tools[source.Tool] = tool
+
+	m.openFork()
+	m.fork.name.SetValue("forked")
+	updated, cmd := m.handleForkKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*Model)
+	m.applyCmd(t, cmd)
+
+	var forked store.Session
+	for _, sess := range m.sessionRows() {
+		if sess.Name == "forked" {
+			forked = sess
+			break
+		}
+	}
+	if forked.ID == "" {
+		t.Fatal("forked session not found")
+	}
+	if forked.WorktreeRepo != source.WorktreeRepo || forked.WorktreeBranch != source.WorktreeBranch {
+		t.Fatalf("forked worktree reference = %+v, source = %+v", forked, source)
 	}
 }
 

--- a/internal/ui/fork_test.go
+++ b/internal/ui/fork_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
@@ -148,6 +149,34 @@ func TestForkCopiesManagedWorktreeReference(t *testing.T) {
 	}
 }
 
+func TestForkLaunchFailureKeepsSharedWorktree(t *testing.T) {
+	m := buildModel(t)
+	repo := seedRepo(t)
+	if err := m.spawnSession("claude", "source", repo, "", "", false, true); err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := m.store.ListSessions(true)
+	if err != nil || len(sessions) != 1 {
+		t.Fatalf("sessions = %v, err %v", sessions, err)
+	}
+	source := sessions[0]
+	badConfig := t.TempDir()
+	if err := os.WriteFile(filepath.Join(badConfig, "hooks"), []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m.hooks = hooks.NewManager(badConfig)
+
+	forked := source
+	forked.ID = "failed-fork"
+	forked.Name = "forked"
+	if err := m.launchNewSession(forked, m.cfg.Tools[forked.Tool], "cat", launchOptions{}); err == nil {
+		t.Fatal("launch failure was not reported")
+	}
+	if _, err := os.Stat(source.Cwd); err != nil {
+		t.Fatalf("source worktree was removed: %v", err)
+	}
+}
+
 func TestOpenForkRequiresConfiguredCommandAndConversationID(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "source", t.TempDir(), "")
@@ -160,9 +189,15 @@ func TestOpenForkRequiresConfiguredCommandAndConversationID(t *testing.T) {
 	}
 
 	tool := m.cfg.Tools[source.Tool]
+	tool.ForkCommand = "tool --fork latest"
+	m.cfg.Tools[source.Tool] = tool
+	m.openFork()
+	if !strings.Contains(m.errBar.text, "must contain {id}") {
+		t.Fatalf("missing placeholder error = %q", m.errBar.text)
+	}
+
 	tool.ForkCommand = "tool --fork {id}"
 	m.cfg.Tools[source.Tool] = tool
-	m.errBar.text = ""
 	m.openFork()
 	if !strings.Contains(m.errBar.text, "no captured conversation id") {
 		t.Fatalf("missing id error = %q", m.errBar.text)

--- a/internal/ui/fork_test.go
+++ b/internal/ui/fork_test.go
@@ -1,0 +1,138 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/tmux"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestExpandForkCommandQuotesPlaceholders(t *testing.T) {
+	got := expandForkCommand("tool --fork {id} --new {new_id} --name {name}", "source", "new", "Sam's fork")
+	want := "tool --fork 'source' --new 'new' --name 'Sam'\\''s fork'"
+	if got != want {
+		t.Fatalf("fork command = %q, want %q", got, want)
+	}
+}
+
+func TestForkSelectedSessionCreatesNamedSibling(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("work", dir); err != nil {
+		t.Fatal(err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "source", dir, "work")
+	m.selectSessionRow(t, "source")
+	source := m.rows[m.cursor].sess
+	if err := m.store.SetAgentSessionID(source.ID, "source-conversation"); err != nil {
+		t.Fatal(err)
+	}
+	for i := range m.sessions {
+		if m.sessions[i].ID == source.ID {
+			m.sessions[i].AgentSessionID = "source-conversation"
+		}
+	}
+	m.rebuildRows()
+	m.selectSessionRow(t, "source")
+
+	argsFile := filepath.Join(t.TempDir(), "fork-args")
+	tool := m.cfg.Tools[source.Tool]
+	tool.ForkCommand = "printf '%s\\n' {id} {new_id} {name} > " + tmux.ShellQuote(argsFile) + "; cat"
+	m.cfg.Tools[source.Tool] = tool
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = updated.(*Model)
+	if m.mode != modeFork || m.fork.source.ID != source.ID {
+		t.Fatalf("fork mode = %v, source = %q", m.mode, m.fork.source.ID)
+	}
+	m.fork.name.SetValue("child fork")
+	updated, cmd := m.handleForkKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*Model)
+	m.applyCmd(t, cmd)
+	if m.mode != modeList || m.errBar.text != "" {
+		t.Fatalf("after fork: mode=%v err=%q", m.mode, m.errBar.text)
+	}
+
+	var forkedID string
+	for _, sess := range m.sessionRows() {
+		if sess.Name != "child fork" {
+			continue
+		}
+		forkedID = sess.ID
+		if sess.Tool != source.Tool || sess.Cwd != source.Cwd || sess.Group != source.Group {
+			t.Fatalf("forked session = %+v, source = %+v", sess, source)
+		}
+		if sess.AgentSessionID == "" || sess.AgentSessionID == source.AgentSessionID {
+			t.Fatalf("forked conversation id = %q", sess.AgentSessionID)
+		}
+	}
+	if forkedID == "" {
+		t.Fatal("forked session not found")
+	}
+	stored, err := m.store.Get(forkedID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var raw []byte
+	for time.Now().Before(deadline) {
+		raw, err = os.ReadFile(argsFile)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	want := []string{"source-conversation", stored.AgentSessionID, "child fork"}
+	if len(got) != len(want) {
+		t.Fatalf("fork args = %q", raw)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("fork args = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestOpenForkRequiresConfiguredCommandAndConversationID(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "source", t.TempDir(), "")
+	m.selectSessionRow(t, "source")
+	source := m.rows[m.cursor].sess
+
+	m.openFork()
+	if !strings.Contains(m.errBar.text, "no fork_command") {
+		t.Fatalf("missing command error = %q", m.errBar.text)
+	}
+
+	tool := m.cfg.Tools[source.Tool]
+	tool.ForkCommand = "tool --fork {id}"
+	m.cfg.Tools[source.Tool] = tool
+	m.errBar.text = ""
+	m.openFork()
+	if !strings.Contains(m.errBar.text, "no captured conversation id") {
+		t.Fatalf("missing id error = %q", m.errBar.text)
+	}
+}
+
+func TestOpenForkRejectsGroup(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("work", ""); err != nil {
+		t.Fatal(err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "work")
+	m.openFork()
+	if m.errBar.text != "select a session to fork" {
+		t.Fatalf("group fork error = %q", m.errBar.text)
+	}
+}

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -606,7 +606,10 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		AgentSessionID: agentSessionID,
 		WorktreeRepo:   worktreeRepo,
 		WorktreeBranch: worktreeBranch,
-	}, base, deferDirective)
+	}, tool, base, launchOptions{
+		deferDirective:   deferDirective,
+		rollbackWorktree: worktreeRepo != "",
+	})
 }
 
 // withPrompt embeds an optional starting prompt into a tool's launch

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -594,16 +594,7 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		agentSessionID = uuid.NewString()
 		base += " " + tool.SessionIDFlag + " " + agentSessionID
 	}
-	command, env, err := m.buildLaunch(toolName, tool, base, id)
-	if err != nil {
-		m.discardWorktree(worktreeRepo, dir, worktreeBranch)
-		return err
-	}
-	if err := m.tmux.Create(id, dir, command, env, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
-		m.discardWorktree(worktreeRepo, dir, worktreeBranch)
-		return err
-	}
-	sess := store.Session{
+	return m.launchNewSession(store.Session{
 		ID:    id,
 		Name:  name,
 		Tool:  toolName,
@@ -615,24 +606,7 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		AgentSessionID: agentSessionID,
 		WorktreeRepo:   worktreeRepo,
 		WorktreeBranch: worktreeBranch,
-	}
-	if err := m.store.CreateSession(sess); err != nil {
-		_ = m.tmux.Kill(id)
-		_ = m.hooks.Remove(id)
-		m.discardWorktree(worktreeRepo, dir, worktreeBranch)
-		return err
-	}
-	if deferDirective {
-		m.poller.markDirectivePending(id)
-	}
-	if err := m.tmux.SetLabel(id, sessionLabel(group, name)); err != nil {
-		return err
-	}
-	// Show the new session at once instead of waiting for the next poll to
-	// reload it from the store.
-	m.sessions = append(m.sessions, sess)
-	m.rebuildRows()
-	return nil
+	}, base, deferDirective)
 }
 
 // withPrompt embeds an optional starting prompt into a tool's launch

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -42,6 +42,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleConfirmKey(msg)
 	case modeRename:
 		return m.handleRenameKey(msg)
+	case modeFork:
+		return m.handleForkKey(msg)
 	case modeSettings:
 		return m.handleSettingsKey(msg)
 	case modeMove:
@@ -97,6 +99,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openForm()
 	case "g":
 		m.openGroupForm()
+	case "f":
+		m.openFork()
 	case "v":
 		return m.reviveSelected()
 	case "V", "shift+v":

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -526,8 +526,6 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.errBar.text = ""
 			m.rebuildRows()
 		case actionDelete:
-			var worktrees []store.Session
-			seenWorktrees := make(map[string]bool)
 			for _, sess := range m.confirm.sessions {
 				if err := m.tmux.Kill(sess.ID); err != nil {
 					m.errBar.text = err.Error()
@@ -558,34 +556,16 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.errBar.text = err.Error()
 					return m, nil
 				}
-				if sess.WorktreeRepo != "" && m.gitDrv != nil && !seenWorktrees[sess.Cwd] {
-					seenWorktrees[sess.Cwd] = true
-					worktrees = append(worktrees, sess)
-				}
-			}
-			if len(worktrees) > 0 {
-				remaining, err := m.store.ListSessions(true)
-				if err != nil {
-					m.errBar.text = "worktree cleanup: " + err.Error()
-				} else {
-					for _, worktree := range worktrees {
-						used := false
-						for _, sess := range remaining {
-							if sess.Cwd == worktree.Cwd {
-								used = true
-								break
-							}
-						}
-						if used {
-							m.errBar.text = "worktree kept (used by another session): " + worktree.Cwd
-							continue
-						}
-						removed, err := m.gitDrv.RemoveWorktreeIfClean(worktree.WorktreeRepo, worktree.Cwd, worktree.WorktreeBranch)
-						if err != nil {
-							m.errBar.text = "worktree cleanup: " + err.Error()
-						} else if !removed {
-							m.errBar.text = "worktree kept (has work): " + worktree.Cwd
-						}
+				if sess.WorktreeRepo != "" && m.gitDrv != nil {
+					used, err := m.sessionUsesDir(sess.Cwd)
+					if err != nil {
+						m.errBar.text = "worktree cleanup: " + err.Error()
+					} else if used {
+						m.errBar.text = "worktree kept (used by another session): " + sess.Cwd
+					} else if removed, err := m.gitDrv.RemoveWorktreeIfClean(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch); err != nil {
+						m.errBar.text = "worktree cleanup: " + err.Error()
+					} else if !removed {
+						m.errBar.text = "worktree kept (has work): " + sess.Cwd
 					}
 				}
 			}
@@ -610,6 +590,19 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	m.confirm = confirmTarget{}
 	return m, nil
+}
+
+func (m *Model) sessionUsesDir(dir string) (bool, error) {
+	sessions, err := m.store.ListSessions(true)
+	if err != nil {
+		return false, err
+	}
+	for _, sess := range sessions {
+		if sess.Cwd == dir {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // deleteConfirmedGroups removes the group rows the confirmed delete

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -526,6 +526,8 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.errBar.text = ""
 			m.rebuildRows()
 		case actionDelete:
+			var worktrees []store.Session
+			seenWorktrees := make(map[string]bool)
 			for _, sess := range m.confirm.sessions {
 				if err := m.tmux.Kill(sess.ID); err != nil {
 					m.errBar.text = err.Error()
@@ -556,12 +558,34 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.errBar.text = err.Error()
 					return m, nil
 				}
-				if sess.WorktreeRepo != "" && m.gitDrv != nil {
-					removed, err := m.gitDrv.RemoveWorktreeIfClean(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch)
-					if err != nil {
-						m.errBar.text = "worktree cleanup: " + err.Error()
-					} else if !removed {
-						m.errBar.text = "worktree kept (has work): " + sess.Cwd
+				if sess.WorktreeRepo != "" && m.gitDrv != nil && !seenWorktrees[sess.Cwd] {
+					seenWorktrees[sess.Cwd] = true
+					worktrees = append(worktrees, sess)
+				}
+			}
+			if len(worktrees) > 0 {
+				remaining, err := m.store.ListSessions(true)
+				if err != nil {
+					m.errBar.text = "worktree cleanup: " + err.Error()
+				} else {
+					for _, worktree := range worktrees {
+						used := false
+						for _, sess := range remaining {
+							if sess.Cwd == worktree.Cwd {
+								used = true
+								break
+							}
+						}
+						if used {
+							m.errBar.text = "worktree kept (used by another session): " + worktree.Cwd
+							continue
+						}
+						removed, err := m.gitDrv.RemoveWorktreeIfClean(worktree.WorktreeRepo, worktree.Cwd, worktree.WorktreeBranch)
+						if err != nil {
+							m.errBar.text = "worktree cleanup: " + err.Error()
+						} else if !removed {
+							m.errBar.text = "worktree kept (has work): " + worktree.Cwd
+						}
 					}
 				}
 			}

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -860,6 +860,49 @@ func TestDeleteRemovesCleanWorktree(t *testing.T) {
 	}
 }
 
+func TestDeleteKeepsWorktreeUntilLastSharingSession(t *testing.T) {
+	m := buildModel(t)
+	repo := seedRepo(t)
+	if err := m.spawnSession("claude", "owner", repo, "", "", false, true); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	sessions, err := m.store.ListSessions(true)
+	if err != nil || len(sessions) != 1 {
+		t.Fatalf("sessions = %v, err %v", sessions, err)
+	}
+	owner := sessions[0]
+	forked := store.Session{
+		ID:             "shared-fork",
+		Name:           "forked",
+		Tool:           owner.Tool,
+		Cwd:            owner.Cwd,
+		Status:         status.Idle,
+		WorktreeRepo:   owner.WorktreeRepo,
+		WorktreeBranch: owner.WorktreeBranch,
+	}
+	if err := m.tmux.Create(forked.ID, forked.Cwd, "cat", nil, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.CreateSession(forked); err != nil {
+		t.Fatal(err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+
+	deleteSession(t, m, "owner")
+	if _, err := os.Stat(owner.Cwd); err != nil {
+		t.Fatalf("shared worktree was removed: %v", err)
+	}
+	if !strings.Contains(m.errBar.text, "used by another session") {
+		t.Fatalf("shared worktree message = %q", m.errBar.text)
+	}
+
+	m.applyCmd(t, m.refreshCmd())
+	deleteSession(t, m, "forked")
+	if _, err := os.Stat(owner.Cwd); !os.IsNotExist(err) {
+		t.Fatalf("last sharing session left worktree behind: %v", err)
+	}
+}
+
 func TestDeleteKeepsDirtyWorktree(t *testing.T) {
 	m := buildModel(t)
 	repo := filepath.Join(t.TempDir(), "repo")

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -350,6 +350,7 @@ func (m *Model) viewMove() string {
 func (m *Model) viewHelp() string {
 	rows := [][2]string{
 		{"n", "new session"},
+		{"f", "fork selected session into a named session in the same group"},
 		{"↵", "attach session / fold group"},
 		{"ctrl+q", "inside a session: back to manager (ctrl+\\ also works)"},
 		{"ctrl+r", "inside a session: review its diff, esc returns"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -33,6 +33,7 @@ const (
 	modeConfirmDelete
 	modeHelp
 	modeRename
+	modeFork
 	modeMove
 	modeRepoPick
 	modeGroupForm
@@ -121,6 +122,7 @@ type Model struct {
 	pathSugg  pathComplete
 	confirm   confirmTarget
 	rename    renameTarget
+	fork      forkState
 	quick     quickState
 	settings  settingsState
 	moveID    string

--- a/internal/ui/rename.go
+++ b/internal/ui/rename.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -18,6 +19,15 @@ import (
 func renameSessionWorktree(gitDrv *git.Driver, st *store.Store, sess *store.Session, name string) error {
 	if gitDrv == nil || sess.WorktreeRepo == "" || sess.WorktreeBranch == "" {
 		return nil
+	}
+	sessions, err := st.ListSessions(true)
+	if err != nil {
+		return err
+	}
+	for _, other := range sessions {
+		if other.ID != sess.ID && other.Cwd == sess.Cwd {
+			return fmt.Errorf("worktree is shared with session %q", other.Name)
+		}
 	}
 	path, branch, err := gitDrv.MoveWorktree(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch, name)
 	if err != nil {

--- a/internal/ui/rename_test.go
+++ b/internal/ui/rename_test.go
@@ -126,6 +126,34 @@ func TestRenameSessionMovesItsWorktree(t *testing.T) {
 	}
 }
 
+func TestRenameSessionRefusesSharedWorktree(t *testing.T) {
+	m := buildModel(t)
+	repo := seedRepo(t)
+	spawned := createWorktreeSession(t, m, "owner", repo)
+	forked := spawned
+	forked.ID = "shared-fork"
+	forked.Name = "forked"
+	if err := m.store.CreateSession(forked); err != nil {
+		t.Fatal(err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+
+	m.selectSessionRow(t, "owner")
+	m.openRename()
+	m.rename.input.SetValue("renamed")
+	m.handleRenameKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !strings.Contains(m.errBar.text, "shared with session \"forked\"") {
+		t.Fatalf("shared worktree error = %q", m.errBar.text)
+	}
+	if m.mode != modeRename {
+		t.Fatalf("mode = %v, want rename card", m.mode)
+	}
+	if _, err := os.Stat(spawned.Cwd); err != nil {
+		t.Fatalf("shared worktree moved: %v", err)
+	}
+}
+
 func TestRenameSessionRefusesAWorktreeNameAlreadyTaken(t *testing.T) {
 	m := buildModel(t)
 	repo := seedRepo(t)

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -1,41 +1,45 @@
 package ui
 
 import (
-	"fmt"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/store"
 )
 
-// launchNewSession creates one new tmux session and its store record. Session
-// forms and forks prepare different commands but share the same launch path.
-func (m *Model) launchNewSession(sess store.Session, baseCommand string, deferDirective bool) error {
-	tool, ok := m.cfg.Tools[sess.Tool]
-	if !ok {
-		return fmt.Errorf("tool %s is no longer configured", sess.Tool)
-	}
+type launchOptions struct {
+	deferDirective   bool
+	rollbackWorktree bool
+}
+
+func (m *Model) launchNewSession(sess store.Session, tool config.Tool, baseCommand string, opts launchOptions) error {
 	if sess.CreatedAt.IsZero() {
 		sess.CreatedAt = time.Now()
 	}
 	if sess.LastStatusAt.IsZero() {
 		sess.LastStatusAt = sess.CreatedAt
 	}
+	discardWorktree := func() {
+		if opts.rollbackWorktree {
+			m.discardWorktree(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch)
+		}
+	}
 	command, env, err := m.buildLaunch(sess.Tool, tool, baseCommand, sess.ID)
 	if err != nil {
-		m.discardWorktree(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch)
+		discardWorktree()
 		return err
 	}
 	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
-		m.discardWorktree(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch)
+		discardWorktree()
 		return err
 	}
 	if err := m.store.CreateSession(sess); err != nil {
 		_ = m.tmux.Kill(sess.ID)
 		_ = m.hooks.Remove(sess.ID)
-		m.discardWorktree(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch)
+		discardWorktree()
 		return err
 	}
-	if deferDirective && m.poller != nil {
+	if opts.deferDirective && m.poller != nil {
 		m.poller.markDirectivePending(sess.ID)
 	}
 	if err := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name)); err != nil {

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -42,10 +42,8 @@ func (m *Model) launchNewSession(sess store.Session, tool config.Tool, baseComma
 	if opts.deferDirective && m.poller != nil {
 		m.poller.markDirectivePending(sess.ID)
 	}
-	if err := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name)); err != nil {
-		return err
-	}
+	labelErr := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name))
 	m.sessions = append(m.sessions, sess)
 	m.rebuildRows()
-	return nil
+	return labelErr
 }

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/store"
+)
+
+// launchNewSession creates one new tmux session and its store record. Session
+// forms and forks prepare different commands but share the same launch path.
+func (m *Model) launchNewSession(sess store.Session, baseCommand string, deferDirective bool) error {
+	tool, ok := m.cfg.Tools[sess.Tool]
+	if !ok {
+		return fmt.Errorf("tool %s is no longer configured", sess.Tool)
+	}
+	if sess.CreatedAt.IsZero() {
+		sess.CreatedAt = time.Now()
+	}
+	if sess.LastStatusAt.IsZero() {
+		sess.LastStatusAt = sess.CreatedAt
+	}
+	command, env, err := m.buildLaunch(sess.Tool, tool, baseCommand, sess.ID)
+	if err != nil {
+		m.discardWorktree(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch)
+		return err
+	}
+	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
+		m.discardWorktree(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch)
+		return err
+	}
+	if err := m.store.CreateSession(sess); err != nil {
+		_ = m.tmux.Kill(sess.ID)
+		_ = m.hooks.Remove(sess.ID)
+		m.discardWorktree(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch)
+		return err
+	}
+	if deferDirective && m.poller != nil {
+		m.poller.markDirectivePending(sess.ID)
+	}
+	if err := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name)); err != nil {
+		return err
+	}
+	m.sessions = append(m.sessions, sess)
+	m.rebuildRows()
+	return nil
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -24,6 +24,8 @@ func (m *Model) View() string {
 		frame = m.viewHelp()
 	case modeSettings:
 		frame = m.viewSettings()
+	case modeFork:
+		frame = m.viewFork()
 	case modeMove:
 		frame = m.viewMove()
 	case modeRepoPick:
@@ -380,7 +382,7 @@ func (m *Model) viewFooter() string {
 	}
 	pairs := [][2]string{
 		{"↑↓/jk", "navigate"}, {"K/J", "reorder"}, {"↵", enterHint}, {"A", attachHint},
-		{"F", "fold all"}, {"n", "new"}, {"g", "group"}, {"space", "prompt"},
+		{"F", "fold all"}, {"n", "new"}, {"g", "group"}, {"f", "fork"}, {"space", "prompt"},
 		{"ctrl+r", "review"}, {"r", "rename"}, {"m", "move"},
 		{"x/X", "kill / all"}, {"v/V", "revive / all"},
 		{"a/u", "archive / restore"}, {"d", "delete"},


### PR DESCRIPTION
## What changed

Press `f` on a session to create a named fork with the same conversation history, group, and working directory.

The feature includes:

- Generic `fork_command` configuration
- Default support for Claude Code and Codex
- Shell-quoted command placeholders
- Exact conversation IDs when the tool supports them
- Safe sharing and cleanup of managed worktrees

## Why

A fork lets you explore another approach without changing or replacing the source conversation.

## How it was verified

- [x] End-to-end tests use real tmux sessions
- [x] Tests cover command expansion, naming, validation, and worktree sharing
- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes