### PR TITLE
fix(ui): stop the wheel from walking the session cursor

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,7 +39,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `?` | Help |
 | `q` | Quit (sessions keep running) |
 
-The wheel scrolls the list and the diff. Mouse tracking stays off so click-drag keeps selecting text natively in your terminal, which is why the pointer does not move the selection ([#110](https://github.com/YoanWai/agent-manager/issues/110)).
+Navigation is keyboard-driven. Mouse tracking stays off so click-drag keeps selecting text natively in your terminal, which is why the pointer does not move the selection; mouse support is tracked in [#110](https://github.com/YoanWai/agent-manager/issues/110). Inside a focused session the wheel walks that pane's scrollback.
 
 ## Quick prompt
 

--- a/internal/ui/altscroll.go
+++ b/internal/ui/altscroll.go
@@ -3,18 +3,11 @@ package ui
 import "os"
 
 // DECSET 1007 (alternate scroll) makes the terminal translate wheel events
-// into arrow keys while the alt screen is up. The manager keeps mouse
-// tracking off so click+drag selects text natively; without 1007 the wheel
-// would scroll the host's scrollback and push the manager out of view.
-const (
-	altScrollOn  = "\x1b[?1007h"
-	altScrollOff = "\x1b[?1007l"
-)
-
-func EnableAlternateScroll() error {
-	_, err := os.Stdout.WriteString(altScrollOn)
-	return err
-}
+// into arrow keys while the alt screen is up. The manager turns it off: the
+// arrows are indistinguishable from real ones, so a wheel notch walked the
+// session cursor. Mouse tracking stays off outside focus mode, so the wheel
+// is inert in the list until real mouse handling lands (#110).
+const altScrollOff = "\x1b[?1007l"
 
 func DisableAlternateScroll() error {
 	_, err := os.Stdout.WriteString(altScrollOff)

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -144,15 +144,12 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 }
 
 // leaveFocus returns to the list and gives the mouse back to the terminal,
-// restoring native selection and wheel-as-arrows.
+// restoring native selection.
 func (m *Model) leaveFocus() tea.Cmd {
 	m.mode = modeList
 	m.sel = focusSelection{}
 	m.copied = 0
-	return tea.Sequence(tea.DisableMouse, func() tea.Msg {
-		_ = EnableAlternateScroll()
-		return nil
-	})
+	return tea.DisableMouse
 }
 
 // handleFocusKey forwards every key into the focused pane. Ctrl+Q and

--- a/main.go
+++ b/main.go
@@ -175,10 +175,11 @@ func run() error {
 
 	model := ui.New(cfg, st, driver, engine, hooks.NewManager(dir), version)
 	// Mouse reporting stays off so the terminal keeps native text selection.
-	// Alternate scroll then turns the wheel into arrow keys instead of host
-	// scrollback, so the manager cannot be scrolled out of view.
+	// Alternate scroll stays off too, so the wheel is inert in the list
+	// instead of arriving as arrow keys that walk the session cursor; a
+	// crashed earlier run can leave it set, so clear it on the way in.
 	program := tea.NewProgram(model, tea.WithAltScreen())
-	if err := ui.EnableAlternateScroll(); err != nil {
+	if err := ui.DisableAlternateScroll(); err != nil {
 		return err
 	}
 	// The terminal's own background follows the theme while the manager
@@ -189,9 +190,6 @@ func run() error {
 	model.StartPoller(program.Send)
 	final, runErr := program.Run()
 	ui.ResetTerminalBackground()
-	if err := ui.DisableAlternateScroll(); err != nil && runErr == nil {
-		runErr = err
-	}
 	if runErr == nil {
 		if finished, ok := final.(*ui.Model); ok && finished.RestartPath() != "" {
 			// A self-update swapped the binary on disk; exec replaces this


### PR DESCRIPTION
The wheel moved the session cursor in the list. Mouse tracking is off outside focus mode, so those events never arrived as mouse events: alternate scroll (DECSET 1007) had the terminal translate each notch into an arrow key, and the list handled it like any other `up`/`down`. A wheel notch therefore retargeted every following keystroke.

1007 is now off. The wheel is inert in the list until real mouse handling lands (#110), and the sequence is cleared at startup so a crashed earlier run cannot leave it set. Focus mode is unchanged: it enables mouse reporting itself, so pane selection, double/triple click and wheel-through-scrollback all keep working.

Verified: `[?1007l` is emitted at startup and `[?1007h` never is, captured from a pty run of the built binary. Full suite green on an isolated tmux socket.