### PR TITLE
feat(update): credit outside contributors in the release digest

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -38,7 +38,7 @@ var releasesURL = "https://api.github.com/repos/YoanWai/agent-manager/releases?p
 
 var (
 	conventionalTitle = regexp.MustCompile(`(?i)^(feat|fix|docs|refactor|perf|test|build|ci|chore|style)(?:\(([^)]+)\))?!?:\s*(.+)$`)
-	pullSuffix        = regexp.MustCompile(`\s+by\s+@[A-Za-z0-9-]+\s+in\s+https://github\.com/\S+\s*$`)
+	pullSuffix        = regexp.MustCompile(`\s+by\s+(@[A-Za-z0-9-]+(?:\[bot])?)\s+in\s+https://github\.com/\S+\s*$`)
 	markdownLink      = regexp.MustCompile(`\[([^]]+)]\([^)]+\)`)
 )
 
@@ -270,6 +270,14 @@ func extractChanges(body string) ([]string, int) {
 }
 
 func cleanChange(change string) string {
+	// Credit outside contributors on their digest lines; the maintainer's
+	// own handle and bot handles would be noise on every row.
+	author := ""
+	if match := pullSuffix.FindStringSubmatch(change); match != nil {
+		if handle := match[1]; handle != "@YoanWai" && !strings.HasSuffix(handle, "[bot]") {
+			author = handle
+		}
+	}
 	change = pullSuffix.ReplaceAllString(change, "")
 	change = markdownLink.ReplaceAllString(change, "$1")
 	change = strings.ReplaceAll(change, "`", "")
@@ -287,6 +295,9 @@ func cleanChange(change string) string {
 	runes := []rune(change)
 	if len(runes) > maxChangeLength {
 		change = strings.TrimSpace(string(runes[:maxChangeLength-1])) + "…"
+	}
+	if author != "" {
+		change += " · " + author
 	}
 	return change
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -61,6 +61,8 @@ func TestExtractChangesHumanizesGeneratedNotes(t *testing.T) {
 		"",
 		"## What's Changed",
 		"* fix(groups): make group creation immediate and reliable by @YoanWai in https://github.com/YoanWai/agent-manager/pull/191",
+		"* feat(config): add Pi as a built-in tool by @steveprentice in https://github.com/YoanWai/agent-manager/pull/201",
+		"* chore(deps): bump gopsutil by @dependabot[bot] in https://github.com/YoanWai/agent-manager/pull/210",
 		"- feat(ui): add a [message browser](https://example.com) with `scrolling`",
 		"- feat(mcp-editor): expose tool capabilities",
 		"",
@@ -71,6 +73,8 @@ func TestExtractChangesHumanizesGeneratedNotes(t *testing.T) {
 	changes, total := extractChanges(body)
 	want := []string{
 		"Groups: Make group creation immediate and reliable",
+		"Config: Add Pi as a built-in tool · @steveprentice",
+		"Deps: Bump gopsutil",
 		"UI: Add a message browser with scrolling",
 		"MCP editor: Expose tool capabilities",
 	}


### PR DESCRIPTION
## What changed

- `cleanChange` keeps the PR author handle it previously stripped and appends it to the digest line as ` · @user`.
- The maintainer's own handle and `[bot]` accounts stay omitted, so attribution only appears on outside contributions.

## Why

v0.20.0 is the first release with outside contributors, and the in-app messages digest dropped their names entirely; the thanks only existed on the GitHub release page.

## Verification

- `gofmt -l .` clean, `go vet ./...` clean
- `go test -race ./internal/update/ ./internal/ui/` green on an isolated tmux socket
- Extended `TestExtractChangesHumanizesGeneratedNotes` with real v0.20.0 changelog lines: contributor line gains ` · @steveprentice`, owner and dependabot lines stay bare.