### PR TITLE
feat(ui): restart a session on an empty context

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The full reference, every key, the quick prompt, killing and reviving, diff revi
 | `enter` | Focus the session in place; keys go to the agent while the list stays |
 | `ctrl+r` | Review the session's changes as full-file diffs; `c` comments a line, `C` sends the comments to the agent |
 | `x` / `v` | Kill a session to free its RAM / revive it on its own conversation |
+| `R` | Restart a session on an empty context: same name, directory and tool, fresh conversation |
 | `s` | Settings (default tool, theme, list density, review layout) |
 | `?` | Help with every binding |
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The full reference, every key, the quick prompt, killing and reviving, diff revi
 | `enter` | Focus the session in place; keys go to the agent while the list stays |
 | `ctrl+r` | Review the session's changes as full-file diffs; `c` comments a line, `C` sends the comments to the agent |
 | `x` / `v` | Kill a session to free its RAM / revive it on its own conversation |
-| `R` | Restart a session on an empty context: same name, directory and tool, fresh conversation |
+| `R` | Restart a session on an empty context: same name, group, directory and tool, fresh conversation |
 | `s` | Settings (default tool, theme, list density, review layout) |
 | `?` | Help with every binding |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,7 +80,7 @@ The id arrives one of two ways: tools with a `session_id_flag` launch under an i
 
 ## Restarting a session on an empty context
 
-`R` keeps the row and drops the context: same name, group, directory and tool, launched on a conversation the agent has never seen. It is what you want when a session has piled up context you are done with, where reviving it would spend the budget re-reading history or land straight in a compact.
+`R` keeps the row and drops the context: same name, group, tool, and working directory, a managed worktree included, launched on a conversation the agent has never seen. It is what you want when a session has piled up context you are done with, where reviving it would spend the budget re-reading history or land straight in a compact.
 
 It asks to confirm first, and it works on a live session too: the running agent ends, then the fresh one launches. The conversation it was on is retired rather than resumed: the manager mints a new id for tools that take one (`session_id_flag`) and captures the new one for tools that mint their own (`session_store`). The retired conversation is left on disk untouched, and the row stops pointing at it, so a later `v` resumes the conversation the restart started rather than the context it dropped.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,6 +25,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `X` | Kill every live session in view |
 | `v` | Revive a dead session, or every dead session under a group |
 | `V` | Revive every dead session in view |
+| `R` | Restart the selected session on an empty context: same name, group, directory and tool |
 | `a` / `u` | Archive / restore a session, or a group and its entire subtree |
 | `d` | Delete session, or a group + its entire subtree |
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
@@ -76,6 +77,12 @@ Deleting (`d`) a session that holds a worktree removes the worktree and its bran
 `v` relaunches a dead session under its old id, keeping its name, group, and history. When the manager holds that session's own conversation id, revive resumes **that exact conversation** through the tool's `resume_by_id_command`: `claude --resume {id}`, `codex resume {id}`, `opencode --session {id}`, `grok --resume {id}`, `gemini --resume {id}`, `pi --session {id}`.
 
 The id arrives one of two ways: tools with a `session_id_flag` launch under an id the manager mints, and tools that mint their own are read back by a `session_store` capturer (`codex`, `opencode`). Without an id, revive falls back to `revive_command` (`claude --continue`), which resumes the working directory's most recent conversation, and the manager says so in the status line, since sessions sharing a directory would otherwise land on the wrong one. On a group row `v` revives every dead session under it, and `V` revives every dead session in view; both revive what they can and name the first failure rather than stopping.
+
+## Restarting a session on an empty context
+
+`R` keeps the row and drops the context: same name, group, directory and tool, launched on a conversation the agent has never seen. It is what you want when a session has piled up context you are done with, where reviving it would spend the budget re-reading history or land straight in a compact.
+
+It asks to confirm first, and it works on a live session too: the running agent ends, then the fresh one launches. The conversation it was on is retired rather than resumed: the manager mints a new id for tools that take one (`session_id_flag`) and captures the new one for tools that mint their own (`session_store`). The retired conversation is left on disk untouched, and the row stops pointing at it, so a later `v` resumes the conversation the restart started rather than the context it dropped.
 
 ## Forking sessions
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,7 +82,7 @@ The id arrives one of two ways: tools with a `session_id_flag` launch under an i
 
 `R` keeps the row and drops the context: same name, group, tool, and working directory, a managed worktree included, launched on a conversation the agent has never seen. It is what you want when a session has piled up context you are done with, where reviving it would spend the budget re-reading history or land straight in a compact.
 
-It asks to confirm first, and it works on a live session too: the running agent ends, then the fresh one launches. The conversation it was on is retired rather than resumed: the manager mints a new id for tools that take one (`session_id_flag`) and captures the new one for tools that mint their own (`session_store`). The retired conversation is left on disk untouched, and the row stops pointing at it, so a later `v` resumes the conversation the restart started rather than the context it dropped.
+It asks to confirm first, and it works on a live session too: the running agent ends, then the fresh one launches. The conversation it was on is retired rather than resumed: the manager mints a new id for tools that take one (`session_id_flag`) and captures the new one for tools that mint their own (`session_store`). The retired conversation is left on disk untouched, and the row stops pointing at it, so a later `v` resumes the conversation the restart started rather than the context it dropped. The row changes hands only once the new agent is up, so a launch that cannot start (a tool gone from `PATH`, a directory that moved) leaves the session on the conversation it had, still there for `v`.
 
 ## Forking sessions
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -46,6 +46,15 @@ type Session struct {
 	WorktreeBranch string
 }
 
+// LaunchTime is when the agent now in the pane started: the last restart,
+// or the row's creation for a session that never restarted.
+func (sess Session) LaunchTime() time.Time {
+	if sess.AgentLaunchedAt.IsZero() {
+		return sess.CreatedAt
+	}
+	return sess.AgentLaunchedAt
+}
+
 type Store struct {
 	db *sql.DB
 }
@@ -391,6 +400,27 @@ func (s *Store) SetAgentSessionID(id, agentSessionID string) error {
 	return requireRow(res, id)
 }
 
