### PR TITLE
fix(ui): spawn one shell per T press and trim the shell row legend

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,13 +59,13 @@ Press `space` to dock a prompt bar at the bottom of the sidebar. The target foll
 
 ## Terminal tabs
 
-`T` opens a shell tab in the group under the cursor: a session like any other — same list, same status column, same `enter`, `x`, `v` and `R` — with your shell in the pane instead of an agent. It lands in the selected session's directory, wherever that session has moved to, or in the group's default path when a group row is selected, so the shell that runs the tests sits next to the agent that wrote them.
+`T` opens a shell tab in the group under the cursor: a session like any other — same list, same row keys, same `enter`, `x`, `v` and `R` — with your shell in the pane instead of an agent. It lands in the selected session's directory, wherever that session has moved to, or in the group's default path when a group row is selected, so the shell that runs the tests sits next to the agent that wrote them. Its status rests at idle throughout, a build included: turn tracking belongs to agents, and a shell has no turns.
 
 The shell is the `[tools.terminal]` block in [config.toml](configuration.md). It ships with no command, which leaves the pane on `$SHELL`; set one to open a different shell. What marks it as a shell is `shell = true`, not its name, so a `[tools.terminal]` block you wrote yourself stays the agent CLI you meant it to be.
 
 **The keys that write into a pane refuse a shell.** `space` and the review screen's `C` both paste their text and press Enter, so on a shell a sentence meant for an agent would run as a command. Both say the row is a shell and send nothing; enter the session (`↵`) to type there, where what you type is plainly a command. `f` says the same, since a shell has no conversation to fork.
 
-A terminal tab carries no session id, so `agent-manager rename` run inside one cannot find its session. Rename it from the list with `r`.
+A shell left on its empty command carries no session id, so `agent-manager rename` run inside one cannot find its session. Rename it from the list with `r`. Give the block a command and the pane gets an id like any other session.
 
 ## Worktree sessions
 

