### PR TITLE
fix(ui): claim the wheel instead of leaving it to the terminal

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,7 +40,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `?` | Help |
 | `q` | Quit (sessions keep running) |
 
-Navigation is keyboard-driven. Mouse tracking stays off so click-drag keeps selecting text natively in your terminal, which is why the pointer does not move the selection; mouse support is tracked in [#110](https://github.com/YoanWai/agent-manager/issues/110). Inside a focused session the wheel walks that pane's scrollback.
+Navigation is keyboard-driven. The manager claims mouse reporting so the wheel stays inside the app and cannot scroll the TUI out of view: a notch scrolls the diff, and in a focused session it walks that pane's scrollback, where click-drag also selects pane text and copies it. In the list the wheel does nothing, since moving the selection with it retargets every key that follows. Fuller mouse support, on by default with a settings toggle, is tracked in [#110](https://github.com/YoanWai/agent-manager/issues/110).
 
 ## Quick prompt
 

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -143,13 +143,14 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 	return m, tea.Batch(tea.EnableMouseCellMotion, m.cursorBlink())
 }
 
-// leaveFocus returns to the list and gives the mouse back to the terminal,
-// restoring native selection.
+// leaveFocus returns to the list. Mouse reporting stays on: handing it back
+// to the terminal here would let a wheel notch scroll the manager out of
+// view, so the list swallows the wheel instead.
 func (m *Model) leaveFocus() tea.Cmd {
 	m.mode = modeList
 	m.sel = focusSelection{}
 	m.copied = 0
-	return tea.DisableMouse
+	return nil
 }
 
 // handleFocusKey forwards every key into the focused pane. Ctrl+Q and

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -329,10 +329,12 @@ func TestFocusExitReleasesMouse(t *testing.T) {
 		t.Fatalf("entering focus never enabled mouse reporting: %T", enterCmd())
 	}
 
+	// Leaving keeps mouse reporting on: handing the wheel back to the
+	// terminal here would let a notch scroll the manager out of view.
 	updated, exitCmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})
 	*m = *updated.(*Model)
