### PR TITLE
feat(ui): highlight report-a-bug and point people at Settings

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,7 +34,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `\|` | Resize the split: `←→` nudge the divider, `enter` commits, `esc` cancels |
 | `t` | Toggle archived view |
 | `w` | Filter to sessions that need attention (`waiting`, `finished`, `errored`); press again to show all |
-| `M` | Messages (updates, tips; `x` dismisses one for good). First run also points at Settings for bug reports. |
+| `M` | Messages (updates, tips; `x` dismisses one for good). The welcome message points at Settings for bug reports. |
 | `e` | Hide / show empty groups |
 | `/` | Search |
 | `?` | Help |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,10 +30,11 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
 | `ctrl+r` | Review the selected session's changes: full-screen whole-file diffs, with `c` to comment a line and `C` to send the comments to the agent |
 | `F` | Fold / unfold every group |
-| `s` | Settings (quick-spawn tool, theme, list density, review layout, after quick send, session keys, worktree sessions) |
+| `s` | Settings (quick-spawn tool, theme, list density, review layout, after quick send, session keys, worktree sessions, report a bug) |
 | `\|` | Resize the split: `←→` nudge the divider, `enter` commits, `esc` cancels |
 | `t` | Toggle archived view |
 | `w` | Filter to sessions that need attention (`waiting`, `finished`, `errored`); press again to show all |
+| `M` | Messages (updates, tips; `x` dismisses one for good). First run also points at Settings for bug reports. |
 | `e` | Hide / show empty groups |
 | `/` | Search |
 | `?` | Help |

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -260,6 +260,20 @@ func (m *Model) viewSettings() string {
 	actionRow := func(field int, name, action string) string {
 		return lead(field, name) + keyStyle.Render("↵") + mutedStyle.Render(" "+action)
 	}
+	// Bug report stays accent-colored even when unfocused so the action
+	// reads as a call-to-action among the picker rows above it.
+	bugLead := func() string {
+		marker := "  "
+		labelStyle := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true)
+		if m.settings.field == settingsFieldBugReport {
+			marker = lipgloss.NewStyle().Foreground(colorAccent).Render("❯ ")
+			labelStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+		}
+		return marker + padRight(labelStyle.Render("report a bug"), 18)
+	}
+	bugRow := bugLead() + keyStyle.Render("↵") +
+		lipgloss.NewStyle().Foreground(colorAccent2).Render(" open a prefilled GitHub issue")
+	bugNote := subtleStyle.Render("  * found a bug? report it (prefilled)")
 	body := row(settingsFieldTool, "default tool", toolValue) + "\n" +
 		row(settingsFieldTheme, "theme", themes[m.settings.themeIndex].Name) + "  " +
 		themeSwatch(themes[m.settings.themeIndex]) + "\n" +
@@ -269,7 +283,8 @@ func (m *Model) viewSettings() string {
 		row(settingsFieldFocusKey, "session keys", focusKey) + "\n" +
 		row(settingsFieldWorktree, "spawn in worktree", worktreeDefault) + "\n" +
 		actionRow(settingsFieldCLIs, "CLIs", "show or hide for new sessions") + "\n" +
-		actionRow(settingsFieldBugReport, "report a bug", "open a prefilled GitHub issue") + "\n" +
+		bugRow + "\n" +
+		bugNote + "\n" +
 		m.settingsVersionRow(lead, actionRow)
 	hint := "↑↓ field · ←→ change · ↵/esc save"
 	switch m.settings.field {
@@ -390,11 +405,11 @@ func (m *Model) viewHelp() string {
 		{"b", "in review: pick the branch from the repo's worktrees"},
 		{"B", "in review: pick the target (merge-into branch) the branch diff compares against"},
 		{"F", "fold / unfold all groups"},
-		{"s", "settings (CLIs, theme, default tool, review layout)"},
+		{"s", "settings (CLIs, theme, default tool, review layout, report a bug)"},
 		{"|", "resize split (←→ / drag, enter commits, esc cancels)"},
 		{"t", "toggle archived view"},
 		{"w", "filter to sessions that need attention (waiting, finished, errored)"},
-		{"M", "messages (updates, tips, bug reporting; x dismisses)"},
+		{"M", "messages (updates, tips; x dismisses)"},
 		{"e", "hide / show empty groups"},
 		{"/", "search"},
 		{"↑↓ / jk", "move cursor"},

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -22,8 +22,7 @@ import (
 )
 
 const (
-	noticeWelcome   = "welcome"
-	noticeBugReport = "bug-report"
+	noticeWelcome = "welcome"
 
 	dismissedNoticesSetting = "dismissed_notices"
 	lastSeenVersionSetting  = "last_seen_version"
@@ -142,20 +141,10 @@ func (m *Model) activeNotices() []notice {
 			body: []string{
 				"Every row on the left is a live agent session: enter attaches,",
 				"space sends a quick prompt, ? shows every key.",
+				"Found a bug? Settings (s) opens a prefilled report.",
 				"Messages like this one live here; x dismisses one for good.",
 			},
 			url: repoURL + "#readme",
-		},
-		notice{
-			id:    noticeBugReport,
-			glyph: "?",
-			tint:  colorAccent,
-			title: "Found a bug?",
-			body: []string{
-				"Enter opens a GitHub issue prefilled with your version and OS.",
-				"A pane screenshot and the steps that led there help the most.",
-			},
-			url: bugReportURL(m.update.version),
 		},
 	)
 

--- a/internal/ui/notices_test.go
+++ b/internal/ui/notices_test.go
@@ -48,10 +48,18 @@ func noticeIDs(notices []notice) []string {
 func TestActiveNoticesPinnedByDefault(t *testing.T) {
 	m := noticeModel(noticeStore(t), "v0.2.0")
 	ids := noticeIDs(m.activeNotices())
-	for _, want := range []string{noticeWelcome, noticeBugReport} {
-		if !contains(ids, want) {
-			t.Fatalf("want %s among %v", want, ids)
+	if !contains(ids, noticeWelcome) {
+		t.Fatalf("want %s among %v", noticeWelcome, ids)
+	}
+	var welcome notice
+	for _, n := range m.activeNotices() {
+		if n.id == noticeWelcome {
+			welcome = n
 		}
+	}
+	joined := strings.Join(welcome.body, " ")
+	if !strings.Contains(joined, "Settings (s)") || !strings.Contains(joined, "Found a bug?") {
+		t.Fatalf("welcome should point at Settings for bug reports: %q", joined)
 	}
 }
 
@@ -66,9 +74,6 @@ func TestDismissPersistsAcrossRestart(t *testing.T) {
 	reopened := noticeModel(st, "v0.2.0")
 	if contains(noticeIDs(reopened.activeNotices()), noticeWelcome) {
 		t.Fatal("dismissal did not survive restart")
-	}
-	if !contains(noticeIDs(reopened.activeNotices()), noticeBugReport) {
-		t.Fatal("other notices must stay")
 	}
 }
 
@@ -296,7 +301,6 @@ func TestFeedUsesOneCanonicalTitleInCardAndModal(t *testing.T) {
 		Body:   []string{"details"},
 	}}
 	m.dismissNotice(noticeWelcome)
-	m.dismissNotice(noticeBugReport)
 
 	card := ansi.Strip(strings.Join(m.noticeCardLines(m.activeNotices(), 50, 5), "\n"))
 	if !strings.Contains(card, "One title everywhere") || strings.Contains(card, "legacy compact copy") {
@@ -309,19 +313,13 @@ func TestFeedUsesOneCanonicalTitleInCardAndModal(t *testing.T) {
 	}
 }
 
-func TestBugReportNoticeCarriesPrefilledURL(t *testing.T) {
-	m := noticeModel(noticeStore(t), "v0.2.0")
-	var bug notice
-	for _, n := range m.activeNotices() {
-		if n.id == noticeBugReport {
-			bug = n
-		}
+func TestBugReportURLPrefillsVersion(t *testing.T) {
+	got := bugReportURL("v0.2.0")
+	if !strings.HasPrefix(got, "https://github.com/YoanWai/agent-manager/issues/new") {
+		t.Fatalf("bug report should open the new-issue page, got %q", got)
 	}
-	if !strings.HasPrefix(bug.url, "https://github.com/YoanWai/agent-manager/issues/new") {
-		t.Fatalf("bug report should open the new-issue page, got %q", bug.url)
-	}
-	if !strings.Contains(bug.url, "v0.2.0") {
-		t.Fatalf("issue URL should carry the version, got %q", bug.url)
+	if !strings.Contains(got, "v0.2.0") {
+		t.Fatalf("issue URL should carry the version, got %q", got)
 	}
 }
 
@@ -470,7 +468,7 @@ func TestOpenNoticesFromList(t *testing.T) {
 func TestNoticesViewListsAndDetails(t *testing.T) {
 	m := modalModel(t)
 	frame := ansi.Strip(m.View())
-	for _, want := range []string{"messages", "Welcome to agent-manager", "Found a bug?", "dismiss"} {
+	for _, want := range []string{"messages", "Welcome to agent-manager", "Settings (s)", "Found a bug?", "dismiss"} {
 		if !strings.Contains(frame, want) {
 			t.Fatalf("modal missing %q:\n%s", want, frame)
 		}
@@ -638,12 +636,11 @@ func TestNoticesEnterOpensURL(t *testing.T) {
 	}
 	t.Cleanup(func() { openBrowser = defaultOpenBrowser })
 
-	m.handleNoticesKey(key("down"))
-	m.handleNoticesKey(key("enter"))
-	if opened == "" {
-		t.Fatal("enter should open the selected notice's url")
+	want := m.activeNotices()[m.noticeCursor].url
+	if want == "" {
+		t.Fatal("selected notice needs a url for this test")
 	}
-	want := m.activeNotices()[1].url
+	m.handleNoticesKey(key("enter"))
 	if opened != want {
 		t.Fatalf("opened %q, want %q", opened, want)
 	}

--- a/internal/ui/notices_test.go
+++ b/internal/ui/notices_test.go
@@ -58,8 +58,14 @@ func TestActiveNoticesPinnedByDefault(t *testing.T) {
 		}
 	}
 	joined := strings.Join(welcome.body, " ")
-	if !strings.Contains(joined, "Settings (s)") || !strings.Contains(joined, "Found a bug?") {
+	if !strings.Contains(joined, "Settings (s)") || !strings.Contains(joined, "Found a bug?") ||
+		!strings.Contains(joined, "prefilled report") {
 		t.Fatalf("welcome should point at Settings for bug reports: %q", joined)
+	}
+	for _, n := range m.activeNotices() {
+		if n.id != noticeWelcome && n.url == bugReportURL(m.update.version) {
+			t.Fatalf("standalone bug-report notice still active: %q", n.id)
+		}
 	}
 }
 

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/update"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestDefaultToolFallsBackWhenSettingStale(t *testing.T) {
@@ -149,6 +150,22 @@ func TestSettingsBugReportRowOpensIssue(t *testing.T) {
 	m.handleSettingsKey(key("esc"))
 	if m.mode != modeList {
 		t.Fatal("esc should still save and close")
+	}
+}
+
+func TestSettingsBugReportRowIsHighlighted(t *testing.T) {
+	m := footModel(t)
+	m.cfg = config.Config{Tools: map[string]config.Tool{"claude": {Command: "cat"}}}
+	m.openSettings()
+	card := ansi.Strip(m.viewSettings())
+	if !strings.Contains(card, "report a bug") {
+		t.Fatalf("settings should show the bug report row: %q", card)
+	}
+	if !strings.Contains(card, "found a bug? report it") {
+		t.Fatalf("settings should show the bug report notice: %q", card)
+	}
+	if !strings.Contains(m.viewSettings(), "\x1b[") {
+		t.Fatal("bug report row should use colored styling")
 	}
 }
 

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/update"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -157,15 +158,20 @@ func TestSettingsBugReportRowIsHighlighted(t *testing.T) {
 	m := footModel(t)
 	m.cfg = config.Config{Tools: map[string]config.Tool{"claude": {Command: "cat"}}}
 	m.openSettings()
+	// Keep focus off the bug row so the accent2 unfocused styling is what paints.
+	m.settings.field = settingsFieldTool
 	card := ansi.Strip(m.viewSettings())
 	if !strings.Contains(card, "report a bug") {
 		t.Fatalf("settings should show the bug report row: %q", card)
 	}
-	if !strings.Contains(card, "found a bug? report it") {
+	if !strings.Contains(card, "found a bug? report it (prefilled)") {
 		t.Fatalf("settings should show the bug report notice: %q", card)
 	}
-	if !strings.Contains(m.viewSettings(), "\x1b[") {
-		t.Fatal("bug report row should use colored styling")
+	// Unfocused label uses accent2 + bold; prove that SGR lands on the label itself.
+	styled := m.viewSettings()
+	label := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true).Render("report a bug")
+	if !strings.Contains(styled, label) {
+		t.Fatalf("unfocused bug report label should use accent2 bold styling")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Settings: **report a bug** stays accent-colored when unfocused, with a short note under it.
- Messages: removed the separate permanent "Found a bug?" notice; welcome points at Settings (`s`).
- Help (`?`) and `docs/usage.md` document the Settings path.

## Why

Bug reporting was easy to miss: the settings row looked like any other action, and the messages notice could be dismissed forever. Settings is the lasting home; other surfaces point there.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes (via `go vet ./internal/ui/`)
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./internal/ui/ -count=1` passes
- [x] CI green on the PR