### PR TITLE
feat: enable fork for opencode, grok, pi, and gemini

### DIFF
--- a/internal/agentsession/capture.go
+++ b/internal/agentsession/capture.go
@@ -9,7 +9,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -61,6 +64,8 @@ func Capture(sessionStore, cwd string, launchedAt time.Time, claimed map[string]
 		return captureCodex(codexRoot(), cwd, launchedAt, claimed)
 	case "opencode":
 		return captureOpencode(cwd, launchedAt, claimed)
+	case "gemini":
+		return captureGemini(geminiRoot(), cwd, launchedAt, claimed)
 	default:
 		return "", false
 	}
@@ -324,4 +329,117 @@ func captureOpencode(cwd string, launchedAt time.Time, claimed map[string]bool) 
 		cands = append(cands, candidate{id: id, modTime: created})
 	}
 	return pickEarliest(cands)
+}
+
+func geminiRoot() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".gemini", "tmp")
+}
+
+// geminiProjectHash mirrors gemini's per-project key, the hex sha256 of the
+// resolved working directory. Session files record it in their header, so a
+// conversation can be matched to its directory without relying on the
+// per-project folder name, which gemini does not derive consistently.
+func geminiProjectHash(cwd string) string {
+	sum := sha256.Sum256([]byte(resolvePath(cwd)))
+	return hex.EncodeToString(sum[:])
+}
+
+// geminiSessionMeta reads the session id and project hash from a gemini
+// session file's first line.
+func geminiSessionMeta(path string) (id, projectHash string, ok bool) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", "", false
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	if !scanner.Scan() {
+		return "", "", false
+	}
+	var header struct {
+		SessionID   string `json:"sessionId"`
+		ProjectHash string `json:"projectHash"`
+	}
+	if err := json.Unmarshal(scanner.Bytes(), &header); err != nil {
+		return "", "", false
+	}
+	if header.SessionID == "" {
+		return "", "", false
+	}
+	return header.SessionID, header.ProjectHash, true
+}
+
+// captureGemini finds the conversation gemini minted for a session launched
+// in cwd. A fork via `gemini --session-file` names its own id, so the file
+// is located by matching the project hash gemini records for cwd among
+// session files written at or after launch.
+func captureGemini(root, cwd string, launchedAt time.Time, claimed map[string]bool) (string, bool) {
+	if root == "" {
+		return "", false
+	}
+	cutoff := launchedAt.Add(-clockSlack)
+	wantHash := geminiProjectHash(cwd)
+	var cands []candidate
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasPrefix(name, "session-") || !strings.HasSuffix(name, ".jsonl") {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil || info.ModTime().Before(cutoff) {
+			return nil
+		}
+		id, hash, ok := geminiSessionMeta(path)
+		if !ok || hash != wantHash || claimed[id] {
+			return nil
+		}
+		cands = append(cands, candidate{id: id, modTime: info.ModTime()})
+		return nil
+	})
+	return pickEarliest(cands)
+}
+
+// GeminiSessionFile locates the on-disk session file gemini stores for a
+// conversation id, so a fork can hand it to `gemini --session-file`.
+func GeminiSessionFile(id string) (string, error) {
+	return geminiSessionFileIn(geminiRoot(), id)
+}
+
+func geminiSessionFileIn(root, id string) (string, error) {
+	if root == "" {
+		return "", fmt.Errorf("cannot resolve the gemini home directory")
+	}
+	prefix := id
+	if len(prefix) > 8 {
+		prefix = prefix[:8]
+	}
+	var found string
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || found != "" {
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasPrefix(name, "session-") || !strings.HasSuffix(name, ".jsonl") {
+			return nil
+		}
+		if !strings.Contains(name, prefix) {
+			return nil
+		}
+		if sessionID, _, ok := geminiSessionMeta(path); ok && sessionID == id {
+			found = path
+		}
+		return nil
+	})
+	if found == "" {
+		return "", fmt.Errorf("no gemini session file found for conversation %s", id)
+	}
+	return found, nil
 }

--- a/internal/agentsession/capture_test.go
+++ b/internal/agentsession/capture_test.go
@@ -135,3 +135,64 @@ func TestCaptureUnknownStore(t *testing.T) {
 		t.Fatal("unknown store should not match")
 	}
 }
