### PR TITLE
feat(ui): float notices, dock search in the rail, rework the detail heads

### DIFF
--- a/internal/ui/confirm_test.go
+++ b/internal/ui/confirm_test.go
@@ -25,7 +25,7 @@ func TestConfirmRendersAsADialog(t *testing.T) {
 			t.Fatalf("confirm dialog missing %q:\n%s", want, out)
 		}
 	}
-	if status := ansi.Strip(m.viewStatus()); strings.Contains(status, "builder") {
+	if status := ansi.Strip(m.statusLine()); strings.Contains(status, "builder") {
 		t.Fatalf("the question moved to the dialog, status should not repeat it: %q", status)
 	}
 }

--- a/internal/ui/detailhead_test.go
+++ b/internal/ui/detailhead_test.go
@@ -1,0 +1,88 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Every line of a detail head has to stay inside the content column: a fact
+// that overflows tears the panel beside it.
+func TestDetailHeadsFitTheirColumn(t *testing.T) {
+	for _, width := range []int{28, 40, 60, 76, 120} {
+		session := shotModel()
+		session.sessions[3].WorktreeBranch = "am/add-rate-limiting"
+		session.rows[4].sess.WorktreeBranch = "am/add-rate-limiting"
+
+		group := shotModel()
+		for i, row := range group.rows {
+			if row.isGroup && row.group == "backend" {
+				group.cursor = i
+			}
+		}
+		heads := map[string]string{
+			"session": session.viewDetail(width),
+			"group":   group.viewDetail(width),
+			"roster":  group.viewGroupAgents("backend", width, 12),
+		}
+		for name, head := range heads {
+			for i, line := range strings.Split(head, "\n") {
+				if got := ansi.StringWidth(line); got > width {
+					t.Errorf("%s head at %d: line %d is %d wide: %q", name, width, i, got, ansi.Strip(line))
+				}
+			}
+		}
+	}
+}
+
+// The branch chip is the first thing the head gives up, then the tool chip,
+// so the name and the state survive the narrowest columns.
+func TestDetailHeadShedsChipsBeforeFacts(t *testing.T) {
+	m := shotModel()
+	m.sessions[3].WorktreeBranch = "am/add-rate-limiting"
+	m.rows[4].sess.WorktreeBranch = "am/add-rate-limiting"
+
+	wide := ansi.Strip(strings.Split(m.viewDetail(120), "\n")[0])
+	for _, want := range []string{"add-rate-limiting", "claude", "am/add-rate-limiting", "working"} {
+		if !strings.Contains(wide, want) {
+			t.Fatalf("wide head is missing %q: %q", want, wide)
+		}
+	}
+	mid := ansi.Strip(strings.Split(m.viewDetail(60), "\n")[0])
+	if strings.Contains(mid, "am/add-rate-limiting") {
+		t.Errorf("60 columns kept the branch chip: %q", mid)
+	}
+	narrow := ansi.Strip(strings.Split(m.viewDetail(30), "\n")[0])
+	if !strings.Contains(narrow, "add-rate") || !strings.Contains(narrow, "working") {
+		t.Errorf("30 columns dropped a fact instead of trimming the name: %q", narrow)
+	}
+}
+
+// A roster is a table: every tool starts on one column and every state ends
+// on one edge, whatever the names around them do.
+func TestGroupRosterColumnsAlign(t *testing.T) {
+	m := shotModel()
+	rows := strings.Split(ansi.Strip(m.viewGroupAgents("backend", 76, 12)), "\n")
+	if len(rows) < 3 {
+		t.Fatalf("roster is only %d rows: %q", len(rows), rows)
+	}
+	column := -1
+	for _, row := range rows[1:] {
+		at := strings.Index(row, "claude")
+		if at < 0 {
+			at = strings.Index(row, "codex")
+		}
+		if at < 0 {
+			t.Fatalf("no tool on roster row %q", row)
+		}
+		if column == -1 {
+			column = at
+		} else if at != column {
+			t.Errorf("tool column moved from %d to %d: %q", column, at, row)
+		}
+		if got := ansi.StringWidth(row); got != 76 && !strings.HasSuffix(row, "ago") {
+			t.Errorf("roster row does not reach the right edge: %q", row)
+		}
+	}
+}

--- a/internal/ui/detailhead_test.go
+++ b/internal/ui/detailhead_test.go
@@ -76,13 +76,16 @@ func TestGroupRosterColumnsAlign(t *testing.T) {
 		if at < 0 {
 			t.Fatalf("no tool on roster row %q", row)
 		}
+		// Byte offsets shift with every multi-byte glyph in a name, so the
+		// column is the display width of what precedes the tool.
+		cell := ansi.StringWidth(row[:at])
 		if column == -1 {
-			column = at
-		} else if at != column {
-			t.Errorf("tool column moved from %d to %d: %q", column, at, row)
+			column = cell
+		} else if cell != column {
+			t.Errorf("tool column moved from %d to %d: %q", column, cell, row)
 		}
-		if got := ansi.StringWidth(row); got != 76 && !strings.HasSuffix(row, "ago") {
-			t.Errorf("roster row does not reach the right edge: %q", row)
+		if got := ansi.StringWidth(row); got != 76 {
+			t.Errorf("roster row is %d wide, want the full 76: %q", got, row)
 		}
 	}
 }

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -73,13 +73,28 @@ func (m *Model) viewListFrame() string {
 		bottom = m.focusBottomRule(leftWidth+1, m.width)
 	}
 	frame = append(frame, bottom)
