### PR TITLE
feat(ui): highlight footer alerts and focus status with a soft wash

### DIFF
--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -63,7 +63,10 @@ func rebuildStyles() {
 	subtleStyle = lipgloss.NewStyle().Foreground(colorSubtle)
 	valueStyle = lipgloss.NewStyle().Foreground(colorText)
 	labelStyle = lipgloss.NewStyle().Foreground(colorSubtle)
-	errStyle = lipgloss.NewStyle().Foreground(colorErrored).Bold(true)
+	errStyle = lipgloss.NewStyle().
+		Foreground(colorErrored).
+		Background(lipgloss.Color(errWashHex())).
+		Bold(true)
 	keyStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 
 	annotationStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
@@ -97,6 +100,26 @@ func renderSelectedRow(s string) string {
 // profile as well as the live theme.
 func annotationBg() string {
 	return bgSeq(mix(current.Bg, current.Accent, 0.18))
+}
+
+// errWashHex is the soft red fill under footer alerts: backdrop lifted
+// toward Errored so the red text sits on a surface that separates it from
+// the key-hint row below.
+func errWashHex() string {
+	return mix(current.Bg, current.Errored, 0.18)
+}
+
+// focusWashHex is the soft accent fill under the focus status notice.
+func focusWashHex() string {
+	return mix(current.Bg, current.Accent, 0.18)
+}
+
+// washText paints a soft fill only as wide as s. Multi-segment styles
+// emit resets that would clear an outer Background; re-applying the fill
+// after each reset keeps the wash continuous under the content.
+func washText(hex, s string) string {
+	fill := bgSeq(hex)
+	return fill + strings.ReplaceAll(s, "\x1b[0m", "\x1b[0m"+fill) + "\x1b[0m"
 }
 
 func statusColor(s string) lipgloss.Color {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -109,7 +109,8 @@ func errWashHex() string {
 	return mix(current.Bg, current.Errored, 0.18)
 }
 
-// focusWashHex is the soft accent fill under the focus status notice.
+// focusWashHex tints only the focus notice's own cells so the hint reads
+// as a surface without painting a full-width status strip.
 func focusWashHex() string {
 	return mix(current.Bg, current.Accent, 0.18)
 }

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -1,0 +1,32 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+func TestWashTextFitsContent(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	applyTheme(themes[0])
+	inner := keyStyle.Render("focus ") + subtleStyle.Render("hint")
+	if !strings.Contains(inner, "\x1b[0m") {
+		t.Fatal("styled input must emit ANSI resets for reapply coverage")
+	}
+	washed := washText(focusWashHex(), inner)
+	if lipgloss.Width(washed) != lipgloss.Width(inner) {
+		t.Fatalf("wash width %d != content width %d", lipgloss.Width(washed), lipgloss.Width(inner))
+	}
+	fill := bgSeq(focusWashHex())
+	if !strings.Contains(washed, fill) {
+		t.Fatal("washText must emit the fill sequence")
+	}
+	if !strings.Contains(washed, "\x1b[0m"+fill) {
+		t.Fatal("washText must re-apply the fill after each ANSI reset")
+	}
+}

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 // tmux forwards a passthrough payload after undoubling ESC bytes; a
@@ -84,26 +85,41 @@ func TestThemeTextContrast(t *testing.T) {
 					theme.Name, theme.Bg, token, accent, ratio)
 			}
 		}
-		// Status washes must differ from the backdrop or the highlight
-		// would not read as a surface under the text.
+		// Status washes sit under bold large text. Softening Errored/Accent
+		// into Bg reduces contrast slightly; keep the tertiary floor (2.0)
+		// so a wash that collapses toward the ink still fails the suite.
+		const washMin = 2.0
 		applyTheme(theme)
-		if wash := errWashHex(); wash == theme.Bg {
-			t.Errorf("%s: err wash equals Bg, alerts would not highlight", theme.Name)
+		if ratio := contrastRatio(theme.Errored, errWashHex()); ratio < washMin {
+			t.Errorf("%s: Errored on err wash contrast %.2f, want >= %.1f",
+				theme.Name, ratio, washMin)
 		}
-		if wash := focusWashHex(); wash == theme.Bg {
-			t.Errorf("%s: focus wash equals Bg, focus notice would not highlight", theme.Name)
+		if ratio := contrastRatio(theme.Accent, focusWashHex()); ratio < washMin {
+			t.Errorf("%s: Accent on focus wash contrast %.2f, want >= %.1f",
+				theme.Name, ratio, washMin)
 		}
 	}
 }
 
 func TestWashTextFitsContent(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
 	applyTheme(themes[0])
 	inner := keyStyle.Render("focus ") + subtleStyle.Render("hint")
+	if !strings.Contains(inner, "\x1b[0m") {
+		t.Fatal("styled input must emit ANSI resets for reapply coverage")
+	}
 	washed := washText(focusWashHex(), inner)
 	if lipgloss.Width(washed) != lipgloss.Width(inner) {
 		t.Fatalf("wash width %d != content width %d", lipgloss.Width(washed), lipgloss.Width(inner))
 	}
-	if !strings.Contains(washed, bgSeq(focusWashHex())) {
+	fill := bgSeq(focusWashHex())
+	if !strings.Contains(washed, fill) {
 		t.Fatal("washText must emit the fill sequence")
+	}
+	if !strings.Contains(washed, "\x1b[0m"+fill) {
+		t.Fatal("washText must re-apply the fill after each ANSI reset")
 	}
 }

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -2,11 +2,7 @@ package ui
 
 import (
 	"math"
-	"strings"
 	"testing"
-
-	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 )
 
 // tmux forwards a passthrough payload after undoubling ESC bytes; a
@@ -98,28 +94,5 @@ func TestThemeTextContrast(t *testing.T) {
 			t.Errorf("%s: Accent on focus wash contrast %.2f, want >= %.1f",
 				theme.Name, ratio, washMin)
 		}
-	}
-}
-
-func TestWashTextFitsContent(t *testing.T) {
-	prev := lipgloss.ColorProfile()
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
-
-	applyTheme(themes[0])
-	inner := keyStyle.Render("focus ") + subtleStyle.Render("hint")
-	if !strings.Contains(inner, "\x1b[0m") {
-		t.Fatal("styled input must emit ANSI resets for reapply coverage")
-	}
-	washed := washText(focusWashHex(), inner)
-	if lipgloss.Width(washed) != lipgloss.Width(inner) {
-		t.Fatalf("wash width %d != content width %d", lipgloss.Width(washed), lipgloss.Width(inner))
-	}
-	fill := bgSeq(focusWashHex())
-	if !strings.Contains(washed, fill) {
-		t.Fatal("washText must emit the fill sequence")
-	}
-	if !strings.Contains(washed, "\x1b[0m"+fill) {
-		t.Fatal("washText must re-apply the fill after each ANSI reset")
 	}
 }

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -2,7 +2,10 @@ package ui
 
 import (
 	"math"
+	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // tmux forwards a passthrough payload after undoubling ESC bytes; a
@@ -81,5 +84,26 @@ func TestThemeTextContrast(t *testing.T) {
 					theme.Name, theme.Bg, token, accent, ratio)
 			}
 		}