+
+// geminiSessionFixture is the header line of a gemini session file; the
+// capturer and resolver only read this first line.
+func geminiSessionFixture(sessionID, projectHash string) string {
+	return `{"sessionId":"` + sessionID + `","projectHash":"` + projectHash +
+		`","startTime":"2026-08-06T00:00:00.000Z","lastUpdated":"2026-08-06T00:00:00.000Z","kind":"main"}` + "\n"
+}
+
+func TestCaptureGeminiPicksSessionAfterLaunchInCwd(t *testing.T) {
+	root := t.TempDir()
+	launch := time.Now()
+	oursHash := geminiProjectHash("/repo")
+	otherHash := geminiProjectHash("/elsewhere")
+	// An older conversation in the same project predates the launch: not ours.
+	writeFile(t, filepath.Join(root, "proj/chats/session-1-old.jsonl"),
+		geminiSessionFixture("old-uuid", oursHash), launch.Add(-time.Hour))
+	// A conversation in a different project started after launch: not ours.
+	writeFile(t, filepath.Join(root, "proj/chats/session-2-other.jsonl"),
+		geminiSessionFixture("other-uuid", otherHash), launch.Add(time.Second))
+	// Ours: matching project hash, written just after launch.
+	writeFile(t, filepath.Join(root, "proj/chats/session-3-ours.jsonl"),
+		geminiSessionFixture("ours-uuid", oursHash), launch.Add(2*time.Second))
+
+	id, ok := captureGemini(root, "/repo", launch, map[string]bool{})
+	if !ok || id != "ours-uuid" {
+		t.Fatalf("got id=%q ok=%v, want ours-uuid true", id, ok)
+	}
+}
+
+func TestCaptureGeminiSkipsClaimed(t *testing.T) {
+	root := t.TempDir()
+	launch := time.Now()
+	hash := geminiProjectHash("/repo")
+	writeFile(t, filepath.Join(root, "p/chats/session-1.jsonl"),
+		geminiSessionFixture("first-uuid", hash), launch.Add(time.Second))
+	writeFile(t, filepath.Join(root, "p/chats/session-2.jsonl"),
+		geminiSessionFixture("second-uuid", hash), launch.Add(2*time.Second))
+
+	// first-uuid already belongs to another session, so the earliest
+	// unclaimed match wins instead.
+	id, ok := captureGemini(root, "/repo", launch, map[string]bool{"first-uuid": true})
+	if !ok || id != "second-uuid" {
+		t.Fatalf("got id=%q ok=%v, want second-uuid true", id, ok)
+	}
+}
+
+func TestGeminiSessionFileInResolvesByID(t *testing.T) {
+	root := t.TempDir()
+	id := "aaaa1111-2222-3333-4444-555566667777"
+	path := filepath.Join(root, "proj/chats/session-1786000000000-aaaa1111.jsonl")
+	writeFile(t, path, geminiSessionFixture(id, geminiProjectHash("/repo")), time.Now())
+
+	got, err := geminiSessionFileIn(root, id)
+	if err != nil || got != path {
+		t.Fatalf("got %q err=%v, want %q", got, err, path)
+	}
+
+	if _, err := geminiSessionFileIn(root, "bbbb9999-0000-0000-0000-000000000000"); err == nil {
+		t.Fatal("expected an error for an unknown conversation id")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,6 +257,7 @@ command = "opencode"
 # opencode mints its own session id; capture it after launch and resume it
 session_store = "opencode"
 resume_by_id_command = "opencode --session {id}"
+fork_command = "opencode --session {id} --fork"
 revive_command = "opencode --continue"
 # opencode's positional argument is the project path, so the optional
 # session prompt travels behind this flag
@@ -305,6 +306,7 @@ rules = [
 command = "grok"
 session_id_flag = "--session-id"
 resume_by_id_command = "grok --resume {id}"
+fork_command = "grok --resume {id} --fork-session --session-id {new_id}"
 # fallback: resumes the most recent session for the working directory
 revive_command = "grok --continue"
 default_status = "idle"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -362,6 +362,7 @@ rules = [
 command = "pi"
 session_id_flag = "--session-id"
 resume_by_id_command = "pi --session {id}"
+fork_command = "pi --fork {id} --session-id {new_id}"
 revive_command = "pi --continue"
 # Pi shows a spinner for active work. A resting pane is a finished turn until
 # the user acknowledges it; a resumed conversation is already acknowledged.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -335,6 +335,11 @@ command = "gemini"
 # that exact conversation regardless of what else ran in the directory
 session_id_flag = "--session-id"
 resume_by_id_command = "gemini --resume {id}"
+# gemini has no fork flag; --session-file imports a session file as a brand
+# new conversation (fresh id), so the fork hands it the source's file. The
+# forked id is captured back via the gemini session store.
+fork_command = "gemini --session-file {session_file}"
+session_store = "gemini"
 # fallback when a session predates id tracking: resumes the project's most
 # recent session
 revive_command = "gemini --resume latest"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -94,6 +94,9 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if got := cfg.Tools["grok"].ForkCommand; got != "grok --resume {id} --fork-session --session-id {new_id}" {
 		t.Fatalf("grok fork_command = %q want \"grok --resume {id} --fork-session --session-id {new_id}\"", got)
 	}
+	if got := cfg.Tools["pi"].ForkCommand; got != "pi --fork {id} --session-id {new_id}" {
+		t.Fatalf("pi fork_command = %q want \"pi --fork {id} --session-id {new_id}\"", got)
+	}
 }
 
 func TestDefaultWaitingRulesPrecedeWorking(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,12 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if got := cfg.Tools["pi"].ForkCommand; got != "pi --fork {id} --session-id {new_id}" {
 		t.Fatalf("pi fork_command = %q want \"pi --fork {id} --session-id {new_id}\"", got)
 	}
+	if got := cfg.Tools["gemini"].ForkCommand; got != "gemini --session-file {session_file}" {
+		t.Fatalf("gemini fork_command = %q want \"gemini --session-file {session_file}\"", got)
+	}
+	if got := cfg.Tools["gemini"].SessionStore; got != "gemini" {
+		t.Fatalf("gemini session_store = %q want \"gemini\" (captures the fork's minted id)", got)
+	}
 }
 
 func TestDefaultWaitingRulesPrecedeWorking(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,6 +88,12 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if got := cfg.Tools["codex"].ForkCommand; got != "codex fork {id}" {
 		t.Fatalf("codex fork_command = %q want \"codex fork {id}\"", got)
 	}
+	if got := cfg.Tools["opencode"].ForkCommand; got != "opencode --session {id} --fork" {
+		t.Fatalf("opencode fork_command = %q want \"opencode --session {id} --fork\"", got)
+	}
+	if got := cfg.Tools["grok"].ForkCommand; got != "grok --resume {id} --fork-session --session-id {new_id}" {
+		t.Fatalf("grok fork_command = %q want \"grok --resume {id} --fork-session --session-id {new_id}\"", got)
+	}
 }
 
 func TestDefaultWaitingRulesPrecedeWorking(t *testing.T) {

--- a/internal/ui/fork.go
+++ b/internal/ui/fork.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/YoanWai/agent-manager/internal/agentsession"
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
@@ -13,6 +14,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/google/uuid"
 )
+
+// forkSessionFileResolver resolves a source conversation's on-disk session
+// file for tools whose fork loads a file instead of an id (gemini). A
+// variable so tests substitute a fixture without touching the real store.
+var forkSessionFileResolver = agentsession.GeminiSessionFile
 
 type forkState struct {
 	source store.Session
@@ -90,7 +96,16 @@ func (m *Model) submitFork() (tea.Model, tea.Cmd) {
 	if strings.Contains(tool.ForkCommand, "{new_id}") {
 		agentID = uuid.NewString()
 	}
-	baseCommand := expandForkCommand(tool.ForkCommand, source.AgentSessionID, agentID, name)
+	sessionFile := ""
+	if strings.Contains(tool.ForkCommand, "{session_file}") {
+		resolved, err := forkSessionFileResolver(source.AgentSessionID)
+		if err != nil {
+			m.errBar.text = err.Error()
+			return m, nil
+		}
+		sessionFile = resolved
+	}
+	baseCommand := expandForkCommand(tool.ForkCommand, source.AgentSessionID, agentID, name, sessionFile)
 	forked := store.Session{
 		ID:             managerID,
 		Name:           name,
@@ -125,8 +140,8 @@ func validateForkSource(toolName string, tool config.Tool, source store.Session)
 	if tool.ForkCommand == "" {
 		return fmt.Errorf("tool %s has no fork_command", toolName)
 	}
-	if !strings.Contains(tool.ForkCommand, "{id}") {
-		return fmt.Errorf("tool %s fork_command must contain {id}", toolName)
+	if !strings.Contains(tool.ForkCommand, "{id}") && !strings.Contains(tool.ForkCommand, "{session_file}") {
+		return fmt.Errorf("tool %s fork_command must reference the source via {id} or {session_file}", toolName)
 	}
 	if source.AgentSessionID == "" {
 		return fmt.Errorf("%s has no captured conversation id", source.Name)
@@ -134,11 +149,12 @@ func validateForkSource(toolName string, tool config.Tool, source store.Session)
 	return nil
 }
 
-func expandForkCommand(template, sourceID, newID, name string) string {
+func expandForkCommand(template, sourceID, newID, name, sessionFile string) string {
 	return strings.NewReplacer(
 		"{id}", tmux.ShellQuote(sourceID),
 		"{new_id}", tmux.ShellQuote(newID),
 		"{name}", tmux.ShellQuote(name),
+		"{session_file}", tmux.ShellQuote(sessionFile),
 	).Replace(template)
 }
 

--- a/internal/ui/fork_test.go
+++ b/internal/ui/fork_test.go
@@ -254,6 +254,7 @@ func TestForkAgentSessionIDFollowsNewIDPlaceholder(t *testing.T) {
 
 			tool := m.cfg.Tools[tc.tool]
 			tool.ForkCommand = tc.forkCmd
+			tool.MCP = "none"
 			m.cfg.Tools[tc.tool] = tool
 
 			m.openFork()
@@ -322,6 +323,7 @@ func TestForkGeminiResolvesSessionFile(t *testing.T) {
 	argsFile := filepath.Join(t.TempDir(), "fork-args")
 	tool := m.cfg.Tools["gemini"]
 	tool.ForkCommand = "printf '%s\\n' {session_file} > " + tmux.ShellQuote(argsFile) + "; cat"
+	tool.MCP = "none"
 	m.cfg.Tools["gemini"] = tool
 
 	m.openFork()

--- a/internal/ui/fork_test.go
+++ b/internal/ui/fork_test.go
@@ -230,6 +230,7 @@ func TestForkAgentSessionIDFollowsNewIDPlaceholder(t *testing.T) {
 	}{
 		{"opencode_session_store", "opencode", "true {id}; cat", false},
 		{"grok_id_flag", "grok", "true {id} {new_id}; cat", true},
+		{"pi_id_flag", "pi", "true {id} {new_id}; cat", true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := buildModel(t)

--- a/internal/ui/fork_test.go
+++ b/internal/ui/fork_test.go
@@ -216,3 +216,71 @@ func TestOpenForkRejectsGroup(t *testing.T) {
 		t.Fatalf("group fork error = %q", m.errBar.text)
 	}
 }
+
+// Tools split into two fork shapes: those that mint their own conversation id
+// (opencode, codex) leave {new_id} out, so the fork starts without one until
+// the session store captures it; those that take an agent-chosen id (grok,
+// claude) include {new_id} and the fork launches with it already set.
+func TestForkAgentSessionIDFollowsNewIDPlaceholder(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		tool      string
+		forkCmd   string
+		wantNewID bool
+	}{
+		{"opencode_session_store", "opencode", "true {id}; cat", false},
+		{"grok_id_flag", "grok", "true {id} {new_id}; cat", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := buildModel(t)
+			dir := t.TempDir()
+			source := store.Session{
+				ID:             "source-" + tc.tool,
+				Name:           "source",
+				Tool:           tc.tool,
+				Cwd:            dir,
+				Status:         status.Idle,
+				AgentSessionID: "source-conversation",
+			}
+			if err := m.store.CreateSession(source); err != nil {
+				t.Fatal(err)
+			}
+			loadStoredRows(t, m)
+			m.selectSessionRow(t, "source")
+
+			tool := m.cfg.Tools[tc.tool]
+			tool.ForkCommand = tc.forkCmd
+			m.cfg.Tools[tc.tool] = tool
+
+			m.openFork()
+			if m.errBar.text != "" {
+				t.Fatalf("openFork error = %q", m.errBar.text)
+			}
+			m.fork.name.SetValue("forked")
+			updated, cmd := m.handleForkKey(tea.KeyMsg{Type: tea.KeyEnter})
+			m = updated.(*Model)
+			m.applyCmd(t, cmd)
+			if m.mode != modeList || m.errBar.text != "" {
+				t.Fatalf("after fork: mode=%v err=%q", m.mode, m.errBar.text)
+			}
+
+			var forked store.Session
+			for _, sess := range m.sessionRows() {
+				if sess.Name == "forked" {
+					forked = sess
+					break
+				}
+			}
+			if forked.ID == "" {
+				t.Fatal("forked session not found")
+			}
+			if tc.wantNewID {
+				if forked.AgentSessionID == "" || forked.AgentSessionID == source.AgentSessionID {
+					t.Fatalf("forked AgentSessionID = %q, want a fresh id", forked.AgentSessionID)
+				}
+			} else if forked.AgentSessionID != "" {
+				t.Fatalf("forked AgentSessionID = %q, want empty until the session store captures it", forked.AgentSessionID)
+			}
+		})
+	}
+}

--- a/internal/ui/fork_test.go
+++ b/internal/ui/fork_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,8 +16,8 @@ import (
 )
 
 func TestExpandForkCommandQuotesPlaceholders(t *testing.T) {
-	got := expandForkCommand("tool --fork {id} --new {new_id} --name {name}", "source", "new", "Sam's fork")
-	want := "tool --fork 'source' --new 'new' --name 'Sam'\\''s fork'"
+	got := expandForkCommand("tool --fork {id} --new {new_id} --name {name} --file {session_file}", "source", "new", "Sam's fork", "/store/session.jsonl")
+	want := "tool --fork 'source' --new 'new' --name 'Sam'\\''s fork' --file '/store/session.jsonl'"
 	if got != want {
 		t.Fatalf("fork command = %q, want %q", got, want)
 	}
@@ -183,16 +184,18 @@ func TestOpenForkRequiresConfiguredCommandAndConversationID(t *testing.T) {
 	m.selectSessionRow(t, "source")
 	source := m.rows[m.cursor].sess
 
+	tool := m.cfg.Tools[source.Tool]
+	tool.ForkCommand = ""
+	m.cfg.Tools[source.Tool] = tool
 	m.openFork()
 	if !strings.Contains(m.errBar.text, "no fork_command") {
 		t.Fatalf("missing command error = %q", m.errBar.text)
 	}
 
-	tool := m.cfg.Tools[source.Tool]
 	tool.ForkCommand = "tool --fork latest"
 	m.cfg.Tools[source.Tool] = tool
 	m.openFork()
-	if !strings.Contains(m.errBar.text, "must contain {id}") {
+	if !strings.Contains(m.errBar.text, "must reference the source via {id} or {session_file}") {
 		t.Fatalf("missing placeholder error = %q", m.errBar.text)
 	}
 
@@ -283,5 +286,126 @@ func TestForkAgentSessionIDFollowsNewIDPlaceholder(t *testing.T) {
 				t.Fatalf("forked AgentSessionID = %q, want empty until the session store captures it", forked.AgentSessionID)
 			}
 		})
+	}
+}
+
+// gemini forks by handing `--session-file` the source's on-disk session file;
+// gemini imports it as a brand-new conversation, so the fork launches with no
+// conversation id and the resolver's path must reach the command line intact.
+func TestForkGeminiResolvesSessionFile(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	source := store.Session{
+		ID:             "gemini-source",
+		Name:           "source",
+		Tool:           "gemini",
+		Cwd:            dir,
+		Status:         status.Idle,
+		AgentSessionID: "gemini-conversation",
+	}
+	if err := m.store.CreateSession(source); err != nil {
+		t.Fatal(err)
+	}
+	loadStoredRows(t, m)
+	m.selectSessionRow(t, "source")
+
+	const sourceFile = "/store/gemini/session-source.jsonl"
+	previousResolver := forkSessionFileResolver
+	forkSessionFileResolver = func(id string) (string, error) {
+		if id != source.AgentSessionID {
+			t.Errorf("resolver id = %q, want %q", id, source.AgentSessionID)
+		}
+		return sourceFile, nil
+	}
+	t.Cleanup(func() { forkSessionFileResolver = previousResolver })
+
+	argsFile := filepath.Join(t.TempDir(), "fork-args")
+	tool := m.cfg.Tools["gemini"]
+	tool.ForkCommand = "printf '%s\\n' {session_file} > " + tmux.ShellQuote(argsFile) + "; cat"
+	m.cfg.Tools["gemini"] = tool
+
+	m.openFork()
+	if m.errBar.text != "" {
+		t.Fatalf("openFork error = %q", m.errBar.text)
+	}
+	m.fork.name.SetValue("forked")
+	updated, cmd := m.handleForkKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*Model)
+	m.applyCmd(t, cmd)
+	if m.mode != modeList || m.errBar.text != "" {
+		t.Fatalf("after fork: mode=%v err=%q", m.mode, m.errBar.text)
+	}
+
+	var forked store.Session
+	for _, sess := range m.sessionRows() {
+		if sess.Name == "forked" {
+			forked = sess
+			break
+		}
+	}
+	if forked.ID == "" {
+		t.Fatal("forked session not found")
+	}
+	if forked.AgentSessionID != "" {
+		t.Fatalf("forked AgentSessionID = %q, want empty until the gemini store captures it", forked.AgentSessionID)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var raw []byte
+	var err error
+	for time.Now().Before(deadline) {
+		raw, err = os.ReadFile(argsFile)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(raw)); got != sourceFile {
+		t.Fatalf("session file passed to fork = %q, want %q", got, sourceFile)
+	}
+}
+
+// A fork whose source file cannot be resolved reports the error and does not
+// launch, leaving the session list unchanged.
+func TestForkGeminiResolverFailureReportsError(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	source := store.Session{
+		ID:             "gemini-source",
+		Name:           "source",
+		Tool:           "gemini",
+		Cwd:            dir,
+		Status:         status.Idle,
+		AgentSessionID: "gemini-conversation",
+	}
+	if err := m.store.CreateSession(source); err != nil {
+		t.Fatal(err)
+	}
+	loadStoredRows(t, m)
+	m.selectSessionRow(t, "source")
+
+	previousResolver := forkSessionFileResolver
+	forkSessionFileResolver = func(id string) (string, error) {
+		return "", fmt.Errorf("no gemini session file found for conversation %s", id)
+	}
+	t.Cleanup(func() { forkSessionFileResolver = previousResolver })
+
+	tool := m.cfg.Tools["gemini"]
+	tool.ForkCommand = "gemini --session-file {session_file}"
+	m.cfg.Tools["gemini"] = tool
+
+	before := len(m.sessionRows())
+	m.openFork()
+	m.fork.name.SetValue("forked")
+	updated, _ := m.handleForkKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*Model)
+	if !strings.Contains(m.errBar.text, "no gemini session file") {
+		t.Fatalf("resolver error = %q", m.errBar.text)
+	}
+	if got := len(m.sessionRows()); got != before {
+		t.Fatalf("session rows = %d, want %d (no fork launched)", got, before)
 	}
 }


### PR DESCRIPTION
## What changed

Extends session forking (`f`) from claude/codex to the remaining four built-in CLIs, so all six fork:

| tool | fork_command | id shape |
|------|--------------|----------|
| opencode | `opencode --session {id} --fork` | mints own id → captured via opencode store |
| grok | `grok --resume {id} --fork-session --session-id {new_id}` | agent-chosen `{new_id}` (like claude) |
| pi | `pi --fork {id} --session-id {new_id}` | agent-chosen `{new_id}` (like claude/grok) |
| gemini | `gemini --session-file {session_file}` + new `gemini` session store | mints own id → captured via gemini store |

Gemini has no fork flag, but `gemini --session-file <file>` imports a session file as a brand-new conversation: it reads the source, mints a fresh session id, recomputes the project hash for the current directory, and writes a new session file, leaving the source untouched. The fork resolves the source's on-disk session file by scanning gemini's per-project chats for the source conversation id, and captures the forked id back through a new gemini session store keyed by the sha256 project hash gemini records in each session file.

Supporting changes: a `{session_file}` fork_command placeholder (resolved at fork time), `validateForkSource` now accepts `{id}` or `{session_file}`, and `expandForkCommand` quotes the resolved path.

## Why

`f` no-op'd on opencode/grok/gemini/pi with "tool <x> has no fork_command" even though each CLI can fork. This completes fork coverage across every built-in tool.

## How it was verified

- opencode/grok/pi fork flags confirmed against each installed CLI's `--help`; pi's `--fork` + `--session-id` combination confirmed in its arg-validation source (they are not mutually exclusive, and the id is passed to `forkFrom`).
- gemini `--session-file` fork confirmed **empirically** against gemini-cli 0.53.1: running it produced a new session file with a fresh `sessionId`, recomputed `projectHash`, the "Imported session from" marker, and the source's messages. (The import runs before model auth, so it was verifiable even though this machine's Gemini Code Assist tier is ineligible.)
- gemini `projectHash` confirmed as `sha256(realpath(cwd))`, which is what the new capturer matches on.
- New tests: default `fork_command` locked for all four tools; `{new_id}` branching for store- vs id-flag tools; gemini session-file resolution and resolver-failure paths; gemini capture by project hash.
- `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green.

## Notes

- Gemini's interactive fork cannot be smoke-tested end-to-end on this machine (Gemini Code Assist auth is ineligible), but the file-import mechanism agent-manager triggers is verified above.
- pi was installed at 0.83.0 (`@earendil-works/pi-coding-agent`) to verify its fork flag.