### PR TITLE
chore: fix the review rules the config got wrong

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,10 +11,16 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    auto_pause_after_reviewed_commits: 0
+  finishing_touches:
+    docstrings:
+      enabled: false
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
   path_filters:
     - "!**/*.gif"
     - "!**/*.png"
-    - "!go.sum"
   path_instructions:
     - path: "**/*.go"
       instructions: |
@@ -26,21 +32,29 @@ reviews:
         untrusted input are correct.
         Errors propagate or are handled explicitly; silent fallbacks that mask a
         failure are a defect.
-        Names spell out intent: no one-letter variables outside tight loop
-        indices, no invented abbreviations.
+        Every tmux invocation names its socket, either by going through the
+        driver in internal/tmux or by passing -L or -S. A bare exec.Command
+        ("tmux", ...) resolves through $TMUX to the developer's own live server,
+        so flag one as critical, and treat a global option, kill-session or
+        set-hook on an unpinned socket as data loss.
+        Names spell out intent. One-letter method receivers and the usual short
+        Go names (i and j for indices, r and w for readers and writers, ctx, err)
+        are idiomatic here and are never worth a comment; flag only a name whose
+        meaning a reader cannot recover, or an invented abbreviation.
     - path: "**/*_test.go"
       instructions: |
         Tests live beside the file they cover (listview.go -> listview_test.go).
-        Every tmux invocation must name its socket explicitly with -L or -S; an
-        explicit socket is sufficient on its own. A bare tmux call resolves
-        through $TMUX to the developer's live server, so flag one that carries
-        neither an explicit socket nor env -u TMUX as critical, and likewise a
-        kill-server or kill-session that is not pinned to an isolated socket.
+        The suite drives a real tmux server, so it runs as
+        env -u TMUX TMUX_TMPDIR=/tmp/<short> go test ./..., and the socket dir
+        must keep TMUX_TMPDIR/tmux-<uid>/default under 104 characters or tmux
+        falls back to the default socket. A helper that already passes -L or -S
+        pins its own socket and needs nothing further. Flag a kill-server or
+        kill-session that is not pinned to an isolated socket as critical.
     - path: "internal/tmux/**"
       instructions: |
-        This package owns the dedicated agentmgr socket. Flag anything that can
-        resolve to the default tmux socket, and any global option or key binding
-        written to a server this process does not own.
+        This package owns the dedicated agentmgr socket, and Driver.args is what
+        pins it. Flag an exec path that bypasses that helper, and any global
+        option or key binding written to a server this process does not own.
     - path: "internal/ui/**"
       instructions: |
         Bubble Tea: one Model, files grouped by feature. Update must not block;
@@ -51,10 +65,37 @@ reviews:
         Existing installs keep their stored config.toml, so editing a
         defaultConfig value never reaches current users. A behavior change that
         must reach them needs a new field, not an edited default.
+    - path: "internal/store/**"
+      instructions: |
+        The migrations slice is append-only. Editing or reordering an existing
+        entry is a defect: the loop swallows "duplicate column", so a changed
+        column default silently reaches fresh installs only and upgraded
+        databases keep the old one. New schema arrives as a new entry at the end,
+        written so re-running it on an already-migrated database is harmless.
+    - path: "internal/update/**"
+      instructions: |
+        This package replaces the running binary. The downloaded asset is
+        checksum-verified before anything is renamed over the executable, so
+        flag a path that skips or weakens that check, follows a redirect to
+        another host, widens the permissions of the staged file, or writes
+        outside the staging directory.
     - path: ".github/workflows/**"
       instructions: |
-        Pin third-party actions to a commit SHA. Flag any workflow that exposes
-        secrets to pull_request_target or to a step running untrusted PR code.
+        Actions are pinned to a release tag and bumped by dependabot, so a tag
+        pin is correct and needs no comment. Flag a mutable ref (a branch such
+        as @main, or no ref at all), and any workflow that exposes secrets to
+        pull_request_target or to a step running untrusted PR code.
+
+code_generation:
+  unit_tests:
+    path_instructions:
+      - path: "**/*_test.go"
+        instructions: |
+          Never call tmux without naming a socket: go through the driver in
+          internal/tmux, or pass -L or -S. A bare tmux call resolves through
+          $TMUX to the developer's live server and can tear down their running
+          sessions. Never emit kill-server, and place the test beside the file
+          it covers.
 
 chat:
   auto_reply: true


### PR DESCRIPTION
A self-review of the config merged in #236 (CodeRabbit itself was rate-limited on that PR, so the last commit landed unreviewed). Ten findings survived an independent verify pass; every one is fixed here. Inline evidence is on #236.

**Rules pointed at the wrong code**
- The tmux socket rule guarded `internal/tmux/**`, where every call already goes through `Driver.args` and gets `-L` (`tmux.go:62`). The one bare `exec.Command("tmux", ...)` in the product is `internal/ui/theme.go:425`, covered only by the Bubble Tea rule. The rule now sits in `**/*.go`.
- `internal/store` has the same upgrade hazard as `internal/config` and had no rule: the migrations slice is append-only, and the loop swallows `duplicate column` (`store.go:140-146`), so an edited column default reaches fresh installs only.
- `internal/update` replaces the running binary after a checksum check and had no rule; a PR dropping `verifyChecksum` was reviewed only for comments and naming.

**Rules the config could not enforce, or that we ourselves break**
- `finishing_touches.docstrings.enabled` (default true) and `pre_merge_checks.docstrings.mode` (default `warning`) kept asking for the doc comments the Go instruction forbids. Both off now — a path instruction cannot suppress a separate top-level key.
- The workflow rule demanded SHA pins while all five `uses:` are tag-pinned and dependabot bumps them weekly. It now accepts tag pins and flags mutable refs instead.
- The one-letter ban contradicted 555+ idiomatic receivers (391 `m`, 53 `d`, 52 `s`). Receivers and the usual short names are exempt.
- The test rule and AGENTS.md disagreed about `env -u TMUX`; CodeRabbit ingests AGENTS.md as a guideline by default, so it held both. The rule now states the suite command AGENTS.md gives and treats an explicit `-L`/`-S` helper as already pinned.

**Defaults that quietly weakened review**
- `!go.sum` also dropped go.sum from CodeRabbit's sparse checkout. Verified: extract the tree, `rm go.sum`, and `go build ./...` fails with `missing go.sum entry` across eight packages — golangci-lint (on by default) had nothing to run against. Filter removed.
- `auto_pause_after_reviewed_commits` defaulted to 5, so commit six onward went unreviewed while the earlier green status stayed visible. Set to 0.
- `code_generation.unit_tests.path_instructions` was empty while unit-test generation is on, so a generated test was never bound by the socket rule. Added.

Validated against `schema.v2.json`.