### PR TITLE
docs(ui): correct the comments that still say mouse reporting is off

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -332,8 +332,8 @@ func SaveToTemp(data []byte, ext string) (string, error) {
 }
 
 // WriteText puts plain text on the OS clipboard. Used by the focused
-// preview's own selection, which the host terminal never sees because
-// mouse reporting is on while a session has focus.
+// preview's own selection, which the host terminal never sees because the
+// app holds mouse reporting.
 //
 // stdout and stderr stay unwired (os/exec points them at /dev/null): X11
 // writers like xclip fork a daemon that holds the selection, and any pipe

--- a/internal/ui/altscroll.go
+++ b/internal/ui/altscroll.go
@@ -5,8 +5,8 @@ import "os"
 // DECSET 1007 (alternate scroll) makes the terminal translate wheel events
 // into arrow keys while the alt screen is up. The manager turns it off: the
 // arrows are indistinguishable from real ones, so a wheel notch walked the
-// session cursor. Mouse tracking stays off outside focus mode, so the wheel
-// is inert in the list until real mouse handling lands (#110).
+// session cursor. Mouse reporting carries the wheel instead, and the list
+// swallows it until real mouse handling lands (#110).
 const altScrollOff = "\x1b[?1007l"
 
 func DisableAlternateScroll() error {

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -310,9 +310,9 @@ func TestFocusModeExitsWhenSessionDies(t *testing.T) {
 	}
 }
 
-// Leaving focus must hand the mouse back to the terminal, or native
-// selection stays broken everywhere in the app after one focus session.
-func TestFocusExitReleasesMouse(t *testing.T) {
+// Leaving focus must keep mouse reporting: handing it back would let a
+// wheel notch scroll the manager out of view from the list.
+func TestFocusExitKeepsMouse(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "mouseback", t.TempDir(), "")
 	m.selectSessionRow(t, "mouseback")

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -84,8 +84,8 @@ func (m *Model) setSplitFromX(x int) {
 	m.split.ratio = float64(left) / float64(m.width)
 }
 
-// enterResizeMode arms divider dragging. Mouse is never enabled by the
-// app so native text selection always works in the terminal.
+// enterResizeMode arms divider dragging, which the arrow keys drive. The
+// app holds mouse reporting, so a drag here reaches handleMouse too.
 func (m *Model) enterResizeMode() (tea.Model, tea.Cmd) {
 	if m.mode != modeList || m.searching || m.quick.active {
 		return m, nil


### PR DESCRIPTION
#218 moved mouse reporting from focus-mode-only to the whole program, and four comments were left describing the world before that.

`internal/ui/split.go` claimed "Mouse is never enabled by the app", `internal/ui/altscroll.go` said tracking "stays off outside focus mode", `internal/clipboard/clipboard.go` tied the clipboard write to focus mode specifically, and the focus-exit test was named and documented for releasing the mouse when it now asserts the opposite. Each one now describes what the code does.

Comments and one test name only; no behavior change. Suite green.