-	if status := m.viewStatus(); status != "" {
-		frame = append(frame, paint(status, m.width, backdropHex()))
-	}
 	for _, line := range splitLines(footer) {
 		frame = append(frame, paint(line, m.width, backdropHex()))
 	}
-	return strings.Join(frame, "\n")
+	return m.overlayTopRight(strings.Join(frame, "\n"), m.statusToast(), m.listChromeRows()+1)
+}
+
+// searchFieldLine is the live filter at the head of the rail: the typed
+// query with a caret, and the key that closes it when there is room.
+func (m *Model) searchFieldLine(width int) string {
+	indent := strings.Repeat(" ", railInset)
+	query := valueStyle.Render(m.search)
+	if m.search == "" {
+		query = subtleStyle.Render("type to filter")
+	}
+	field := keyStyle.Render("⌕ ") + query +
+		lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
+	hint := keyCapQuiet("esc", "close")
+	gap := width - railInset - ansi.StringWidth(field) - ansi.StringWidth(hint) - 1
+	if gap < 2 {
+		return indent + field
+	}
+	return indent + field + strings.Repeat(" ", gap) + hint
 }
 
 // railLines is the sessions rail: the entry list on top, the machine
@@ -91,16 +106,26 @@ func (m *Model) railLines(width, height int) []contentLine {
 		listHeight, meters = height, nil
 	}
 	var rows []contentLine
+	// Both banners cost the list three rows each, so each one is only laid
+	// while entries still have room under it: a rail that is all banner
+	// says nothing about the fleet.
+	const railBannerRows, railListMin = 3, 3
+	room := func() bool { return listHeight-len(rows)-railBannerRows >= railListMin }
+	// Search heads the list it filters, so the query sits over the entries
+	// it is narrowing rather than away from them.
+	if m.searching && room() {
+		rows = append(rows, contentLine{}, contentLine{text: m.searchFieldLine(width)}, contentLine{})
+	}
 	// The list starts straight under the pane's top edge; the empty state
 	// centers itself in the full list area instead.
-	if m.showArchived {
+	if m.showArchived && room() {
 		rows = append(rows, contentLine{})
 		rows = append(rows,
 			contentLine{text: strings.Repeat(" ", railInset) + scopeBadgeStyle.Render("ARCHIVED") +
 				subtleStyle.Render("  ") + keyCap("t", "back to active")},
 			contentLine{})
 	}
-	rows = append(rows, m.entryLines(width, listHeight-len(rows))...)
+	rows = append(rows, m.entryLines(width, max(listHeight-len(rows), 0))...)
 	for len(rows) < listHeight {
 		rows = append(rows, contentLine{})
 	}
@@ -581,6 +606,56 @@ func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 	return lines
 }
 
+// detailLabelWidth is the column every fact label in the content head is
+// padded to, so the values under it line up as one column.
+const detailLabelWidth = 7
+
+// factRow is one line of a detail head: a quiet label, its value, and a
+// reading set against the right edge. The value is rendered against the
+// columns it actually gets, and the reading is dropped rather than pushed
+// off the edge when the column is too narrow to hold both.
+func factRow(label string, value func(room int) string, right string, width int) string {
+	room := width - detailLabelWidth - ansi.StringWidth(right) - 2
+	if room < 12 {
+		right, room = "", width-detailLabelWidth
+	}
+	return rowColumns(labelStyle.Render(padRight(label, detailLabelWidth))+value(max(room, 1)), right, width)
+}
+
+// plainValue is a factRow value that is already short enough to stand as it
+// is, for facts whose text does not vary with the terminal.
+func plainValue(value string) func(int) string {
+	return func(int) string { return value }
+}
+
+// trimmedValue is a factRow value cut to the columns it gets, for readings
+// that grow with the fleet rather than with the terminal.
+func trimmedValue(value string) func(int) string {
+	return func(room int) string { return ansi.Truncate(value, room, "…") }
+}
+
+// fitColumns lays the richest pair of readings that fits: rights are tried
+// from richest to plainest, and for each, the lefts in turn. Nothing fitting
+// means the plainest left is trimmed to what the column has.
+func fitColumns(lefts, rights []string, width int) string {
+	for _, right := range rights {
+		for _, left := range lefts {
+			if ansi.StringWidth(left)+ansi.StringWidth(right)+2 <= width {
+				return rowColumns(left, right, width)
+			}
+		}
+	}
+	// Nothing fits whole, so the plainest left is trimmed to keep the richest
+	// reading that still leaves it something readable.
+	last := lefts[len(lefts)-1]
+	for _, right := range rights {
+		if room := width - ansi.StringWidth(right) - 2; room >= 8 {
+			return rowColumns(ansi.Truncate(last, room, "…"), right, width)
+		}
+	}
+	return rowColumns(ansi.Truncate(last, max(width, 1), "…"), "", width)
+}
+
 // viewDetail heads the content column: the selected session's name, its
 // state, and the facts that place it (group, directory, age, usage).
 func (m *Model) viewDetail(width int) string {
@@ -598,19 +673,32 @@ func (m *Model) viewDetail(width int) string {
 		}
 	}
 