+// BindAgentSessionID records a captured conversation id, but only while the
+// session is still the launch the capture ran for: unbound, and launched at
+// the moment the capturing pass read. It reports whether the write landed.
+// Capture reads a tool's store from a snapshot and can take minutes, long
+// enough for a restart to clear the id and move the launch on underneath it,
+// and that stale answer names the conversation the restart just dropped.
+func (s *Store) BindAgentSessionID(id, agentSessionID string, launchedAt time.Time) (bool, error) {
+	res, err := s.db.Exec(
+		`UPDATE sessions SET agent_session_id = ?
+		 WHERE id = ? AND agent_session_id = '' AND agent_launched_at = ?`,
+		agentSessionID, id, encodeTime(launchedAt))
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
 // RestartAgent rebinds a session to a fresh agent run: the conversation it
 // was resuming is retired, the new one (empty until capture for tools that
 // mint their own id) takes its place, and the launch clock moves to now.
@@ -405,15 +435,6 @@ func (s *Store) RestartAgent(id, agentSessionID string, launchedAt time.Time) er
 		return err
 	}
 	return requireRow(res, id)
-}
-
-// LaunchTime is when the agent now in the pane started: the last restart,
-// or the row's creation for a session that never restarted.
-func (sess Session) LaunchTime() time.Time {
-	if sess.AgentLaunchedAt.IsZero() {
-		return sess.CreatedAt
-	}
-	return sess.AgentLaunchedAt
 }
 
 // SetSnapshot stores the session's final pane capture, kept out of the

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,6 +32,13 @@ type Session struct {
 	// gemini/pi session UUID, codex rollout id, opencode session id). Revive resumes
 	// this exact conversation instead of the cwd's most recent one.
 	AgentSessionID string
+	// AgentLaunchedAt is when the agent process now in the pane started, which
+	// restart moves forward while CreatedAt keeps marking the row's birth.
+	// Zero for sessions that never restarted, whose launch is CreatedAt.
+	AgentLaunchedAt time.Time
+	// RetiredAgentSessionID is the conversation a restart left behind, kept so
+	// id capture never binds the fresh run back to the context it dropped.
+	RetiredAgentSessionID string
 	// WorktreeRepo and WorktreeBranch are set for sessions running in a
 	// worktree Agent Manager created. Forks share these values so the last
 	// session to leave can clean up the worktree and its am/ branch.
@@ -118,6 +125,8 @@ CREATE TABLE IF NOT EXISTS settings (
 		`ALTER TABLE sessions ADD COLUMN worktree_repo TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN worktree_branch TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE groups ADD COLUMN worktree TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN agent_launched_at INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE sessions ADD COLUMN retired_agent_session_id TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, migration := range migrations {
 		if _, err := s.db.Exec(migration); err != nil {
@@ -293,7 +302,7 @@ func (s *Store) AddGroup(name, path, worktree string) error {
 }
 
 func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
-	query := `SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch
+	query := `SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id
 	          FROM sessions`
 	if !includeArchived {
 		query += ` WHERE archived = 0`
@@ -309,16 +318,18 @@ func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
 	for rows.Next() {
 		var sess Session
 		var archived, acked int
-		var created, lastStatus int64
+		var created, lastStatus, agentLaunched int64
 		if err := rows.Scan(&sess.ID, &sess.Name, &sess.Tool, &sess.Cwd,
 			&sess.Group, &sess.Status, &archived, &acked, &created, &lastStatus,
-			&sess.AgentSessionID, &sess.WorktreeRepo, &sess.WorktreeBranch); err != nil {
+			&sess.AgentSessionID, &sess.WorktreeRepo, &sess.WorktreeBranch,
+			&agentLaunched, &sess.RetiredAgentSessionID); err != nil {
 			return nil, err
 		}
 		sess.Archived = archived != 0
 		sess.Acked = acked != 0
 		sess.CreatedAt = decodeTime(created)
 		sess.LastStatusAt = decodeTime(lastStatus)
+		sess.AgentLaunchedAt = decodeTime(agentLaunched)
 		sessions = append(sessions, sess)
 	}
 	return sessions, rows.Err()
@@ -327,13 +338,13 @@ func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
 func (s *Store) Get(id string) (Session, error) {
 	var sess Session
 	var archived, acked int
-	var created, lastStatus int64
+	var created, lastStatus, agentLaunched int64
 	err := s.db.QueryRow(
-		`SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch
+		`SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id
 		 FROM sessions WHERE id = ?`, id,
 	).Scan(&sess.ID, &sess.Name, &sess.Tool, &sess.Cwd, &sess.Group,
 		&sess.Status, &archived, &acked, &created, &lastStatus, &sess.AgentSessionID,
-		&sess.WorktreeRepo, &sess.WorktreeBranch)
+		&sess.WorktreeRepo, &sess.WorktreeBranch, &agentLaunched, &sess.RetiredAgentSessionID)
 	if err != nil {
 		return Session{}, err
 	}
@@ -341,6 +352,7 @@ func (s *Store) Get(id string) (Session, error) {
 	sess.Acked = acked != 0
 	sess.CreatedAt = decodeTime(created)
 	sess.LastStatusAt = decodeTime(lastStatus)
+	sess.AgentLaunchedAt = decodeTime(agentLaunched)
 	return sess, nil
 }
 
@@ -377,6 +389,31 @@ func (s *Store) SetAgentSessionID(id, agentSessionID string) error {
 		return err
 	}
 	return requireRow(res, id)
+}
+
+// RestartAgent rebinds a session to a fresh agent run: the conversation it
+// was resuming is retired, the new one (empty until capture for tools that
+// mint their own id) takes its place, and the launch clock moves to now.
+func (s *Store) RestartAgent(id, agentSessionID string, launchedAt time.Time) error {
+	res, err := s.db.Exec(
+		`UPDATE sessions SET
+			retired_agent_session_id = CASE WHEN agent_session_id != '' THEN agent_session_id ELSE retired_agent_session_id END,
+			agent_session_id = ?,
+			agent_launched_at = ?
+		 WHERE id = ?`, agentSessionID, encodeTime(launchedAt), id)
+	if err != nil {
+		return err
+	}
+	return requireRow(res, id)
+}
+
+// LaunchTime is when the agent now in the pane started: the last restart,
+// or the row's creation for a session that never restarted.
+func (sess Session) LaunchTime() time.Time {
+	if sess.AgentLaunchedAt.IsZero() {
+		return sess.CreatedAt
+	}
+	return sess.AgentLaunchedAt
 }
 
 // SetSnapshot stores the session's final pane capture, kept out of the

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -842,3 +842,71 @@ func TestRestartAgentRetiresTheConversationItReplaces(t *testing.T) {
 		t.Fatalf("retired = %q, want it kept", got.RetiredAgentSessionID)
 	}
 }
+
+// Capture answers a launch that may already be over by the time it lands, so
+// binding is a compare-and-set: the row must still be unbound and still carry
+// the launch the capture ran for.
+func TestBindAgentSessionIDOnlyBindsTheLaunchItAnswers(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.CreateSession(sample("a", "g1")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	created, err := st.Get("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A session that never restarted stores a zero launch time, and the
+	// capture that read it carries that same zero.
+	bound, err := st.BindAgentSessionID("a", "first", created.AgentLaunchedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bound {
+		t.Fatal("a capture for the current launch should bind")
+	}
+	got, err := st.Get("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentSessionID != "first" {
+		t.Fatalf("conversation id = %q, want first", got.AgentSessionID)
+	}
+
+	// A second answer for the same launch arrives after the row is bound.
+	bound, err = st.BindAgentSessionID("a", "second", created.AgentLaunchedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bound {
+		t.Fatal("a bound row must not take another capture")
+	}
+
+	// A restart clears the id and moves the launch on; an answer from the
+	// launch before it names the conversation the restart dropped.
+	restarted := created.CreatedAt.Add(time.Minute)
+	if err := st.RestartAgent("a", "", restarted); err != nil {
+		t.Fatal(err)
+	}
+	bound, err = st.BindAgentSessionID("a", "stale", created.AgentLaunchedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bound {
+		t.Fatal("a capture from the launch before the restart must not bind")
+	}
+	bound, err = st.BindAgentSessionID("a", "fresh", restarted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bound {
+		t.Fatal("a capture for the launch now running should bind")
+	}
+	got, err = st.Get("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentSessionID != "fresh" {
+		t.Fatalf("conversation id = %q, want fresh", got.AgentSessionID)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newTestStore(t *testing.T) *Store {
@@ -781,5 +782,63 @@ func TestAddGroupStoresSettingsWithoutReplacingExistingGroup(t *testing.T) {
 	}
 	if len(groups) != 1 || groups[0].Path != "/first" || groups[0].Worktree != "off" {
 		t.Fatalf("duplicate add changed group: %+v", groups)
+	}
+}
+
+func TestRestartAgentRetiresTheConversationItReplaces(t *testing.T) {
+	st := newTestStore(t)
+	sess := sample("a", "g1")
+	sess.AgentSessionID = "first"
+	if err := st.CreateSession(sess); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	created, err := st.Get("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created.LaunchTime().Equal(created.CreatedAt) {
+		t.Fatalf("launch time before any restart = %v, want the creation time %v", created.LaunchTime(), created.CreatedAt)
+	}
+
+	firstRestart := created.CreatedAt.Add(time.Minute)
+	if err := st.RestartAgent("a", "second", firstRestart); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	got, err := st.Get("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentSessionID != "second" || got.RetiredAgentSessionID != "first" {
+		t.Fatalf("after restart: id = %q, retired = %q", got.AgentSessionID, got.RetiredAgentSessionID)
+	}
+	if !got.LaunchTime().Equal(firstRestart) {
+		t.Fatalf("launch time = %v, want %v", got.LaunchTime(), firstRestart)
+	}
+
+	// A tool that mints its own id restarts with no id to record; the
+	// conversation it just left is still the one to keep out of capture.
+	secondRestart := firstRestart.Add(time.Minute)
+	if err := st.RestartAgent("a", "", secondRestart); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	got, err = st.Get("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentSessionID != "" || got.RetiredAgentSessionID != "second" {
+		t.Fatalf("after second restart: id = %q, retired = %q", got.AgentSessionID, got.RetiredAgentSessionID)
+	}
+
+	// A restart that follows without a conversation to retire keeps the
+	// last real one rather than forgetting it.
+	if err := st.RestartAgent("a", "", secondRestart.Add(time.Minute)); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	got, err = st.Get("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RetiredAgentSessionID != "second" {
+		t.Fatalf("retired = %q, want it kept", got.RetiredAgentSessionID)
 	}
 }

--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -24,6 +24,8 @@ func (m *Model) confirmTitle() string {
 		return "◇ Archive " + subject
 	case actionRestore:
 		return "◆ Restore " + subject
+	case actionRestart:
+		return "↻ Restart " + subject
 	default:
 		return "⚠ Delete " + subject
 	}
@@ -32,7 +34,8 @@ func (m *Model) confirmTitle() string {
 // confirmDestructive reports whether the pending answer takes something
 // away, which decides whether the dialog reads as an alarm or as a move.
 func (m *Model) confirmDestructive() bool {
-	return m.confirm.action == actionKill || m.confirm.action == actionDelete
+	return m.confirm.action == actionKill || m.confirm.action == actionDelete ||
+		m.confirm.action == actionRestart
 }
 
 func (m *Model) viewConfirm() string {
@@ -64,6 +67,8 @@ func (m *Model) viewConfirm() string {
 		answer = "archive"
 	case actionRestore:
 		answer = "restore"
+	case actionRestart:
+		answer = "restart"
 	}
 	hint := [][2]string{{"y/↵", answer}, {"n/esc", "cancel"}}
 	return m.cardSized(width, m.confirmTitle(), strings.TrimRight(body.String(), "\n"), hint)

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1089,7 +1089,7 @@ func (m *Model) sendAnnotations() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if !m.tmux.Exists(sess.ID) {
-		m.errBar.text = "session is dead - press v to revive"
+		m.errBar.text = deadSessionHint
 		return m, nil
 	}
 	notes := m.diff.annotations[m.reviewKey()]

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -106,7 +106,7 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 		return m.attachSelected()
 	}
 	if !m.tmux.Exists(sess.ID) {
-		m.errBar.text = "session is dead - press v to revive"
+		m.errBar.text = deadSessionHint
 		return m, nil
 	}
 	m.errBar.text = ""

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -105,6 +105,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.reviveSelected()
 	case "V", "shift+v":
 		return m.reviveAllDead()
+	case "R", "shift+r":
+		return m.restartSelected()
 	case "x":
 		return m.killSelected()
 	case "X", "shift+x":

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
 )
 
 func (m *Model) attachSelected() (tea.Model, tea.Cmd) {
@@ -200,6 +203,16 @@ func (m *Model) reviveSession(sess store.Session) error {
 	if sess.AgentSessionID != "" && tool.ResumeByIDCommand != "" {
 		baseCommand = strings.ReplaceAll(tool.ResumeByIDCommand, "{id}", sess.AgentSessionID)
 	}
+	return m.relaunchSession(sess, tool, baseCommand, tool.DefaultStatus, nil)
+}
+
+// relaunchSession puts a dead session's row back on a running tmux window
+// under its old id, keeping its name, group and history. Both revive and
+// restart end here; they differ only in the command they hand it and in
+// bindConversation, which records the conversation the new pane is on once
+// the launch has actually taken. A launch that fails leaves the row exactly
+// as it was, still pointing at the conversation it can be revived on.
+func (m *Model) relaunchSession(sess store.Session, tool config.Tool, baseCommand, newStatus string, bindConversation func() error) error {
 	command, env, err := m.buildLaunch(sess.Tool, tool, baseCommand, sess.ID)
 	if err != nil {
 		return err
@@ -207,10 +220,16 @@ func (m *Model) reviveSession(sess store.Session) error {
 	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
 		return err
 	}
+	if bindConversation != nil {
+		if err := bindConversation(); err != nil {
+			_ = m.tmux.Kill(sess.ID)
+			return err
+		}
+	}
 	if err := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name)); err != nil {
 		return err
 	}
-	if err := m.store.UpdateStatus(sess.ID, tool.DefaultStatus); err != nil {
+	if err := m.store.UpdateStatus(sess.ID, newStatus); err != nil {
 		return err
 	}
 	// The session is alive again; any watcher backoff from its dead spell
@@ -218,9 +237,91 @@ func (m *Model) reviveSession(sess store.Session) error {
 	if m.focus != nil {
 		m.focus.retryNow()
 	}
-	// A leftover ack from the previous life must not swallow the revived
+	// A leftover ack from the previous life must not swallow the relaunched
 	// agent's first finished alert.
 	return m.store.SetAcked(sess.ID, false)
+}
+
+// restartSelected asks to relaunch the selected session with an empty
+// context: the same row, directory and tool, running a brand new
+// conversation instead of resuming the one it held.
+func (m *Model) restartSelected() (tea.Model, tea.Cmd) {
+	entry, ok := m.selectedRow()
+	if !ok {
+		return m, nil
+	}
+	if entry.isGroup {
+		m.errBar.text = "restart applies to a session; pick one under " + displayGroup(entry.group)
+		return m, nil
+	}
+	label := fmt.Sprintf("restart %s with an empty context? its current conversation is left behind.", entry.sess.Name)
+	if m.tmux.Exists(entry.sess.ID) {
+		label = fmt.Sprintf("restart %s with an empty context? ends the running agent and leaves its conversation behind.", entry.sess.Name)
+	}
+	m.confirm = confirmTarget{
+		action:   actionRestart,
+		sessions: []store.Session{entry.sess},
+		label:    label,
+	}
+	m.mode = modeConfirmDelete
+	return m, nil
+}
+
+// restartSession relaunches a session's tool from scratch. The conversation
+// it was resuming is retired rather than resumed, so the agent comes back
+// with the same name, directory and group but no context to carry.
+func (m *Model) restartSession(sess store.Session) error {
+	tool, ok := m.cfg.Tools[sess.Tool]
+	if !ok {
+		return fmt.Errorf("tool %s is no longer configured", sess.Tool)
+	}
+	if info, err := os.Stat(sess.Cwd); err != nil || !info.IsDir() {
+		return fmt.Errorf("working directory no longer exists: %s", sess.Cwd)
+	}
+	if err := m.killSession(sess); err != nil {
+		return err
+	}
+	baseCommand, agentSessionID := restartLaunch(tool)
+	bind := func() error {
+		launchedAt := time.Now()
+		if err := m.store.RestartAgent(sess.ID, agentSessionID, launchedAt); err != nil {
+			return err
+		}
+		m.bindRestartLocally(sess.ID, agentSessionID, launchedAt)
+		return nil
+	}
+	// Starting, like a fresh spawn: the row reads as booting until the new
+	// agent paints its pane.
+	return m.relaunchSession(sess, tool, baseCommand, status.Starting, bind)
+}
+
+// restartLaunch builds what a restart runs: the tool's plain launch command,
+// exactly as a brand new session gets it, plus a fresh conversation id for
+// the tools that take one. Tools that mint their own id instead get nothing
+// to carry, and the poller captures what they wrote.
+func restartLaunch(tool config.Tool) (baseCommand, agentSessionID string) {
+	if tool.SessionIDFlag == "" {
+		return tool.Command, ""
+	}
+	agentSessionID = uuid.NewString()
+	return tool.Command + " " + tool.SessionIDFlag + " " + agentSessionID, agentSessionID
+}
+
+// bindRestartLocally mirrors the store write in the loaded rows, so the list
+// redraws on the new conversation before the next poll re-reads it.
+func (m *Model) bindRestartLocally(id, agentSessionID string, launchedAt time.Time) {
+	for i := range m.sessions {
+		if m.sessions[i].ID != id {
+			continue
+		}
+		if m.sessions[i].AgentSessionID != "" {
+			m.sessions[i].RetiredAgentSessionID = m.sessions[i].AgentSessionID
+		}
+		m.sessions[i].AgentSessionID = agentSessionID
+		m.sessions[i].AgentLaunchedAt = launchedAt
+		m.sessions[i].Status = status.Starting
+		m.sessions[i].Acked = false
+	}
 }
 
 // killSelected asks to end the selected session, or every live session
@@ -519,6 +620,15 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case actionKill:
 			for _, sess := range m.confirm.sessions {
 				if err := m.killSession(sess); err != nil {
+					m.errBar.text = err.Error()
+					return m, nil
+				}
+			}
+			m.errBar.text = ""
+			m.rebuildRows()
+		case actionRestart:
+			for _, sess := range m.confirm.sessions {
+				if err := m.restartSession(sess); err != nil {
 					m.errBar.text = err.Error()
 					return m, nil
 				}

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -14,13 +14,17 @@ import (
 	"github.com/google/uuid"
 )
 
+// deadSessionHint names both ways back from a dead row: revive resumes the
+// conversation it held, restart drops it.
+const deadSessionHint = "session is dead - press v to revive or R to restart"
+
 func (m *Model) attachSelected() (tea.Model, tea.Cmd) {
 	sess, ok := m.selected()
 	if !ok {
 		return m, nil
 	}
 	if !m.tmux.Exists(sess.ID) {
-		m.errBar.text = "session is dead - press v to revive"
+		m.errBar.text = deadSessionHint
 		return m, nil
 	}
 	m.errBar.text = ""
@@ -68,7 +72,7 @@ func (m *Model) reattach(id string, diffGen int) tea.Cmd {
 	poller := m.poller
 	return func() tea.Msg {
 		if !driver.Exists(id) {
-			return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: errors.New("session is dead - press v to revive")}
+			return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: errors.New(deadSessionHint)}
 		}
 		sess, err := stor.Get(id)
 		if err != nil {

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -396,12 +396,14 @@ func argCaptureCommand(argsFile string) string {
 	return "sh -c " + tmux.ShellQuote(script) + " sh"
 }
 
+// readWhenWritten waits for content, not merely for the file: the launching
+// shell truncates it before printf runs, so a read that lands between the two
+// comes back empty and would fail the assertion it was fetched for.
 func readWhenWritten(t *testing.T, path string) string {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		raw, err := os.ReadFile(path)
-		if err == nil {
+		if raw, err := os.ReadFile(path); err == nil && len(raw) > 0 {
 			return string(raw)
 		}
 		time.Sleep(20 * time.Millisecond)
@@ -482,6 +484,12 @@ func TestRestartClearsCapturedConversationID(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "codexish", t.TempDir(), "")
 	sess := m.sessionRows()[0]
+	// The precondition under test, spelled out rather than inherited from
+	// whatever flags the fake tools happen to carry.
+	tool := m.cfg.Tools[sess.Tool]
+	tool.SessionIDFlag = ""
+	tool.SessionStore = "codex"
+	m.cfg.Tools[sess.Tool] = tool
 
 	if err := m.store.SetAgentSessionID(sess.ID, "captured-conversation"); err != nil {
 		t.Fatal(err)

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -9,9 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
 )
 
 func TestCreateArchiveRestoreDelete(t *testing.T) {
@@ -382,6 +385,178 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	}
 	if got.Acked {
 		t.Fatal("revive should clear a leftover ack")
+	}
+}
+
+// argCaptureCommand builds a launch command that records the arguments the
+// manager appended to it and then holds the pane open, so a test can prove
+// which flags a launch carried.
+func argCaptureCommand(argsFile string) string {
+	script := `printf '%s\n' "$@" > ` + tmux.ShellQuote(argsFile) + `; cat`
+	return "sh -c " + tmux.ShellQuote(script) + " sh"
+}
+
+func readWhenWritten(t *testing.T, path string) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			return string(raw)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("no launch arguments written to %s", path)
+	return ""
+}
+
+// Restart is revive's opposite number: same row, same directory, same tool,
+// but a conversation the agent has never seen. The old one is retired rather
+// than resumed, so the resume flags revive would have used stay unused.
+func TestRestartLaunchesAFreshConversation(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "phoenix", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+
+	argsFile := filepath.Join(t.TempDir(), "launch-args")
+	tool := m.cfg.Tools[sess.Tool]
+	tool.Command = argCaptureCommand(argsFile)
+	tool.SessionIDFlag = "--session-id"
+	tool.ResumeByIDCommand = "false --resume {id}"
+	tool.ReviveCommand = "false --continue"
+	m.cfg.Tools[sess.Tool] = tool
+
+	if err := m.store.SetAgentSessionID(sess.ID, "old-conversation"); err != nil {
+		t.Fatal(err)
+	}
+	m.sessions[0].AgentSessionID = "old-conversation"
+	if err := m.tmux.Kill(sess.ID); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	m.selectSessionRow(t, "phoenix")
+
+	if _, _ = m.restartSelected(); m.mode != modeConfirmDelete {
+		t.Fatalf("restart should ask first, mode = %v err = %q", m.mode, m.errBar.text)
+	}
+	_, cmd := m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m.applyCmd(t, cmd)
+	if m.errBar.text != "" {
+		t.Fatalf("restart: %q", m.errBar.text)
+	}
+	if !m.tmux.Exists(sess.ID) {
+		t.Fatal("restart should leave the session running")
+	}
+
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentSessionID == "" || got.AgentSessionID == "old-conversation" {
+		t.Fatalf("restarted conversation id = %q, want a fresh one", got.AgentSessionID)
+	}
+	if got.RetiredAgentSessionID != "old-conversation" {
+		t.Fatalf("retired conversation = %q, want old-conversation", got.RetiredAgentSessionID)
+	}
+	if got.AgentLaunchedAt.Before(got.CreatedAt) || got.AgentLaunchedAt.IsZero() {
+		t.Fatalf("launch time = %v, created = %v", got.AgentLaunchedAt, got.CreatedAt)
+	}
+	if got.Status != status.Starting {
+		t.Fatalf("after restart, status = %q want %q", got.Status, status.Starting)
+	}
+
+	// The fresh conversation id rides the launch; the resume flags revive
+	// would have used never appear.
+	args := readWhenWritten(t, argsFile)
+	if !strings.Contains(args, "--session-id\n"+got.AgentSessionID) {
+		t.Fatalf("launch arguments = %q, want the fresh session id", args)
+	}
+	if strings.Contains(args, "--resume") || strings.Contains(args, "--continue") {
+		t.Fatalf("restart must not resume, launch arguments = %q", args)
+	}
+}
+
+// A tool that mints its own conversation id (codex, opencode) has nothing to
+// hand the launch, so restart clears the binding and leaves the id for the
+// poller to capture once the new conversation lands.
+func TestRestartClearsCapturedConversationID(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "codexish", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+
+	if err := m.store.SetAgentSessionID(sess.ID, "captured-conversation"); err != nil {
+		t.Fatal(err)
+	}
+	m.sessions[0].AgentSessionID = "captured-conversation"
+	if err := m.tmux.Kill(sess.ID); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	m.selectSessionRow(t, "codexish")
+
+	m.restartSelected()
+	_, cmd := m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m.applyCmd(t, cmd)
+	if m.errBar.text != "" {
+		t.Fatalf("restart: %q", m.errBar.text)
+	}
+
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentSessionID != "" {
+		t.Fatalf("conversation id = %q, want it cleared for capture", got.AgentSessionID)
+	}
+	if got.RetiredAgentSessionID != "captured-conversation" {
+		t.Fatalf("retired conversation = %q", got.RetiredAgentSessionID)
+	}
+}
+
+// Restart also serves the session that is still running: it ends the agent
+// holding the context and brings the row back empty-handed.
+func TestRestartEndsALiveAgentFirst(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "busy", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+	tool := m.cfg.Tools[sess.Tool]
+	tool.Command = argCaptureCommand(filepath.Join(t.TempDir(), "launch-args"))
+	m.cfg.Tools[sess.Tool] = tool
+	m.selectSessionRow(t, "busy")
+
+	if _, _ = m.restartSelected(); m.mode != modeConfirmDelete {
+		t.Fatalf("restart should ask first, mode = %v err = %q", m.mode, m.errBar.text)
+	}
+	if !strings.Contains(m.confirm.label, "ends the running agent") {
+		t.Fatalf("confirm label = %q", m.confirm.label)
+	}
+	_, cmd := m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m.applyCmd(t, cmd)
+	if m.errBar.text != "" {
+		t.Fatalf("restart: %q", m.errBar.text)
+	}
+	if !m.tmux.Exists(sess.ID) {
+		t.Fatal("restart should leave the session running")
+	}
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != status.Starting {
+		t.Fatalf("after restart, status = %q want %q", got.Status, status.Starting)
+	}
+}
+
+func TestRestartRefusesGroupRow(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("work", dir); err != nil {
+		t.Fatal(err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "member", dir, "work")
+	m.selectGroupRow(t, "work")
+
+	if _, _ = m.restartSelected(); m.mode != modeList || m.errBar.text == "" {
+		t.Fatalf("group restart should refuse, mode = %v err = %q", m.mode, m.errBar.text)
 	}
 }
 
@@ -929,5 +1104,49 @@ func TestDeleteKeepsDirtyWorktree(t *testing.T) {
 	}
 	if remaining, _ := m.store.ListSessions(true); len(remaining) != 0 {
 		t.Fatal("session record should still be deleted")
+	}
+}
+
+// Restart has to hold for every CLI the manager ships with, not just the one
+// the fake tools stand in for: it launches each tool the way a brand new
+// session does, and never reaches for a resume, continue or fork command.
+func TestRestartLaunchIsAFreshStartForEveryShippedTool(t *testing.T) {
+	cfg, err := config.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Tools) < 6 {
+		t.Fatalf("built-in tools = %d, expected every shipped CLI", len(cfg.Tools))
+	}
+	for name, tool := range cfg.Tools {
+		command, agentSessionID := restartLaunch(tool)
+		if !strings.HasPrefix(command, tool.Command) {
+			t.Errorf("%s: restart command %q does not start from its launch command %q", name, command, tool.Command)
+		}
+		rest := strings.TrimPrefix(command, tool.Command)
+		for _, resume := range []string{"resume", "continue", "fork", "--session ", "--last"} {
+			if strings.Contains(rest, resume) {
+				t.Errorf("%s: restart command %q carries %q", name, command, resume)
+			}
+		}
+		if tool.SessionIDFlag == "" {
+			// codex and opencode mint their own id; the poller captures it.
+			if agentSessionID != "" || rest != "" {
+				t.Errorf("%s: restart handed an id to a tool that mints its own: %q", name, command)
+			}
+			if tool.SessionStore == "" {
+				t.Errorf("%s: no session_id_flag and no session_store leaves restart with no conversation id at all", name)
+			}
+			continue
+		}
+		if _, err := uuid.Parse(agentSessionID); err != nil {
+			t.Errorf("%s: restart conversation id %q is not a uuid: %v", name, agentSessionID, err)
+		}
+		if want := " " + tool.SessionIDFlag + " " + agentSessionID; rest != want {
+			t.Errorf("%s: restart command tail = %q, want %q", name, rest, want)
+		}
+		if _, second := restartLaunch(tool); second == agentSessionID {
+			t.Errorf("%s: two restarts reused conversation id %q", name, agentSessionID)
+		}
 	}
 }

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -435,6 +435,7 @@ func (m *Model) viewHelp() string {
 		{"X", "kill every live session"},
 		{"v", "revive killed session, or every dead session in a group (resumes the agent)"},
 		{"V", "revive every dead session"},
+		{"R", "restart session with an empty context (same name, dir and tool)"},
 		{"a / u", "archive / restore"},
 		{"d", "delete session, or group + subtree"},
 		{"K / J", "reorder row up / down (shift+↑↓ also works)"},

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -435,7 +435,7 @@ func (m *Model) viewHelp() string {
 		{"X", "kill every live session"},
 		{"v", "revive killed session, or every dead session in a group (resumes the agent)"},
 		{"V", "revive every dead session"},
-		{"R", "restart session with an empty context (same name, dir and tool)"},
+		{"R", "restart session with an empty context (same name, group, dir and tool)"},
 		{"a / u", "archive / restore"},
 		{"d", "delete session, or group + subtree"},
 		{"K / J", "reorder row up / down (shift+↑↓ also works)"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -245,6 +245,7 @@ const (
 	actionArchive = "archive"
 	actionRestore = "restore"
 	actionKill    = "kill"
+	actionRestart = "restart"
 )
 
 type confirmTarget struct {

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -323,7 +323,7 @@ func (p *poller) refreshOnce() tea.Msg {
 				// flashing idle before it has booted. A grace cap keeps a tool
 				// that never paints from sticking on starting forever.
 				if sess.Status == status.Starting && !paneBooted(pane) &&
-					time.Since(sess.CreatedAt) < startingGrace {
+					time.Since(sess.LaunchTime()) < startingGrace {
 					newStatus = status.Starting
 				}
 				// Any real transition re-arms the finished alert.
@@ -453,13 +453,19 @@ func (p *poller) startCaptureIfIdle(sessions []store.Session, panes map[string]i
 // bound. Sessions are processed in launch order so the earliest one claims
 // the earliest unclaimed conversation in its directory; a later session
 // started in the same directory then skips that one via claimed and captures
-// its own. CreatedAt carries nanosecond precision, so sessions launched a
+// its own. Launch times carry nanosecond precision, so sessions launched a
 // moment apart in the same directory still order deterministically.
 func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[string]int) (int, error) {
 	claimed := make(map[string]bool, len(sessions))
 	for _, sess := range sessions {
 		if sess.AgentSessionID != "" {
 			claimed[sess.AgentSessionID] = true
+		}
+		// A restart's old conversation still sits in the directory, newer
+		// than every other candidate; claiming it keeps the fresh run from
+		// binding straight back to the context the restart dropped.
+		if sess.RetiredAgentSessionID != "" {
+			claimed[sess.RetiredAgentSessionID] = true
 		}
 	}
 	pending := make([]int, 0, len(sessions))
@@ -469,12 +475,12 @@ func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[stri
 		}
 	}
 	sort.SliceStable(pending, func(a, b int) bool {
-		return sessions[pending[a]].CreatedAt.Before(sessions[pending[b]].CreatedAt)
+		return sessions[pending[a]].LaunchTime().Before(sessions[pending[b]].LaunchTime())
 	})
 	captured := 0
 	for _, i := range pending {
 		sess := sessions[i]
-		agentID, ok := agentsession.Capture(p.sessionStores[sess.Tool], sess.Cwd, sess.CreatedAt, claimed)
+		agentID, ok := agentsession.Capture(p.sessionStores[sess.Tool], sess.Cwd, sess.LaunchTime(), claimed)
 		if !ok {
 			continue
 		}

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -484,6 +484,9 @@ func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[stri
 		if !ok {
 			continue
 		}
+		// The raw field, never LaunchTime(): the compare-and-set matches the
+		// stored column, which is zero for a session that never restarted,
+		// while LaunchTime() answers CreatedAt and would match nothing.
 		bound, err := p.store.BindAgentSessionID(sess.ID, agentID, sess.AgentLaunchedAt)
 		if err != nil {
 			return captured, err

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -484,8 +484,15 @@ func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[stri
 		if !ok {
 			continue
 		}
-		if err := ignoreDeletedSession(p.store.SetAgentSessionID(sess.ID, agentID)); err != nil {
+		bound, err := p.store.BindAgentSessionID(sess.ID, agentID, sess.AgentLaunchedAt)
+		if err != nil {
 			return captured, err
+		}
+		if !bound {
+			// The session was restarted (or bound elsewhere) while this pass
+			// was reading the tool's store, so this id answers a launch that
+			// is over. The next pass captures the one now in the pane.
+			continue
 		}
 		claimed[agentID] = true
 		captured++

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -788,3 +788,50 @@ func TestCaptureAgentSessionIDsSkipsARetiredConversation(t *testing.T) {
 		t.Fatalf("captured %q, want new-id", got.AgentSessionID)
 	}
 }
+
+// Capture reads a tool's session store from a snapshot and can take minutes,
+// so a restart can land while a pass is still looking. The answer it comes
+// back with names the conversation the restart dropped, and writing it would
+// walk the row straight back into the context the user just left.
+func TestCaptureAgentSessionIDsDropsAnAnswerARestartOutran(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	cwd := t.TempDir()
+	created := time.Now().Add(-time.Hour)
+	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-old.jsonl"), "old-id", cwd, created)
+
+	if err := st.CreateSession(store.Session{ID: "sess", Name: "s", Tool: "codex", Cwd: cwd, Group: "g", Status: "idle", CreatedAt: created}); err != nil {
+		t.Fatal(err)
+	}
+	// The pass reads the session before the restart: no id yet, so it is a
+	// capture candidate and the old rollout is the answer it will find.
+	snapshot, err := st.Get("sess")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.RestartAgent("sess", "", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &poller{store: st, sessionStores: map[string]string{"codex": "codex"}}
+	captured, err := p.captureAgentSessionIDs([]store.Session{snapshot}, map[string]int{"sess": 7})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured != 0 {
+		t.Fatalf("captured %d, want the stale answer dropped", captured)
+	}
+	got, err := st.Get("sess")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentSessionID != "" {
+		t.Fatalf("restarted session bound to %q, want it left for the next pass", got.AgentSessionID)
+	}
+}

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -763,7 +763,7 @@ func TestCaptureAgentSessionIDsSkipsARetiredConversation(t *testing.T) {
 	// The retired rollout's last write lands two seconds before the restart,
 	// inside the clock slack the capture window allows.
 	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-old.jsonl"), "old-id", cwd, restarted.Add(-2*time.Second))
-	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-new.jsonl"), "new-id", cwd, restarted)
+	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-new.jsonl"), "new-id", cwd, restarted.Add(time.Second))
 
 	if err := st.CreateSession(store.Session{ID: "sess", Name: "s", Tool: "codex", Cwd: cwd, Group: "g", Status: "idle", CreatedAt: created, AgentSessionID: "old-id"}); err != nil {
 		t.Fatal(err)

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -742,3 +742,49 @@ func TestCaptureAgentSessionIDsAssignsInLaunchOrder(t *testing.T) {
 		t.Fatalf("session B captured %q, want B-id", gotB.AgentSessionID)
 	}
 }
+
+// A restarted codex session still has its old rollout sitting in the same
+// directory, written moments before the restart and so inside the capture
+// window. Capture must bind the fresh conversation, not walk the session
+// straight back into the context the restart dropped.
+func TestCaptureAgentSessionIDsSkipsARetiredConversation(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	cwd := t.TempDir()
+
+	created := time.Now().Add(-time.Hour)
+	restarted := time.Now().Add(-time.Second)
+	// The retired rollout's last write lands two seconds before the restart,
+	// inside the clock slack the capture window allows.
+	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-old.jsonl"), "old-id", cwd, restarted.Add(-2*time.Second))
+	writeCodexRollout(t, filepath.Join(codexHome, "sessions", "rollout-new.jsonl"), "new-id", cwd, restarted)
+
+	if err := st.CreateSession(store.Session{ID: "sess", Name: "s", Tool: "codex", Cwd: cwd, Group: "g", Status: "idle", CreatedAt: created, AgentSessionID: "old-id"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.RestartAgent("sess", "", restarted); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := st.Get("sess")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &poller{store: st, sessionStores: map[string]string{"codex": "codex"}}
+	if _, err := p.captureAgentSessionIDs([]store.Session{sess}, map[string]int{"sess": 42}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.Get("sess")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentSessionID != "new-id" {
+		t.Fatalf("captured %q, want new-id", got.AgentSessionID)
+	}
+}

--- a/internal/ui/quick.go
+++ b/internal/ui/quick.go
@@ -238,7 +238,7 @@ func (m *Model) submitQuick() (tea.Model, tea.Cmd) {
 		return m.quickSpawn(entry.group, text)
 	}
 	if !m.tmux.Exists(entry.sess.ID) {
-		m.errBar.text = "session is dead - press v to revive"
+		m.errBar.text = deadSessionHint
 		return m, nil
 	}
 	if err := m.tmux.SendText(entry.sess.ID, text); err != nil {

--- a/internal/ui/quick_test.go
+++ b/internal/ui/quick_test.go
@@ -69,7 +69,7 @@ func TestQuickPromptDeadSessionSetsError(t *testing.T) {
 
 	m.openQuickMode()
 	m.quick.input.SetValue("hello?")
-	if _, _ = m.submitQuick(); m.errBar.text != "session is dead - press v to revive" {
+	if _, _ = m.submitQuick(); m.errBar.text != deadSessionHint {
 		t.Fatalf("err = %q", m.errBar.text)
 	}
 	if !m.quick.active {

--- a/internal/ui/quick_test.go
+++ b/internal/ui/quick_test.go
@@ -69,7 +69,7 @@ func TestQuickPromptDeadSessionSetsError(t *testing.T) {
 
 	m.openQuickMode()
 	m.quick.input.SetValue("hello?")
-	if _, _ = m.submitQuick(); m.errBar.text != deadSessionHint {
+	if _, _ = m.submitQuick(); m.errBar.text != "session is dead - press v to revive or R to restart" {
 		t.Fatalf("err = %q", m.errBar.text)
 	}
 	if !m.quick.active {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -493,7 +493,7 @@ func (m *Model) rowLegend() legendSection {
 	return legendSection{title: "Session", pairs: [][2]string{
 		{"↵", enterHint}, {"A", attachHint}, {"space", "prompt"}, {"ctrl+r", "review"},
 		{"f", "fork"}, {"r", "rename"}, {"m", "move"},
-		{"x/X", "kill / all"}, {"v/V", "revive / all"},
+		{"x/X", "kill / all"}, {"v/V", "revive / all"}, {"R", "restart"},
 		{"a/u", "archive / restore"}, {"d", "delete"},
 	}}
 }


### PR DESCRIPTION
Closes #230.

Revive brings a session back on the conversation it was holding. When that context is exactly what you wanted rid of, the agent spends the budget re-reading it or lands straight in a compact.

`R` relaunches the row from scratch instead: same name, group, directory, tool and worktree, running a conversation the agent has never seen. It asks first, and it takes a live session too, ending the running agent before the fresh one launches. A group row says to pick a session under it.

## How the fresh conversation is bound

The launch command is the tool's own `command`, exactly what a brand new session gets. Tools with a `session_id_flag` (claude, grok, gemini, pi) launch under a freshly minted id; tools that mint their own (codex, opencode) are captured by the poller once the new conversation lands on disk.

The conversation the row was on is retired, and two columns carry that:

- `agent_launched_at` moves the capture window to the restart, so a conversation from before it falls outside.
- `retired_agent_session_id` keeps the conversation just dropped out of capture's reach, which is what decides the case where the restart follows the kill by seconds and the old rollout is still inside the capture clock slack.

`agent_launched_at` also anchors the starting-up grace, so a restarted row reads as booting until the new agent paints its pane.

The launch runs before either column is written, so a launch that fails leaves the row on the conversation it can still be revived on.

## Verified

Each of the six shipped CLIs was restarted for real, in an isolated store and tmux socket, on its own working directory:

| CLI | Result |
|-----|--------|
| claude | new `--session-id`, booted on an empty conversation, old id retired |
| codex | id cleared, new rollout captured (`019fd7e8…`), retired `019fd7e6…`; a later `v` resumed the post-restart conversation |
| opencode | new session captured (`ses_02813ae0b…`), retired `ses_028158af0…` |
| grok | new `--session-id`, fresh prompt |
| gemini | new `--session-id`, fresh splash |
| pi | new `--session-id`, pi reports "creating a new session with that id" |

The codex run is the case the retired id exists for: the previous rollout was written ~2 minutes before the restart, well inside the capture window, and capture bound the new conversation.

Tests: a restart launch check across every shipped tool from the built-in config, the retired-conversation capture case (fails without the fix), fresh-id and cleared-id restarts, the live-session path, the group refusal, and the store's retire-and-relaunch bookkeeping. `gofmt`, `go vet`, `go build`, `go test -race` all clean.

Docs: README key table, `docs/usage.md` key table plus a section, `?` help and the session legend.