### PR TITLE
fix(ui): keep the search field up while its query still filters the list

### DIFF
--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -134,6 +134,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "/":
 		m.searching = true
 		m.errBar.text = ""
+	case "esc":
+		return m, m.clearSearch()
 	case "r":
 		m.openRename()
 	case "m":
@@ -427,8 +429,11 @@ const hiddenToolsSetting = "hidden_tools"
 
 func (m *Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "enter", "esc":
+	case "enter":
 		m.searching = false
+	case "esc":
+		m.searching = false
+		return m, m.clearSearch()
 	case "backspace":
 		if len(m.search) > 0 {
 			m.search = m.search[:len(m.search)-1]
@@ -441,4 +446,20 @@ func (m *Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+// clearSearch drops the query and re-lists. A query that outlives its field
+// with no way back is what makes filtered-away sessions read as sessions
+// that are gone, so esc answers from the list as well as from the field.
+func (m *Model) clearSearch() tea.Cmd {
+	if m.search == "" {
+		return nil
+	}
+	previousKey := ""
+	if entry, ok := m.selectedRow(); ok {
+		previousKey = rowKey(entry)
+	}
+	m.search = ""
+	m.rebuildRows()
+	return m.afterListFilter(previousKey)
 }

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -80,13 +80,19 @@ func (m *Model) viewListFrame() string {
 }
 
 // searchFieldLine is the live filter at the head of the rail: the typed
-// query with a caret, and the key that closes it when there is room.
+// query with a caret, and the key that closes it when there is room. With
+// the field closed and a query still applied it drops the caret and offers
+// to clear instead, so the rail always accounts for the entries it is
+// holding back.
 func (m *Model) searchFieldLine(width int) string {
 	indent := strings.Repeat(" ", railInset)
 	glyph := keyStyle.Render("⌕ ")
 	caret := lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
 	hint := keyCapQuiet("esc", "close")
-	chrome := railInset + ansi.StringWidth(glyph) + 1
+	if !m.searching {
+		caret, hint = "", keyCapQuiet("esc", "clear")
+	}
+	chrome := railInset + ansi.StringWidth(glyph) + ansi.StringWidth(caret)
 
 	if m.search == "" {
 		field := glyph + subtleStyle.Render("type to filter") + caret
@@ -130,7 +136,7 @@ func (m *Model) railLines(width, height int) []contentLine {
 	// Search heads the list it filters, so the query sits over the entries it
 	// is narrowing. It is also the field being typed into, so a rail too tight
 	// for the padded block keeps the bare field rather than dropping it.
-	if m.searching {
+	if m.searching || m.search != "" {
 		field := contentLine{text: m.searchFieldLine(width)}
 		switch {
 		case room(railBannerRows):

--- a/internal/ui/searchpersist_test.go
+++ b/internal/ui/searchpersist_test.go
@@ -1,0 +1,89 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func searchModel() *Model {
+	m := &Model{width: 120, height: 30, collapsed: map[string]bool{}}
+	m.sessions = []store.Session{
+		{ID: "1", Name: "api-server", Status: status.Idle},
+		{ID: "2", Name: "web-ui", Status: status.Idle},
+		{ID: "3", Name: "docs", Status: status.Idle},
+	}
+	m.rebuildRows()
+	return m
+}
+
+func railHead(m *Model) string {
+	var b strings.Builder
+	for _, line := range m.railLines(40, 24) {
+		b.WriteString(ansi.Strip(line.text) + "\n")
+	}
+	return b.String()
+}
+
+// A query that outlives its field has to keep saying so: without the row the
+// filtered-away sessions read as sessions that are gone.
+func TestSearchFieldOutlivesTheOpenField(t *testing.T) {
+	m := searchModel()
+	m.searching, m.search = true, "api"
+	m.rebuildRows()
+	if !strings.Contains(railHead(m), "⌕") {
+		t.Fatal("an open field should be in the rail")
+	}
+	m.searching = false
+	rail := railHead(m)
+	if !strings.Contains(rail, "⌕") {
+		t.Fatalf("a query still filtering should stay in the rail:\n%s", rail)
+	}
+	if !strings.Contains(rail, "clear") {
+		t.Fatalf("a closed field should offer the way out:\n%s", rail)
+	}
+}
+
+func TestSearchRailIsCleanWithNoQuery(t *testing.T) {
+	if rail := railHead(searchModel()); strings.Contains(rail, "⌕") {
+		t.Fatalf("no query should mean no field:\n%s", rail)
+	}
+}
+
+func TestEnterKeepsTheQueryAndEscClearsIt(t *testing.T) {
+	m := searchModel()
+	m.searching, m.search = true, "api"
+	m.rebuildRows()
+	filtered := len(m.rows)
+
+	m.handleSearchKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.searching || m.search != "api" || len(m.rows) != filtered {
+		t.Fatalf("enter should close the field and keep the filter, got searching=%v query=%q rows=%d",
+			m.searching, m.search, len(m.rows))
+	}
+
+	m.clearSearch()
+	if m.search != "" {
+		t.Fatalf("esc should clear the query, got %q", m.search)
+	}
+	if len(m.rows) <= filtered {
+		t.Fatalf("clearing should bring the sessions back, still %d rows", len(m.rows))
+	}
+}
+
+func TestEscInTheFieldClearsIt(t *testing.T) {
+	m := searchModel()
+	m.searching, m.search = true, "api"
+	m.rebuildRows()
+	m.handleSearchKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.searching || m.search != "" {
+		t.Fatalf("esc should close and clear, got searching=%v query=%q", m.searching, m.search)
+	}
+	if strings.Contains(railHead(m), "⌕") {
+		t.Fatal("a cleared search should leave no field behind")
+	}
+}


### PR DESCRIPTION
## What changed

The rail's search field is drawn only while the field is open:

```go
if m.searching {
    field := contentLine{text: m.searchFieldLine(width)}
```

and neither answer to it clears the query behind it:

```go
case "enter", "esc":
    m.searching = false
```

`m.search` is what `rebuildRows` filters on, so leaving the field takes it off screen with the filter still applied. Reproduced on `7ead765` with three sessions and the query `api`:

```
no query:      4 rows
typing 'api':  2 rows, field shown
after esc:     2 rows, query still "api", no field

rail after esc:
       root                            ○ 3
     ○ api-server    idle ·  · 106751d ago
```

`web-ui` and `docs` are gone from the rail, the root row still counts three, and nothing on screen says a filter is on or offers a way out. The only paths back are typing the rest of a name until the match widens, or opening the new-session form, which clears it as a side effect.

## The fix

The field stays for as long as a query narrows the list. Once closed it drops its caret and swaps its hint, so the row reads as a filter that is on rather than a field being typed into:

```
⌕ api▏                    esc close     while typing
⌕ api                     esc clear     still filtering
```

`enter` closes the field and keeps the filter. `esc` clears, from inside the field or from the list. Clearing runs through `afterListFilter` like the `w` and `e` filters, so the preview follows whatever row the selection lands on rather than going stale.

## Why not just clear on close

Because keeping a filter is the useful half. `w` and `e` both persist and both say so in the footer; search was the one filter that persisted silently. This makes it behave like its neighbours instead of taking the feature away.

## Testing

`gofmt -l .` clean, `go vet ./...` clean, `go test -race ./...` green, including four new tests in `internal/ui/searchpersist_test.go`: the field outliving the open field, a clean rail with no query, `enter` keeping the query while `esc` clears it, and `esc` inside the field leaving nothing behind. The existing `TestSearchFieldSitsInTheRail` and `TestSearchFieldSurvivesTightRails` from #237 still pass, so the tight-rail budgeting is untouched.

Built and run against real sessions.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] Ran it against real sessions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search queries now remain visible after closing search mode.
  - Press Enter to close search while keeping the current filter active.
  - Press Escape to clear the active query and restore the full list.
  - The search interface displays updated prompts and remains available for clearing retained filters.

- **Bug Fixes**
  - Improved search state, filtering, selection, and preview updates when queries are cleared or changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->