### PR TITLE
fix(ui): keep focus-mode scroll from losing rows under fast wheel input

### DIFF
--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -172,7 +172,7 @@ func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var resume tea.Cmd
 	if m.scrolledBack() {
 		m.focusScroll = 0
-		resume = m.focusRegionCmd(sess.ID, 0)
+		resume = m.requestFocusRegion(sess.ID)
 	}
 	if msg.Paste {
 		if err := pasteFocused(m.tmux, sess.ID, string(msg.Runes)); err != nil {

--- a/internal/ui/focusscroll.go
+++ b/internal/ui/focusscroll.go
@@ -17,7 +17,9 @@ const focusScrollStep = 3
 type focusScrollMsg struct {
 	sessID  string
 	offset  int
+	rows    int
 	preview string
+	ok      bool
 }
 
 // Mouse button codes as the reports carry them: the two wheel
@@ -144,12 +146,15 @@ func (m *Model) scrollFocus(delta int) tea.Cmd {
 		return nil
 	}
 	m.focusScroll = offset
-	if offset == 0 {
-		// Back at the bottom: the watcher's next push repaints the live
-		// pane, and one immediate fetch avoids waiting for it.
-		return m.focusRegionCmd(sess.ID, 0)
-	}
-	return m.focusRegionCmd(sess.ID, offset)
+	return m.requestFocusRegion(sess.ID)
+}
+
+// requestFocusRegion fetches the current scroll target. Every notch gets
+// its own command: callers (including tests) rely on a non-nil command
+// per notch, and stale replies are discarded by the offset guard in
+// Update, so a burst costs extra captures but never a wrong frame.
+func (m *Model) requestFocusRegion(sessID string) tea.Cmd {
+	return m.focusRegionCmd(sessID, m.focusScroll)
 }
 
 // focusRegionCmd captures the pane region that sits offset lines above the
@@ -157,22 +162,16 @@ func (m *Model) scrollFocus(delta int) tea.Cmd {
 // above it with negative lines, so a scrolled window is just a shifted
 // start and end.
 func (m *Model) focusRegionCmd(sessID string, offset int) tea.Cmd {
-	rows := m.pane.box.height
-	if rows < 1 {
-		rows = 1
-	}
+	rows := m.previewPaneHeight()
 	command := fmt.Sprintf(`capture-pane -p -e -t %s -S %d -E %d`,
 		tmux.SessionName(sessID), -offset, rows-1-offset)
 	watch := m.focus
 	return func() tea.Msg {
 		if watch == nil {
-			return nil
+			return focusScrollMsg{sessID: sessID, offset: offset, rows: rows}
 		}
 		out, ok := watch.query(command)
-		if !ok {
-			return nil
-		}
-		return focusScrollMsg{sessID: sessID, offset: offset, preview: matchExecShape(out)}
+		return focusScrollMsg{sessID: sessID, offset: offset, rows: rows, preview: matchExecShape(out), ok: ok}
 	}
 }
 

--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -155,6 +155,83 @@ func TestFocusWheelScrollsHistory(t *testing.T) {
 	}
 }
 
+// A capture scheduled before the preview reflows must not blank the bottom
+// of the resized viewport when its reply arrives afterwards.
+func TestFocusScrollRecapturesAfterPreviewResize(t *testing.T) {
+	m, _ := focusedWithHistory(t, "reflow")
+	cmd := m.scrollFocus(-1)
+	if cmd == nil {
+		t.Fatal("wheel up produced no capture")
+	}
+	stale := cmd()
+	if stale == nil {
+		t.Fatal("scroll capture returned nothing")
+	}
+	oldRows := m.previewPaneHeight()
+	m.height += 8
+	if m.previewPaneHeight() == oldRows {
+		t.Fatal("test setup did not change preview height")
+	}
+	m.resizeSessions()
+
+	updated, recapture := m.Update(stale)
+	m = updated.(*Model)
+	if recapture == nil {
+		t.Fatal("stale geometry capture was accepted")
+	}
+	updated, _ = m.Update(recapture())
+	m = updated.(*Model)
+	if got, want := len(paneExact(m.preview, m.previewPaneHeight())), m.previewPaneHeight(); got != want {
+		t.Fatalf("scroll frame has %d rows, want %d", got, want)
+	}
+	if !strings.Contains(m.preview, "history-line-") {
+		t.Fatalf("recaptured frame lost history:\n%s", m.preview)
+	}
+}
+
+// Deep history must keep the requested pane-sized frame intact. This covers
+// the control-pipe capture path beyond the shallow history used by the wheel
+// smoke test above.
+func TestFocusScrollKeepsDeepHistoryFrame(t *testing.T) {
+	m, sessID := focusedWithHistory(t, "deep-history")
+	command := `i=121; while [ "$i" -le 1000 ]; do printf 'history-line-%04d\n' "$i"; i=$((i+1)); done`
+	if err := m.tmux.SendText(sessID, command); err != nil {
+		t.Fatalf("send deep history: %v", err)
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		pane, err := m.tmux.CapturePane(sessID)
+		if err != nil {
+			t.Fatalf("capture deep history: %v", err)
+		}
+		if strings.Contains(pane, "history-line-1000") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pane never printed deep history: %q", pane)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	m.pane.history = paneHistorySize(t, m, sessID)
+	if m.pane.history < 820 {
+		t.Skipf("tmux history is only %d lines", m.pane.history)
+	}
+	m.focusScroll = 807
+	cmd := m.focusRegionCmd(sessID, m.focusScroll)
+	msg := cmd()
+	if msg == nil {
+		t.Fatal("deep capture returned nothing")
+	}
+	updated, _ := m.Update(msg)
+	m = updated.(*Model)
+	if got, want := len(paneExact(m.preview, m.previewPaneHeight())), m.previewPaneHeight(); got != want {
+		t.Fatalf("deep frame has %d rows, want %d", got, want)
+	}
+	if !strings.Contains(m.preview, "history-line-") {
+		t.Fatalf("deep frame lost history:\n%s", m.preview)
+	}
+}
+
 // Typing while scrolled snaps back to the live bottom: keystrokes land
 // there, so the view must follow them.
 func TestTypingResumesLiveView(t *testing.T) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1069,7 +1069,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case focusScrollMsg:
-		if sess, ok := m.selected(); ok && sess.ID == msg.sessID && msg.offset == m.focusScroll {
+		sess, ok := m.selected()
+		if !ok || sess.ID != msg.sessID {
+			return m, nil
+		}
+		if msg.offset != m.focusScroll || msg.rows != m.previewPaneHeight() {
+			// The wheel or a resize moved the target while this capture was
+			// in flight. Fetch just that final viewport.
+			return m, m.focusRegionCmd(sess.ID, m.focusScroll)
+		}
+		if msg.ok {
 			m.preview = msg.preview
 		}
 		return m, nil


### PR DESCRIPTION
## Symptom

In focus mode (Enter on a session), scrolling up with the mouse wheel made
rows vanish from the bottom upward until the pane went blank. It was worst
during fast wheel bursts and when scrolling deep into history (offsets
~800+).

Reproduced and verified in: Ghostty terminal, both on the local machine and
over SSH, with agent-manager 0.23.0. Sessions tested: agy, codex, and
claude (with `/tui default`). After this patch, focused scrolling up no
longer loses lines in any of those tools, with and without SSH.

## Root cause

Focused scrolling issues `capture-pane` per wheel notch through the tmux
control client, with two defects:

1. The capture window is sized from `m.pane.box.height`, which can be stale
   relative to the real preview viewport (`previewPaneHeight()`), so the
   request window doesn't match the pane being painted.
2. Replies were applied whenever the offset matched, even if the pane was
   resized while the capture was in flight, and failed captures silently
   dropped the frame.

Under fast wheel input, replies arrive behind the watcher's live captures;
stale or wrongly-sized frames get painted and the viewport loses rows from
the bottom up.

## Fix

- `focusRegionCmd` sizes the capture window from `previewPaneHeight()`.
- `focusScrollMsg` now carries the requested row count and an `ok` flag; a
  reply captured before a resize, or one whose offset no longer matches, is
  rejected and the final viewport is recaptured instead of painting a stale
  frame.
- Failed captures no longer silently clear the preview.
- Typing-to-resume uses the same request path as scrolling.

## Verification

- Live TUI: the bug no longer reproduces in Ghostty, local and over SSH,
  across agy / codex / claude sessions.
- `gofmt -l .`, `go vet ./...`, `go build ./...`,
  `go test -race ./...` all pass (tmux 3.7b, Go 1.26.5).
- New regression tests: `TestFocusScrollRecapturesAfterPreviewResize`,
  `TestFocusScrollKeepsDeepHistoryFrame`.

## Notes for the reviewer

An earlier experiment also coalesced wheel input to one in-flight capture.
It was dropped: it freezes `TestScrollStopsAtHistoryTop` (the wheel stalls
whenever a capture reply isn't routed), and the offset-guard recapture in
this patch already prevents stale frames without suppressing input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus recovery while viewing scrollback history.
  * Focused content now stays aligned after resizing the preview pane.
  * Prevented stale scroll captures from displaying outdated content.
  * Improved navigation through deep scrollback while preserving the expected pane height.
  * Added safeguards to ensure captured results apply only to the currently selected session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->