+		// Status washes must differ from the backdrop or the highlight
+		// would not read as a surface under the text.
+		applyTheme(theme)
+		if wash := errWashHex(); wash == theme.Bg {
+			t.Errorf("%s: err wash equals Bg, alerts would not highlight", theme.Name)
+		}
+		if wash := focusWashHex(); wash == theme.Bg {
+			t.Errorf("%s: focus wash equals Bg, focus notice would not highlight", theme.Name)
+		}
+	}
+}
+
+func TestWashTextFitsContent(t *testing.T) {
+	applyTheme(themes[0])
+	inner := keyStyle.Render("focus ") + subtleStyle.Render("hint")
+	washed := washText(focusWashHex(), inner)
+	if lipgloss.Width(washed) != lipgloss.Width(inner) {
+		t.Fatalf("wash width %d != content width %d", lipgloss.Width(washed), lipgloss.Width(inner))
+	}
+	if !strings.Contains(washed, bgSeq(focusWashHex())) {
+		t.Fatal("washText must emit the fill sequence")
 	}
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -165,8 +165,9 @@ func (m *Model) viewStatus() string {
 		return "  " + keyStyle.Render("copied ") +
 			subtleStyle.Render(fmt.Sprintf("%d chars to clipboard", m.copied))
 	case m.mode == modeFocus:
-		return "  " + keyStyle.Render("focus ") +
-			subtleStyle.Render("typing goes to the agent · drag/double/triple click to copy · ctrl+q or ctrl+\\ back")
+		return "  " + washText(focusWashHex(),
+			keyStyle.Render("focus ")+
+				subtleStyle.Render("typing goes to the agent · drag/double/triple click to copy · ctrl+q or ctrl+\\ back"))
 	case m.mode == modeConfirmDelete:
 		return "  " + errStyle.Render("⚠ "+m.confirm.label) + subtleStyle.Render("  y/n")
 	case m.split.resizeMode:


### PR DESCRIPTION
## What changed

Footer status notices that used plain colored text now sit on a soft, content-width wash:

- **Errors / confirm prompts**: red text on a backdrop→Errored mix (`errStyle`)
- **Focus mode notice**: accent-tinted wash under the multi-segment focus line (`washText` + `focusWashHex`)

The wash is only as wide as the message, not a full-width status strip.

## Why

Red alert text on the terminal backdrop was easy to miss against the key-hint footer. A slight background surface makes alerts and the focus notice read as intentional chrome without dominating the row.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] Rebuilt `agent-manager-dev` and checked error + focus status rendering locally