### PR TITLE
feat(update): update in place from any install source

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,7 @@ Run inside [WSL2](https://learn.microsoft.com/windows/wsl/install): agent-manage
 
 ## Updating
 
-The manager checks GitHub Releases once a day and shows a `↑ vX.Y.Z available` badge in the header when a newer version is out. Press `u` on the update message (or `enter` on the version row in Settings) and the manager updates itself whatever the install source: a Homebrew, mise, or AUR install hands the terminal to that package manager's upgrade command, a direct install downloads the release and swaps the binary in place, and either way the manager restarts into the new build with every session intact.
+The manager checks GitHub Releases once a day and shows a `↑ vX.Y.Z available` badge in the header when a newer version is out. Press `u` on the update message (or `enter` on the version row in Settings) and the manager updates itself whatever the install source: a Homebrew, mise, or AUR install hands the terminal to that package manager's upgrade command, a direct install downloads the release and swaps the binary in place, and either way the manager restarts into the new build with every session intact. A pacman install needs an AUR helper (`yay` or `paru`) on PATH; without one the manager shows the command to run instead: `yay -S agent-manager-bin`.
 
 The same commands work from a shell:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,9 @@ Run inside [WSL2](https://learn.microsoft.com/windows/wsl/install): agent-manage
 
 ## Updating
 
-The manager checks GitHub Releases once a day and shows a `↑ vX.Y.Z available` badge in the header when a newer version is out. Pull it in the way you installed:
+The manager checks GitHub Releases once a day and shows a `↑ vX.Y.Z available` badge in the header when a newer version is out. Press `u` on the update message (or `enter` on the version row in Settings) and the manager updates itself whatever the install source: a Homebrew, mise, or AUR install hands the terminal to that package manager's upgrade command, a direct install downloads the release and swaps the binary in place, and either way the manager restarts into the new build with every session intact.
+
+The same commands work from a shell:
 
 ```bash
 brew upgrade yoanwai/tap/agent-manager                                                    # Homebrew

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -420,9 +421,26 @@ var applyUpdate = update.Apply
 // even when several releases landed after the notice was first cached.
 var refreshUpdatesForApply = update.Refresh
 
-// applyUpdateCmd downloads the latest release off the event loop, swaps
-// the running binary, and reports the path to restart into.
+// detectManager is the install-source seam: tests swap it to steer u
+// between the in-place swap and a delegated package manager.
+var detectManager = update.DetectManager
+
+// applyUpdateCmd routes u by install source. A package-manager install
+// hands the terminal to that manager's upgrade command; a direct install
+// downloads the latest release off the event loop and swaps the running
+// binary. Both report the path to restart into.
 func (m *Model) applyUpdateCmd() tea.Cmd {
+	execPath, err := os.Executable()
+	if err != nil {
+		return func() tea.Msg { return updateAppliedMsg{err: err} }
+	}
+	manager := detectManager(execPath)
+	if manager.Advice != "" {
+		return func() tea.Msg { return updateAppliedMsg{err: errors.New(manager.Advice)} }
+	}
+	if manager.Delegated() {
+		return delegatedUpdateCmd(manager, execPath)
+	}
 	return func() tea.Msg {
 		dir, err := config.Dir()
 		if err != nil {
@@ -435,15 +453,28 @@ func (m *Model) applyUpdateCmd() tea.Cmd {
 		if result.Latest == "" {
 			return updateAppliedMsg{result: result, upToDate: true}
 		}
-		execPath, err := os.Executable()
-		if err != nil {
-			return updateAppliedMsg{result: result, err: err}
-		}
 		if err := applyUpdate(context.Background(), result.Latest, execPath); err != nil {
 			return updateAppliedMsg{result: result, err: err}
 		}
 		return updateAppliedMsg{path: execPath, result: result}
 	}
+}
+
+// delegatedUpdateCmd suspends the TUI and runs the manager's upgrade
+// command on the real terminal, so its progress output and any password
+// prompt work as in a plain shell.
+func delegatedUpdateCmd(manager update.Manager, execPath string) tea.Cmd {
+	command := exec.Command(manager.Command[0], manager.Command[1:]...)
+	return tea.ExecProcess(command, func(err error) tea.Msg {
+		return delegatedUpdateResult(manager, execPath, err)
+	})
+}
+
+func delegatedUpdateResult(manager update.Manager, execPath string, err error) updateAppliedMsg {
+	if err != nil {
+		return updateAppliedMsg{err: fmt.Errorf("%s: %w", manager.String(), err)}
+	}
+	return updateAppliedMsg{path: update.RestartTarget(execPath)}
 }
 
 func (m *Model) handleNoticesKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/notices_test.go
+++ b/internal/ui/notices_test.go
@@ -908,3 +908,68 @@ func uiReleaseWithTotal(version string, total int, changes ...string) update.Rel
 		TotalChanges: total,
 	}
 }
+
+func TestUpdateDelegatesToPackageManager(t *testing.T) {
+	m := noticeModel(noticeStore(t), "v0.2.0")
+	m.update.latest = "v0.3.0"
+	m.openNotices("update-v0.3.0")
+
+	origDetect := detectManager
+	defer func() { detectManager = origDetect }()
+	detectManager = func(string) update.Manager {
+		return update.Manager{Name: "Homebrew", Command: []string{"brew", "upgrade", "--cask", "yoanwai/tap/agent-manager"}}
+	}
+
+	_, cmd := m.handleNoticesKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	if cmd == nil {
+		t.Fatal("u on a package-manager install should start the delegated upgrade")
+	}
+	if !m.update.applying {
+		t.Fatal("applying should be marked while the manager runs")
+	}
+}
+
+func TestDelegatedUpdateResult(t *testing.T) {
+	manager := update.Manager{Name: "Homebrew", Command: []string{"brew", "upgrade", "--cask", "yoanwai/tap/agent-manager"}}
+	// A base name no PATH holds, so RestartTarget deterministically falls
+	// back to execPath on any machine.
+	execPath := "/x/agent-manager-delegated-test"
+
+	msg := delegatedUpdateResult(manager, execPath, nil)
+	if msg.err != nil {
+		t.Fatalf("success reported %v", msg.err)
+	}
+	if msg.path != execPath {
+		t.Fatalf("restart path = %q, want %q", msg.path, execPath)
+	}
+
+	failed := delegatedUpdateResult(manager, execPath, errors.New("exit status 1"))
+	if failed.err == nil || !strings.Contains(failed.err.Error(), "brew upgrade --cask yoanwai/tap/agent-manager") {
+		t.Fatalf("failure should name the command, got %v", failed.err)
+	}
+	if failed.path != "" {
+		t.Fatal("a failed upgrade must not restart")
+	}
+}
+
+func TestUpdateWithoutRunnableManagerSurfacesAdvice(t *testing.T) {
+	m := noticeModel(noticeStore(t), "v0.2.0")
+	m.update.latest = "v0.3.0"
+	m.openNotices("update-v0.3.0")
+
+	origDetect := detectManager
+	defer func() { detectManager = origDetect }()
+	advice := "installed with pacman; install an AUR helper first, then: yay -S agent-manager-bin"
+	detectManager = func(string) update.Manager {
+		return update.Manager{Name: "pacman", Advice: advice}
+	}
+
+	_, cmd := m.handleNoticesKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	if cmd == nil {
+		t.Fatal("u should still answer with the advice")
+	}
+	msg, ok := cmd().(updateAppliedMsg)
+	if !ok || msg.err == nil || msg.err.Error() != advice {
+		t.Fatalf("want the advice as the error, got %#v", cmd())
+	}
+}

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -44,23 +44,7 @@ func homebrewManaged(source, execPath string) bool {
 	if resolved, err := filepath.EvalSymlinks(execPath); err == nil {
 		path = resolved
 	}
-	parts := strings.Split(filepath.ToSlash(path), "/")
-	for i := 0; i+1 < len(parts); i++ {
-		if parts[i+1] != "agent-manager" {
-			continue
-		}
-		switch parts[i] {
-		case "Cellar", "Caskroom":
-			return true
-		case "opt":
-			// Only brew's opt tree counts: /opt/agent-manager is a
-			// conventional manual-install prefix, not Homebrew.
-			if i > 0 && (parts[i-1] == "homebrew" || parts[i-1] == ".linuxbrew") {
-				return true
-			}
-		}
-	}
-	return false
+	return homebrewTree(filepath.ToSlash(path)) != ""
 }
 
 // Apply downloads the release named by tag, verifies the archive for this

--- a/internal/update/source.go
+++ b/internal/update/source.go
@@ -1,0 +1,122 @@
+package update
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Manager describes who owns the installed binary. A delegated manager
+// carries the upgrade command that replaces the in-place download, and
+// Advice names the command to run by hand when none is runnable here.
+type Manager struct {
+	Name    string
+	Command []string
+	Advice  string
+}
+
+func (m Manager) Delegated() bool { return len(m.Command) > 0 }
+
+func (m Manager) String() string { return strings.Join(m.Command, " ") }
+
+// Test seams: lookPath finds upgrade helpers, pacmanOwns asks pacman
+// whether it installed the binary.
+var (
+	lookPath   = exec.LookPath
+	pacmanOwns = pacmanOwnsPath
+)
+
+// DetectManager reports which package manager owns the binary at execPath,
+// from the ldflag package managers inject and the resolved install path.
+// The zero Manager means the install is direct (install script, go install,
+// manual download) and self-updates in place.
+func DetectManager(execPath string) Manager {
+	path := execPath
+	if resolved, err := filepath.EvalSymlinks(execPath); err == nil {
+		path = resolved
+	}
+	slashPath := filepath.ToSlash(path)
+	switch {
+	case homebrewTree(slashPath) == "Caskroom":
+		return Manager{Name: "Homebrew", Command: []string{"brew", "upgrade", "--cask", "yoanwai/tap/agent-manager"}}
+	case buildSource == "Homebrew" || homebrewTree(slashPath) != "":
+		return Manager{Name: "Homebrew", Command: []string{"brew", "upgrade", "agent-manager"}}
+	case miseManaged(slashPath):
+		return Manager{Name: "mise", Command: []string{"mise", "upgrade", "--bump", "ubi:YoanWai/agent-manager"}}
+	case pacmanOwns(path):
+		return archManager()
+	}
+	return Manager{}
+}
+
+// homebrewTree reports which Homebrew install tree the path sits in:
+// "Caskroom", "Cellar", "opt", or "" when the path is not a brew install.
+func homebrewTree(slashPath string) string {
+	parts := strings.Split(slashPath, "/")
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i+1] != "agent-manager" {
+			continue
+		}
+		switch parts[i] {
+		case "Cellar", "Caskroom":
+			return parts[i]
+		case "opt":
+			// Only brew's opt tree counts: /opt/agent-manager is a
+			// conventional manual-install prefix, not Homebrew.
+			if i > 0 && (parts[i-1] == "homebrew" || parts[i-1] == ".linuxbrew") {
+				return parts[i]
+			}
+		}
+	}
+	return ""
+}
+
+// miseManaged matches mise's install layout regardless of MISE_DATA_DIR:
+// .../installs/ubi-yoan-wai-agent-manager/<version>/agent-manager.
+func miseManaged(slashPath string) bool {
+	parts := strings.Split(slashPath, "/")
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i] != "installs" {
+			continue
+		}
+		tool := parts[i+1]
+		if strings.HasPrefix(tool, "ubi-") && strings.HasSuffix(tool, "-agent-manager") {
+			return true
+		}
+	}
+	return false
+}
+
+func pacmanOwnsPath(path string) bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	pacman, err := lookPath("pacman")
+	if err != nil {
+		return false
+	}
+	return exec.Command(pacman, "-Qqo", path).Run() == nil
+}
+
+// archManager picks an installed AUR helper; pacman alone cannot build
+// agent-manager-bin from the AUR.
+func archManager() Manager {
+	for _, helper := range []string{"yay", "paru"} {
+		if _, err := lookPath(helper); err == nil {
+			return Manager{Name: helper, Command: []string{helper, "-S", "agent-manager-bin"}}
+		}
+	}
+	return Manager{Name: "pacman", Advice: "installed with pacman; install an AUR helper first, then: yay -S agent-manager-bin"}
+}
+
+// RestartTarget is the path main should exec after a delegated upgrade.
+// The PATH entry wins over the resolved install dir: brew and mise may
+// delete the version directory the running image was loaded from, while
+// the PATH entry tracks the new install.
+func RestartTarget(execPath string) string {
+	if found, err := lookPath(filepath.Base(execPath)); err == nil {
+		return found
+	}
+	return execPath
+}

--- a/internal/update/source.go
+++ b/internal/update/source.go
@@ -80,8 +80,7 @@ func miseManaged(slashPath string) bool {
 		if parts[i] != "installs" {
 			continue
 		}
-		tool := parts[i+1]
-		if strings.HasPrefix(tool, "ubi-") && strings.HasSuffix(tool, "-agent-manager") {
+		if parts[i+1] == "ubi-yoan-wai-agent-manager" {
 			return true
 		}
 	}

--- a/internal/update/source_test.go
+++ b/internal/update/source_test.go
@@ -97,6 +97,10 @@ func TestDetectManager(t *testing.T) {
 			wantAdvice:  true,
 		},
 		{
+			label: "another ubi tool is direct",
+			path:  "/home/user/.local/share/mise/installs/ubi-other-user-agent-manager/1.0.0/agent-manager",
+		},
+		{
 			label: "install script dir is direct",
 			path:  "/home/user/.local/bin/agent-manager",
 		},

--- a/internal/update/source_test.go
+++ b/internal/update/source_test.go
@@ -1,0 +1,183 @@
+package update
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func stubSourceSeams(t *testing.T, helpers map[string]string, owned bool) {
+	t.Helper()
+	origLook := lookPath
+	origOwns := pacmanOwns
+	t.Cleanup(func() {
+		lookPath = origLook
+		pacmanOwns = origOwns
+	})
+	lookPath = func(name string) (string, error) {
+		if path, ok := helpers[name]; ok {
+			return path, nil
+		}
+		return "", errors.New("not found")
+	}
+	pacmanOwns = func(string) bool { return owned }
+}
+
+func TestDetectManager(t *testing.T) {
+	cases := []struct {
+		label       string
+		source      string
+		path        string
+		helpers     map[string]string
+		pacmanOwned bool
+		wantName    string
+		wantCommand string
+		wantAdvice  bool
+	}{
+		{
+			label:       "caskroom upgrades the tap cask",
+			path:        "/opt/homebrew/Caskroom/agent-manager/0.19.0/agent-manager",
+			wantName:    "Homebrew",
+			wantCommand: "brew upgrade --cask yoanwai/tap/agent-manager",
+		},
+		{
+			label:       "cellar upgrades the formula",
+			path:        "/opt/homebrew/Cellar/agent-manager/0.19.0/bin/agent-manager",
+			wantName:    "Homebrew",
+			wantCommand: "brew upgrade agent-manager",
+		},
+		{
+			label:       "linuxbrew opt tree",
+			path:        "/home/linuxbrew/.linuxbrew/opt/agent-manager/bin/agent-manager",
+			wantName:    "Homebrew",
+			wantCommand: "brew upgrade agent-manager",
+		},
+		{
+			label:       "homebrew ldflag without a brew path",
+			source:      "Homebrew",
+			path:        "/usr/local/bin/agent-manager",
+			wantName:    "Homebrew",
+			wantCommand: "brew upgrade agent-manager",
+		},
+		{
+			label:       "mise install dir",
+			path:        "/home/user/.local/share/mise/installs/ubi-yoan-wai-agent-manager/0.19.0/agent-manager",
+			wantName:    "mise",
+			wantCommand: "mise upgrade --bump ubi:YoanWai/agent-manager",
+		},
+		{
+			label:       "mise custom data dir",
+			path:        "/data/tools/installs/ubi-yoan-wai-agent-manager/0.20.0/agent-manager",
+			wantName:    "mise",
+			wantCommand: "mise upgrade --bump ubi:YoanWai/agent-manager",
+		},
+		{
+			label:       "pacman owned with yay",
+			path:        "/usr/bin/agent-manager",
+			helpers:     map[string]string{"yay": "/usr/bin/yay"},
+			pacmanOwned: true,
+			wantName:    "yay",
+			wantCommand: "yay -S agent-manager-bin",
+		},
+		{
+			label:       "pacman owned with paru only",
+			path:        "/usr/bin/agent-manager",
+			helpers:     map[string]string{"paru": "/usr/bin/paru"},
+			pacmanOwned: true,
+			wantName:    "paru",
+			wantCommand: "paru -S agent-manager-bin",
+		},
+		{
+			label:       "pacman owned without a helper",
+			path:        "/usr/bin/agent-manager",
+			pacmanOwned: true,
+			wantName:    "pacman",
+			wantAdvice:  true,
+		},
+		{
+			label: "install script dir is direct",
+			path:  "/home/user/.local/bin/agent-manager",
+		},
+		{
+			label: "gopath is direct",
+			path:  "/home/user/go/bin/agent-manager",
+		},
+		{
+			label: "manual opt prefix is direct",
+			path:  "/opt/agent-manager/bin/agent-manager",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			stubSourceSeams(t, tc.helpers, tc.pacmanOwned)
+			origSource := buildSource
+			buildSource = tc.source
+			t.Cleanup(func() { buildSource = origSource })
+
+			manager := DetectManager(tc.path)
+			if manager.Name != tc.wantName {
+				t.Fatalf("Name = %q, want %q", manager.Name, tc.wantName)
+			}
+			if manager.String() != tc.wantCommand {
+				t.Fatalf("Command = %q, want %q", manager.String(), tc.wantCommand)
+			}
+			if (manager.Advice != "") != tc.wantAdvice {
+				t.Fatalf("Advice = %q, wantAdvice %v", manager.Advice, tc.wantAdvice)
+			}
+			if manager.Delegated() != (tc.wantCommand != "") {
+				t.Fatalf("Delegated() = %v with command %q", manager.Delegated(), tc.wantCommand)
+			}
+		})
+	}
+}
+
+func TestDetectManagerFollowsSymlink(t *testing.T) {
+	stubSourceSeams(t, nil, false)
+	dir := t.TempDir()
+	caskroom := filepath.Join(dir, "Caskroom", "agent-manager", "0.19.0")
+	if err := os.MkdirAll(caskroom, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	real := filepath.Join(caskroom, "agent-manager")
+	if err := os.WriteFile(real, []byte("cask build"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "bin", "agent-manager")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	manager := DetectManager(link)
+	if manager.String() != "brew upgrade --cask yoanwai/tap/agent-manager" {
+		t.Fatalf("symlink into Caskroom got %q", manager.String())
+	}
+}
+
+func TestPacmanOwnsOffLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("exercises the non-linux short circuit")
+	}
+	if pacmanOwnsPath("/usr/bin/agent-manager") {
+		t.Fatal("pacman ownership must be linux-only")
+	}
+}
+
+func TestRestartTargetPrefersPathEntry(t *testing.T) {
+	stubSourceSeams(t, map[string]string{"agent-manager": "/opt/homebrew/bin/agent-manager"}, false)
+	got := RestartTarget("/opt/homebrew/Caskroom/agent-manager/0.19.0/agent-manager")
+	if got != "/opt/homebrew/bin/agent-manager" {
+		t.Fatalf("RestartTarget = %q", got)
+	}
+}
+
+func TestRestartTargetFallsBackToExecPath(t *testing.T) {
+	stubSourceSeams(t, nil, false)
+	got := RestartTarget("/weird/place/agent-manager")
+	if got != "/weird/place/agent-manager" {
+		t.Fatalf("RestartTarget = %q", got)
+	}
+}


### PR DESCRIPTION
## What

`u` on the update message (and `enter` on the Settings version row) now updates every install source instead of refusing package-manager installs with an error.

## How

- `internal/update/source.go`: `DetectManager` reports who owns the binary from the `main.buildSource` ldflag and the symlink-resolved install path: Homebrew Caskroom/Cellar/opt trees, mise's `installs/ubi-…-agent-manager` layout, and `pacman -Qqo` ownership on Linux. Everything else is a direct install.
- Package-manager installs suspend the TUI with `tea.ExecProcess` and hand the real terminal to the manager's own upgrade command (`brew upgrade --cask yoanwai/tap/agent-manager`, `brew upgrade agent-manager`, `mise upgrade --bump ubi:YoanWai/agent-manager`, `yay`/`paru -S agent-manager-bin`), so progress output and password prompts work as in a plain shell.
- Direct installs keep the verified download and atomic swap.
- On success the manager restarts into the new build through the PATH entry: brew and mise delete the version directory the running image was loaded from, so the resolved exec path of the old build can vanish mid-upgrade.
- A pacman install without an AUR helper surfaces the exact command to run instead of attempting anything.

## Verification

- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...` green, `gofmt`/`go vet` clean.
- Live end-to-end on the Homebrew cask path: built this branch as 0.19.0 into the real Caskroom, pressed `u` on the update message, watched `brew upgrade --cask` run on the terminal, and the manager came back as 0.20.0 (`✦ Updated to 0.20.0` digest, process running `/opt/homebrew/bin/agent-manager`) with every session intact.
- mise layout verified against a real `mise use -g ubi:YoanWai/agent-manager` install (`installs/ubi-yoan-wai-agent-manager/<version>/agent-manager`).