### PR TITLE
feat(ui): filter sessions that need attention

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,7 +33,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `s` | Settings (quick-spawn tool, theme, list density, review layout, after quick send, session keys, worktree sessions) |
 | `\|` | Resize the split: `←→` nudge the divider, `enter` commits, `esc` cancels |
 | `t` | Toggle archived view |
-| `f` | Filter to sessions that need attention (`waiting`, `finished`, `errored`); press again to show all |
+| `w` | Filter to sessions that need attention (`waiting`, `finished`, `errored`); press again to show all |
 | `e` | Hide / show empty groups |
 | `/` | Search |
 | `?` | Help |
@@ -159,7 +159,7 @@ Each session's tmux pane is polled (default every 2s) to derive a status:
 | `idle` | Nothing running |
 | `dead` | The tmux session is gone |
 
-`f` narrows the list to sessions that need attention (`waiting`, `finished`, `errored`). Press again to show every status. The header badge and session counts follow the filter; folds open so matches are not hidden.
+`w` narrows the list to sessions that need attention (`waiting`, `finished`, `errored`). Press again to show every status. The header badge and session counts follow the filter; folds open so matches are not hidden.
 
 ![the session tree, with a waiting agent's permission prompt in the preview](screenshot-sessions.png)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,6 +33,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `s` | Settings (quick-spawn tool, theme, list density, review layout, after quick send, session keys, worktree sessions) |
 | `\|` | Resize the split: `←→` nudge the divider, `enter` commits, `esc` cancels |
 | `t` | Toggle archived view |
+| `f` | Filter to sessions that need attention (`waiting`, `finished`, `errored`); press again to show all |
 | `e` | Hide / show empty groups |
 | `/` | Search |
 | `?` | Help |
@@ -157,6 +158,8 @@ Each session's tmux pane is polled (default every 2s) to derive a status:
 | `errored` | The tool reported an error |
 | `idle` | Nothing running |
 | `dead` | The tmux session is gone |
+
+`f` narrows the list to sessions that need attention (`waiting`, `finished`, `errored`). Press again to show every status. The header badge and session counts follow the filter; folds open so matches are not hidden.
 
 ![the session tree, with a waiting agent's permission prompt in the preview](screenshot-sessions.png)
 

--- a/internal/ui/fork.go
+++ b/internal/ui/fork.go
@@ -106,6 +106,10 @@ func (m *Model) submitFork() (tea.Model, tea.Cmd) {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
+	// Forks start as starting, which attention excludes; clear so the row
+	// the fork just created is on screen.
+	m.statusFilter = statusFilterAll
+	m.rebuildRows()
 	m.mode = modeList
 	m.errBar.text = ""
 	for i, row := range m.rows {

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -813,6 +813,7 @@ func (m *Model) submitGroupForm() (tea.Model, tea.Cmd) {
 	m.searching = false
 	m.showArchived = false
 	m.hideEmptyGroups = false
+	m.statusFilter = statusFilterAll
 	m.errBar.text = ""
 	m.mode = modeList
 	m.rebuildRows()

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -513,6 +513,9 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
+	// New sessions start as starting, which attention excludes; clear so
+	// the row the form just created is on screen.
+	m.statusFilter = statusFilterAll
 	m.mode = modeList
 	return m, m.refreshCmd()
 }

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -89,6 +89,7 @@ func TestGroupFormShowsNewEmptyGroupWithWorktreeOff(t *testing.T) {
 	m.hideEmptyGroups = true
 	m.search = "does-not-match"
 	m.showArchived = true
+	m.statusFilter = statusFilterAttention
 	m.openGroupForm()
 	m.groupForm.name.SetValue("manual")
 	m.groupForm.path.SetValue(t.TempDir())
@@ -98,8 +99,9 @@ func TestGroupFormShowsNewEmptyGroupWithWorktreeOff(t *testing.T) {
 	if m.hideEmptyGroups {
 		t.Fatal("creating a group should reveal it when empty groups were hidden")
 	}
-	if m.search != "" || m.showArchived {
-		t.Fatalf("creation left list filters active: search=%q archived=%v", m.search, m.showArchived)
+	if m.search != "" || m.showArchived || m.statusFilter.active() {
+		t.Fatalf("creation left list filters active: search=%q archived=%v statusFilter=%v",
+			m.search, m.showArchived, m.statusFilter)
 	}
 	if got := m.groupRowPaths(); !reflect.DeepEqual(got, []string{"manual"}) {
 		t.Fatalf("group rows before refresh = %v, want [manual]", got)

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -119,6 +119,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openQuickMode()
 	case "F", "shift+f":
 		m.toggleCollapseAll()
+	case "f":
+		return m, m.cycleStatusFilter()
 	case "s":
 		m.openSettings()
 	case "|":
@@ -339,6 +341,19 @@ var pasteFocused = func(driver *tmux.Driver, id, text string) error {
 	return driver.Paste(id, text)
 }
 
+// cycleStatusFilter advances the list status filter (all → attention → …).
+// Modes live in statusFilterCycle so new ones only need a const and a
+// matches case; this handler stays the same.
+func (m *Model) cycleStatusFilter() tea.Cmd {
+	previousKey := ""
+	if entry, ok := m.selectedRow(); ok {
+		previousKey = rowKey(entry)
+	}
+	m.statusFilter = m.statusFilter.next()
+	m.rebuildRows()
+	return m.afterListFilter(previousKey)
+}
+
 // toggleEmptyGroups hides or restores group rows whose subtree has no
 // sessions in the current active/archive view. It never changes the store.
 func (m *Model) toggleEmptyGroups() tea.Cmd {
@@ -348,7 +363,12 @@ func (m *Model) toggleEmptyGroups() tea.Cmd {
 	}
 	m.hideEmptyGroups = !m.hideEmptyGroups
 	m.rebuildRows()
+	return m.afterListFilter(previousKey)
+}
 
+// afterListFilter keeps the preview tied to the selection when a filter
+// change leaves the cursor on the same row, and refreshes it when not.
+func (m *Model) afterListFilter(previousKey string) tea.Cmd {
 	currentKey := ""
 	if entry, ok := m.selectedRow(); ok {
 		currentKey = rowKey(entry)

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -119,7 +119,7 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openQuickMode()
 	case "F", "shift+f":
 		m.toggleCollapseAll()
-	case "f":
+	case "w":
 		return m, m.cycleStatusFilter()
 	case "s":
 		m.openSettings()

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -115,7 +115,7 @@ func (m *Model) reviveSelected() (tea.Model, tea.Cmd) {
 // reviveAllDead relaunches every dead session in the current view, resuming
 // each by its captured id where one exists.
 func (m *Model) reviveAllDead() (tea.Model, tea.Cmd) {
-	return m.reviveMany(m.visibleSessions(), "no dead sessions to revive")
+	return m.reviveMany(m.listedSessions(), "no dead sessions to revive")
 }
 
 // reviveMany relaunches every dead session in the list. It revives what it
@@ -157,7 +157,7 @@ func (m *Model) reviveMany(sessions []store.Session, emptyNotice string) (tea.Mo
 // group, so a group action covers exactly the rows under it on screen.
 func (m *Model) sessionsInGroup(path string) []store.Session {
 	var sessions []store.Session
-	for _, sess := range m.visibleSessions() {
+	for _, sess := range m.listedSessions() {
 		if inGroupSubtree(sess.Group, path) {
 			sessions = append(sessions, sess)
 		}
@@ -267,7 +267,7 @@ func (m *Model) killSelected() (tea.Model, tea.Cmd) {
 // killAllLive asks to end every live session in the current view, the
 // batch counterpart to V.
 func (m *Model) killAllLive() (tea.Model, tea.Cmd) {
-	live, err := m.liveSessions(m.visibleSessions())
+	live, err := m.liveSessions(m.listedSessions())
 	if err != nil {
 		m.errBar.text = err.Error()
 		return m, nil

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -228,7 +228,7 @@ func (m *Model) emptyRailLines(width, height int) []string {
 	}
 	if m.statusFilter.active() {
 		title = "nothing needs " + m.statusFilter.label()
-		hint = keyCap("f", "show all")
+		hint = keyCap("w", "show all")
 	}
 	if search := strings.TrimSpace(m.search); search != "" {
 		title = "no matches"

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -226,6 +226,10 @@ func (m *Model) emptyRailLines(width, height int) []string {
 		title = "nothing archived"
 		hint = keyCap("t", "back to active")
 	}
+	if m.statusFilter.active() {
+		title = "nothing needs attention"
+		hint = keyCap("f", "show all")
+	}
 	if search := strings.TrimSpace(m.search); search != "" {
 		title = "no matches"
 		hint = subtleStyle.Render("for \"" + search + "\"")
@@ -753,7 +757,7 @@ func joinHeaderPieces(sep string, pieces ...string) string {
 // up; counting painted rows instead would drop everything folded inside
 // a collapsed group.
 func (m *Model) headerScope() string {
-	count := len(m.visibleSessions())
+	count := len(m.listedSessions())
 	label := " sessions"
 	if count == 1 {
 		label = " session"
@@ -761,6 +765,10 @@ func (m *Model) headerScope() string {
 	scope := subtleStyle.Render(" · active")
 	if m.showArchived {
 		scope = subtleStyle.Render(" · ") + scopeBadgeStyle.Render("ARCHIVED")
+	}
+	if m.statusFilter.active() {
+		scope += subtleStyle.Render(" · ") +
+			scopeBadgeStyle.Render(strings.ToUpper(m.statusFilter.label()))
 	}
 	return valueStyle.Render(fmt.Sprintf("%d", count)) + subtleStyle.Render(label) + scope
 }
@@ -783,7 +791,7 @@ func (m *Model) headerAgents() string {
 // per state present among the listed sessions.
 func (m *Model) viewStatusCounts(compact bool) string {
 	counts := map[string]int{}
-	for _, sess := range m.visibleSessions() {
+	for _, sess := range m.listedSessions() {
 		counts[sess.Status]++
 	}
 	var parts []string

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -227,7 +227,7 @@ func (m *Model) emptyRailLines(width, height int) []string {
 		hint = keyCap("t", "back to active")
 	}
 	if m.statusFilter.active() {
-		title = "nothing needs attention"
+		title = "nothing needs " + m.statusFilter.label()
 		hint = keyCap("f", "show all")
 	}
 	if search := strings.TrimSpace(m.search); search != "" {
@@ -666,7 +666,7 @@ func (m *Model) viewGroupAgents(group string, width, height int) string {
 	if total == 0 {
 		return lines[0] + "\n" + mutedStyle.Render("(none yet — press space to spawn one)")
 	}
-	for _, sess := range m.visibleSessions() {
+	for _, sess := range m.listedSessions() {
 		if !inGroupSubtree(sess.Group, group) {
 			continue
 		}

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -432,6 +432,7 @@ func TestEmptyListKeepsItsGuidance(t *testing.T) {
 		{"no sessions", func(m *Model) {}, "no sessions yet"},
 		{"no matches", func(m *Model) { m.search = "nothing-matches-this" }, "no matches"},
 		{"nothing archived", func(m *Model) { m.showArchived = true }, "nothing archived"},
+		{"nothing needs attention", func(m *Model) { m.statusFilter = statusFilterAttention }, "nothing needs attention"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := shotModel()

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -378,6 +378,7 @@ func (m *Model) viewHelp() string {
 		{"s", "settings (CLIs, theme, default tool, review layout)"},
 		{"|", "resize split (←→ / drag, enter commits, esc cancels)"},
 		{"t", "toggle archived view"},
+		{"f", "filter to sessions that need attention (waiting, finished, errored)"},
 		{"M", "messages (updates, tips, bug reporting; x dismisses)"},
 		{"e", "hide / show empty groups"},
 		{"/", "search"},

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -378,7 +378,7 @@ func (m *Model) viewHelp() string {
 		{"s", "settings (CLIs, theme, default tool, review layout)"},
 		{"|", "resize split (←→ / drag, enter commits, esc cancels)"},
 		{"t", "toggle archived view"},
-		{"f", "filter to sessions that need attention (waiting, finished, errored)"},
+		{"w", "filter to sessions that need attention (waiting, finished, errored)"},
 		{"M", "messages (updates, tips, bug reporting; x dismisses)"},
 		{"e", "hide / show empty groups"},
 		{"/", "search"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -112,6 +112,7 @@ type Model struct {
 	mode              mode
 	showArchived      bool
 	hideEmptyGroups   bool
+	statusFilter      statusFilter
 	collapsed         map[string]bool
 	search            string
 	searching         bool
@@ -720,7 +721,8 @@ func (m *Model) refreshExistingSessionUX() tea.Msg {
 // visibleSessions filters to the sessions the current view scope shows:
 // active ones normally, archived ones in the archived view. It also
 // covers the frames between a scope toggle and the next refresh, when
-// m.sessions still carries the other scope's list.
+// m.sessions still carries the other scope's list. Status filters apply
+// later via listedSessions.
 func (m *Model) visibleSessions() []store.Session {
 	visible := make([]store.Session, 0, len(m.sessions))
 	for _, sess := range m.sessions {
@@ -729,6 +731,23 @@ func (m *Model) visibleSessions() []store.Session {
 		}
 	}
 	return visible
+}
+
+// listedSessions is the archived scope narrowed by the status filter.
+// Header counts, group rollups, and the tree all share this set so the
+// numbers always match what the list can show.
+func (m *Model) listedSessions() []store.Session {
+	visible := m.visibleSessions()
+	if !m.statusFilter.active() {
+		return visible
+	}
+	listed := make([]store.Session, 0, len(visible))
+	for _, sess := range visible {
+		if m.statusFilter.matches(sess.Status) {
+			listed = append(listed, sess)
+		}
+	}
+	return listed
 }
 
 func (m *Model) selected() (store.Session, bool) {
@@ -1266,20 +1285,21 @@ func rowKey(entry treeRow) string {
 }
 
 // rebuildRows walks the group tree depth-first and emits one row per
-// group node and per session, honoring collapse state and search.
-// The cursor follows the previously selected row's identity, so list
-// changes from the 2s poll never yank the selection around.
+// group node and per session, honoring collapse state, search, and the
+// status filter. The cursor follows the previously selected row's
+// identity, so list changes from the 2s poll never yank the selection.
 func (m *Model) rebuildRows() {
 	previousKey := ""
 	if entry, ok := m.selectedRow(); ok {
 		previousKey = rowKey(entry)
 	}
 	query := strings.ToLower(strings.TrimSpace(m.search))
+	prunedView := query != "" || m.statusFilter.active()
 
 	// m.sessions arrives ordered by the store (group, sort_order), so
 	// per-group slices inherit the user's manual order.
 	sessionsByGroup := map[string][]store.Session{}
-	for _, sess := range m.visibleSessions() {
+	for _, sess := range m.listedSessions() {
 		if query != "" && !matchesSearch(sess, query) {
 			continue
 		}
@@ -1305,7 +1325,7 @@ func (m *Model) rebuildRows() {
 				delete(paths, path)
 			}
 		}
-		if query != "" {
+		if prunedView {
 			paths = pathsWithSessions(paths, sessionsByGroup)
 		}
 	}
@@ -1317,10 +1337,10 @@ func (m *Model) rebuildRows() {
 	}
 	children := childIndex(paths, m.groups)
 
-	// Folds are a browsing convenience for the active tree; the archived
-	// and search views already prune to matching groups, so honoring folds
-	// there would hide the very sessions the user came to act on.
-	honorFolds := query == "" && !m.showArchived
+	// Folds are a browsing convenience for the active tree; the archived,
+	// search, and status-filter views already prune to matching groups, so
+	// honoring folds there would hide the very sessions the user came for.
+	honorFolds := !prunedView && !m.showArchived
 
 	// Root is a standing move and spawn target; its sessions stay flat.
 	rows := make([]treeRow, 0, len(m.sessions)+len(paths)+1)

--- a/internal/ui/quick.go
+++ b/internal/ui/quick.go
@@ -277,6 +277,8 @@ func (m *Model) quickSpawn(group, prompt string) (tea.Model, tea.Cmd) {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
+	// Spawned sessions start outside the attention set; clear so the new row shows.
+	m.statusFilter = statusFilterAll
 	m.clearQuickAfterSend()
 	m.errBar.text = ""
 	return m, m.refreshCmd()

--- a/internal/ui/statusfilter.go
+++ b/internal/ui/statusfilter.go
@@ -12,7 +12,7 @@ const (
 	statusFilterAttention
 )
 
-// statusFilterCycle is the order `f` walks. Append new modes before the
+// statusFilterCycle is the order `w` walks. Append new modes before the
 // wrap back to all happens at the end of next().
 var statusFilterCycle = []statusFilter{
 	statusFilterAll,

--- a/internal/ui/statusfilter.go
+++ b/internal/ui/statusfilter.go
@@ -1,0 +1,59 @@
+package ui
+
+import "github.com/YoanWai/agent-manager/internal/status"
+
+// statusFilter is which status set the list shows. The zero value is all
+// sessions. To add a mode: define a const, append it to statusFilterCycle,
+// and handle it in label and matches.
+type statusFilter int
+
+const (
+	statusFilterAll statusFilter = iota
+	statusFilterAttention
+)
+
+// statusFilterCycle is the order `f` walks. Append new modes before the
+// wrap back to all happens at the end of next().
+var statusFilterCycle = []statusFilter{
+	statusFilterAll,
+	statusFilterAttention,
+}
+
+func (f statusFilter) next() statusFilter {
+	for i, mode := range statusFilterCycle {
+		if mode == f {
+			return statusFilterCycle[(i+1)%len(statusFilterCycle)]
+		}
+	}
+	return statusFilterAll
+}
+
+func (f statusFilter) active() bool {
+	return f != statusFilterAll
+}
+
+// label is the short badge word for the header and empty state, empty when
+// the filter shows every status.
+func (f statusFilter) label() string {
+	switch f {
+	case statusFilterAttention:
+		return "attention"
+	default:
+		return ""
+	}
+}
+
+// matches reports whether a session status is visible under this filter.
+func (f statusFilter) matches(st string) bool {
+	switch f {
+	case statusFilterAttention:
+		switch st {
+		case status.Waiting, status.Finished, status.Errored:
+			return true
+		default:
+			return false
+		}
+	default:
+		return true
+	}
+}

--- a/internal/ui/statusfilter_test.go
+++ b/internal/ui/statusfilter_test.go
@@ -33,10 +33,10 @@ func TestStatusFilterAttentionMatches(t *testing.T) {
 
 func TestStatusFilterCycleStartsAtAttention(t *testing.T) {
 	if got := statusFilterAll.next(); got != statusFilterAttention {
-		t.Fatalf("first f press = %v want attention", got)
+		t.Fatalf("first w press = %v want attention", got)
 	}
 	if got := statusFilterAttention.next(); got != statusFilterAll {
-		t.Fatalf("second f press = %v want all (only one mode for now)", got)
+		t.Fatalf("second w press = %v want all (only one mode for now)", got)
 	}
 	if statusFilterAll.active() {
 		t.Fatal("all should not report active")
@@ -171,5 +171,80 @@ func TestStatusFilterGroupRosterMatchesCount(t *testing.T) {
 	}
 	if strings.Contains(roster, "grinding") || strings.Contains(roster, "quiet") {
 		t.Fatalf("roster should only list attention sessions:\n%s", roster)
+	}
+}
+
+func TestBulkActionsRespectStatusFilter(t *testing.T) {
+	m := buildModel(t)
+	for _, sess := range []store.Session{
+		{ID: "w", Name: "needs-you", Tool: "claude", Cwd: "/tmp", Status: status.Waiting},
+		{ID: "busy", Name: "grinding", Tool: "claude", Cwd: "/tmp", Status: status.Working},
+		{ID: "gone", Name: "killed", Tool: "claude", Cwd: "/tmp", Status: status.Dead},
+	} {
+		if err := m.store.CreateSession(sess); err != nil {
+			t.Fatalf("create session %q: %v", sess.ID, err)
+		}
+	}
+	loadStoredRows(t, m)
+	for _, id := range []string{"w", "busy"} {
+		if err := m.tmux.Create(id, t.TempDir(), "cat", nil, 80, 24); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m.statusFilter = statusFilterAttention
+	m.rebuildRows()
+
+	updated, _ := m.killAllLive()
+	m = updated.(*Model)
+	if len(m.confirm.sessions) != 1 || m.confirm.sessions[0].ID != "w" {
+		t.Fatalf("filtered kill-all targets = %+v, want only the listed session", m.confirm.sessions)
+	}
+	m.mode = modeList
+
+	if got := m.sessionsInGroup(""); len(got) != 1 || got[0].ID != "w" {
+		t.Fatalf("filtered group sessions = %+v, want only the listed session", got)
+	}
+
+	updated, _ = m.reviveAllDead()
+	m = updated.(*Model)
+	if m.errBar.text != "no dead sessions to revive" {
+		t.Fatalf("filtered revive-all touched hidden sessions: %q", m.errBar.text)
+	}
+}
+
+func TestForkClearsStatusFilter(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	createSession(t, m, "source", dir, "")
+	m.selectSessionRow(t, "source")
+	source := m.rows[m.cursor].sess
+	if err := m.store.SetAgentSessionID(source.ID, "source-conversation"); err != nil {
+		t.Fatal(err)
+	}
+	for i := range m.sessions {
+		if m.sessions[i].ID == source.ID {
+			m.sessions[i].AgentSessionID = "source-conversation"
+			m.sessions[i].Status = status.Waiting
+		}
+	}
+	m.statusFilter = statusFilterAttention
+	m.rebuildRows()
+	m.selectSessionRow(t, "source")
+
+	tool := m.cfg.Tools[source.Tool]
+	tool.ForkCommand = "true {id}; cat"
+	m.cfg.Tools[source.Tool] = tool
+
+	m.openFork()
+	m.fork.name.SetValue("fork-under-filter")
+	updated, cmd := m.handleForkKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*Model)
+	m.applyCmd(t, cmd)
+
+	if m.statusFilter != statusFilterAll {
+		t.Fatalf("fork should clear the filter, got %v", m.statusFilter)
+	}
+	if entry, ok := m.selectedRow(); !ok || entry.isGroup || entry.sess.Name != "fork-under-filter" {
+		t.Fatalf("cursor should land on the forked row, got %+v", entry)
 	}
 }

--- a/internal/ui/statusfilter_test.go
+++ b/internal/ui/statusfilter_test.go
@@ -143,3 +143,33 @@ func TestStatusFilterEmptyState(t *testing.T) {
 		t.Fatalf("rail missing empty attention copy:\n%s", rail)
 	}
 }
+
+func TestStatusFilterGroupRosterMatchesCount(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("fleet", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	for _, sess := range []store.Session{
+		{ID: "w", Name: "needs-you", Tool: "claude", Cwd: "/tmp", Group: "fleet", Status: status.Waiting},
+		{ID: "busy", Name: "grinding", Tool: "claude", Cwd: "/tmp", Group: "fleet", Status: status.Working},
+		{ID: "rest", Name: "quiet", Tool: "claude", Cwd: "/tmp", Group: "fleet", Status: status.Idle},
+	} {
+		if err := m.store.CreateSession(sess); err != nil {
+			t.Fatalf("create session %q: %v", sess.ID, err)
+		}
+	}
+	loadStoredRows(t, m)
+	m.statusFilter = statusFilterAttention
+	m.rebuildRows()
+
+	if got := m.groupSessionCount("fleet"); got != 1 {
+		t.Fatalf("group count under attention = %d want 1", got)
+	}
+	roster := ansi.Strip(m.viewGroupAgents("fleet", 60, 20))
+	if !strings.Contains(roster, "needs-you") {
+		t.Fatalf("roster missing waiting session:\n%s", roster)
+	}
+	if strings.Contains(roster, "grinding") || strings.Contains(roster, "quiet") {
+		t.Fatalf("roster should only list attention sessions:\n%s", roster)
+	}
+}

--- a/internal/ui/statusfilter_test.go
+++ b/internal/ui/statusfilter_test.go
@@ -1,0 +1,145 @@
+package ui
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestStatusFilterAttentionMatches(t *testing.T) {
+	want := map[string]bool{
+		status.Waiting:  true,
+		status.Finished: true,
+		status.Errored:  true,
+		status.Working:  false,
+		status.Idle:     false,
+		status.Dead:     false,
+		status.Starting: false,
+	}
+	for st, keep := range want {
+		if got := statusFilterAttention.matches(st); got != keep {
+			t.Fatalf("attention.matches(%q) = %v want %v", st, got, keep)
+		}
+	}
+	if !statusFilterAll.matches(status.Idle) {
+		t.Fatal("all filter should match every status")
+	}
+}
+
+func TestStatusFilterCycleStartsAtAttention(t *testing.T) {
+	if got := statusFilterAll.next(); got != statusFilterAttention {
+		t.Fatalf("first f press = %v want attention", got)
+	}
+	if got := statusFilterAttention.next(); got != statusFilterAll {
+		t.Fatalf("second f press = %v want all (only one mode for now)", got)
+	}
+	if statusFilterAll.active() {
+		t.Fatal("all should not report active")
+	}
+	if !statusFilterAttention.active() {
+		t.Fatal("attention should report active")
+	}
+	if statusFilterAttention.label() != "attention" {
+		t.Fatalf("label = %q", statusFilterAttention.label())
+	}
+}
+
+func TestStatusFilterKeyKeepsAttentionSessions(t *testing.T) {
+	m := buildModel(t)
+	for _, sess := range []store.Session{
+		{ID: "w", Name: "needs-you", Tool: "claude", Cwd: "/tmp", Status: status.Waiting},
+		{ID: "f", Name: "done-turn", Tool: "claude", Cwd: "/tmp", Status: status.Finished},
+		{ID: "e", Name: "broke", Tool: "claude", Cwd: "/tmp", Status: status.Errored},
+		{ID: "busy", Name: "grinding", Tool: "claude", Cwd: "/tmp", Status: status.Working},
+		{ID: "rest", Name: "quiet", Tool: "claude", Cwd: "/tmp", Status: status.Idle},
+		{ID: "gone", Name: "killed", Tool: "claude", Cwd: "/tmp", Status: status.Dead},
+	} {
+		if err := m.store.CreateSession(sess); err != nil {
+			t.Fatalf("create session %q: %v", sess.ID, err)
+		}
+	}
+	loadStoredRows(t, m)
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = updated.(*Model)
+	if cmd != nil {
+		m.applyCmd(t, cmd)
+	}
+	if m.statusFilter != statusFilterAttention {
+		t.Fatalf("statusFilter = %v want attention", m.statusFilter)
+	}
+	got := sessionNames(m)
+	want := []string{"needs-you", "done-turn", "broke"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("attention list = %v want %v", got, want)
+	}
+	header := ansi.Strip(strings.Join(m.viewHeaderRows(), "\n"))
+	if !strings.Contains(header, "ATTENTION") {
+		t.Fatalf("header missing ATTENTION badge:\n%s", header)
+	}
+	if !strings.Contains(header, "3 session") {
+		t.Fatalf("header count should match listed sessions:\n%s", header)
+	}
+	footer := ansi.Strip(m.viewFooter())
+	if !strings.Contains(footer, "show all") {
+		t.Fatalf("footer should offer clearing the filter:\n%s", footer)
+	}
+
+	updated, cmd = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m = updated.(*Model)
+	if cmd != nil {
+		m.applyCmd(t, cmd)
+	}
+	if m.statusFilter != statusFilterAll {
+		t.Fatalf("second f should clear filter, got %v", m.statusFilter)
+	}
+	if got := sessionNames(m); len(got) != 6 {
+		t.Fatalf("cleared filter should show all 6 sessions, got %v", got)
+	}
+}
+
+func TestStatusFilterIgnoresFolds(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("work", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	for _, sess := range []store.Session{
+		{ID: "wait", Name: "blocked", Tool: "claude", Cwd: "/tmp", Group: "work", Status: status.Waiting},
+		{ID: "idle", Name: "resting", Tool: "claude", Cwd: "/tmp", Group: "work", Status: status.Idle},
+	} {
+		if err := m.store.CreateSession(sess); err != nil {
+			t.Fatalf("create session %q: %v", sess.ID, err)
+		}
+	}
+	loadStoredRows(t, m)
+	m.collapsed["work"] = true
+	m.rebuildRows()
+	if len(m.sessionRows()) != 0 {
+		t.Fatalf("fold should hide sessions before filter, got %d", len(m.sessionRows()))
+	}
+
+	m.statusFilter = statusFilterAttention
+	m.rebuildRows()
+	got := sessionNames(m)
+	if !slices.Equal(got, []string{"blocked"}) {
+		t.Fatalf("attention filter should reveal the waiting session past the fold, got %v", got)
+	}
+}
+
+func TestStatusFilterEmptyState(t *testing.T) {
+	m := shotModel()
+	m.sessions = []store.Session{
+		{ID: "idle", Name: "quiet", Tool: "claude", Cwd: "/tmp", Status: status.Idle},
+	}
+	m.statusFilter = statusFilterAttention
+	m.rebuildRows()
+	rail := ansi.Strip(strings.Join(splitLines(joinContentText(m.railLines(40, 20))), "\n"))
+	if !strings.Contains(rail, "nothing needs attention") {
+		t.Fatalf("rail missing empty attention copy:\n%s", rail)
+	}
+}

--- a/internal/ui/statusfilter_test.go
+++ b/internal/ui/statusfilter_test.go
@@ -65,7 +65,7 @@ func TestStatusFilterKeyKeepsAttentionSessions(t *testing.T) {
 	}
 	loadStoredRows(t, m)
 
-	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}})
 	m = updated.(*Model)
 	if cmd != nil {
 		m.applyCmd(t, cmd)
@@ -90,13 +90,13 @@ func TestStatusFilterKeyKeepsAttentionSessions(t *testing.T) {
 		t.Fatalf("footer should offer clearing the filter:\n%s", footer)
 	}
 
-	updated, cmd = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	updated, cmd = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}})
 	m = updated.(*Model)
 	if cmd != nil {
 		m.applyCmd(t, cmd)
 	}
 	if m.statusFilter != statusFilterAll {
-		t.Fatalf("second f should clear filter, got %v", m.statusFilter)
+		t.Fatalf("second w should clear filter, got %v", m.statusFilter)
 	}
 	if got := sessionNames(m); len(got) != 6 {
 		t.Fatalf("cleared filter should show all 6 sessions, got %v", got)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -390,7 +390,7 @@ func (m *Model) viewFooter() string {
 		{"ctrl+r", "review"}, {"r", "rename"}, {"m", "move"},
 		{"x/X", "kill / all"}, {"v/V", "revive / all"},
 		{"a/u", "archive / restore"}, {"d", "delete"},
-		{"t", "archived"}, {"f", statusFilterAction}, {"e", emptyGroupsAction},
+		{"t", "archived"}, {"w", statusFilterAction}, {"e", emptyGroupsAction},
 		{"/", "search"}, {"|", "resize"}, {"s", "settings"},
 		{"?", "keys"}, {"q", "quit"},
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -167,7 +167,7 @@ func inGroupSubtree(sessGroup, group string) bool {
 
 func (m *Model) groupSessionCount(path string) int {
 	count := 0
-	for _, sess := range m.visibleSessions() {
+	for _, sess := range m.listedSessions() {
 		if inGroupSubtree(sess.Group, path) {
 			count++
 		}
@@ -293,7 +293,7 @@ func (m *Model) groupStatusBreakdown(group string) string {
 
 func (m *Model) groupStatusCounts(group string) map[string]int {
 	counts := map[string]int{}
-	for _, sess := range m.visibleSessions() {
+	for _, sess := range m.listedSessions() {
 		if inGroupSubtree(sess.Group, group) {
 			counts[sess.Status]++
 		}
@@ -380,13 +380,17 @@ func (m *Model) viewFooter() string {
 	if m.hideEmptyGroups {
 		emptyGroupsAction = "show empty"
 	}
+	statusFilterAction := "attention"
+	if m.statusFilter.active() {
+		statusFilterAction = "show all"
+	}
 	pairs := [][2]string{
 		{"↑↓/jk", "navigate"}, {"K/J", "reorder"}, {"↵", enterHint}, {"A", attachHint},
 		{"F", "fold all"}, {"n", "new"}, {"g", "group"}, {"f", "fork"}, {"space", "prompt"},
 		{"ctrl+r", "review"}, {"r", "rename"}, {"m", "move"},
 		{"x/X", "kill / all"}, {"v/V", "revive / all"},
 		{"a/u", "archive / restore"}, {"d", "delete"},
-		{"t", "archived"}, {"e", emptyGroupsAction},
+		{"t", "archived"}, {"f", statusFilterAction}, {"e", emptyGroupsAction},
 		{"/", "search"}, {"|", "resize"}, {"s", "settings"},
 		{"?", "keys"}, {"q", "quit"},
 	}


### PR DESCRIPTION
## Summary
- Press `w` to show only sessions that need attention (`waiting`, `finished`, `errored`); press again to show all.
- Header badge, session counts, and group rollups follow the filter; folds open so matches stay visible.
- Filter modes live in `statusFilterCycle` so more statuses can be added later without rewiring keys.

## Test plan
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./internal/ui/ -run StatusFilter`
- [ ] Manual: with mixed statuses, `w` shows only attention rows and `ATTENTION` badge; second `w` restores the full list
- [ ] Manual: folded group still reveals a waiting session under the filter
- [ ] Manual: `?` help and footer list the new binding