-	title := lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(sess.Name)
 	state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).
 		Render(statusGlyph(sess.Status)+" "+statusLabel(sess.Status)) +
 		subtleStyle.Render(" · "+relSince(lastActivity(sess)))
-
-	facts := []string{tool, displayGroup(sess.Group), "started " + relSince(sess.CreatedAt)}
-	if m.procFor == sess.ID && m.proc.OK {
-		facts = append(facts, fmt.Sprintf("cpu %.1f%% · ram %.1f%% · %s",
-			m.proc.CPUPercent, m.proc.RamPercent, humanBytes(m.proc.RSS)))
+	// The branch a worktree session lives on is the fact that tells it apart
+	// from its siblings, so it rides beside the tool while the row has room,
+	// and the tool chip goes before the name does.
+	name := lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(sess.Name)
+	withTool := name + "  " + chipStyle.Render(tool)
+	heads := []string{withTool, name}
+	if sess.WorktreeBranch != "" {
+		heads = append([]string{withTool + " " + chipStyle.Render("⑂ "+sess.WorktreeBranch)}, heads...)
 	}
-	meta := subtleStyle.Render(strings.Join(facts, " · "))
-	dir := subtleStyle.Render(truncateTail(sess.Cwd, width))
-	return rowColumns(title, state, width) + "\n" + meta + "\n" + dir
+
+	usage := ""
+	if m.procFor == sess.ID && m.proc.OK {
+		usage = labelStyle.Render("cpu ") + valueStyle.Render(fmt.Sprintf("%.1f%%", m.proc.CPUPercent)) +
+			subtleStyle.Render(" · ") + labelStyle.Render("ram ") +
+			valueStyle.Render(fmt.Sprintf("%.1f%%", m.proc.RamPercent)) +
+			subtleStyle.Render(" · ") + valueStyle.Render(humanBytes(m.proc.RSS))
+	}
+	started := subtleStyle.Render("started " + relSince(sess.CreatedAt))
+	group := lipgloss.NewStyle().Foreground(colorAccent2).Render(displayGroup(sess.Group))
+	dir := func(room int) string { return mutedStyle.Render(truncateTail(sess.Cwd, room)) }
+	return fitColumns(heads, []string{state}, width) + "\n" +
+		factRow("group", plainValue(group), started, width) + "\n" +
+		factRow("dir", dir, usage, width)
 }
 
 // viewGroupDetail heads the content column for a group: its name, how many
@@ -622,7 +710,7 @@ func (m *Model) viewGroupDetail(group string, width int) string {
 		countLabel = "1 agent"
 	}
 	title := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true).Render(displayGroup(group))
