### PR TITLE
test(ui): drive the search-clearing test through the esc binding

### DIFF
--- a/internal/ui/searchpersist_test.go
+++ b/internal/ui/searchpersist_test.go
@@ -66,7 +66,9 @@ func TestEnterKeepsTheQueryAndEscClearsIt(t *testing.T) {
 			m.searching, m.search, len(m.rows))
 	}
 
-	m.clearSearch()
+	// Through handleKey rather than clearSearch: the binding is half of what
+	// this covers, so a test that skips it would pass with esc unbound.
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
 	if m.search != "" {
 		t.Fatalf("esc should clear the query, got %q", m.search)
 	}


### PR DESCRIPTION
CodeRabbit's note on #239, which I merged before reading it.

`TestEnterKeepsTheQueryAndEscClearsIt` called `m.clearSearch()` directly, so the `case "esc"` I added to `handleKey` had no coverage: unbind it and the test still passes. It now goes through `m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})`.

Verified the test actually guards the binding by deleting the case and re-running:

```
--- FAIL: TestEnterKeepsTheQueryAndEscClearsIt
    searchpersist_test.go:73: esc should clear the query, got "api"
```

Test-only, no production change.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes