### PR TITLE
test(ui): pin alternate scroll off

### DIFF
--- a/internal/ui/altscroll_test.go
+++ b/internal/ui/altscroll_test.go
@@ -1,0 +1,71 @@
+package ui
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The reset reaches the terminal verbatim: a wheel notch stays inert in the
+// list only while the terminal is not translating it into arrow keys.
+func TestDisableAlternateScrollEmitsReset(t *testing.T) {
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	saved := os.Stdout
+	os.Stdout = write
+	emitErr := DisableAlternateScroll()
+	os.Stdout = saved
+	if err := write.Close(); err != nil {
+		t.Fatalf("close write end: %v", err)
+	}
+	if emitErr != nil {
+		t.Fatalf("DisableAlternateScroll: %v", emitErr)
+	}
+	got, err := io.ReadAll(read)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if want := "\x1b[?1007l"; string(got) != want {
+		t.Fatalf("emitted %q, want %q", got, want)
+	}
+}
+
+// Re-enabling alternate scroll anywhere puts the wheel back on the session
+// cursor, which is the bug this reset exists to keep fixed (#110).
+func TestNoAlternateScrollEnableInTree(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if name := entry.Name(); name == ".git" || name == ".claude" || name == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" || path == filepath.Join(root, "internal", "ui", "altscroll_test.go") {
+			return nil
+		}
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(source), `?1007h`) {
+			rel, _ := filepath.Rel(root, path)
+			t.Errorf("%s turns alternate scroll back on", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +13,44 @@ import (
 
 	"github.com/YoanWai/agent-manager/internal/hooks"
 )
+
+// Startup is the only place the alternate-scroll reset goes out, and it
+// cannot be exercised headlessly: run() takes over the terminal. Reading
+// the call out of the syntax tree still fails if it is dropped, which is
+// what would put wheel notches back on the session cursor (#110).
+func TestStartupDisablesAlternateScroll(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "main.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+	var run *ast.FuncDecl
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "run" && fn.Recv == nil {
+			run = fn
+		}
+	}
+	if run == nil {
+		t.Fatal("main.go has no run function")
+	}
+	found := false
+	ast.Inspect(run, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != "DisableAlternateScroll" {
+			return true
+		}
+		if pkg, ok := selector.X.(*ast.Ident); ok && pkg.Name == "ui" {
+			found = true
+		}
+		return true
+	})
+	if !found {
+		t.Fatal("run() never calls ui.DisableAlternateScroll")
+	}
+}
 
 func TestResolveVersion(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
#215 turned DECSET 1007 off so wheel notches stop arriving as arrow keys that walk the session cursor, but nothing in CI held that in place. Three tests now do.

`TestDisableAlternateScrollEmitsReset` swaps `os.Stdout` for a pipe and asserts the exact bytes `\x1b[?1007l` go out. `TestStartupDisablesAlternateScroll` reads `ui.DisableAlternateScroll` out of `run()`'s syntax tree, since `run()` takes over the terminal and cannot be exercised headlessly. `TestNoAlternateScrollEnableInTree` walks the repo's Go sources for the enable sequence, so re-introducing it anywhere fails rather than silently restoring the old behavior.

All three were mutation-checked. Flipping the constant to `1007h` fails the first with `emitted "\x1b[?1007h", want "\x1b[?1007l"`. Removing the call from `run()` fails the second with `run() never calls ui.DisableAlternateScroll`. Adding the sequence to another file fails the third, naming that file. Full suite and `go vet` green.