-	head := rowColumns(title, subtleStyle.Render(countLabel), width)
+	head := fitColumns([]string{title + "  " + chipStyle.Render(countLabel), title}, []string{""}, width)
 
 	if m.renamingGroup(group) {
 		pathLabel := labelStyle
@@ -649,36 +737,107 @@ func (m *Model) viewGroupDetail(group string, width int) string {
 	source := ""
 	if path == "" {
 		path = m.groupDefaultDir(group)
-		source = subtleStyle.Render(" · inherited")
+		source = subtleStyle.Render("inherited")
 	}
-	lines := []string{head, subtleStyle.Render(truncateTail(path, width-len(source))) + source}
+	dir := func(room int) string { return mutedStyle.Render(truncateTail(path, room)) }
+	lines := []string{head, factRow("dir", dir, source, width)}
 	if breakdown := m.groupStatusBreakdown(group); breakdown != "" {
-		lines = append(lines, breakdown)
+		lines = append(lines, factRow("state", trimmedValue(breakdown), "", width))
 	}
 	return strings.Join(lines, "\n")
 }
 
+// rosterToolColumn is the column a roster's tool names start at, so the
+// roster reads as a table rather than as ragged pairs, and rosterNameMin
+// the width under which a name column stops being worth reading.
+const (
+	rosterToolColumn = 14
+	rosterNameMin    = 8
+)
+
 // viewGroupAgents lists a group's sessions where a session's pane preview
-// would sit, so a group reads as a roster.
+// would sit, so a group reads as a roster: one row per agent, its name, the
+// CLI running it, and what it is doing.
 func (m *Model) viewGroupAgents(group string, width, height int) string {
-	lines := []string{subtleStyle.Render("agents")}
-	shown, total := 0, m.groupSessionCount(group)
+	total := m.groupSessionCount(group)
 	if total == 0 {
-		return lines[0] + "\n" + mutedStyle.Render("(none yet — press space to spawn one)")
+		return subtleStyle.Render("agents") + "\n" +
+			mutedStyle.Render("(none yet — press space to spawn one)")
 	}
+
+	type rosterRow struct{ name, tool, state string }
+	var rows []rosterRow
+	overflow := ""
+	shown := 0
 	for _, sess := range m.listedSessions() {
 		if !inGroupSubtree(sess.Group, group) {
 			continue
 		}
 		if shown >= height-2 && total > shown+1 {
-			lines = append(lines, subtleStyle.Render(fmt.Sprintf("… %d more", total-shown)))
+			overflow = subtleStyle.Render(fmt.Sprintf("… %d more", total-shown))
 			break
 		}
-		dot := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
-		line := rowColumns(dot+" "+valueStyle.Render(sess.Name),
-			subtleStyle.Render(sess.Tool+" · "+relSince(lastActivity(sess))), width)
-		lines = append(lines, line)
+		tint := lipgloss.NewStyle().Foreground(statusColor(sess.Status))
+		rows = append(rows, rosterRow{
+			name:  tint.Render(statusGlyph(sess.Status)) + " " + valueStyle.Render(sess.Name),
+			tool:  subtleStyle.Render(sess.Tool),
+			state: tint.Render(statusLabel(sess.Status)) + subtleStyle.Render(" · "+relSince(lastActivity(sess))),
+		})
 		shown++
+	}
+
+	// The name column is as wide as the longest name allows, bounded by what
+	// the tool and state columns need, so tools land on one column and the
+	// states share a right edge. A column too narrow for all three gives up
+	// the tool first and the state second: a roster of names still answers
+	// "who is in this group".
+	nameWidth, toolWidth, stateWidth := rosterToolColumn, 0, 0
+	for _, row := range rows {
+		if w := ansi.StringWidth(row.name) + 2; w > nameWidth {
+			nameWidth = w
+		}
+		if w := ansi.StringWidth(row.tool); w > toolWidth {
+			toolWidth = w
+		}
+		if w := ansi.StringWidth(row.state); w > stateWidth {
+			stateWidth = w
+		}
+	}
+	showTool, showState := true, true
+	if width-toolWidth-stateWidth-3 < rosterNameMin {
+		showTool, toolWidth = false, 0
+	}
+	if width-stateWidth-2 < rosterNameMin {
+		showState, stateWidth = false, 0
+	}
+	if room := width - toolWidth - stateWidth - 3; nameWidth > room {
+		nameWidth = max(room, rosterNameMin)
+	}
+
+	head := padRight(subtleStyle.Render("agent"), nameWidth)
+	if showTool {
+		head += subtleStyle.Render("tool")
+	}
+	activity := ""
+	if showState {
+		activity = subtleStyle.Render("last activity")
+	}
+	lines := []string{rowColumns(head, activity, width)}
+	for _, row := range rows {
+		// A name trimmed to the column exactly would touch the tool beside
+		// it, so the trim leaves the column's last cell as the gap.
+		line := padRight(ansi.Truncate(row.name, max(nameWidth-1, 1), "…"), nameWidth)
+		if showTool {
+			line += row.tool
+		}
+		state := row.state
+		if !showState {
+			state = ""
+		}
+		lines = append(lines, rowColumns(line, state, width))
+	}
+	if overflow != "" {
+		lines = append(lines, overflow)
 	}
 	return strings.Join(lines, "\n")
 }
@@ -697,19 +856,37 @@ func lastActivity(sess store.Session) time.Time {
 // viewQuickBar is the docked prompt: enter answers the selected session, or
 // spawns a fresh agent when a group is selected.
 func (m *Model) viewQuickBar(width int) string {
-	target := "no selection"
+	label := func(text string) string { return labelStyle.Render(padRight(text, detailLabelWidth)) }
+	target := rowColumns(label("target")+mutedStyle.Render("no selection"), "", width)
 	if entry, ok := m.selectedRow(); ok {
 		if entry.isGroup {
-			target = "new " + m.quickTool() + " agent in " + displayGroup(entry.group)
+			// Spawning: the tool and the worktree choice decide what gets
+			// created, so they sit where the eye lands before typing.
+			worktree := subtleStyle.Render("worktree off")
+			switch {
+			case !m.worktreeCapable(m.quickTargetDir()):
+				worktree = subtleStyle.Render(worktreeUnavailable)
+			case m.quickWorktreeOn():
+				worktree = lipgloss.NewStyle().Foreground(colorAccent2).Render("worktree on")
+			}
+			tool := chipStyle.Render(m.quickTool())
+			target = fitColumns(
+				[]string{label("new") + lipgloss.NewStyle().Foreground(colorAccent2).Render(displayGroup(entry.group))},
+				[]string{tool + " " + worktree, tool, ""}, width)
 		} else {
-			target = "answer " + entry.sess.Name
+			sess := entry.sess
+			state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).
+				Render(statusGlyph(sess.Status) + " " + statusLabel(sess.Status))
+			target = fitColumns(
+				[]string{label("answer") + lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(sess.Name)},
+				[]string{state + " " + chipStyle.Render(sess.Tool), state, ""}, width)
 		}
 	}
 	m.quick.input.SetWidth(width)
 	m.quick.input.SetHeight(m.quickBarRows(width - 2))
 	// Chips are tokens inside the typed text, so they wrap and reflow with
 	// the words around them; painting happens on the rendered prompt.
-	return subtleStyle.Render(target) + "\n" + m.renderQuickChips(m.quick.input.View())
+	return target + "\n" + m.renderQuickChips(m.quick.input.View())
 }
 
 // viewHeaderRows is the full-width band over both columns: the wordmark

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -83,18 +83,34 @@ func (m *Model) viewListFrame() string {
 // query with a caret, and the key that closes it when there is room.
 func (m *Model) searchFieldLine(width int) string {
 	indent := strings.Repeat(" ", railInset)
-	query := valueStyle.Render(m.search)
-	if m.search == "" {
-		query = subtleStyle.Render("type to filter")
-	}
-	field := keyStyle.Render("⌕ ") + query +
-		lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
+	glyph := keyStyle.Render("⌕ ")
+	caret := lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
 	hint := keyCapQuiet("esc", "close")
-	gap := width - railInset - ansi.StringWidth(field) - ansi.StringWidth(hint) - 1
-	if gap < 2 {
+	chrome := railInset + ansi.StringWidth(glyph) + 1
+
+	if m.search == "" {
+		field := glyph + subtleStyle.Render("type to filter") + caret
+		if gap := width - railInset - ansi.StringWidth(field) - ansi.StringWidth(hint) - 1; gap >= 2 {
+			return indent + field + strings.Repeat(" ", gap) + hint
+		}
 		return indent + field
 	}
-	return indent + field + strings.Repeat(" ", gap) + hint
+	// A query longer than the rail keeps its end: that is where the caret is
+	// and where the next keystroke lands.
+	room := width - chrome - ansi.StringWidth(hint) - 2
+	if room < 8 {
+		hint, room = "", width-chrome
+	}
+	query := m.search
+	if ansi.StringWidth(query) > room {
+		query = "…" + string([]rune(query)[len([]rune(query))-max(room-1, 1):])
+	}
+	field := glyph + valueStyle.Render(query) + caret
+	if hint == "" {
+		return indent + field
+	}
+	gap := width - railInset - ansi.StringWidth(field) - ansi.StringWidth(hint) - 1
+	return indent + field + strings.Repeat(" ", max(gap, 1)) + hint
 }
 
 // railLines is the sessions rail: the entry list on top, the machine
@@ -110,15 +126,22 @@ func (m *Model) railLines(width, height int) []contentLine {
 	// while entries still have room under it: a rail that is all banner
 	// says nothing about the fleet.
 	const railBannerRows, railListMin = 3, 3
-	room := func() bool { return listHeight-len(rows)-railBannerRows >= railListMin }
-	// Search heads the list it filters, so the query sits over the entries
-	// it is narrowing rather than away from them.
-	if m.searching && room() {
-		rows = append(rows, contentLine{}, contentLine{text: m.searchFieldLine(width)}, contentLine{})
+	room := func(cost int) bool { return listHeight-len(rows)-cost >= railListMin }
+	// Search heads the list it filters, so the query sits over the entries it
+	// is narrowing. It is also the field being typed into, so a rail too tight
+	// for the padded block keeps the bare field rather than dropping it.
+	if m.searching {
+		field := contentLine{text: m.searchFieldLine(width)}
+		switch {
+		case room(railBannerRows):
+			rows = append(rows, contentLine{}, field, contentLine{})
+		case room(1):
+			rows = append(rows, field)
+		}
 	}
 	// The list starts straight under the pane's top edge; the empty state
 	// centers itself in the full list area instead.
-	if m.showArchived && room() {
+	if m.showArchived && room(railBannerRows) {
 		rows = append(rows, contentLine{})
 		rows = append(rows,
 			contentLine{text: strings.Repeat(" ", railInset) + scopeBadgeStyle.Render("ARCHIVED") +

--- a/internal/ui/railfit_test.go
+++ b/internal/ui/railfit_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/x/ansi"
 )
 
 // The rail's banners (search, archived) cost the list rows, so a short
@@ -48,4 +50,27 @@ func railLinesText(lines []contentLine) string {
 		b.WriteString(line.text + "\n")
 	}
 	return b.String()
+}
+
+// The query is the field being typed into: a rail too tight for the padded
+// block keeps the bare field, and a query longer than the rail keeps its end,
+// where the caret is.
+func TestSearchFieldSurvivesTightRails(t *testing.T) {
+	for _, height := range []int{14, 20, 34} {
+		m := shotModel()
+		m.width, m.height = 120, height
+		m.searching, m.search = true, "add-rate-limiting-in-the-public-api-handler"
+		rail := railLinesText(m.railLines(36, m.listBodyHeight()))
+		if !strings.Contains(rail, "⌕") {
+			t.Errorf("height %d dropped the search field:\n%s", height, rail)
+		}
+		if !strings.Contains(rail, "api-handler") {
+			t.Errorf("height %d cut the end of the query away:\n%s", height, rail)
+		}
+		for _, line := range strings.Split(rail, "\n") {
+			if got := ansi.StringWidth(ansi.Strip(line)); got > 36 {
+				t.Errorf("height %d: rail line is %d wide: %q", height, got, ansi.Strip(line))
+			}
+		}
+	}
 }

--- a/internal/ui/railfit_test.go
+++ b/internal/ui/railfit_test.go
@@ -1,0 +1,51 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// The rail's banners (search, archived) cost the list rows, so a short
+// terminal has to keep painting entries under them — and keep painting at
+// all: claiming rows the list does not have used to slice past the end.
+func TestRailBannersSurviveShortTerminals(t *testing.T) {
+	for _, height := range []int{4, 6, 8, 10, 14} {
+		for _, width := range []int{30, 60, 120} {
+			for _, searching := range []bool{false, true} {
+				for _, archived := range []bool{false, true} {
+					m := shotModel()
+					m.width, m.height = width, height
+					m.searching, m.showArchived = searching, archived
+					m.errBar.text = "worktree kept (has work): /Users/yoan/dev/spaze/api"
+					rows := strings.Split(m.View(), "\n")
+					if len(rows) != height {
+						t.Errorf("%dx%d search=%v archived=%v: frame is %d rows",
+							width, height, searching, archived, len(rows))
+					}
+				}
+			}
+		}
+	}
+}
+
+// A rail with room for its banners still lists entries under them.
+func TestRailBannersLeaveRoomForEntries(t *testing.T) {
+	m := shotModel()
+	m.width, m.height = 120, 34
+	m.searching, m.search = true, "rate"
+	rail := railLinesText(m.railLines(36, m.listBodyHeight()))
+	if !strings.Contains(rail, "⌕ rate") {
+		t.Fatalf("no search field in the rail:\n%s", rail)
+	}
+	if !strings.Contains(rail, "db-migrations") {
+		t.Fatalf("search banner crowded the entries out:\n%s", rail)
+	}
+}
+
+func railLinesText(lines []contentLine) string {
+	var b strings.Builder
+	for _, line := range lines {
+		b.WriteString(line.text + "\n")
+	}
+	return b.String()
+}

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -132,13 +132,10 @@ func (m *Model) nudgeSplit(delta int) {
 func (m *Model) listChromeRows() int { return m.headerRows() + 1 }
 
 // listBodyHeight is the vertical budget for the sessions/sidebar panels.
-// Matches View: height - (header, seam, status when one shows, footer).
+// Matches View: height - (header, seam, footer). Notices float over the body
+// instead of taking a row, so the budget is the same with one up.
 func (m *Model) listBodyHeight() int {
-	statusRow := 0
-	if m.viewStatus() != "" {
-		statusRow = 1
-	}
-	bodyHeight := m.height - m.listChromeRows() - 1 - statusRow - lipgloss.Height(m.viewFooter())
+	bodyHeight := m.height - m.listChromeRows() - 1 - lipgloss.Height(m.viewFooter())
 	if bodyHeight < 3 {
 		bodyHeight = 3
 	}

--- a/internal/ui/toast.go
+++ b/internal/ui/toast.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+const (
+	// toastMaxWidth is the widest a notice card gets before it wraps, and
+	// toastMargin is the gap it keeps from the frame's right edge.
+	toastMaxWidth = 52
+	toastMinWidth = 20
+	toastMargin   = 2
+	toastChromeX  = 4
+)
+
+// statusToast is the transient message rendered as a card that floats over
+// the frame's top right, so a notice never costs the body a row.
+func (m *Model) statusToast() []string {
+	text := m.statusLine()
+	if text == "" {
+		return nil
+	}
+	// The card lives in the content column: it shrinks to its text, and never
+	// reaches back over the seam into the sessions rail.
+	leftWidth, _ := m.splitWidths()
+	width := ansi.StringWidth(text) + toastChromeX
+	for _, limit := range []int{toastMaxWidth, m.width - leftWidth - 2 - toastMargin} {
+		if width > limit {
+			width = limit
+		}
+	}
+	if width < toastMinWidth {
+		return nil
+	}
+	inner := width - toastChromeX
+	border := cardBorderStyle()
+	edge := border.Render("│")
+	rows := []string{paint(border.Render("╭"+strings.Repeat("─", width-2)+"╮"), width, blockHex())}
+	for _, line := range strings.Split(ansi.Wordwrap(text, inner, ""), "\n") {
+		rows = append(rows, paint(edge+" "+padRight(line, inner)+" "+edge, width, blockHex()))
+	}
+	return append(rows, paint(border.Render("╰"+strings.Repeat("─", width-2)+"╯"), width, blockHex()))
+}
+
+// overlayTopRight splices a pre-painted box over the frame's rows, anchored
+// under the header band and inset from the right edge. Rows past the frame's
+// bottom are dropped rather than extending it, so the layout never moves.
+func (m *Model) overlayTopRight(frame string, box []string, top int) string {
+	if len(box) == 0 {
+		return frame
+	}
+	left := m.width - maxLineWidth(box) - toastMargin
+	if left < 0 {
+		left = 0
+	}
+	lines := strings.Split(frame, "\n")
+	for i, patch := range box {
+		row := top + i
+		if row < 0 || row >= len(lines) {
+			continue
+		}
+		lines[row] = spliceAtColumn(lines[row], patch, left)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// spliceAtColumn overpaints a run of cells inside a styled row, keeping the
+// escape state on both sides of the patch intact.
+func spliceAtColumn(row, patch string, left int) string {
+	head := ansi.Truncate(row, left, "")
+	if pad := left - ansi.StringWidth(head); pad > 0 {
+		head += strings.Repeat(" ", pad)
+	}
+	tail := ansi.TruncateLeft(row, left+ansi.StringWidth(patch), "")
+	return head + patch + tail
+}

--- a/internal/ui/toast_test.go
+++ b/internal/ui/toast_test.go
@@ -1,0 +1,103 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// A notice used to take a row from the body, so the whole layout shrank
+// whenever one showed. It floats over the frame now: same rows, same body.
+func TestStatusToastKeepsLayoutStill(t *testing.T) {
+	for _, width := range []int{80, 120, 200} {
+		for _, height := range []int{24, 34, 50} {
+			quiet := shotModel()
+			quiet.width, quiet.height = width, height
+			quietRows := strings.Split(quiet.viewListFrame(), "\n")
+			quietBody := quiet.listBodyHeight()
+
+			noticed := shotModel()
+			noticed.width, noticed.height = width, height
+			noticed.errBar.text = "worktree kept (has work): /Users/someone/projects/agent-manager"
+			noticedRows := strings.Split(noticed.viewListFrame(), "\n")
+
+			if len(noticedRows) != len(quietRows) {
+				t.Errorf("%dx%d: notice changed the frame from %d rows to %d",
+					width, height, len(quietRows), len(noticedRows))
+			}
+			if got := noticed.listBodyHeight(); got != quietBody {
+				t.Errorf("%dx%d: notice changed the body from %d rows to %d", width, height, quietBody, got)
+			}
+			for i, line := range noticedRows {
+				if got := ansi.StringWidth(line); got != ansi.StringWidth(quietRows[i]) {
+					t.Fatalf("%dx%d: row %d is %d wide with a notice, %d without",
+						width, height, i, got, ansi.StringWidth(quietRows[i]))
+				}
+			}
+			if !strings.Contains(ansi.Strip(noticed.viewListFrame()), "worktree kept") {
+				t.Errorf("%dx%d: the notice is not on the frame", width, height)
+			}
+		}
+	}
+}
+
+// The card sits at the top right, under the header, not over the rail.
+func TestStatusToastSitsTopRight(t *testing.T) {
+	m := shotModel()
+	m.width, m.height = 120, 34
+	m.errBar.text = "already up to date"
+	rows := strings.Split(ansi.Strip(m.viewListFrame()), "\n")
+	row := m.listChromeRows() + 2
+	if row >= len(rows) {
+		t.Fatalf("frame is only %d rows", len(rows))
+	}
+	if !strings.Contains(rows[row], "already up to date") {
+		t.Fatalf("notice is not on row %d: %q", row, rows[row])
+	}
+	leftWidth, _ := m.splitWidths()
+	if column := strings.Index(rows[row], "already up to date"); column <= leftWidth {
+		t.Fatalf("notice starts at column %d, inside the rail (%d wide)", column, leftWidth)
+	}
+}
+
+// Splicing a card into a styled row must not shift the cells around it.
+func TestSpliceAtColumnKeepsWidth(t *testing.T) {
+	row := paint(keyStyle.Render("session ")+subtleStyle.Render("running"), 40, panelHex())
+	spliced := spliceAtColumn(row, paint(errStyle.Render("boom"), 6, blockHex()), 20)
+	if got := ansi.StringWidth(spliced); got != 40 {
+		t.Fatalf("spliced row is %d wide, want 40: %q", got, ansi.Strip(spliced))
+	}
+	if plain := ansi.Strip(spliced); !strings.Contains(plain, "boom") || !strings.HasPrefix(plain, "session ") {
+		t.Fatalf("splice lost content: %q", plain)
+	}
+}
+
+// Search is a field over the list it filters, in the rail, not a card that
+// floats away from the entries.
+func TestSearchFieldSitsInTheRail(t *testing.T) {
+	m := shotModel()
+	m.width, m.height = 120, 34
+	m.searching = true
+	m.search = "rate"
+
+	if status := ansi.Strip(m.statusLine()); strings.Contains(status, "rate") {
+		t.Fatalf("the query moved to the rail, the notice should not repeat it: %q", status)
+	}
+	leftWidth, _ := m.splitWidths()
+	rows := strings.Split(ansi.Strip(m.viewListFrame()), "\n")
+	found := false
+	for _, row := range rows {
+		column := strings.Index(row, "⌕ rate")
+		if column < 0 {
+			continue
+		}
+		found = true
+		if column > leftWidth {
+			t.Fatalf("search field starts at column %d, past the rail (%d wide)", column, leftWidth)
+		}
+	}
+	if !found {
+		t.Fatalf("no search field on the frame:\n%s", strings.Join(rows, "\n"))
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -152,34 +152,31 @@ func (m *Model) previewPaneHeight() int {
 	return rest
 }
 
-// viewStatus is the transient message line: prompts, search, and
-// self-dismissing errors. Keeps the footer free for key hints.
-func (m *Model) viewStatus() string {
+// statusLine is the transient message: prompts, search, and self-dismissing
+// errors. It floats in a card over the frame rather than taking a row, so the
+// body keeps its height whether or not a notice is up.
+func (m *Model) statusLine() string {
 	switch {
 	// Errors outrank the focus notices: a scrolled or focused pane must
 	// not hide a failure report.
 	case m.mode == modeFocus && m.errBar.text != "":
-		return "  " + errStyle.Render("✕ "+m.errBar.text)
+		return errStyle.Render("✕ " + m.errBar.text)
 	case m.scrolledBack():
-		return "  " + keyStyle.Render("scrolled ") +
+		return keyStyle.Render("scrolled ") +
 			subtleStyle.Render(fmt.Sprintf("%d lines back · wheel down or type to catch up", m.focusScroll))
 	case m.mode == modeFocus && m.copied > 0:
-		return "  " + keyStyle.Render("copied ") +
+		return keyStyle.Render("copied ") +
 			subtleStyle.Render(fmt.Sprintf("%d chars to clipboard", m.copied))
 	case m.split.resizeMode:
 		hint := "←→ resize · drag divider · enter set · esc cancel"
 		if m.split.dragging {
 			hint = "release to set · esc cancels"
 		}
-		return "  " + keyStyle.Render("resize ") + subtleStyle.Render(hint)
-	case m.searching:
-		cursor := lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
-		return "  " + keyStyle.Render("search ") + valueStyle.Render(m.search) + cursor +
-			subtleStyle.Render("  enter/esc to close")
+		return keyStyle.Render("resize ") + subtleStyle.Render(hint)
 	case m.errBar.text != "":
-		return "  " + errStyle.Render("✕ "+m.errBar.text)
+		return errStyle.Render("✕ " + m.errBar.text)
 	case m.diff.notice != "":
-		return "  " + lipgloss.NewStyle().Foreground(colorFinished).Render("● "+m.diff.notice)
+		return lipgloss.NewStyle().Foreground(colorFinished).Render("● " + m.diff.notice)
 	default:
 		return ""
 	}


### PR DESCRIPTION
## What

A notice used to take a row from the body, so the whole layout shrank and grew as messages came and went. Notices now float as a card over the content column's top right, and the body keeps its height either way.

Search moves out of that line into the head of the sessions rail, over the entries it filters. The detail heads become aligned fact rows.

## Sections

**Session head** — tool and worktree-branch chips beside the name, labeled facts under it:

```
add-rate-limiting   claude   ⑂ am/add-rate-limiting        ◐ working · 40s ago
group  backend                                                  started 1d ago
dir    /Users/yoan/dev/spaze/api                 cpu 4.2% · ram 3.6% · 583.6MB
```

The branch a worktree session lives on was stored but never shown; it reads there now.

**Group head** — the agent count becomes a chip beside the name, path and rollup become labeled facts.

**Group roster** — a table: tools share a column, states share a right edge.

```
agent                tool                                        last activity
● auth-refresh       claude                                  finished · 2m ago
◐ add-rate-limiting  claude                                  working · 40s ago
```

**Quick prompt** — the target line names the session's state and tool, and for a group, the tool and worktree choice that decide what gets created.

## Fitting

Every head lays the richest pair of readings that fits, sheds chips next, and trims last, so a narrow content column keeps its facts inside the panel. Two overflow bugs are fixed along the way: the group rollup and the roster rows tore past the panel edge under about 40 columns.

## Tests

- `TestStatusToastKeepsLayoutStill` — frame rows, row widths and body height are identical with and without a notice.
- `TestStatusToastSitsTopRight`, `TestSpliceAtColumnKeepsWidth` — placement, and that splicing a card into a styled row preserves its width.
- `TestSearchFieldSitsInTheRail` — the query renders in the rail, not in the notice.
- `TestDetailHeadsFitTheirColumn`, `TestDetailHeadShedsChipsBeforeFacts`, `TestGroupRosterColumnsAlign` — every head line stays inside 28..120 columns, chips shed before facts, roster columns hold.
- `TestRailBannersSurviveShortTerminals`, `TestRailBannersLeaveRoomForEntries` — banners keep entries on screen at 4..14 rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live search to the navigation rail.
  - Added responsive detail and group views with adaptive columns, chips, and worktree context.
  - Added status toast notifications that overlay content without changing layout height.
  - Improved quick-bar context with target, tool, status, and worktree details.

- **Bug Fixes**
  - Improved narrow-window rendering, text truncation, roster alignment, and banner handling.
  - Preserved visible entries and layout dimensions when notices or search banners appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->