### PR TITLE
fix(ui): keep pure-RTL pane rows inside the content column

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.7
 	golang.design/x/clipboard v0.8.0
 	golang.org/x/sys v0.47.0
+	golang.org/x/text v0.37.0
 	modernc.org/sqlite v1.55.0
 )
 
@@ -58,7 +59,6 @@ require (
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	modernc.org/libc v1.74.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -53,7 +53,7 @@ func TestFocusKeyCommand(t *testing.T) {
 // bgRun returns, for each column, whether a background color is active,
 // by walking the row's SGR sequences the way a terminal would.
 func bgRun(row string, width int) []bool {
-	row = strings.NewReplacer("\u2066", "", "\u2069", "").Replace(row)
+	row = strings.NewReplacer("\u200e", "", "\u2066", "", "\u2069", "").Replace(row)
 	out := make([]bool, 0, width)
 	bg := false
 	i := 0
@@ -99,12 +99,17 @@ func TestPreviewLinePreservesBackgroundColumns(t *testing.T) {
 	t.Logf("raw plain=%q width=%d", ansi.Strip(raw), ansi.StringWidth(ansi.Strip(raw)))
 	t.Logf("raw bg cells=%v", rawCells)
 	t.Logf("out bg cells=%v", gotCells)
-	if len(rawCells) != len(gotCells) {
-		t.Fatalf("cell counts differ: raw %d, rendered %d", len(rawCells), len(gotCells))
+	if len(gotCells) < len(rawCells) {
+		t.Fatalf("rendered shorter than raw: raw %d, rendered %d", len(rawCells), len(gotCells))
 	}
 	for i := range rawCells {
 		if rawCells[i] != gotCells[i] {
 			t.Fatalf("column %d background differs: raw %v, rendered %v", i, rawCells[i], gotCells[i])
+		}
+	}
+	for i := len(rawCells); i < len(gotCells); i++ {
+		if gotCells[i] {
+			t.Fatalf("padding column %d invented a background", i)
 		}
 	}
 }

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -154,7 +154,7 @@ func TestTripleClickOnRealFrameTakesPaneRowOnly(t *testing.T) {
 // plainCells is a painted frame row as visible cells, escape sequences
 // removed, so a column index in the frame is a column on screen.
 func plainCells(row string) []rune {
-	return []rune(strings.NewReplacer("\u2066", "", "\u2069", "").Replace(ansi.Strip(row)))
+	return []rune(strings.NewReplacer("\u200e", "", "\u2066", "", "\u2069", "").Replace(ansi.Strip(row)))
 }
 
 // A capture taken by the slower poll path must not repaint over a frame
@@ -311,8 +311,8 @@ func TestCursorPaintedOnItsRow(t *testing.T) {
 	if !strings.Contains(withCursor, "\x1b[") {
 		t.Fatalf("cursor row carries no styling: %q", withCursor)
 	}
-	if string(plainCells(withCursor)) != "abc" {
-		t.Fatalf("cursor changed the row text: %q", ansi.Strip(withCursor))
+	if plain := strings.TrimRight(string(plainCells(withCursor)), " "); plain != "abc" {
+		t.Fatalf("cursor changed the row text: %q", plain)
 	}
 	if other := m.renderPaneRow(1, "def", 20); other != previewLine("def", 20) {
 		t.Fatalf("non-cursor row was restyled: %q", other)

--- a/internal/ui/hebrew_paragraph_test.go
+++ b/internal/ui/hebrew_paragraph_test.go
@@ -53,3 +53,17 @@ func TestHebrewPaneRowKeepsLTRParagraph(t *testing.T) {
 		}
 	}
 }
+
+func TestHebrewRailNameStaysLTR(t *testing.T) {
+	got := pinRowsLTR("█ ◆ העצמון   waiting\nplain row\n‎⁦שלום⁩")
+	lines := strings.Split(got, "\n")
+	if !strings.HasPrefix(lines[0], "‎") {
+		t.Fatalf("row with a leading Hebrew rail name should gain an LRM: %q", lines[0])
+	}
+	if lines[1] != "plain row" {
+		t.Fatalf("LTR row should be untouched: %q", lines[1])
+	}
+	if strings.HasPrefix(lines[2], "‎‎") {
+		t.Fatalf("already pinned row should not gain a second mark: %q", lines[2])
+	}
+}

--- a/internal/ui/hebrew_paragraph_test.go
+++ b/internal/ui/hebrew_paragraph_test.go
@@ -1,0 +1,50 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Pure-RTL pane rows that sit beside empty rail cells must still open with a
+// strong LTR mark before any Hebrew. Hosts that pick paragraph direction from
+// the first strong character otherwise right-justify the whole terminal line
+// and the pane text lands in the rail.
+func TestHebrewPaneRowKeepsLTRParagraph(t *testing.T) {
+	he := strings.Join([]string{
+		"english line",
+		"  העצמון 25 חולון",
+		"mixed ת.ז. end",
+		"",
+		"  העצמון 25 חולון",
+	}, "\n")
+	// Tall frames put pure-Hebrew pane rows next to empty rail padding, which
+	// is the geometry that flips paragraph direction without a leading LRM.
+	for _, width := range []int{100, 140, 180} {
+		for _, height := range []int{40, 50} {
+			m := shotModel()
+			m.width, m.height = width, height
+			m.preview = he + "\n" + strings.Repeat("  העצמון 25 חולון\n", 20)
+			m.mode = modeFocus
+			for i, line := range strings.Split(m.View(), "\n") {
+				plain := ansi.Strip(line)
+				heb := strings.IndexFunc(plain, func(r rune) bool {
+					return unicode.In(r, unicode.Hebrew)
+				})
+				if heb < 0 {
+					continue
+				}
+				lrm := strings.IndexRune(plain, '\u200e')
+				if lrm < 0 || lrm > heb {
+					t.Errorf("%dx%d line %d: LRM missing or after Hebrew (lrm=%d heb=%d)\n%q",
+						width, height, i, lrm, heb, plain)
+				}
+				if got := ansi.StringWidth(line); got > width {
+					t.Errorf("%dx%d line %d overflows at %d", width, height, i, got)
+				}
+			}
+		}
+	}
+}

--- a/internal/ui/hebrew_paragraph_test.go
+++ b/internal/ui/hebrew_paragraph_test.go
@@ -24,6 +24,7 @@ func TestHebrewPaneRowKeepsLTRParagraph(t *testing.T) {
 	// is the geometry that flips paragraph direction without a leading LRM.
 	for _, width := range []int{100, 140, 180} {
 		for _, height := range []int{40, 50} {
+			foundHebrew := false
 			m := shotModel()
 			m.width, m.height = width, height
 			m.preview = he + "\n" + strings.Repeat("  העצמון 25 חולון\n", 20)
@@ -36,6 +37,7 @@ func TestHebrewPaneRowKeepsLTRParagraph(t *testing.T) {
 				if heb < 0 {
 					continue
 				}
+				foundHebrew = true
 				lrm := strings.IndexRune(plain, '\u200e')
 				if lrm < 0 || lrm > heb {
 					t.Errorf("%dx%d line %d: LRM missing or after Hebrew (lrm=%d heb=%d)\n%q",
@@ -44,6 +46,9 @@ func TestHebrewPaneRowKeepsLTRParagraph(t *testing.T) {
 				if got := ansi.StringWidth(line); got > width {
 					t.Errorf("%dx%d line %d overflows at %d", width, height, i, got)
 				}
+			}
+			if !foundHebrew {
+				t.Fatalf("%dx%d frame did not render a Hebrew preview row", width, height)
 			}
 		}
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"golang.org/x/text/unicode/bidi"
 )
 
 func (m *Model) View() string {
@@ -39,7 +40,35 @@ func (m *Model) View() string {
 	default:
 		frame = m.viewListFrame()
 	}
-	return clampFrame(frame, m.height)
+	return clampFrame(pinRowsLTR(frame), m.height)
+}
+
+// pinRowsLTR prepends an LRM to any frame row whose first strong character
+// is RTL (a Hebrew session name in the rail, say). UAX#9 takes paragraph
+// direction from that first strong character, so without the mark a bidi
+// host right-justifies the whole row and pulls it out of column. The mark
+// is zero width and applied after layout, so geometry is untouched.
+func pinRowsLTR(frame string) string {
+	lines := strings.Split(frame, "\n")
+	changed := false
+	for i, line := range lines {
+	scan:
+		for _, r := range line {
+			props, _ := bidi.LookupRune(r)
+			switch props.Class() {
+			case bidi.L:
+				break scan
+			case bidi.R, bidi.AL:
+				lines[i] = "\u200e" + line
+				changed = true
+				break scan
+			}
+		}
+	}
+	if !changed {
+		return frame
+	}
+	return strings.Join(lines, "\n")
 }
 
 // clampFrame pins a rendered frame to exactly height rows so the outer

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -334,14 +334,24 @@ func previewLine(line string, width int) string {
 		}
 		return r
 	}, line)
-	if ansi.StringWidth(line) > width {
+	w := ansi.StringWidth(line)
+	if w > width {
 		line = ansi.Truncate(line, width, "")
+		w = ansi.StringWidth(line)
 	}
+	// Reset before padding so an open background from the agent does not
+	// paint the rest of the column.
 	if strings.ContainsRune(line, 0x1b) {
 		line += "\x1b[0m"
 	}
-	// Keep a leading RTL run inside the preview instead of the terminal's full row.
-	return "\u2066" + line + "\u2069"
+	if w < width {
+		line += strings.Repeat(" ", width-w)
+	}
+	// LRM is strong LTR (zero width). On rows where the rail is only neutrals,
+	// a leading Hebrew run is the line's first strong character; hosts that
+	// right-justify RTL paragraphs then pull the pane into the rail. Isolate
+	// plus a full-width pad keep the run inside the content column.
+	return "\u200e\u2066" + line + "\u2069"
 }
 
 // paneExact returns up to n lines of pane text as captured, preserving

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -76,27 +76,31 @@ func TestClampFrame(t *testing.T) {
 	}
 }
 
+func stripPreviewMarks(s string) string {
+	return strings.NewReplacer("\u200e", "", "\u2066", "", "\u2069", "").Replace(s)
+}
+
 func TestPreviewLine(t *testing.T) {
 	colored := "\x1b[38;5;42mgreen text\x1b[39m"
 	got := previewLine(colored, 80)
 	if !strings.Contains(got, "\x1b[38;5;42m") {
 		t.Fatalf("color escapes should survive: %q", got)
 	}
-	if !strings.HasSuffix(got, "\x1b[0m\u2069") {
-		t.Fatalf("line with ANSI must end in SGR reset: %q", got)
+	if !strings.Contains(got, "\x1b[0m") || !strings.HasSuffix(got, "\u2069") {
+		t.Fatalf("line with ANSI must reset SGR and close the isolate: %q", got)
 	}
 
 	erased := "abc\x1b[K\x1b[2Jdef"
-	if got := previewLine(erased, 80); ansi.Strip(got) != "\u2066abcdef\u2069" {
+	if got := stripPreviewMarks(ansi.Strip(previewLine(erased, 80))); strings.TrimRight(got, " ") != "abcdef" {
 		t.Fatalf("erase sequences should be stripped: %q", got)
 	}
 	scrolled := "a\x1b[1Sb\x1bMc\x1b[2Td"
-	if got := previewLine(scrolled, 80); ansi.Strip(got) != "\u2066abcd\u2069" {
+	if got := stripPreviewMarks(ansi.Strip(previewLine(scrolled, 80))); strings.TrimRight(got, " ") != "abcd" {
 		t.Fatalf("scroll sequences should be stripped: %q", got)
 	}
 
 	control := "a\rb\bc"
-	if got := previewLine(control, 80); ansi.Strip(got) != "\u2066abc\u2069" {
+	if got := stripPreviewMarks(ansi.Strip(previewLine(control, 80))); strings.TrimRight(got, " ") != "abc" {
 		t.Fatalf("control chars should be dropped: %q", got)
 	}
 
@@ -110,11 +114,25 @@ func TestPreviewLine(t *testing.T) {
 	if strings.Contains(plain, "\x1b") {
 		t.Fatalf("plain line should gain no escapes: %q", plain)
 	}
-	if !strings.HasPrefix(plain, "\u2066") || !strings.HasSuffix(plain, "\u2069") {
-		t.Fatalf("pane row should be directionally isolated: %q", plain)
+	if !strings.HasPrefix(plain, "\u200e\u2066") || !strings.HasSuffix(plain, "\u2069") {
+		t.Fatalf("pane row should open LTR and stay isolated: %q", plain)
 	}
-	if got := ansi.Strip(previewLine("קודינג\",\"slowly\":false", 80)); got != "\u2066קודינג\",\"slowly\":false\u2069" {
-		t.Fatalf("mixed-direction pane row lost its isolation: %q", got)
+	if w := ansi.StringWidth(plain); w != 80 {
+		t.Fatalf("pane row should fill its column, width %d", w)
+	}
+	mixed := stripPreviewMarks(ansi.Strip(previewLine("קודינג\",\"slowly\":false", 80)))
+	if strings.TrimRight(mixed, " ") != "קודינג\",\"slowly\":false" {
+		t.Fatalf("mixed-direction pane row lost its text: %q", mixed)
+	}
+	hebrew := previewLine("  העצמון 25 חולון", 40)
+	if !strings.HasPrefix(hebrew, "\u200e\u2066") {
+		t.Fatalf("pure RTL row needs a leading LRM so the host keeps LTR: %q", hebrew)
+	}
+	if w := ansi.StringWidth(hebrew); w != 40 {
+		t.Fatalf("pure RTL row must pad inside the isolate to column width, got %d", w)
+	}
+	if body := strings.TrimRight(stripPreviewMarks(ansi.Strip(hebrew)), " "); body != "  העצמון 25 חולון" {
+		t.Fatalf("pure RTL row text changed: %q", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Prefix every captured pane row with a zero-width LRM and pad to full column width inside the directional isolate so pure-Hebrew lines cannot flip the host terminal's paragraph direction.
- Reset open SGR before padding so agent backgrounds do not paint the pad.
- Add a frame regression for pure-RTL rows that sit beside empty rail padding (the geometry that was reflowing into the sessions list on iTerm2).

## Why

On iTerm2, empty rail cells are neutrals. A pure-RTL pane row (e.g. a Hebrew address line) was the first strong character on that terminal line, so the host treated the whole row as RTL and right-justified it. The pane text then appeared over the left rail. Isolates alone (`#192`) are not strong LTR, so they did not stop first-strong detection.

## Test plan

- [x] `gofmt -l` clean on touched files
- [x] `go vet ./internal/ui/`
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amhe go test ./internal/ui/ -run 'TestHebrew|TestPreviewLine|TestFrameFits|TestCaret|TestCursor|TestPreviewLinePreserves'`
- [ ] Quit shipped `agent-manager`, run `agent-manager-dev`, focus a session with a pure-Hebrew pane line (e.g. `העצמון 25 חולון`) and confirm it stays inside the content pane, not the rail
- [ ] Spot-check mixed English/Hebrew lines still read in place (local bidi runs, no rail spill)