### PR TITLE
fix(ui): keep selected session under attention filter after ack

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -737,14 +737,21 @@ func (m *Model) visibleSessions() []store.Session {
 // listedSessions is the archived scope narrowed by the status filter.
 // Header counts, group rollups, and the tree all share this set so the
 // numbers always match what the list can show.
+//
+// The selected session stays listed when its status leaves the filter
+// (finished → idle on enter/ack) so rebuild cannot eject the cursor mid-work.
 func (m *Model) listedSessions() []store.Session {
 	visible := m.visibleSessions()
 	if !m.statusFilter.active() {
 		return visible
 	}
+	heldID := ""
+	if sess, ok := m.selected(); ok {
+		heldID = sess.ID
+	}
 	listed := make([]store.Session, 0, len(visible))
 	for _, sess := range visible {
-		if m.statusFilter.matches(sess.Status) {
+		if m.statusFilter.matches(sess.Status) || sess.ID == heldID {
 			listed = append(listed, sess)
 		}
 	}

--- a/internal/ui/statusfilter_test.go
+++ b/internal/ui/statusfilter_test.go
@@ -212,6 +212,71 @@ func TestBulkActionsRespectStatusFilter(t *testing.T) {
 	}
 }
 
+func TestAttentionFilterKeepsSelectedAfterAck(t *testing.T) {
+	m := attentionFilterAckFixture(t)
+	m.selectSessionRow(t, "just-finished")
+
+	sess, ok := m.selected()
+	if !ok {
+		t.Fatal("expected a selected session")
+	}
+	if err := m.acknowledgeFinished(sess); err != nil {
+		t.Fatalf("acknowledge: %v", err)
+	}
+	loadStoredRows(t, m)
+
+	if got := sessionNames(m); !slices.Equal(got, []string{"just-finished", "still-waiting"}) {
+		t.Fatalf("attention list after ack = %v want both sessions still listed", got)
+	}
+	entry, ok := m.selectedRow()
+	if !ok || entry.isGroup || entry.sess.Name != "just-finished" {
+		t.Fatalf("cursor should stay on the acked session, got %+v", entry)
+	}
+	if entry.sess.Status != status.Idle {
+		t.Fatalf("acked row status = %q want idle", entry.sess.Status)
+	}
+}
+
+func TestAttentionFilterDropsAckedAfterMove(t *testing.T) {
+	m := attentionFilterAckFixture(t)
+	m.selectSessionRow(t, "just-finished")
+
+	sess, ok := m.selected()
+	if !ok {
+		t.Fatal("expected a selected session")
+	}
+	if err := m.acknowledgeFinished(sess); err != nil {
+		t.Fatalf("acknowledge: %v", err)
+	}
+	loadStoredRows(t, m)
+	m.selectSessionRow(t, "still-waiting")
+	loadStoredRows(t, m)
+
+	if got := sessionNames(m); !slices.Equal(got, []string{"still-waiting"}) {
+		t.Fatalf("attention list after move = %v want only the still-matching session", got)
+	}
+	if entry, ok := m.selectedRow(); !ok || entry.isGroup || entry.sess.Name != "still-waiting" {
+		t.Fatalf("cursor should stay on the waiting session, got %+v", entry)
+	}
+}
+
+func attentionFilterAckFixture(t *testing.T) *Model {
+	t.Helper()
+	m := buildModel(t)
+	for _, sess := range []store.Session{
+		{ID: "done", Name: "just-finished", Tool: "claude", Cwd: "/tmp", Status: status.Finished},
+		{ID: "wait", Name: "still-waiting", Tool: "claude", Cwd: "/tmp", Status: status.Waiting},
+	} {
+		if err := m.store.CreateSession(sess); err != nil {
+			t.Fatalf("create session %q: %v", sess.ID, err)
+		}
+	}
+	loadStoredRows(t, m)
+	m.statusFilter = statusFilterAttention
+	m.rebuildRows()
+	return m
+}
+
 func TestForkClearsStatusFilter(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Fixes #220: with the attention filter on, enter/ack turns a finished session idle, the next rebuild drops the row, and focus/selection jumps away.

`listedSessions` now keeps the currently selected session visible even when its status no longer matches the filter. Move the cursor off it and the next rebuild drops it again, so the filter stays truthful for every other row.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./...` green
- [x] New tests: keep selected after ack; drop after move away