--- a/internal/ui/fork.go
+++ b/internal/ui/fork.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/agentsession"
@@ -86,7 +85,7 @@ func (m *Model) submitFork() (tea.Model, tea.Cmd) {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
-	if info, err := os.Stat(source.Cwd); err != nil || !info.IsDir() {
+	if !isDir(source.Cwd) {
 		m.errBar.text = "working directory no longer exists: " + source.Cwd
 		return m, nil
 	}
@@ -127,12 +126,7 @@ func (m *Model) submitFork() (tea.Model, tea.Cmd) {
 	m.rebuildRows()
 	m.mode = modeList
 	m.errBar.text = ""
-	for i, row := range m.rows {
-		if !row.isGroup && row.sess.ID == managerID {
-			m.cursor = i
-			break
-		}
-	}
+	m.focusSession(managerID)
 	return m, m.refreshCmd()
 }
 

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -108,8 +108,12 @@ func resolveExistingDir(raw, fallback string) (string, bool) {
 	if abs, err := filepath.Abs(dir); err == nil {
 		dir = abs
 	}
-	info, err := os.Stat(dir)
-	return dir, err == nil && info.IsDir()
+	return dir, isDir(dir)
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
 func textField(placeholder string, limit int) textinput.Model {
@@ -187,10 +191,8 @@ func (m *Model) contextGroup() string {
 // from the group to the root; empty when no ancestor has one.
 func (m *Model) ancestorGroupDir(group string) string {
 	for g := group; g != ""; g = parentGroup(g) {
-		if p := m.groupPaths[g]; p != "" {
-			if info, err := os.Stat(p); err == nil && info.IsDir() {
-				return p
-			}
+		if p := m.groupPaths[g]; p != "" && isDir(p) {
+			return p
 		}
 	}
 	return ""

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -130,6 +130,9 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.showArchived = !m.showArchived
 		m.requestRefresh()
 	case "T", "shift+t":
+		if m.terminalKeyRepeat() {
+			return m, nil
+		}
 		return m.openTerminal()
 	case "e":
 		return m, m.toggleEmptyGroups()

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -205,7 +204,7 @@ func (m *Model) reviveSession(sess store.Session) error {
 	if !ok {
 		return fmt.Errorf("tool %s is no longer configured", sess.Tool)
 	}
-	if info, err := os.Stat(sess.Cwd); err != nil || !info.IsDir() {
+	if !isDir(sess.Cwd) {
 		return fmt.Errorf("working directory no longer exists: %s", sess.Cwd)
 	}
 	baseCommand := tool.ReviveCommand
@@ -287,7 +286,7 @@ func (m *Model) restartSession(sess store.Session) error {
 	if !ok {
 		return fmt.Errorf("tool %s is no longer configured", sess.Tool)
 	}
-	if info, err := os.Stat(sess.Cwd); err != nil || !info.IsDir() {
+	if !isDir(sess.Cwd) {
 		return fmt.Errorf("working directory no longer exists: %s", sess.Cwd)
 	}
 	if err := m.killSession(sess); err != nil {

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -1127,9 +1127,8 @@ func TestRestartLaunchIsAFreshStartForEveryShippedTool(t *testing.T) {
 		t.Fatalf("built-in tools = %d, expected every shipped CLI", len(cfg.Tools))
 	}
 	for name, tool := range cfg.Tools {
-		// A block carrying no command is a shell, not a CLI: the terminal
-		// tab has no conversation for a restart to start fresh.
-		if tool.Command == "" {
+		// A shell has no conversation for a restart to start fresh.
+		if tool.Shell {
 			continue
 		}
 		command, agentSessionID := restartLaunch(tool)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -145,6 +145,10 @@ type Model struct {
 	// settle timers with an older gen are dropped so key-repeat cannot
 	// queue a second of tmux work after the user stops.
 	previewGen uint64
+	// terminalKeyAt is when T last arrived. Held down it autorepeats into a
+	// burst of keystrokes, and T is the only key that spawns on the
+	// keystroke itself rather than opening a form that would swallow them.
+	terminalKeyAt time.Time
 
 	// bannerPhase advances the wordmark's current sweep and then rests, so
 	// the frame is not repainted forever.
@@ -772,6 +776,18 @@ func (m *Model) selectedRow() (treeRow, bool) {
 		return treeRow{}, false
 	}
 	return m.rows[m.cursor], true
+}
+
+// focusSession puts the cursor on a session's row, for the keys that make
+// one and leave the user on it. A session filtered out of the current view
+// has no row, and the cursor stays where it was.
+func (m *Model) focusSession(id string) {
+	for i, row := range m.rows {
+		if !row.isGroup && row.sess.ID == id {
+			m.cursor = i
+			return
+		}
+	}
 }
 
 // schedulePreview arms a single capture after previewSettle. Call after

--- a/internal/ui/quick_test.go
+++ b/internal/ui/quick_test.go
@@ -723,7 +723,7 @@ func TestQuickPromptRefusesAShell(t *testing.T) {
 }
 
 // The same guard from the other end: what the user typed never reaches the
-// shell, so it never runs. This is the maintainer's repro from #232.
+// shell, so it never runs.
 func TestQuickPromptNeverRunsWhatIsTypedAtAShell(t *testing.T) {
 	m := buildModel(t)
 	m.applyCmd(t, m.refreshCmd())

--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -1,8 +1,7 @@
 package ui
 
 import (
-	"os"
-	"sort"
+	"time"
 
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/status"
@@ -10,22 +9,26 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// terminalKeyWindow is how long after a T keystroke another one reads as
+// autorepeat rather than a second request: comfortably longer than the
+// interval a held key repeats at, shorter than a deliberate second press.
+const terminalKeyWindow = 250 * time.Millisecond
+
 // shellTool finds the config block T spawns: the first one declaring
 // shell = true, by name so the pick is the same on every launch. Nothing
 // keys off the block being called "terminal", so a user who already has a
 // [tools.terminal] block of their own keeps it as the agent CLI they wrote.
 func (m *Model) shellTool() (string, config.Tool, bool) {
-	names := make([]string, 0, len(m.cfg.Tools))
+	chosen := ""
 	for name, tool := range m.cfg.Tools {
-		if tool.Shell {
-			names = append(names, name)
+		if tool.Shell && (chosen == "" || name < chosen) {
+			chosen = name
 		}
 	}
-	if len(names) == 0 {
+	if chosen == "" {
 		return "", config.Tool{}, false
 	}
-	sort.Strings(names)
-	return names[0], m.cfg.Tools[names[0]], true
+	return chosen, m.cfg.Tools[chosen], true
 }
 
 // isShell reports whether a session's tool opens a shell rather than an
@@ -33,6 +36,17 @@ func (m *Model) shellTool() (string, config.Tool, bool) {
 // not something we can claim runs a shell.
 func (m *Model) isShell(toolName string) bool {
 	return m.cfg.Tools[toolName].Shell
+}
+
+// terminalKeyRepeat reports whether T arrived inside the burst a held key
+// sends. Each keystroke pushes the window out, so holding T spawns one
+// shell however long it is held. The other keys that create something open
+// a form first, which absorbs a burst on its own.
+func (m *Model) terminalKeyRepeat() bool {
+	now := time.Now()
+	repeated := now.Sub(m.terminalKeyAt) < terminalKeyWindow
+	m.terminalKeyAt = now
+	return repeated
 }
 
 // openTerminal spawns a shell tab in the group under the cursor. The block
@@ -66,12 +80,7 @@ func (m *Model) openTerminal() (tea.Model, tea.Cmd) {
 	// would be filtered off screen.
 	m.statusFilter = statusFilterAll
 	m.errBar.text = ""
-	for i, row := range m.rows {
-		if !row.isGroup && row.sess.ID == sess.ID {
-			m.cursor = i
-			break
-		}
-	}
+	m.focusSession(sess.ID)
 	return m, m.refreshCmd()
 }
 
@@ -92,9 +101,4 @@ func (m *Model) rowDir() (string, bool) {
 		return path, true
 	}
 	return entry.sess.Cwd, isDir(entry.sess.Cwd)
-}
-
-func isDir(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.IsDir()
 }

--- a/internal/ui/terminal_test.go
+++ b/internal/ui/terminal_test.go
@@ -5,11 +5,29 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
+	tea "github.com/charmbracelet/bubbletea"
 )
+
+func shellCount(m *Model) int {
+	count := 0
+	for _, sess := range m.sessions {
+		if m.isShell(sess.Tool) {
+			count++
+		}
+	}
+	return count
+}
+
+func pressTerminalKey(t *testing.T, m *Model) {
+	t.Helper()
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'T'}})
+	m.applyCmd(t, cmd)
+}
 
 // shellToolName is the block buildModel ships with shell = true.
 const shellToolName = "terminal"
@@ -175,5 +193,75 @@ func TestShellToolIsFoundByItsFlag(t *testing.T) {
 	name, tool, ok := m.shellTool()
 	if !ok || name != "zsh" || tool.Command != "" {
 		t.Fatalf("shellTool() = %q %+v %v, want the zsh block", name, tool, ok)
+	}
+}
+
+// Holding T autorepeats into a burst of keystrokes. T spawns on the
+// keystroke itself, so without a guard a held key fills the list with
+// shells and tmux windows nobody asked for.
+func TestTerminalKeyIgnoresAutorepeat(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+
+	for i := 0; i < 5; i++ {
+		pressTerminalKey(t, m)
+	}
+
+	if got := shellCount(m); got != 1 {
+		t.Fatalf("a held T made %d shells, want 1", got)
+	}
+}
+
+// A press once the burst is over is a second request, not a repeat.
+func TestTerminalKeySpawnsAgainAfterTheWindow(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+
+	pressTerminalKey(t, m)
+	m.terminalKeyAt = time.Now().Add(-2 * terminalKeyWindow)
+	pressTerminalKey(t, m)
+
+	if got := shellCount(m); got != 2 {
+		t.Fatalf("two separate presses made %d shells, want 2", got)
+	}
+}
+
+// The footer offers what the row can do: a shell has no conversation, so
+// the keys that prompt, review or fork one are left off.
+func TestShellRowLegendDropsTheConversationKeys(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	sess := spawnTerminal(t, m)
+	m.selectSessionRow(t, sess.Name)
+
+	legend := m.rowLegend()
+	if legend.title != "Shell" {
+		t.Fatalf("legend title = %q, want Shell", legend.title)
+	}
+	for _, pair := range legend.pairs {
+		switch pair[0] {
+		case "space", "ctrl+r", "f":
+			t.Fatalf("legend offers %q on a shell row, which refuses it", pair[0])
+		}
+	}
+	if !slices.ContainsFunc(legend.pairs, func(pair [2]string) bool { return pair[0] == "R" }) {
+		t.Fatal("legend should still offer the keys a shell answers, R included")
+	}
+}
+
+// An agent row keeps the full set.
+func TestAgentRowLegendKeepsTheConversationKeys(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "agent", t.TempDir(), "")
+	m.selectSessionRow(t, "agent")
+
+	legend := m.rowLegend()
+	if legend.title != "Session" {
+		t.Fatalf("legend title = %q, want Session", legend.title)
+	}
+	for _, key := range []string{"space", "ctrl+r", "f"} {
+		if !slices.ContainsFunc(legend.pairs, func(pair [2]string) bool { return pair[0] == key }) {
+			t.Fatalf("legend should offer %q on an agent row", key)
+		}
 	}
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -487,12 +487,21 @@ func (m *Model) rowLegend() legendSection {
 			{"a/u", "archive / restore"}, {"d", "delete"},
 		}}
 	}
-	return legendSection{title: "Session", pairs: [][2]string{
-		{"↵", enterHint}, {"A", attachHint}, {"space", "prompt"}, {"ctrl+r", "review"},
-		{"f", "fork"}, {"r", "rename"}, {"m", "move"},
+	title := "Session"
+	conversation := [][2]string{{"space", "prompt"}, {"ctrl+r", "review"}, {"f", "fork"}}
+	if m.isShell(row.sess.Tool) {
+		// A shell has no conversation, so the keys that would prompt,
+		// review or fork one are left off rather than offered and refused.
+		title, conversation = "Shell", nil
+	}
+	pairs := [][2]string{{"↵", enterHint}, {"A", attachHint}}
+	pairs = append(pairs, conversation...)
+	pairs = append(pairs, [][2]string{
+		{"r", "rename"}, {"m", "move"},
 		{"x/X", "kill / all"}, {"v/V", "revive / all"}, {"R", "restart"},
 		{"a/u", "archive / restore"}, {"d", "delete"},
-	}}
+	}...)
+	return legendSection{title: title, pairs: pairs}
 }
 
 // viewLegend is the tier that never changes with the cursor: moving around


### PR DESCRIPTION
Follow-up to #232.

## One shell per press

`T` spawns on the keystroke itself, so a held key autorepeated into a burst of shells and tmux windows. A keystroke arriving inside the repeat window is now dropped, and each one pushes the window out, so holding `T` makes one shell however long it is held. The other keys that create something open a form first, which absorbs a burst on its own.

## The legend matches the row

The footer offered `space`, `ctrl+r` and `f` on a shell row, all three of which the row refuses. A shell row now reads **Shell** and lists only the keys it answers, `R` included.

## Docs

A shell rests at idle throughout, a build included, since turn tracking belongs to agents. And it carries a session id as soon as its block has a command, so the `agent-manager rename` caveat is about the empty one.

## Shared out along the way

`isDir`, which four directory checks spelled by hand, and `focusSession`, which fork and the terminal key both walked the rows for.

## Testing

`gofmt -l .` clean, `go vet ./...` clean, and `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./...` green, including four new tests covering the held key, a deliberate second press, and both legends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer session controls and labels for shell tabs versus conversational sessions.
  * Shell tabs now hide unsupported prompt, review, and fork actions.
  * Newly opened or forked sessions are automatically focused.
* **Bug Fixes**
  * Prevented repeated `T` key events from opening multiple terminals.
  * Improved handling and validation of session working directories.
* **Documentation**
  * Clarified shell tab behavior, session IDs, and supported actions in the terminal-tab documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->