### PR TITLE
fix(status): prefer waiting over working matches

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,7 +202,8 @@ func writeDefault(path string) error {
 const defaultConfig = `poll_interval = "2s"
 
 # Rules are matched top-down against the visible pane text (ANSI stripped);
-# first match wins. When no rule matches, the newest turn decides:
+# first match wins, except a matching waiting rule outranks a working match.
+# When no rule matches, the newest turn decides:
 # the content region is the text above the last activity_cutoff match
 # (the tool's input box). If the region's last content line — skipping
 # chrome_line matches (blanks, separators, input-box borders) — is a
@@ -236,13 +237,13 @@ trailing_note = "^※"
 # their wait line carries the same shape as a turn-end summary
 busy_line = "^[✻✳✶✽✢·✦✧+*] Waiting for \\d+ background agents? to finish"
 rules = [
+  # selection dialogs (trust prompt, permission asks, questions) block on the user
+  { state = "waiting", pattern = "Enter to confirm" },
+  { state = "waiting", pattern = "(?m)^[ \\x{A0}]*❯[ \\x{A0}]+\\d+\\." },
   # spinner row of an active turn, any duration format:
   # "✳ Drizzling… (6s · thinking)" / "✽ Zigzagging… (3m 18s · ↓ 1.4k tokens)"
   { state = "working", pattern = "(?m)^[✻✳✶✽✢·✦✧+*] \\S+… \\(" },
   { state = "working", pattern = "esc to interrupt" },
-  # selection dialogs (trust prompt, permission asks, questions) block on the user
-  { state = "waiting", pattern = "Enter to confirm" },
-  { state = "waiting", pattern = "(?m)^[ \\x{A0}]*❯[ \\x{A0}]+\\d+\\." },
   { state = "errored", pattern = "(?im)^\\s*error:" },
 ]
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,34 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	}
 }
 
+func TestDefaultWaitingRulesPrecedeWorking(t *testing.T) {
+	cfg, err := Default()
+	if err != nil {
+		t.Fatalf("Default: %v", err)
+	}
+
+	for name, tool := range cfg.Tools {
+		firstWorking := -1
+		lastWaiting := -1
+		for i, rule := range tool.Rules {
+			switch rule.State {
+			case "working":
+				if firstWorking < 0 {
+					firstWorking = i
+				}
+			case "waiting":
+				lastWaiting = i
+			}
+		}
+		if name == "claude" && (firstWorking < 0 || lastWaiting < 0) {
+			t.Fatalf("claude defaults need both working and waiting rules: %#v", tool.Rules)
+		}
+		if firstWorking >= 0 && lastWaiting > firstWorking {
+			t.Errorf("%s waiting rule at %d follows first working rule at %d", name, lastWaiting, firstWorking)
+		}
+	}
+}
+
 func TestBackfillToolDefaults(t *testing.T) {
 	cfg := Config{Tools: map[string]Tool{
 		"opencode": {Command: "opencode", ReviveCommand: "opencode --continue"},

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -84,18 +84,29 @@ func NewEngine(cfg config.Config) (*Engine, error) {
 
 // Match derives a status and reports whether any signal matched, so the
 // caller can distinguish a real signal from the default fallback. Rules
-// run first, scoped to the current turn; when none hit, the newest turn
-// in the content region decides finished versus waiting.
+// run first, scoped to the current turn. If the first matching rule is
+// working, a matching waiting rule later in the list overrides it so persisted
+// rule order cannot mask a user prompt. Every other first match returns as
+// configured. When no rule hits, the newest turn in the content region decides
+// finished versus waiting.
 func (e *Engine) Match(tool, pane string) (string, bool) {
 	tr, ok := e.tools[tool]
 	if !ok {
 		return Idle, false
 	}
 	scope := tr.matchScope(pane)
-	for _, r := range tr.rules {
-		if r.re.MatchString(scope) {
-			return r.state, true
+	for i, r := range tr.rules {
+		if !r.re.MatchString(scope) {
+			continue
 		}
+		if r.state == Working {
+			for _, later := range tr.rules[i+1:] {
+				if later.state == Waiting && later.re.MatchString(scope) {
+					return Waiting, true
+				}
+			}
+		}
+		return r.state, true
 	}
 	if tr.isBusy(pane) {
 		return Working, true
@@ -134,8 +145,9 @@ func (tr toolRules) isBusy(pane string) bool {
 // the newest turn_end marker in the content region. Completed turns can
 // quote spinner lines or dialog text verbatim (any session working on
 // terminal tooling will), and whole-pane matching would read those
-// echoes as live signals. Panes without a marker (fresh sessions,
-// dialogs that replace the input box) match in full.
+// echoes as live signals. Dialogs that replace the input box match in full.
+// With an input box but no marker, matching stays in the content region so
+// typed input cannot masquerade as a status signal.
 func (tr toolRules) matchScope(pane string) string {
 	if tr.turnEnd == nil {
 		return pane
@@ -144,11 +156,39 @@ func (tr toolRules) matchScope(pane string) string {
 	if !ok {
 		return pane
 	}
+	cutoffTail := pane[len(region):]
+	hasWaitingFooter := tr.hasWaitingFooter(cutoffTail)
 	lines := strings.Split(region, "\n")
 	if lastEnd := tr.lastTurnEndIndex(lines); lastEnd >= 0 {
-		return strings.Join(lines[lastEnd+1:], "\n")
+		scope := strings.Join(lines[lastEnd+1:], "\n")
+		if hasWaitingFooter {
+			return scope + cutoffTail
+		}
+		return scope
 	}
-	return pane
+	// Some selection dialogs reuse the prompt marker as their first option.
+	// Keep treating ordinary typed input as outside the match scope, but include
+	// the full pane when a separate waiting signal appears below that marker.
+	// Codex overlays render such a footer; the selected option line alone is
+	// indistinguishable from a numbered draft and must not expand the scope.
+	if hasWaitingFooter {
+		return pane
+	}
+	return region
+}
+
+func (tr toolRules) hasWaitingFooter(cutoffTail string) bool {
+	lineEnd := strings.IndexByte(cutoffTail, '\n')
+	if lineEnd < 0 {
+		return false
+	}
+	footer := cutoffTail[lineEnd+1:]
+	for _, r := range tr.rules {
+		if r.state == Waiting && r.re.MatchString(footer) {
+			return true
+		}
+	}
+	return false
 }
 
 // lastTurnEndIndex finds the newest turn_end marker line, -1 when absent.

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -15,6 +15,7 @@ func testEngine(t *testing.T) *Engine {
 				DefaultStatus: "idle",
 				Rules: []config.Rule{
 					{State: "working", Pattern: "esc to interrupt"},
+					{State: "waiting", Pattern: `(?m)^ ❯ 1\.`},
 					{State: "errored", Pattern: "(?i)^error:"},
 				},
 			},
@@ -36,6 +37,8 @@ func TestMatch(t *testing.T) {
 		want string
 	}{
 		{"working spinner", "claude", "thinking... (esc to interrupt)", Working},
+		{"persisted working-first rules still prefer waiting", "claude",
+			"✶ Cooking… (2m 14s · esc to interrupt)\nDo you want to proceed?\n ❯ 1. Yes\n   2. No, and tell Claude what to do differently", Waiting},
 		{"errored", "claude", "Error: something broke", Errored},
 		{"idle fallback", "claude", "> ", Idle},
 		{"first rule wins", "claude", "Error: x\nesc to interrupt", Working},
@@ -47,6 +50,86 @@ func TestMatch(t *testing.T) {
 				t.Fatalf("Match(%q)=%q want %q", tc.pane, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestMatchWaitingOnlyOverridesWorkingFirstMatch(t *testing.T) {
+	cfg := config.Config{Tools: map[string]config.Tool{
+		"custom": {Rules: []config.Rule{
+			{State: "errored", Pattern: "error signal"},
+			{State: "working", Pattern: "working signal"},
+			{State: "waiting", Pattern: "waiting signal"},
+		}},
+	}}
+	engine, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	if got, _ := engine.Match("custom", "error signal\nworking signal\nwaiting signal"); got != Errored {
+		t.Fatalf("Match() = %q want %q", got, Errored)
+	}
+
+	cfg.Tools["custom"] = config.Tool{Rules: []config.Rule{
+		{State: "working", Pattern: "working signal"},
+		{State: "errored", Pattern: "error signal"},
+		{State: "waiting", Pattern: "waiting signal"},
+	}}
+	engine, err = NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if got, _ := engine.Match("custom", "working signal\nerror signal\nwaiting signal"); got != Waiting {
+		t.Fatalf("Match() = %q want %q", got, Waiting)
+	}
+}
+
+func TestMatchLegacyClaudeRuleOrderStillResolvesWaiting(t *testing.T) {
+	cfg, err := config.Default()
+	if err != nil {
+		t.Fatalf("Default: %v", err)
+	}
+	claude := cfg.Tools["claude"]
+	claude.Rules = []config.Rule{
+		{State: Working, Pattern: `(?m)^[✻✳✶✽✢·✦✧+*] \S+… \(`},
+		{State: Working, Pattern: "esc to interrupt"},
+		{State: Waiting, Pattern: "Enter to confirm"},
+		{State: Waiting, Pattern: `(?m)^[ \x{A0}]*❯[ \x{A0}]+\d+\.`},
+		{State: Errored, Pattern: `(?im)^\s*error:`},
+	}
+	cfg.Tools["claude"] = claude
+	engine, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	// Include a prior turn and the input cutoff so the real Claude scope
+	// settings narrow matching to the current mixed-signal turn.
+	pane := "⏺ Previous turn\n✻ Worked for 1s\n" +
+		"✶ Cooking… (2m 14s · esc to interrupt)\nDo you want to proceed?\n" +
+		" ❯ 1. Yes\n   2. No, and tell Claude what to do differently\n❯ "
+	if got, matched := engine.Match("claude", pane); got != Waiting || !matched {
+		t.Fatalf("Match() = (%q, %t) want (%q, true)", got, matched, Waiting)
+	}
+}
+
+// Reconstructs the mixed signals reported in issue #112: an unanswered
+// approval dialog while Claude's active-turn hint remains visible.
+func TestClaudeMixedApprovalPane(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "✶ Cooking… (2m 14s · esc to interrupt)\nDo you want to proceed?\n" +
+		" ❯ 1. Yes\n   2. Yes, and don't ask again\n" +
+		"   3. No, and tell Claude what to do differently"
+	if got, matched := engine.Match("claude", pane); got != Waiting || !matched {
+		t.Fatalf("Match() = (%q, %t) want (%q, true)", got, matched, Waiting)
+	}
+}
+
+func TestClaudeNumberedInputDoesNotLookLikeDialog(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "✳ Drizzling… (6s · esc to interrupt)\n❯ 1. refactor the parser"
+	if got, matched := engine.Match("claude", pane); got != Working || !matched {
+		t.Fatalf("Match() = (%q, %t) want (%q, true)", got, matched, Working)
 	}
 }
 
@@ -202,12 +285,20 @@ func TestCodexRealPanes(t *testing.T) {
 			"• Working (0s • esc to interrupt)\n\n› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Working},
 		{"codex active turn, other status verb", "codex",
 			"• Analyzing (12s • esc to interrupt)\n\n› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Working},
+		{"codex numbered draft is not a dialog", "codex",
+			"• Working (0s • esc to interrupt)\n\n› 1. keep this as ordinary input\n  gpt-5.6-terra medium · /home/dev", Working},
+		{"codex option-shaped draft without footer is not a dialog", "codex",
+			"• Working (0s • esc to interrupt)\n\n› 1. Yes, proceed (y)", Working},
 		{"codex finished work turn", "codex",
 			"• Ran echo preparing\n  └ preparing\n\n────────────────────────────────\n\n• Final response.\n\n─ Worked for 2m 05s ─────────────\n\n› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Finished},
 		{"codex finished turn ending on a question", "codex",
 			"• Which file should I edit, A or B?\n\n─ Worked for 3s ─────────────────\n\n› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Waiting},
 		{"codex command-approval modal", "codex",
 			"  $ echo hello world\n\n› 1. Yes, proceed (y)\n  2. Yes, and don't ask again for commands that start with `echo hello world` (p)\n  3. No, and tell Codex what to do differently (esc)\n\n  Press enter to confirm or esc to cancel", Waiting},
+		{"codex command-approval modal overrides stale working signal", "codex",
+			"• Working (0s • esc to interrupt)\n\n  $ echo hello world\n\n› 1. Yes, proceed (y)\n  2. No, and tell Codex what to do differently (esc)\n\n  Press enter to confirm or esc to cancel", Waiting},
+		{"codex command-approval modal after completed turn", "codex",
+			"• Previous response.\n\n─ Worked for 1s ─────────────\n\n• Working (0s • esc to interrupt)\n\n  $ echo hello world\n\n› 1. Yes, proceed (y)\n  2. No, and tell Codex what to do differently (esc)\n\n  Press enter to confirm or esc to cancel", Waiting},
 		{"codex first-run trust dialog", "codex",
 			"Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt injection.\n\n› 1. Yes, continue\n  2. No, quit\n\n  Press enter to continue", Waiting},
 		{"codex request-user-input selection", "codex",

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -125,6 +125,15 @@ func TestClaudeMixedApprovalPane(t *testing.T) {
 	}
 }
 
+func TestClaudeEnterToConfirmOverridesWorking(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "✶ Cooking… (2m 14s · esc to interrupt)\n" +
+		"Review the selected choice\nEnter to confirm · Esc to cancel"
+	if got, matched := engine.Match("claude", pane); got != Waiting || !matched {
+		t.Fatalf("Match() = (%q, %t) want (%q, true)", got, matched, Waiting)
+	}
+}
+
 func TestClaudeNumberedInputDoesNotLookLikeDialog(t *testing.T) {
 	engine := defaultEngine(t)
 	pane := "✳ Drizzling… (6s · esc to interrupt)\n❯ 1. refactor the parser"


### PR DESCRIPTION
## What changed

- Prefer a matching `waiting` rule over an earlier `working` match within the current pane turn.
- Put Claude's built-in waiting rules before working rules for newly generated configs while preserving the fix for existing configs.
- Keep typed input outside the matching scope unless a real waiting footer is present.
- Add regression coverage for mixed approval panes, persisted rule order, modal footers, and numbered-input false positives.

## Why

An approval dialog can coexist with a stale spinner or `esc to interrupt` line. Returning the first working match makes the session look busy even though it is blocked on the user. The match-time precedence is required for existing `config.toml` files whose rule order is not migrated.

Closes #112

## How it was verified

- `go test ./internal/config ./internal/status`
- `go vet ./...`
- `go build ./...`
- `git diff --check`
- Every changed Go file passes `gofmt -l`.
- Synthetic merge trees with the current heads of #200 and #201 are conflict-free; those PRs touch adjacent config/test sections but do not implement this status precedence.
- `go test ./...` was also attempted on Windows. The touched packages pass, while unrelated packages hit existing Windows-specific assertions and Application Control blocks some temporary test executables.

- [ ] `gofmt -l .` prints nothing (the Windows CRLF checkout makes the repository-wide form non-actionable; all four changed files pass)
- [x] `go vet ./...` passes
- [ ] `go test -race ./...` passes (not run: this Windows host has no C compiler)
- [ ] Ran it against real sessions