-	if exitCmd == nil {
-		t.Fatal("leaving focus issued no mouse command")
+	if exitCmd != nil && batchContains(exitCmd(), tea.DisableMouse()) {
+		t.Fatal("leaving focus released mouse reporting to the terminal")
 	}
 	if m.sel.active {
 		t.Fatal("selection survived leaving focus")

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -217,34 +217,22 @@ func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleMouseWheel keeps the wheel inside the app: list cursor, diff
-// scroll, or a no-op swallow so the outer terminal cannot scroll away.
+// handleMouseWheel keeps the wheel inside the app so the outer terminal
+// cannot scroll the manager away. It scrolls the diff, and is swallowed
+// everywhere else: in the list a notch would move the session cursor,
+// silently retargeting every keystroke that follows (#110).
 func (m *Model) handleMouseWheel(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
-	if m.split.resizeMode {
+	if m.split.resizeMode || m.mode != modeDiff {
 		return m, nil
 	}
-	delta := 0
+	if m.diff.annotating || m.diff.sendConfirm {
+		return m, nil
+	}
 	switch msg.Button {
 	case tea.MouseButtonWheelUp:
-		delta = -1
+		m.moveDiffCursor(-1, m.diffCodeHeight())
 	case tea.MouseButtonWheelDown:
-		delta = 1
-	default:
-		return m, nil
+		m.moveDiffCursor(1, m.diffCodeHeight())
 	}
-	switch m.mode {
-	case modeDiff:
-		if m.diff.annotating || m.diff.sendConfirm {
-			return m, nil
-		}
-		m.moveDiffCursor(delta, m.diffCodeHeight())
-		return m, nil
-	case modeList, modeRename:
-		if m.searching {
-			return m, nil
-		}
-		return m, m.moveCursor(delta)
-	default:
-		return m, nil
-	}
+	return m, nil
 }

--- a/internal/ui/split_test.go
+++ b/internal/ui/split_test.go
@@ -475,9 +475,10 @@ func TestNewLoadsPersistedSplitRatio(t *testing.T) {
 	}
 }
 
-// Wheel events must be consumed by the app (so the host terminal cannot
-// scroll the TUI away) and advance the list cursor outside resize mode.
-func TestWheelScrollMovesListCursor(t *testing.T) {
+// Wheel events must be consumed by the app so the host terminal cannot
+// scroll the TUI away, and swallowed in the list: moving the cursor there
+// retargets every keystroke that follows (#110).
+func TestWheelSwallowedInList(t *testing.T) {
 	m := &Model{
 		mode:   modeList,
 		cursor: 0,
@@ -485,19 +486,17 @@ func TestWheelScrollMovesListCursor(t *testing.T) {
 		width:  80,
 		height: 24,
 	}
-	updated, _ := m.handleMouse(tea.MouseMsg{
-		Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress,
-	})
-	m = updated.(*Model)
-	if m.cursor != 1 {
-		t.Fatalf("wheel down cursor = %d want 1", m.cursor)
-	}
-	updated, _ = m.handleMouse(tea.MouseMsg{
-		Button: tea.MouseButtonWheelUp, Action: tea.MouseActionPress,
-	})
-	m = updated.(*Model)
-	if m.cursor != 0 {
-		t.Fatalf("wheel up cursor = %d want 0", m.cursor)
+	for _, button := range []tea.MouseButton{tea.MouseButtonWheelDown, tea.MouseButtonWheelUp} {
+		updated, cmd := m.handleMouse(tea.MouseMsg{
+			Button: button, Action: tea.MouseActionPress,
+		})
+		m = updated.(*Model)
+		if m.cursor != 0 {
+			t.Fatalf("wheel moved the list cursor to %d", m.cursor)
+		}
+		if cmd != nil {
+			t.Fatal("wheel in the list scheduled work")
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -174,11 +174,11 @@ func run() error {
 	defer st.Close()
 
 	model := ui.New(cfg, st, driver, engine, hooks.NewManager(dir), version)
-	// Mouse reporting stays off so the terminal keeps native text selection.
-	// Alternate scroll stays off too, so the wheel is inert in the list
-	// instead of arriving as arrow keys that walk the session cursor; a
-	// crashed earlier run can leave it set, so clear it on the way in.
-	program := tea.NewProgram(model, tea.WithAltScreen())
+	// Mouse reporting claims the wheel for the app, so a notch neither
+	// scrolls the host's scrollback out from under the manager nor arrives
+	// as an arrow key that walks the session cursor. Alternate scroll is
+	// cleared too: a crashed earlier run can leave it set.
+	program := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if err := ui.DisableAlternateScroll(); err != nil {
 		return err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -52,6 +52,40 @@ func TestStartupDisablesAlternateScroll(t *testing.T) {
 	}
 }
 
+// Without mouse reporting the terminal keeps the wheel and scrolls the
+// manager out of view, which is what alternate scroll used to prevent.
+func TestStartupClaimsMouse(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "main.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+	found := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != "NewProgram" {
+			return true
+		}
+		for _, arg := range call.Args {
+			option, ok := arg.(*ast.CallExpr)
+			if !ok {
+				continue
+			}
+			name, ok := option.Fun.(*ast.SelectorExpr)
+			if ok && name.Sel.Name == "WithMouseCellMotion" {
+				found = true
+			}
+		}
+		return true
+	})
+	if !found {
+		t.Fatal("the program starts without mouse reporting")
+	}
+}
+
 func TestResolveVersion(t *testing.T) {
 	cases := []struct {
 		label         string


### PR DESCRIPTION
#215 turned alternate scroll (DECSET 1007) off so wheel notches stopped arriving as arrow keys that walked the session cursor. That fixed the retargeting, and broke something worse: with 1007 off and mouse reporting off, the wheel belongs to the terminal, which scrolls its own buffer and pushes the manager out of view. That is the exact failure 1007 was covering, and my earlier reading that it only bites under an outer tmux with `mouse on` was wrong: it reproduces with tmux `mouse off`.

The app now takes mouse reporting for itself (`tea.WithMouseCellMotion`), so notches arrive as events rather than as terminal scrolling. The list swallows them, the diff still scrolls, and focus mode is unchanged. `leaveFocus` no longer releases mouse reporting, since handing it back re-opens the same hole.

The cost is native click-drag text selection in the list column, which is the trade the settings toggle in #110 exists to give back.

Verified live, not just in tests: a pty capture of the built binary shows `?1002h` and `?1006h` (cell-motion tracking, SGR encoding) alongside `?1007l` before the alt-screen switch, where the previous build emitted only `?1007l`.

Tests: `TestWheelSwallowedInList` replaces the old test that asserted the wheel moves the cursor, `TestStartupClaimsMouse` reads `WithMouseCellMotion` out of `run()`'s syntax tree, and `TestFocusExitReleasesMouse` now asserts the exit path does not disable mouse reporting. All mutation-checked: restoring `moveCursor` on wheel fails the first with `wheel moved the list cursor to 1`, dropping the program option fails the second with `the program starts without mouse reporting`. Full suite and `go vet` green.