### PR TITLE
fix(ui): add bidi controls to pane rows only when they hold RTL text

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -376,11 +376,30 @@ func previewLine(line string, width int) string {
 	if w < width {
 		line += strings.Repeat(" ", width-w)
 	}
+	if !containsRTL(line) {
+		// Terminals that give format characters a cell (Windows Terminal
+		// under conpty) would overflow the row and scroll the whole frame.
+		return line
+	}
 	// LRM is strong LTR (zero width). On rows where the rail is only neutrals,
 	// a leading Hebrew run is the line's first strong character; hosts that
 	// right-justify RTL paragraphs then pull the pane into the rail. Isolate
 	// plus a full-width pad keep the run inside the content column.
 	return "\u200e\u2066" + line + "\u2069"
+}
+
+func containsRTL(line string) bool {
+	for _, r := range line {
+		if r < 0x0590 {
+			continue
+		}
+		props, _ := bidi.LookupRune(r)
+		switch props.Class() {
+		case bidi.R, bidi.AL:
+			return true
+		}
+	}
+	return false
 }
 
 // paneExact returns up to n lines of pane text as captured, preserving

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -92,6 +92,10 @@ func TestPreviewLine(t *testing.T) {
 	if closed := previewLine("\x1b[31m\u05e9\u05dc\u05d5\u05dd\x1b[0m", 80); !strings.HasSuffix(closed, "\u2069") {
 		t.Fatalf("RTL line must close the isolate: %q", closed)
 	}
+	arabic := previewLine("\u0645\u0631\u062d\u0628\u0627", 40)
+	if !strings.HasPrefix(arabic, "\u200e\u2066") || !strings.HasSuffix(arabic, "\u2069") {
+		t.Fatalf("Arabic (bidi.AL) row must be isolated: %q", arabic)
+	}
 
 	erased := "abc\x1b[K\x1b[2Jdef"
 	if got := stripPreviewMarks(ansi.Strip(previewLine(erased, 80))); strings.TrimRight(got, " ") != "abcdef" {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -86,8 +86,11 @@ func TestPreviewLine(t *testing.T) {
 	if !strings.Contains(got, "\x1b[38;5;42m") {
 		t.Fatalf("color escapes should survive: %q", got)
 	}
-	if !strings.Contains(got, "\x1b[0m") || !strings.HasSuffix(got, "\u2069") {
-		t.Fatalf("line with ANSI must reset SGR and close the isolate: %q", got)
+	if !strings.Contains(got, "\x1b[0m") {
+		t.Fatalf("line with ANSI must reset SGR: %q", got)
+	}
+	if closed := previewLine("\x1b[31m\u05e9\u05dc\u05d5\u05dd\x1b[0m", 80); !strings.HasSuffix(closed, "\u2069") {
+		t.Fatalf("RTL line must close the isolate: %q", closed)
 	}
 
 	erased := "abc\x1b[K\x1b[2Jdef"
@@ -114,8 +117,11 @@ func TestPreviewLine(t *testing.T) {
 	if strings.Contains(plain, "\x1b") {
 		t.Fatalf("plain line should gain no escapes: %q", plain)
 	}
-	if !strings.HasPrefix(plain, "\u200e\u2066") || !strings.HasSuffix(plain, "\u2069") {
-		t.Fatalf("pane row should open LTR and stay isolated: %q", plain)
+	// Terminals that give format characters a cell (Windows Terminal under
+	// conpty, issue 213) overflow the row and scroll the whole frame, so a
+	// line without an RTL run must carry no bidi controls at all.
+	if strings.ContainsAny(plain, "\u200e\u2066\u2069") {
+		t.Fatalf("LTR-only pane row must carry no bidi controls: %q", plain)
 	}
 	if w := ansi.StringWidth(plain); w != 80 {
 		t.Fatalf("pane row should fill its column, width %d", w)


### PR DESCRIPTION
## Problem

#213: dashboard flickers on WSL2 since v0.18.

Since v0.18 (#192, extended in #204) every preview row is wrapped in invisible bidi format characters (LRM + LRI/PDI). Windows Terminal under conpty gives such zero-width format characters a full cell (microsoft/terminal#8667). Each full-width row then renders 3 cells too wide, wraps, the terminal scrolls, and the renderer repaints the whole frame on every preview tick: constant flicker.

Frame pulled from the issue's recording shows the torn repaint (dashboard and session view interleaved mid-scroll).

## Fix

`previewLine` adds the LRM+isolate wrapper only when the row contains a strong RTL character (bidi classes R/AL). LTR-only rows, the common case and the reporter's case, carry no format characters at all, matching pre-0.18 output. RTL panes keep the #192/#204 containment; terminals that reorder bidi treat the controls as zero-width, so they are unaffected.

## Verification

- New test: LTR-only rows must carry no bidi controls; RTL rows must still open LTR and close the isolate.
- Full suite green on isolated tmux socket.
- Mechanism evidence: `go-runewidth` (wcwidth-style, same class of table conpty uses) measures U+2066 as width 1 while `x/ansi` measures 0, and microsoft/terminal#8667 documents the one-cell rendering. Not reproduced live on WSL2 (no Windows box here); asking the reporter to confirm on this build.

Fixes #213