### PR TITLE
chore: add CodeRabbit review config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,11 +11,9 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    base_branches:
-      - main
   path_filters:
-    - "!dist/**"
-    - "!docs/demo/**"
+    - "!**/*.gif"
+    - "!**/*.png"
     - "!go.sum"
   path_instructions:
     - path: "**/*.go"
@@ -33,10 +31,11 @@ reviews:
     - path: "**/*_test.go"
       instructions: |
         Tests live beside the file they cover (listview.go -> listview_test.go).
-        Any test that starts a tmux server must run on an isolated socket via
-        env -u TMUX TMUX_TMPDIR=/tmp/<short>; $TMUX overrides TMUX_TMPDIR, so a
-        test that omits env -u TMUX reaches the user's live tmux server. Flag
-        kill-server or kill-session against a non-isolated socket as critical.
+        Every tmux invocation must name its socket explicitly with -L or -S; an
+        explicit socket is sufficient on its own. A bare tmux call resolves
+        through $TMUX to the developer's live server, so flag one that carries
+        neither an explicit socket nor env -u TMUX as critical, and likewise a
+        kill-server or kill-session that is not pinned to an isolated socket.
     - path: "internal/tmux/**"
       instructions: |
         This package owns the dedicated agentmgr socket. Flag anything that can

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,65 @@
+language: en-US
+early_access: false
+
+reviews:
+  profile: assertive
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  path_filters:
+    - "!dist/**"
+    - "!docs/demo/**"
+    - "!go.sum"
+  path_instructions:
+    - path: "**/*.go"
+      instructions: |
+        Comments are rare and explain a non-obvious why, never what the code
+        does. Do not ask for doc comments, JSDoc-style blocks, or "what" comments
+        on exported identifiers.
+        Reject speculative branches: a fallback or nil-guard for a shape that
+        cannot occur is a defect, not safety. Guards on genuinely external or
+        untrusted input are correct.
+        Errors propagate or are handled explicitly; silent fallbacks that mask a
+        failure are a defect.
+        Names spell out intent: no one-letter variables outside tight loop
+        indices, no invented abbreviations.
+    - path: "**/*_test.go"
+      instructions: |
+        Tests live beside the file they cover (listview.go -> listview_test.go).
+        Any test that starts a tmux server must run on an isolated socket via
+        env -u TMUX TMUX_TMPDIR=/tmp/<short>; $TMUX overrides TMUX_TMPDIR, so a
+        test that omits env -u TMUX reaches the user's live tmux server. Flag
+        kill-server or kill-session against a non-isolated socket as critical.
+    - path: "internal/tmux/**"
+      instructions: |
+        This package owns the dedicated agentmgr socket. Flag anything that can
+        resolve to the default tmux socket, and any global option or key binding
+        written to a server this process does not own.
+    - path: "internal/ui/**"
+      instructions: |
+        Bubble Tea: one Model, files grouped by feature. Update must not block;
+        flag synchronous I/O, exec, or sleeps on the update path instead of a
+        tea.Cmd.
+    - path: "internal/config/**"
+      instructions: |
+        Existing installs keep their stored config.toml, so editing a
+        defaultConfig value never reaches current users. A behavior change that
+        must reach them needs a new field, not an edited default.
+    - path: ".github/workflows/**"
+      instructions: |
+        Pin third-party actions to a commit SHA. Flag any workflow that exposes
+        secrets to pull_request_target or to a step running untrusted PR code.
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: local

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,9 +3,9 @@ early_access: false
 
 reviews:
   profile: assertive
-  request_changes_workflow: false
+  request_changes_workflow: true
   high_level_summary: true
-  poem: false
+  poem: true
   review_status: true
   collapse_walkthrough: true
   auto_review:


### PR DESCRIPTION
Adds `.coderabbit.yaml` so CodeRabbit reviews follow the conventions in AGENTS.md rather than its dashboard defaults.

`path_instructions` cover:
- **`**/*.go`** — comments explain a non-obvious why; speculative branches for shapes that cannot occur are defects; errors propagate rather than fall back silently; names spell out intent.
- **`**/*_test.go`** — tmux-touching tests run on an isolated socket via `env -u TMUX TMUX_TMPDIR=/tmp/<short>`; a missing `env -u TMUX` reaches the live server.
- **`internal/tmux/**`** — flag anything resolving to the default socket.
- **`internal/ui/**`** — `Update` stays non-blocking; I/O belongs in a `tea.Cmd`.
- **`internal/config/**`** — a behavior change that must reach existing installs needs a new field, since a stored config.toml keeps its old defaults.
- **`.github/workflows/**`** — actions pinned to a commit SHA.

Also: drafts skipped, poem off, `dist/`, `docs/demo/` and `go.sum` filtered from review.

Validated against CodeRabbit's published `schema.v2.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated review configuration for the main development branch.
  * Enabled review summaries, status reporting, and automatic responses.
  * Added tailored review guidance for Go, tests, terminal workflows, UI, configuration, and GitHub workflows.
  * Configured selected path exclusions and local knowledge-base learning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->