### PR TITLE
fix(ui): honor the default tool in new sessions

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -252,7 +252,7 @@ func (m *Model) enabledToolNames() []string {
 }
 
 func (m *Model) openForm() {
-	tools := m.enabledToolNames()
+	tools, toolIndex := m.defaultToolSelection()
 	if len(tools) == 0 {
 		m.errBar.text = "no CLIs enabled: open settings (s), then CLIs, to turn some on"
 		return
@@ -270,6 +270,7 @@ func (m *Model) openForm() {
 		prompt:    prompt,
 		dirAuto:   true,
 		toolNames: tools,
+		toolIndex: toolIndex,
 		focus:     fieldName,
 	}
 	m.errBar.text = ""

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
+func TestNewSessionFormUsesSettingsDefaultTool(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.SetSetting("default_tool", "ready-tool"); err != nil {
+		t.Fatal(err)
+	}
+	m.openForm()
+	if got := m.form.toolNames[m.form.toolIndex]; got != "ready-tool" {
+		t.Fatalf("new session tool = %q, want settings default", got)
+	}
+}
+
 func TestNewSessionPreselectsContextGroup(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -260,7 +260,7 @@ func (m *Model) viewSettings() string {
 	actionRow := func(field int, name, action string) string {
 		return lead(field, name) + keyStyle.Render("↵") + mutedStyle.Render(" "+action)
 	}
-	body := row(settingsFieldTool, "quick spawn tool", toolValue) + "\n" +
+	body := row(settingsFieldTool, "default tool", toolValue) + "\n" +
 		row(settingsFieldTheme, "theme", themes[m.settings.themeIndex].Name) + "  " +
 		themeSwatch(themes[m.settings.themeIndex]) + "\n" +
 		row(settingsFieldDensity, "list density", density) + "\n" +
@@ -374,7 +374,7 @@ func (m *Model) viewHelp() string {
 		{"b", "in review: pick the branch from the repo's worktrees"},
 		{"B", "in review: pick the target (merge-into branch) the branch diff compares against"},
 		{"F", "fold / unfold all groups"},
-		{"s", "settings (CLIs, theme, quick spawn, review layout)"},
+		{"s", "settings (CLIs, theme, default tool, review layout)"},
 		{"|", "resize split (←→ / drag, enter commits, esc cancels)"},
 		{"t", "toggle archived view"},
 		{"M", "messages (updates, tips, bug reporting; x dismisses)"},


### PR DESCRIPTION
## Summary

- initialize the New Session tool picker from the Settings default
- label the setting consistently as the default tool
- add a regression test for the selected tool

## Why

Quick spawn honored this setting, but the New Session form always selected the first enabled tool.

## Verification

- `gofmt -l .`
- `go vet ./...`
- `env -u TMUX TMUX_TMPDIR=/tmp/amtest-default go test -race ./...`
- `go build ./...`