### PR TITLE
feat(ui): acknowledge finished sessions from the list

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -375,6 +375,30 @@ func (s *Store) UpdateStatus(id, newStatus string) error {
 	return requireRow(res, id)
 }
 
+// AcknowledgeFinished atomically marks a session idle and acked if its stored
+// status is still finished. A newer status makes the operation a no-op.
+func (s *Store) AcknowledgeFinished(id string) error {
+	res, err := s.db.Exec(
+		`UPDATE sessions SET status = ?, acked = 1, last_status_at = ? WHERE id = ? AND status = ?`,
+		"idle", encodeTime(time.Now()), id, "finished")
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n > 0 {
+		return nil
+	}
+	var exists int
+	err = s.db.QueryRow(`SELECT 1 FROM sessions WHERE id = ?`, id).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("session %s: %w", id, ErrSessionGone)
+	}
+	return err
+}
+
 // SetAcked marks whether the user has acknowledged the session's last
 // finished turn; an acked session renders idle even while its pane still
 // shows the finished turn.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/status"
 	_ "modernc.org/sqlite"
 )
 
@@ -380,23 +381,11 @@ func (s *Store) UpdateStatus(id, newStatus string) error {
 func (s *Store) AcknowledgeFinished(id string) error {
 	res, err := s.db.Exec(
 		`UPDATE sessions SET status = ?, acked = 1, last_status_at = ? WHERE id = ? AND status = ?`,
-		"idle", encodeTime(time.Now()), id, "finished")
+		status.Idle, encodeTime(time.Now()), id, status.Finished)
 	if err != nil {
 		return err
 	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if n > 0 {
-		return nil
-	}
-	var exists int
-	err = s.db.QueryRow(`SELECT 1 FROM sessions WHERE id = ?`, id).Scan(&exists)
-	if err == sql.ErrNoRows {
-		return fmt.Errorf("session %s: %w", id, ErrSessionGone)
-	}
-	return err
+	return s.requireRowOrNoop(res, id)
 }
 
 // SetAcked marks whether the user has acknowledged the session's last
@@ -639,21 +628,7 @@ func (s *Store) UpdateTool(id, tool string) error {
 	if err != nil {
 		return err
 	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if n > 0 {
-		return nil
-	}
-	// Zero rows: either the tool already matched (success no-op) or the
-	// session is gone. Distinguish so callers still see ErrSessionGone.
-	var exists int
-	err = s.db.QueryRow(`SELECT 1 FROM sessions WHERE id = ?`, id).Scan(&exists)
-	if err == sql.ErrNoRows {
-		return fmt.Errorf("session %s: %w", id, ErrSessionGone)
-	}
-	return err
+	return s.requireRowOrNoop(res, id)
 }
 
 // DeleteGroup removes a group and all its descendant groups, reporting
@@ -1060,6 +1035,25 @@ func (s *Store) persistGroupOrder(groups []Group) error {
 		}
 	}
 	return tx.Commit()
+}
+
+// requireRowOrNoop resolves a guarded UPDATE that matched zero rows: either
+// the WHERE condition already held (success no-op) or the session is gone.
+// Distinguish so callers still see ErrSessionGone.
+func (s *Store) requireRowOrNoop(res sql.Result, id string) error {
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected > 0 {
+		return nil
+	}
+	var exists int
+	err = s.db.QueryRow(`SELECT 1 FROM sessions WHERE id = ?`, id).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("session %s: %w", id, ErrSessionGone)
+	}
+	return err
 }
 
 func requireRow(res sql.Result, id string) error {

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -110,7 +110,7 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.errBar.text = ""
-	if err := m.acknowledgeFinished(sess); err != nil {
+	if err := m.store.AcknowledgeFinished(sess.ID); err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
 	}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -74,6 +74,7 @@ func helpSections() []helpSection {
 			{"↵", "focus it: keys reach the agent, the list stays on screen"},
 			{"A", "attach it: the pane takes the whole terminal"},
 			{"", "settings swap what ↵ and A do"},
+			{".", "mark it idle when it is finished, without entering it"},
 			{"space", "quick prompt: answer the session without attaching"},
 			{"ctrl+r", "review its diff"},
 			{"f", "fork it into a new session in the same group"},

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -102,6 +102,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openFork()
 	case "v":
 		return m.reviveSelected()
+	case ".":
+		return m.acknowledgeSelected()
 	case "V", "shift+v":
 		return m.reviveAllDead()
 	case "R", "shift+r":

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -95,10 +95,7 @@ func (m *Model) reattach(id string, diffGen int) tea.Cmd {
 			return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: err}
 		}
 		if sess.Status == status.Finished {
-			if err := stor.UpdateStatus(sess.ID, status.Idle); err != nil {
-				return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: err}
-			}
-			if err := stor.SetAcked(sess.ID, true); err != nil {
+			if err := stor.AcknowledgeFinished(sess.ID); err != nil {
 				return reattachPreparedMsg{sessID: id, diffGen: diffGen, err: err}
 			}
 		}

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -35,32 +35,28 @@ func (m *Model) attachSelected() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.errBar.text = ""
-	if err := m.acknowledgeFinished(sess); err != nil {
+	if err := m.store.AcknowledgeFinished(sess.ID); err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
 	return m, m.attachCmd(sess.ID)
 }
 
-type acknowledgeFinishedMsg struct{ err error }
-
+// acknowledgeSelected marks the selected finished session idle and acked
+// without entering it. Archived sessions keep their preserved status: the
+// poller never re-derives it for them, so an ack would stick forever.
 func (m *Model) acknowledgeSelected() (tea.Model, tea.Cmd) {
 	sess, ok := m.selected()
-	if !ok || sess.Status != status.Finished {
+	if !ok || sess.Archived || sess.Status != status.Finished {
 		return m, nil
 	}
-	return m, func() tea.Msg {
-		return acknowledgeFinishedMsg{err: m.acknowledgeFinished(sess)}
+	m.errBar.text = ""
+	if err := m.store.AcknowledgeFinished(sess.ID); err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
 	}
-}
-
-// acknowledgeFinished marks a finished session idle and acked while its pane
-// keeps showing the completed turn without raising another alert.
-func (m *Model) acknowledgeFinished(sess store.Session) error {
-	if sess.Status != status.Finished {
-		return nil
-	}
-	return m.store.AcknowledgeFinished(sess.ID)
+	m.requestRefresh()
+	return m, nil
 }
 
 func (m *Model) attachCmd(id string) tea.Cmd {

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -60,10 +60,7 @@ func (m *Model) acknowledgeFinished(sess store.Session) error {
 	if sess.Status != status.Finished {
 		return nil
 	}
-	if err := m.store.UpdateStatus(sess.ID, status.Idle); err != nil {
-		return err
-	}
-	return m.store.SetAcked(sess.ID, true)
+	return m.store.AcknowledgeFinished(sess.ID)
 }
 
 func (m *Model) attachCmd(id string) tea.Cmd {

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -42,8 +42,21 @@ func (m *Model) attachSelected() (tea.Model, tea.Cmd) {
 	return m, m.attachCmd(sess.ID)
 }
 
-// acknowledgeFinished marks a finished session idle and acked so entering it
-// clears the alert while the pane still shows the acknowledged turn.
+func (m *Model) acknowledgeSelected() (tea.Model, tea.Cmd) {
+	sess, ok := m.selected()
+	if !ok || sess.Status != status.Finished {
+		return m, nil
+	}
+	if err := m.acknowledgeFinished(sess); err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	m.errBar.text = ""
+	return m, m.refreshCmd()
+}
+
+// acknowledgeFinished marks a finished session idle and acked while its pane
+// keeps showing the completed turn without raising another alert.
 func (m *Model) acknowledgeFinished(sess store.Session) error {
 	if sess.Status != status.Finished {
 		return nil

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -42,17 +42,16 @@ func (m *Model) attachSelected() (tea.Model, tea.Cmd) {
 	return m, m.attachCmd(sess.ID)
 }
 
+type acknowledgeFinishedMsg struct{ err error }
+
 func (m *Model) acknowledgeSelected() (tea.Model, tea.Cmd) {
 	sess, ok := m.selected()
 	if !ok || sess.Status != status.Finished {
 		return m, nil
 	}
-	if err := m.acknowledgeFinished(sess); err != nil {
-		m.errBar.text = err.Error()
-		return m, nil
+	return m, func() tea.Msg {
+		return acknowledgeFinishedMsg{err: m.acknowledgeFinished(sess)}
 	}
-	m.errBar.text = ""
-	return m, m.refreshCmd()
 }
 
 // acknowledgeFinished marks a finished session idle and acked while its pane

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -278,6 +278,66 @@ func TestAttachAcknowledgesFinished(t *testing.T) {
 	}
 }
 
+func TestDotAcknowledgesFinishedWithoutAttach(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "alert-me", t.TempDir(), "")
+
+	sess := m.sessionRows()[0]
+	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
+		t.Fatalf("set finished: %v", err)
+	}
+	m.sessions[0].Status = status.Finished
+	m.rebuildRows()
+	m.selectSessionRow(t, "alert-me")
+	if footer := m.viewFooter(); !strings.Contains(footer, "mark idle") {
+		t.Fatalf("finished-session footer has no dot action: %q", footer)
+	}
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
+	*m = *updated.(*Model)
+	if cmd == nil {
+		t.Fatal("dot did not schedule a refresh")
+	}
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != status.Idle || !got.Acked {
+		t.Fatalf("after dot, status = %q acked = %v", got.Status, got.Acked)
+	}
+	if m.mode != modeList {
+		t.Fatalf("dot left list mode: %v", m.mode)
+	}
+}
+
+func TestDotIgnoresWorkingSession(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "busy-one", t.TempDir(), "")
+
+	sess := m.sessionRows()[0]
+	if err := m.store.UpdateStatus(sess.ID, status.Working); err != nil {
+		t.Fatalf("set working: %v", err)
+	}
+	m.sessions[0].Status = status.Working
+	m.rebuildRows()
+	m.selectSessionRow(t, "busy-one")
+	if footer := m.viewFooter(); strings.Contains(footer, "mark idle") {
+		t.Fatalf("working-session footer offers dot action: %q", footer)
+	}
+
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
+	if cmd != nil {
+		t.Fatal("dot refreshed a working session")
+	}
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != status.Working || got.Acked {
+		t.Fatalf("after dot, status = %q acked = %v", got.Status, got.Acked)
+	}
+}
+
 func TestAttachKeepsWorking(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "busy-one", t.TempDir(), "")

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -280,42 +280,47 @@ func TestAttachAcknowledgesFinished(t *testing.T) {
 
 func TestDotAcknowledgesOnlyCurrentFinishedStatus(t *testing.T) {
 	cases := []struct {
-		name       string
-		newer      string
-		wantStatus string
-		wantAcked  bool
+		name        string
+		selected    string
+		newer       string
+		wantStatus  string
+		wantAcked   bool
+		wantCommand bool
 	}{
-		{name: "finished", wantStatus: status.Idle, wantAcked: true},
-		{name: "newer working", newer: status.Working, wantStatus: status.Working},
+		{name: "finished", selected: status.Finished, wantStatus: status.Idle, wantAcked: true, wantCommand: true},
+		{name: "newer working", selected: status.Finished, newer: status.Working, wantStatus: status.Working, wantCommand: true},
+		{name: "working", selected: status.Working, wantStatus: status.Working},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := buildModel(t)
 			createSession(t, m, "alert-me", t.TempDir(), "")
 			sess := m.sessionRows()[0]
-			if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
-				t.Fatalf("set finished: %v", err)
+			if err := m.store.UpdateStatus(sess.ID, tc.selected); err != nil {
+				t.Fatalf("set selected status: %v", err)
 			}
-			m.sessions[0].Status = status.Finished
+			m.sessions[0].Status = tc.selected
 			m.rebuildRows()
 			m.selectSessionRow(t, "alert-me")
-			if footer := m.viewFooter(); !strings.Contains(footer, "mark idle") {
-				t.Fatalf("finished-session footer has no dot action: %q", footer)
+			if offered := strings.Contains(m.viewFooter(), "mark idle"); offered != tc.wantCommand {
+				t.Fatalf("dot footer offered = %v, want %v", offered, tc.wantCommand)
 			}
 
 			_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
-			if cmd == nil {
-				t.Fatal("dot did not schedule the acknowledgment")
+			if (cmd != nil) != tc.wantCommand {
+				t.Fatalf("dot command = %v, want command %v", cmd != nil, tc.wantCommand)
 			}
-			if tc.newer != "" {
-				if err := m.store.UpdateStatus(sess.ID, tc.newer); err != nil {
-					t.Fatalf("set newer status: %v", err)
+			if cmd != nil {
+				if tc.newer != "" {
+					if err := m.store.UpdateStatus(sess.ID, tc.newer); err != nil {
+						t.Fatalf("set newer status: %v", err)
+					}
 				}
-			}
-			updated, refresh := m.Update(cmd())
-			*m = *updated.(*Model)
-			if refresh == nil {
-				t.Fatal("acknowledgment did not schedule a refresh")
+				updated, refresh := m.Update(cmd())
+				*m = *updated.(*Model)
+				if refresh == nil {
+					t.Fatal("acknowledgment did not schedule a refresh")
+				}
 			}
 			got, err := m.store.Get(sess.ID)
 			if err != nil {

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -296,7 +296,19 @@ func TestDotAcknowledgesFinishedWithoutAttach(t *testing.T) {
 	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
 	*m = *updated.(*Model)
 	if cmd == nil {
-		t.Fatal("dot did not schedule a refresh")
+		t.Fatal("dot did not schedule the acknowledgment")
+	}
+	before, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("get before command: %v", err)
+	}
+	if before.Status != status.Finished || before.Acked {
+		t.Fatalf("before command, status = %q acked = %v", before.Status, before.Acked)
+	}
+	updated, refresh := m.Update(cmd())
+	*m = *updated.(*Model)
+	if refresh == nil {
+		t.Fatal("successful acknowledgment did not schedule a refresh")
 	}
 	got, err := m.store.Get(sess.ID)
 	if err != nil {
@@ -307,6 +319,35 @@ func TestDotAcknowledgesFinishedWithoutAttach(t *testing.T) {
 	}
 	if m.mode != modeList {
 		t.Fatalf("dot left list mode: %v", m.mode)
+	}
+}
+
+func TestDotAcknowledgementErrorDoesNotRefresh(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "deleted-alert", t.TempDir(), "")
+
+	sess := m.sessionRows()[0]
+	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
+		t.Fatalf("set finished: %v", err)
+	}
+	m.sessions[0].Status = status.Finished
+	m.rebuildRows()
+	m.selectSessionRow(t, "deleted-alert")
+
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
+	if cmd == nil {
+		t.Fatal("dot did not schedule the acknowledgment")
+	}
+	if err := m.store.Delete(sess.ID); err != nil {
+		t.Fatalf("delete before command: %v", err)
+	}
+	updated, refresh := m.Update(cmd())
+	*m = *updated.(*Model)
+	if refresh != nil {
+		t.Fatal("failed acknowledgment scheduled a refresh")
+	}
+	if !strings.Contains(m.errBar.text, store.ErrSessionGone.Error()) {
+		t.Fatalf("acknowledgment error = %q", m.errBar.text)
 	}
 }
 

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -278,104 +278,56 @@ func TestAttachAcknowledgesFinished(t *testing.T) {
 	}
 }
 
-func TestDotAcknowledgesFinishedWithoutAttach(t *testing.T) {
-	m := buildModel(t)
-	createSession(t, m, "alert-me", t.TempDir(), "")
+func TestDotAcknowledgesOnlyCurrentFinishedStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		newer      string
+		wantStatus string
+		wantAcked  bool
+	}{
+		{name: "finished", wantStatus: status.Idle, wantAcked: true},
+		{name: "newer working", newer: status.Working, wantStatus: status.Working},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := buildModel(t)
+			createSession(t, m, "alert-me", t.TempDir(), "")
+			sess := m.sessionRows()[0]
+			if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
+				t.Fatalf("set finished: %v", err)
+			}
+			m.sessions[0].Status = status.Finished
+			m.rebuildRows()
+			m.selectSessionRow(t, "alert-me")
+			if footer := m.viewFooter(); !strings.Contains(footer, "mark idle") {
+				t.Fatalf("finished-session footer has no dot action: %q", footer)
+			}
 
-	sess := m.sessionRows()[0]
-	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
-		t.Fatalf("set finished: %v", err)
-	}
-	m.sessions[0].Status = status.Finished
-	m.rebuildRows()
-	m.selectSessionRow(t, "alert-me")
-	if footer := m.viewFooter(); !strings.Contains(footer, "mark idle") {
-		t.Fatalf("finished-session footer has no dot action: %q", footer)
-	}
-
-	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
-	*m = *updated.(*Model)
-	if cmd == nil {
-		t.Fatal("dot did not schedule the acknowledgment")
-	}
-	before, err := m.store.Get(sess.ID)
-	if err != nil {
-		t.Fatalf("get before command: %v", err)
-	}
-	if before.Status != status.Finished || before.Acked {
-		t.Fatalf("before command, status = %q acked = %v", before.Status, before.Acked)
-	}
-	updated, refresh := m.Update(cmd())
-	*m = *updated.(*Model)
-	if refresh == nil {
-		t.Fatal("successful acknowledgment did not schedule a refresh")
-	}
-	got, err := m.store.Get(sess.ID)
-	if err != nil {
-		t.Fatalf("get: %v", err)
-	}
-	if got.Status != status.Idle || !got.Acked {
-		t.Fatalf("after dot, status = %q acked = %v", got.Status, got.Acked)
-	}
-	if m.mode != modeList {
-		t.Fatalf("dot left list mode: %v", m.mode)
-	}
-}
-
-func TestDotAcknowledgementErrorDoesNotRefresh(t *testing.T) {
-	m := buildModel(t)
-	createSession(t, m, "deleted-alert", t.TempDir(), "")
-
-	sess := m.sessionRows()[0]
-	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
-		t.Fatalf("set finished: %v", err)
-	}
-	m.sessions[0].Status = status.Finished
-	m.rebuildRows()
-	m.selectSessionRow(t, "deleted-alert")
-
-	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
-	if cmd == nil {
-		t.Fatal("dot did not schedule the acknowledgment")
-	}
-	if err := m.store.Delete(sess.ID); err != nil {
-		t.Fatalf("delete before command: %v", err)
-	}
-	updated, refresh := m.Update(cmd())
-	*m = *updated.(*Model)
-	if refresh != nil {
-		t.Fatal("failed acknowledgment scheduled a refresh")
-	}
-	if !strings.Contains(m.errBar.text, store.ErrSessionGone.Error()) {
-		t.Fatalf("acknowledgment error = %q", m.errBar.text)
-	}
-}
-
-func TestDotIgnoresWorkingSession(t *testing.T) {
-	m := buildModel(t)
-	createSession(t, m, "busy-one", t.TempDir(), "")
-
-	sess := m.sessionRows()[0]
-	if err := m.store.UpdateStatus(sess.ID, status.Working); err != nil {
-		t.Fatalf("set working: %v", err)
-	}
-	m.sessions[0].Status = status.Working
-	m.rebuildRows()
-	m.selectSessionRow(t, "busy-one")
-	if footer := m.viewFooter(); strings.Contains(footer, "mark idle") {
-		t.Fatalf("working-session footer offers dot action: %q", footer)
-	}
-
-	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
-	if cmd != nil {
-		t.Fatal("dot refreshed a working session")
-	}
-	got, err := m.store.Get(sess.ID)
-	if err != nil {
-		t.Fatalf("get: %v", err)
-	}
-	if got.Status != status.Working || got.Acked {
-		t.Fatalf("after dot, status = %q acked = %v", got.Status, got.Acked)
+			_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
+			if cmd == nil {
+				t.Fatal("dot did not schedule the acknowledgment")
+			}
+			if tc.newer != "" {
+				if err := m.store.UpdateStatus(sess.ID, tc.newer); err != nil {
+					t.Fatalf("set newer status: %v", err)
+				}
+			}
+			updated, refresh := m.Update(cmd())
+			*m = *updated.(*Model)
+			if refresh == nil {
+				t.Fatal("acknowledgment did not schedule a refresh")
+			}
+			got, err := m.store.Get(sess.ID)
+			if err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			if got.Status != tc.wantStatus || got.Acked != tc.wantAcked {
+				t.Fatalf("after dot, status = %q acked = %v", got.Status, got.Acked)
+			}
+			if m.mode != modeList {
+				t.Fatalf("dot left list mode: %v", m.mode)
+			}
+		})
 	}
 }
 

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -280,48 +280,33 @@ func TestAttachAcknowledgesFinished(t *testing.T) {
 
 func TestDotAcknowledgesOnlyCurrentFinishedStatus(t *testing.T) {
 	cases := []struct {
-		name        string
-		selected    string
-		newer       string
-		wantStatus  string
-		wantAcked   bool
-		wantCommand bool
+		name       string
+		listed     string
+		stored     string
+		wantStatus string
+		wantAcked  bool
+		wantOffer  bool
 	}{
-		{name: "finished", selected: status.Finished, wantStatus: status.Idle, wantAcked: true, wantCommand: true},
-		{name: "newer working", selected: status.Finished, newer: status.Working, wantStatus: status.Working, wantCommand: true},
-		{name: "working", selected: status.Working, wantStatus: status.Working},
+		{name: "finished", listed: status.Finished, stored: status.Finished, wantStatus: status.Idle, wantAcked: true, wantOffer: true},
+		{name: "stale snapshot", listed: status.Finished, stored: status.Working, wantStatus: status.Working, wantOffer: true},
+		{name: "working", listed: status.Working, stored: status.Working, wantStatus: status.Working},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := buildModel(t)
 			createSession(t, m, "alert-me", t.TempDir(), "")
 			sess := m.sessionRows()[0]
-			if err := m.store.UpdateStatus(sess.ID, tc.selected); err != nil {
-				t.Fatalf("set selected status: %v", err)
+			if err := m.store.UpdateStatus(sess.ID, tc.stored); err != nil {
+				t.Fatalf("set stored status: %v", err)
 			}
-			m.sessions[0].Status = tc.selected
+			m.sessions[0].Status = tc.listed
 			m.rebuildRows()
 			m.selectSessionRow(t, "alert-me")
-			if offered := strings.Contains(m.viewFooter(), "mark idle"); offered != tc.wantCommand {
-				t.Fatalf("dot footer offered = %v, want %v", offered, tc.wantCommand)
+			if offered := strings.Contains(m.viewFooter(), "mark idle"); offered != tc.wantOffer {
+				t.Fatalf("dot footer offered = %v, want %v", offered, tc.wantOffer)
 			}
 
-			_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
-			if (cmd != nil) != tc.wantCommand {
-				t.Fatalf("dot command = %v, want command %v", cmd != nil, tc.wantCommand)
-			}
-			if cmd != nil {
-				if tc.newer != "" {
-					if err := m.store.UpdateStatus(sess.ID, tc.newer); err != nil {
-						t.Fatalf("set newer status: %v", err)
-					}
-				}
-				updated, refresh := m.Update(cmd())
-				*m = *updated.(*Model)
-				if refresh == nil {
-					t.Fatal("acknowledgment did not schedule a refresh")
-				}
-			}
+			m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
 			got, err := m.store.Get(sess.ID)
 			if err != nil {
 				t.Fatalf("get: %v", err)
@@ -333,6 +318,35 @@ func TestDotAcknowledgesOnlyCurrentFinishedStatus(t *testing.T) {
 				t.Fatalf("dot left list mode: %v", m.mode)
 			}
 		})
+	}
+}
+
+func TestDotKeepsArchivedFinishedStatus(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "kept", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
+		t.Fatalf("set finished: %v", err)
+	}
+	if err := m.store.SetArchived(sess.ID, true); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	m.sessions[0].Status = status.Finished
+	m.sessions[0].Archived = true
+	m.showArchived = true
+	m.rebuildRows()
+	m.selectSessionRow(t, "kept")
+	if strings.Contains(m.viewFooter(), "mark idle") {
+		t.Fatal("dot offered on an archived session")
+	}
+
+	m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != status.Finished || got.Acked {
+		t.Fatalf("archived session changed: status = %q acked = %v", got.Status, got.Acked)
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1147,14 +1147,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case diffProbeMsg:
 		return m, m.handleDiffProbe(msg)
 
-	case acknowledgeFinishedMsg:
-		if msg.err != nil {
-			m.errBar.text = msg.err.Error()
-			return m, nil
-		}
-		m.errBar.text = ""
-		return m, m.refreshCmd()
-
 	case errMsg:
 		m.errBar.text = msg.err.Error()
 		return m, nil

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1147,6 +1147,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case diffProbeMsg:
 		return m, m.handleDiffProbe(msg)
 
+	case acknowledgeFinishedMsg:
+		if msg.err != nil {
+			m.errBar.text = msg.err.Error()
+			return m, nil
+		}
+		m.errBar.text = ""
+		return m, m.refreshCmd()
+
 	case errMsg:
 		m.errBar.text = msg.err.Error()
 		return m, nil

--- a/internal/ui/statusfilter_test.go
+++ b/internal/ui/statusfilter_test.go
@@ -220,7 +220,7 @@ func TestAttentionFilterKeepsSelectedAfterAck(t *testing.T) {
 	if !ok {
 		t.Fatal("expected a selected session")
 	}
-	if err := m.acknowledgeFinished(sess); err != nil {
+	if err := m.store.AcknowledgeFinished(sess.ID); err != nil {
 		t.Fatalf("acknowledge: %v", err)
 	}
 	loadStoredRows(t, m)
@@ -245,7 +245,7 @@ func TestAttentionFilterDropsAckedAfterMove(t *testing.T) {
 	if !ok {
 		t.Fatal("expected a selected session")
 	}
-	if err := m.acknowledgeFinished(sess); err != nil {
+	if err := m.store.AcknowledgeFinished(sess.ID); err != nil {
 		t.Fatalf("acknowledge: %v", err)
 	}
 	loadStoredRows(t, m)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -495,7 +495,7 @@ func (m *Model) rowLegend() legendSection {
 		title, conversation = "Shell", nil
 	}
 	pairs := [][2]string{{"↵", enterHint}, {"A", attachHint}}
-	if row.sess.Status == status.Finished {
+	if row.sess.Status == status.Finished && !row.sess.Archived {
 		pairs = append(pairs, [2]string{".", "mark idle"})
 	}
 	pairs = append(pairs, conversation...)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -495,6 +495,9 @@ func (m *Model) rowLegend() legendSection {
 		title, conversation = "Shell", nil
 	}
 	pairs := [][2]string{{"↵", enterHint}, {"A", attachHint}}
+	if row.sess.Status == status.Finished {
+		pairs = append(pairs, [2]string{".", "mark idle"})
+	}
 	pairs = append(pairs, conversation...)
 	pairs = append(pairs, [][2]string{
 		{"r", "rename"}, {"m", "move"},


### PR DESCRIPTION
## What changed

- Bind `.` to acknowledge the selected finished session and refresh the list.
- Keep the shortcut inactive for other session states.
- Show the shortcut in the finished-session footer and the key map.
- Add tests for the finished and working states.

## Why

The manager only acknowledged a finished session after the user entered it. This shortcut clears the alert without changing the current screen.

No linked issue.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [ ] Ran it against real sessions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `.` keyboard shortcut to mark a finished session as idle without opening it.
  * Updated session help and the action legend to display the new shortcut.
  * The session list refreshes after a successful action.

* **Bug Fixes**
  * Persistence errors are reported when marking a session idle fails.
  * The shortcut is ignored for active sessions, preventing unintended state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->