### PR TITLE
feat(ui): add OS dark/light mode auto-detection for themes

### DIFF
--- a/internal/sysstat/color_scheme.go
+++ b/internal/sysstat/color_scheme.go
@@ -1,6 +1,7 @@
 package sysstat
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -8,34 +9,57 @@ import (
 	"strings"
 )
 
-// ColorScheme represents the system's color mode preference
 type ColorScheme string
 
 const (
-	ColorSchemeLight ColorScheme = "light"
-	ColorSchemeDark  ColorScheme = "dark"
+	ColorSchemeLight   ColorScheme = "light"
+	ColorSchemeDark    ColorScheme = "dark"
 	ColorSchemeUnknown ColorScheme = "unknown"
 )
+
+// CommandRunner is an interface for running system commands, used for testing.
+type CommandRunner interface {
+	Run(name string, args ...string) ([]byte, error)
+}
+
+// RealCommandRunner uses the actual exec.Command to run system commands.
+type RealCommandRunner struct{}
+
+// Run executes the given command and returns its output.
+func (RealCommandRunner) Run(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// DefaultRunner is the default command runner that uses exec.Command.
+var DefaultRunner CommandRunner = RealCommandRunner{}
 
 // DetectSystemColorScheme returns the system's preferred color scheme (light or dark).
 // Returns ColorSchemeUnknown if detection fails or is not supported on the platform.
 func DetectSystemColorScheme() ColorScheme {
+	return DetectSystemColorSchemeWithRunner(DefaultRunner)
+}
+
+// DetectSystemColorSchemeWithRunner allows passing a custom command runner for testing.
+func DetectSystemColorSchemeWithRunner(runner CommandRunner) ColorScheme {
 	switch runtime.GOOS {
 	case "darwin":
-		return detectDarwinColorScheme()
+		return detectDarwinColorSchemeWithRunner(runner)
 	case "windows":
-		return detectWindowsColorScheme()
+		return detectWindowsColorSchemeWithRunner(runner)
 	case "linux":
-		return detectLinuxColorScheme()
+		return detectLinuxColorSchemeWithRunner(runner)
 	default:
 		return ColorSchemeUnknown
 	}
 }
 
-// detectDarwinColorScheme detects macOS system appearance
 func detectDarwinColorScheme() ColorScheme {
+	return detectDarwinColorSchemeWithRunner(DefaultRunner)
+}
+
+func detectDarwinColorSchemeWithRunner(runner CommandRunner) ColorScheme {
 	// Try AppleInterfaceStyle first (most reliable)
-	out, err := exec.Command("defaults", "read", "-g", "AppleInterfaceStyle").Output()
+	out, err := runner.Run("defaults", "read", "-g", "AppleInterfaceStyle")
 	if err == nil {
 		style := strings.TrimSpace(string(out))
 		if style == "Dark" {
@@ -44,10 +68,16 @@ func detectDarwinColorScheme() ColorScheme {
 		return ColorSchemeLight
 	}
 
+	// When defaults launches successfully but the key is missing,
+	// macOS defaults to light mode
+	var exitErr *exec.ExitError
+	if err != nil && !errors.As(err, &exitErr) {
+		return ColorSchemeUnknown
+	}
+
 	// Fallback: check NSRequiresAquaSystemAppearance
 	// If this is set to true, the app should use light mode
-	// If false or not set, it can use dark mode
-	out, err = exec.Command("defaults", "read", "-g", "NSRequiresAquaSystemAppearance").Output()
+	out, err = runner.Run("defaults", "read", "-g", "NSRequiresAquaSystemAppearance")
 	if err == nil {
 		style := strings.TrimSpace(string(out))
 		if style == "1" || strings.ToLower(style) == "true" {
@@ -56,16 +86,24 @@ func detectDarwinColorScheme() ColorScheme {
 		return ColorSchemeDark
 	}
 
-	return ColorSchemeUnknown
+	// Same logic for NSRequiresAquaSystemAppearance
+	if err != nil && !errors.As(err, &exitErr) {
+		return ColorSchemeUnknown
+	}
+
+	return ColorSchemeLight
 }
 
-// detectWindowsColorScheme detects Windows system appearance
 func detectWindowsColorScheme() ColorScheme {
+	return detectWindowsColorSchemeWithRunner(DefaultRunner)
+}
+
+func detectWindowsColorSchemeWithRunner(runner CommandRunner) ColorScheme {
 	// Check the registry for AppsUseLightTheme
 	// HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize
-	out, err := exec.Command("reg", "query", 
-		`HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize`, 
-		"/v", "AppsUseLightTheme").Output()
+	out, err := runner.Run("reg", "query",
+		`HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize`,
+		"/v", "AppsUseLightTheme")
 	if err == nil {
 		output := string(out)
 		if strings.Contains(output, "0x1") || strings.Contains(output, "1") {
@@ -76,16 +114,18 @@ func detectWindowsColorScheme() ColorScheme {
 	return ColorSchemeUnknown
 }
 
-// detectLinuxColorScheme detects Linux system appearance
-// Uses various environment variables and tools commonly available on Linux
 func detectLinuxColorScheme() ColorScheme {
+	return detectLinuxColorSchemeWithRunner(DefaultRunner)
+}
+
+func detectLinuxColorSchemeWithRunner(runner CommandRunner) ColorScheme {
 	// Try XDG desktop portal first (most modern)
-	if scheme := detectXDGPortal(); scheme != ColorSchemeUnknown {
+	if scheme := detectXDGPortalWithRunner(runner); scheme != ColorSchemeUnknown {
 		return scheme
 	}
 
 	// Try gsettings (GNOME)
-	if scheme := detectGSettings(); scheme != ColorSchemeUnknown {
+	if scheme := detectGSettingsWithRunner(runner); scheme != ColorSchemeUnknown {
 		return scheme
 	}
 
@@ -97,31 +137,43 @@ func detectLinuxColorScheme() ColorScheme {
 	return ColorSchemeUnknown
 }
 
-// detectXDGPortal uses xdg-desktop-portal to get color scheme
 func detectXDGPortal() ColorScheme {
-	out, err := exec.Command("dbus-send", 
-		"--print-reply=literal", 
+	return detectXDGPortalWithRunner(DefaultRunner)
+}
+
+func detectXDGPortalWithRunner(runner CommandRunner) ColorScheme {
+	out, err := runner.Run("dbus-send",
+		"--print-reply=literal",
 		"--dest=org.freedesktop.portal.Desktop",
 		"/org/freedesktop/portal/desktop",
 		"org.freedesktop.DBus.Properties.Get",
 		"string:org.freedesktop.portal.Settings",
-		"string:color-scheme").Output()
+		"string:color-scheme")
 	if err == nil {
 		output := string(out)
-		if strings.Contains(output, "uint32 1") || strings.Contains(output, "1") {
+		// Parse the uint32 value from the dbus-send output
+		// Expected format contains "uint32 <value>" where value is 0, 1, or 2
+		if strings.Contains(output, "uint32 1") {
 			return ColorSchemeDark
 		}
-		if strings.Contains(output, "uint32 0") || strings.Contains(output, "0") {
+		if strings.Contains(output, "uint32 2") {
 			return ColorSchemeLight
+		}
+		// 0 or any other value means unknown/unset
+		if strings.Contains(output, "uint32 0") {
+			return ColorSchemeUnknown
 		}
 	}
 	return ColorSchemeUnknown
 }
 
-// detectGSettings uses gsettings to get the GTK theme preference
 func detectGSettings() ColorScheme {
+	return detectGSettingsWithRunner(DefaultRunner)
+}
+
+func detectGSettingsWithRunner(runner CommandRunner) ColorScheme {
 	// Try the gsettings approach for GTK-based desktops
-	out, err := exec.Command("gsettings", "get", "org.gnome.desktop.interface", "color-scheme").Output()
+	out, err := runner.Run("gsettings", "get", "org.gnome.desktop.interface", "color-scheme")
 	if err == nil {
 		output := strings.TrimSpace(string(out))
 		if output == "'prefer-dark'" || output == "prefer-dark" {
@@ -132,17 +184,20 @@ func detectGSettings() ColorScheme {
 		}
 		if output == "'default'" || output == "default" {
 			// Try to detect from GTK theme name
-			return detectGTKTheme()
+			return detectGTKThemeWithRunner(runner)
 		}
 	}
 
 	// Fallback: try the gtk-theme-name setting
-	return detectGTKTheme()
+	return detectGTKThemeWithRunner(runner)
 }
 
-// detectGTKTheme checks the GTK theme name for dark variants
 func detectGTKTheme() ColorScheme {
-	out, err := exec.Command("gsettings", "get", "org.gnome.desktop.interface", "gtk-theme").Output()
+	return detectGTKThemeWithRunner(DefaultRunner)
+}
+
+func detectGTKThemeWithRunner(runner CommandRunner) ColorScheme {
+	out, err := runner.Run("gsettings", "get", "org.gnome.desktop.interface", "gtk-theme")
 	if err == nil {
 		theme := strings.TrimSpace(string(out))
 		theme = strings.Trim(theme, "'\"")
@@ -164,7 +219,6 @@ func detectGTKTheme() ColorScheme {
 	return ColorSchemeUnknown
 }
 
-// detectEnvVars checks common environment variables for color scheme
 func detectEnvVars() ColorScheme {
 	// Check common environment variables that indicate color scheme
 	// DARK_MODE is used by some applications
@@ -199,7 +253,6 @@ func detectEnvVars() ColorScheme {
 	return ColorSchemeUnknown
 }
 
-// parseHexColor parses a 2-character hex string into a 0-255 integer
 func parseHexColor(hexStr string) int {
 	var val int
 	if _, err := fmt.Sscanf(hexStr, "%02x", &val); err == nil {
@@ -208,9 +261,6 @@ func parseHexColor(hexStr string) int {
 	return 0
 }
 
-// ThemeForColorScheme returns the recommended agent-manager theme name
-// for the given color scheme. Returns the dark "classic" theme for dark mode
-// and the light "solarized light" theme for light mode.
 func ThemeForColorScheme(scheme ColorScheme) string {
 	switch scheme {
 	case ColorSchemeDark:

--- a/internal/sysstat/color_scheme.go
+++ b/internal/sysstat/color_scheme.go
@@ -1,0 +1,223 @@
+package sysstat
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// ColorScheme represents the system's color mode preference
+type ColorScheme string
+
+const (
+	ColorSchemeLight ColorScheme = "light"
+	ColorSchemeDark  ColorScheme = "dark"
+	ColorSchemeUnknown ColorScheme = "unknown"
+)
+
+// DetectSystemColorScheme returns the system's preferred color scheme (light or dark).
+// Returns ColorSchemeUnknown if detection fails or is not supported on the platform.
+func DetectSystemColorScheme() ColorScheme {
+	switch runtime.GOOS {
+	case "darwin":
+		return detectDarwinColorScheme()
+	case "windows":
+		return detectWindowsColorScheme()
+	case "linux":
+		return detectLinuxColorScheme()
+	default:
+		return ColorSchemeUnknown
+	}
+}
+
+// detectDarwinColorScheme detects macOS system appearance
+func detectDarwinColorScheme() ColorScheme {
+	// Try AppleInterfaceStyle first (most reliable)
+	out, err := exec.Command("defaults", "read", "-g", "AppleInterfaceStyle").Output()
+	if err == nil {
+		style := strings.TrimSpace(string(out))
+		if style == "Dark" {
+			return ColorSchemeDark
+		}
+		return ColorSchemeLight
+	}
+
+	// Fallback: check NSRequiresAquaSystemAppearance
+	// If this is set to true, the app should use light mode
+	// If false or not set, it can use dark mode
+	out, err = exec.Command("defaults", "read", "-g", "NSRequiresAquaSystemAppearance").Output()
+	if err == nil {
+		style := strings.TrimSpace(string(out))
+		if style == "1" || strings.ToLower(style) == "true" {
+			return ColorSchemeLight
+		}
+		return ColorSchemeDark
+	}
+
+	return ColorSchemeUnknown
+}
+
+// detectWindowsColorScheme detects Windows system appearance
+func detectWindowsColorScheme() ColorScheme {
+	// Check the registry for AppsUseLightTheme
+	// HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize
+	out, err := exec.Command("reg", "query", 
+		`HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize`, 
+		"/v", "AppsUseLightTheme").Output()
+	if err == nil {
+		output := string(out)
+		if strings.Contains(output, "0x1") || strings.Contains(output, "1") {
+			return ColorSchemeLight
+		}
+		return ColorSchemeDark
+	}
+	return ColorSchemeUnknown
+}
+
+// detectLinuxColorScheme detects Linux system appearance
+// Uses various environment variables and tools commonly available on Linux
+func detectLinuxColorScheme() ColorScheme {
+	// Try XDG desktop portal first (most modern)
+	if scheme := detectXDGPortal(); scheme != ColorSchemeUnknown {
+		return scheme
+	}
+
+	// Try gsettings (GNOME)
+	if scheme := detectGSettings(); scheme != ColorSchemeUnknown {
+		return scheme
+	}
+
+	// Try environment variables
+	if scheme := detectEnvVars(); scheme != ColorSchemeUnknown {
+		return scheme
+	}
+
+	return ColorSchemeUnknown
+}
+
+// detectXDGPortal uses xdg-desktop-portal to get color scheme
+func detectXDGPortal() ColorScheme {
+	out, err := exec.Command("dbus-send", 
+		"--print-reply=literal", 
+		"--dest=org.freedesktop.portal.Desktop",
+		"/org/freedesktop/portal/desktop",
+		"org.freedesktop.DBus.Properties.Get",
+		"string:org.freedesktop.portal.Settings",
+		"string:color-scheme").Output()
+	if err == nil {
+		output := string(out)
+		if strings.Contains(output, "uint32 1") || strings.Contains(output, "1") {
+			return ColorSchemeDark
+		}
+		if strings.Contains(output, "uint32 0") || strings.Contains(output, "0") {
+			return ColorSchemeLight
+		}
+	}
+	return ColorSchemeUnknown
+}
+
+// detectGSettings uses gsettings to get the GTK theme preference
+func detectGSettings() ColorScheme {
+	// Try the gsettings approach for GTK-based desktops
+	out, err := exec.Command("gsettings", "get", "org.gnome.desktop.interface", "color-scheme").Output()
+	if err == nil {
+		output := strings.TrimSpace(string(out))
+		if output == "'prefer-dark'" || output == "prefer-dark" {
+			return ColorSchemeDark
+		}
+		if output == "'prefer-light'" || output == "prefer-light" {
+			return ColorSchemeLight
+		}
+		if output == "'default'" || output == "default" {
+			// Try to detect from GTK theme name
+			return detectGTKTheme()
+		}
+	}
+
+	// Fallback: try the gtk-theme-name setting
+	return detectGTKTheme()
+}
+
+// detectGTKTheme checks the GTK theme name for dark variants
+func detectGTKTheme() ColorScheme {
+	out, err := exec.Command("gsettings", "get", "org.gnome.desktop.interface", "gtk-theme").Output()
+	if err == nil {
+		theme := strings.TrimSpace(string(out))
+		theme = strings.Trim(theme, "'\"")
+		// Common dark theme identifiers
+		darkThemes := []string{"Adwaita-dark", "dark", "night", "black", "dracula", "nord", "solarized-dark"}
+		for _, dark := range darkThemes {
+			if strings.Contains(strings.ToLower(theme), strings.ToLower(dark)) {
+				return ColorSchemeDark
+			}
+		}
+		// Common light theme identifiers
+		lightThemes := []string{"Adwaita", "light", "white", "paper", "solarized-light"}
+		for _, light := range lightThemes {
+			if strings.Contains(strings.ToLower(theme), strings.ToLower(light)) {
+				return ColorSchemeLight
+			}
+		}
+	}
+	return ColorSchemeUnknown
+}
+
+// detectEnvVars checks common environment variables for color scheme
+func detectEnvVars() ColorScheme {
+	// Check common environment variables that indicate color scheme
+	// DARK_MODE is used by some applications
+	if darkMode := os.Getenv("DARK_MODE"); darkMode != "" {
+		if darkMode == "1" || strings.ToLower(darkMode) == "true" {
+			return ColorSchemeDark
+		}
+		return ColorSchemeLight
+	}
+
+	// COLORFGBG is used by some terminals (format: "fg;bg" in hex RRGGBB)
+	// Dark backgrounds typically have low RGB values
+	if colorFgBg := os.Getenv("COLORFGBG"); colorFgBg != "" {
+		parts := strings.Split(colorFgBg, ";")
+		if len(parts) >= 2 {
+			// Parse the background color (second part)
+			bgHex := parts[1]
+			if len(bgHex) >= 6 {
+				// Extract RGB components
+				r, g, b := parseHexColor(bgHex[:2]), parseHexColor(bgHex[2:4]), parseHexColor(bgHex[4:6])
+				// Calculate relative luminance
+				luminance := 0.2126*float64(r) + 0.7152*float64(g) + 0.0722*float64(b)
+				// If luminance is low, it's likely a dark theme
+				if luminance < 130 {
+					return ColorSchemeDark
+				}
+				return ColorSchemeLight
+			}
+		}
+	}
+
+	return ColorSchemeUnknown
+}
+
+// parseHexColor parses a 2-character hex string into a 0-255 integer
+func parseHexColor(hexStr string) int {
+	var val int
+	if _, err := fmt.Sscanf(hexStr, "%02x", &val); err == nil {
+		return val
+	}
+	return 0
+}
+
+// ThemeForColorScheme returns the recommended agent-manager theme name
+// for the given color scheme. Returns the dark "classic" theme for dark mode
+// and the light "solarized light" theme for light mode.
+func ThemeForColorScheme(scheme ColorScheme) string {
+	switch scheme {
+	case ColorSchemeDark:
+		return "classic" // or any other dark theme
+	case ColorSchemeLight:
+		return "solarized light" // or any other light theme
+	default:
+		return "classic" // fallback to default
+	}
+}

--- a/internal/sysstat/color_scheme_test.go
+++ b/internal/sysstat/color_scheme_test.go
@@ -1,0 +1,138 @@
+package sysstat
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDetectSystemColorScheme(t *testing.T) {
+	// Test that the function returns a valid ColorScheme for all platforms
+	// We can't easily mock the system calls, so we just verify the return type
+	scheme := DetectSystemColorScheme()
+	if scheme != ColorSchemeLight && scheme != ColorSchemeDark && scheme != ColorSchemeUnknown {
+		t.Errorf("DetectSystemColorScheme() returned unexpected value: %s", scheme)
+	}
+}
+
+func TestThemeForColorScheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		scheme   ColorScheme
+		expected string
+	}{
+		{"dark scheme", ColorSchemeDark, "classic"},
+		{"light scheme", ColorSchemeLight, "solarized light"},
+		{"unknown scheme", ColorSchemeUnknown, "classic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ThemeForColorScheme(tt.scheme)
+			if result != tt.expected {
+				t.Errorf("ThemeForColorScheme(%s) = %s, want %s", tt.scheme, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDetectDarwinColorScheme(t *testing.T) {
+	// Only run on macOS - we can't test this on other platforms
+	// without complex mocking of exec.Command
+	t.Skip("Skipping macOS-specific test (requires mocking)")
+}
+
+func TestParseHexColor(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"00", 0},
+		{"ff", 255},
+		{"a0", 160},
+		{"0a", 10},
+		{"FF", 255},
+		{"", 0},
+		{"gg", 0}, // invalid hex
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := parseHexColor(tt.input)
+			if result != tt.expected {
+				t.Errorf("parseHexColor(%s) = %d, want %d", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDetectEnvVars(t *testing.T) {
+	// Save and restore environment
+	originalDarkMode := os.Getenv("DARK_MODE")
+	originalColorFgBg := os.Getenv("COLORFGBG")
+	defer func() {
+		os.Setenv("DARK_MODE", originalDarkMode)
+		os.Setenv("COLORFGBG", originalColorFgBg)
+	}()
+
+	// Test with DARK_MODE=true
+	os.Setenv("DARK_MODE", "true")
+	os.Unsetenv("COLORFGBG")
+	if result := detectEnvVars(); result != ColorSchemeDark {
+		t.Errorf("detectEnvVars() with DARK_MODE=true = %s, want %s", result, ColorSchemeDark)
+	}
+
+	// Test with DARK_MODE=1
+	os.Setenv("DARK_MODE", "1")
+	if result := detectEnvVars(); result != ColorSchemeDark {
+		t.Errorf("detectEnvVars() with DARK_MODE=1 = %s, want %s", result, ColorSchemeDark)
+	}
+
+	// Test with DARK_MODE=false
+	os.Setenv("DARK_MODE", "false")
+	if result := detectEnvVars(); result != ColorSchemeLight {
+		t.Errorf("detectEnvVars() with DARK_MODE=false = %s, want %s", result, ColorSchemeLight)
+	}
+
+	// Test with COLORFGBG indicating dark background
+	os.Unsetenv("DARK_MODE")
+	os.Setenv("COLORFGBG", "ffffff;000000")
+	if result := detectEnvVars(); result != ColorSchemeDark {
+		t.Errorf("detectEnvVars() with dark COLORFGBG = %s, want %s", result, ColorSchemeDark)
+	}
+
+	// Test with COLORFGBG indicating light background
+	os.Setenv("COLORFGBG", "000000;ffffff")
+	if result := detectEnvVars(); result != ColorSchemeLight {
+		t.Errorf("detectEnvVars() with light COLORFGBG = %s, want %s", result, ColorSchemeLight)
+	}
+
+	// Test with no environment variables set
+	os.Unsetenv("DARK_MODE")
+	os.Unsetenv("COLORFGBG")
+	if result := detectEnvVars(); result != ColorSchemeUnknown {
+		t.Errorf("detectEnvVars() with no env vars = %s, want %s", result, ColorSchemeUnknown)
+	}
+}
+
+// Mock for testing - we can't easily mock exec.Command, but we can test
+// that the functions don't panic and return valid values
+func TestDetectWindowsColorSchemeNoPanic(t *testing.T) {
+	t.Skip("Skipping Windows-specific test (requires mocking)")
+}
+
+func TestDetectLinuxColorSchemeNoPanic(t *testing.T) {
+	t.Skip("Skipping Linux-specific test (requires mocking)")
+}
+
+// Test that the ColorScheme type has the expected string values
+func TestColorSchemeStringValues(t *testing.T) {
+	if string(ColorSchemeLight) != "light" {
+		t.Errorf("ColorSchemeLight string value = %s, want light", string(ColorSchemeLight))
+	}
+	if string(ColorSchemeDark) != "dark" {
+		t.Errorf("ColorSchemeDark string value = %s, want dark", string(ColorSchemeDark))
+	}
+	if string(ColorSchemeUnknown) != "unknown" {
+		t.Errorf("ColorSchemeUnknown string value = %s, want unknown", string(ColorSchemeUnknown))
+	}
+}

--- a/internal/sysstat/color_scheme_test.go
+++ b/internal/sysstat/color_scheme_test.go
@@ -1,7 +1,8 @@
 package sysstat
 
 import (
-	"os"
+	"errors"
+	"os/exec"
 	"testing"
 )
 
@@ -35,10 +36,358 @@ func TestThemeForColorScheme(t *testing.T) {
 	}
 }
 
-func TestDetectDarwinColorScheme(t *testing.T) {
-	// Only run on macOS - we can't test this on other platforms
-	// without complex mocking of exec.Command
-	t.Skip("Skipping macOS-specific test (requires mocking)")
+// MockCommandRunner is a mock implementation of CommandRunner for testing.
+type MockCommandRunner struct {
+	// commands maps command name + args to (output, error)
+	commands map[string][]byte
+	errors   map[string]error
+}
+
+// Run implements CommandRunner interface for mock.
+func (m *MockCommandRunner) Run(name string, args ...string) ([]byte, error) {
+	key := name
+	for _, arg := range args {
+		key += " " + arg
+	}
+	if output, ok := m.commands[key]; ok {
+		return output, nil
+	}
+	if err, ok := m.errors[key]; ok {
+		return nil, err
+	}
+	// Default: command not found behavior
+	return nil, &exec.ExitError{}
+}
+
+// newMockRunner creates a mock runner with the given command outputs and errors.
+func newMockRunner() *MockCommandRunner {
+	return &MockCommandRunner{
+		commands: make(map[string][]byte),
+		errors:   make(map[string]error),
+	}
+}
+
+func TestDetectDarwinColorSchemeWithRunner(t *testing.T) {
+	tests := []struct {
+		name     string
+		runner   *MockCommandRunner
+		expected ColorScheme
+	}{
+		{
+			name: "AppleInterfaceStyle Dark",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["defaults read -g AppleInterfaceStyle"] = []byte("Dark\n")
+				return r
+			}(),
+			expected: ColorSchemeDark,
+		},
+		{
+			name: "AppleInterfaceStyle Light",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["defaults read -g AppleInterfaceStyle"] = []byte("Light\n")
+				return r
+			}(),
+			expected: ColorSchemeLight,
+		},
+		{
+			name: "AppleInterfaceStyle missing key, falls back to NSRequiresAquaSystemAppearance true",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				// Simulate key not found error (exit code 1)
+				r.errors["defaults read -g AppleInterfaceStyle"] = &exec.ExitError{}
+				r.commands["defaults read -g NSRequiresAquaSystemAppearance"] = []byte("1\n")
+				return r
+			}(),
+			expected: ColorSchemeLight,
+		},
+		{
+			name: "AppleInterfaceStyle missing key, NSRequiresAquaSystemAppearance false",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.errors["defaults read -g AppleInterfaceStyle"] = &exec.ExitError{}
+				r.commands["defaults read -g NSRequiresAquaSystemAppearance"] = []byte("0\n")
+				return r
+			}(),
+			expected: ColorSchemeDark,
+		},
+		{
+			name: "AppleInterfaceStyle missing key, NSRequiresAquaSystemAppearance missing, defaults to light",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.errors["defaults read -g AppleInterfaceStyle"] = &exec.ExitError{}
+				r.errors["defaults read -g NSRequiresAquaSystemAppearance"] = &exec.ExitError{}
+				return r
+			}(),
+			expected: ColorSchemeLight,
+		},
+		{
+			name: "defaults command fails",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.errors["defaults read -g AppleInterfaceStyle"] = errors.New("command not found")
+				return r
+			}(),
+			expected: ColorSchemeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectDarwinColorSchemeWithRunner(tt.runner)
+			if result != tt.expected {
+				t.Errorf("detectDarwinColorSchemeWithRunner() = %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDetectWindowsColorSchemeWithRunner(t *testing.T) {
+	tests := []struct {
+		name     string
+		runner   *MockCommandRunner
+		expected ColorScheme
+	}{
+		{
+			name: "AppsUseLightTheme = 1 (light mode)",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["reg query HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize /v AppsUseLightTheme"] = []byte("AppsUseLightTheme    REG_DWORD    0x1\n")
+				return r
+			}(),
+			expected: ColorSchemeLight,
+		},
+		{
+			name: "AppsUseLightTheme = 0 (dark mode)",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["reg query HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize /v AppsUseLightTheme"] = []byte("AppsUseLightTheme    REG_DWORD    0x0\n")
+				return r
+			}(),
+			expected: ColorSchemeDark,
+		},
+		{
+			name: "reg command fails",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.errors["reg query HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize /v AppsUseLightTheme"] = errors.New("registry not found")
+				return r
+			}(),
+			expected: ColorSchemeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectWindowsColorSchemeWithRunner(tt.runner)
+			if result != tt.expected {
+				t.Errorf("detectWindowsColorSchemeWithRunner() = %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDetectXDGPortalWithRunner(t *testing.T) {
+	tests := []struct {
+		name     string
+		runner   *MockCommandRunner
+		expected ColorScheme
+	}{
+		{
+			name: "color-scheme = 1 (dark)",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands[`dbus-send --print-reply=literal --dest=org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop org.freedesktop.DBus.Properties.Get string:org.freedesktop.portal.Settings string:color-scheme`] = []byte("uint32 1\n")
+				return r
+			}(),
+			expected: ColorSchemeDark,
+		},
+		{
+			name: "color-scheme = 2 (light)",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands[`dbus-send --print-reply=literal --dest=org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop org.freedesktop.DBus.Properties.Get string:org.freedesktop.portal.Settings string:color-scheme`] = []byte("uint32 2\n")
+				return r
+			}(),
+			expected: ColorSchemeLight,
+		},
+		{
+			name: "color-scheme = 0 (unknown)",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands[`dbus-send --print-reply=literal --dest=org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop org.freedesktop.DBus.Properties.Get string:org.freedesktop.portal.Settings string:color-scheme`] = []byte("uint32 0\n")
+				return r
+			}(),
+			expected: ColorSchemeUnknown,
+		},
+		{
+			name: "dbus-send command fails",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.errors[`dbus-send --print-reply=literal --dest=org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop org.freedesktop.DBus.Properties.Get string:org.freedesktop.portal.Settings string:color-scheme`] = errors.New("dbus not available")
+				return r
+			}(),
+			expected: ColorSchemeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectXDGPortalWithRunner(tt.runner)
+			if result != tt.expected {
+				t.Errorf("detectXDGPortalWithRunner() = %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDetectGSettingsWithRunner(t *testing.T) {
+	tests := []struct {
+		name     string
+		runner   *MockCommandRunner
+		expected ColorScheme
+	}{
+		{
+			name: "color-scheme prefer-dark",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["gsettings get org.gnome.desktop.interface color-scheme"] = []byte("'prefer-dark'\n")
+				return r
+			}(),
+			expected: ColorSchemeDark,
+		},
+		{
+			name: "color-scheme prefer-light",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["gsettings get org.gnome.desktop.interface color-scheme"] = []byte("'prefer-light'\n")
+				return r
+			}(),
+			expected: ColorSchemeLight,
+		},
+		{
+			name: "color-scheme default, falls back to GTK theme dark",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["gsettings get org.gnome.desktop.interface color-scheme"] = []byte("'default'\n")
+				r.commands["gsettings get org.gnome.desktop.interface gtk-theme"] = []byte("'Adwaita-dark'\n")
+				return r
+			}(),
+			expected: ColorSchemeDark,
+		},
+		{
+			name: "color-scheme default, falls back to GTK theme light",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["gsettings get org.gnome.desktop.interface color-scheme"] = []byte("'default'\n")
+				r.commands["gsettings get org.gnome.desktop.interface gtk-theme"] = []byte("'Adwaita'\n")
+				return r
+			}(),
+			expected: ColorSchemeLight,
+		},
+		{
+			name: "gsettings command fails, falls back to GTK theme",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.errors["gsettings get org.gnome.desktop.interface color-scheme"] = errors.New("gsettings not found")
+				r.commands["gsettings get org.gnome.desktop.interface gtk-theme"] = []byte("'Adwaita-dark'\n")
+				return r
+			}(),
+			expected: ColorSchemeDark,
+		},
+		{
+			name: "both gsettings commands fail",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.errors["gsettings get org.gnome.desktop.interface color-scheme"] = errors.New("gsettings not found")
+				r.errors["gsettings get org.gnome.desktop.interface gtk-theme"] = errors.New("gsettings not found")
+				return r
+			}(),
+			expected: ColorSchemeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectGSettingsWithRunner(tt.runner)
+			if result != tt.expected {
+				t.Errorf("detectGSettingsWithRunner() = %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDetectGTKThemeWithRunner(t *testing.T) {
+	tests := []struct {
+		name     string
+		runner   *MockCommandRunner
+		expected ColorScheme
+	}{
+		{
+			name: "Adwaita-dark theme",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["gsettings get org.gnome.desktop.interface gtk-theme"] = []byte("'Adwaita-dark'\n")
+				return r
+			}(),
+			expected: ColorSchemeDark,
+		},
+		{
+			name: "Adwaita light theme",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["gsettings get org.gnome.desktop.interface gtk-theme"] = []byte("'Adwaita'\n")
+				return r
+			}(),
+			expected: ColorSchemeLight,
+		},
+		{
+			name: "dracula theme",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["gsettings get org.gnome.desktop.interface gtk-theme"] = []byte("'dracula'\n")
+				return r
+			}(),
+			expected: ColorSchemeDark,
+		},
+		{
+			name: "solarized-light theme",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["gsettings get org.gnome.desktop.interface gtk-theme"] = []byte("'solarized-light'\n")
+				return r
+			}(),
+			expected: ColorSchemeLight,
+		},
+		{
+			name: "unknown theme",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.commands["gsettings get org.gnome.desktop.interface gtk-theme"] = []byte("'unknown-theme'\n")
+				return r
+			}(),
+			expected: ColorSchemeUnknown,
+		},
+		{
+			name: "gsettings command fails",
+			runner: func() *MockCommandRunner {
+				r := newMockRunner()
+				r.errors["gsettings get org.gnome.desktop.interface gtk-theme"] = errors.New("gsettings not found")
+				return r
+			}(),
+			expected: ColorSchemeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectGTKThemeWithRunner(tt.runner)
+			if result != tt.expected {
+				t.Errorf("detectGTKThemeWithRunner() = %s, want %s", result, tt.expected)
+			}
+		})
+	}
 }
 
 func TestParseHexColor(t *testing.T) {
@@ -67,61 +416,47 @@ func TestParseHexColor(t *testing.T) {
 
 func TestDetectEnvVars(t *testing.T) {
 	// Save and restore environment
-	originalDarkMode := os.Getenv("DARK_MODE")
-	originalColorFgBg := os.Getenv("COLORFGBG")
-	defer func() {
-		os.Setenv("DARK_MODE", originalDarkMode)
-		os.Setenv("COLORFGBG", originalColorFgBg)
-	}()
+	t.Setenv("DARK_MODE", "")
+	t.Setenv("COLORFGBG", "")
 
 	// Test with DARK_MODE=true
-	os.Setenv("DARK_MODE", "true")
-	os.Unsetenv("COLORFGBG")
+	t.Setenv("DARK_MODE", "true")
+	t.Setenv("COLORFGBG", "")
 	if result := detectEnvVars(); result != ColorSchemeDark {
 		t.Errorf("detectEnvVars() with DARK_MODE=true = %s, want %s", result, ColorSchemeDark)
 	}
 
 	// Test with DARK_MODE=1
-	os.Setenv("DARK_MODE", "1")
+	t.Setenv("DARK_MODE", "1")
 	if result := detectEnvVars(); result != ColorSchemeDark {
 		t.Errorf("detectEnvVars() with DARK_MODE=1 = %s, want %s", result, ColorSchemeDark)
 	}
 
 	// Test with DARK_MODE=false
-	os.Setenv("DARK_MODE", "false")
+	t.Setenv("DARK_MODE", "false")
 	if result := detectEnvVars(); result != ColorSchemeLight {
 		t.Errorf("detectEnvVars() with DARK_MODE=false = %s, want %s", result, ColorSchemeLight)
 	}
 
 	// Test with COLORFGBG indicating dark background
-	os.Unsetenv("DARK_MODE")
-	os.Setenv("COLORFGBG", "ffffff;000000")
+	t.Setenv("DARK_MODE", "")
+	t.Setenv("COLORFGBG", "ffffff;000000")
 	if result := detectEnvVars(); result != ColorSchemeDark {
 		t.Errorf("detectEnvVars() with dark COLORFGBG = %s, want %s", result, ColorSchemeDark)
 	}
 
 	// Test with COLORFGBG indicating light background
-	os.Setenv("COLORFGBG", "000000;ffffff")
+	t.Setenv("COLORFGBG", "000000;ffffff")
 	if result := detectEnvVars(); result != ColorSchemeLight {
 		t.Errorf("detectEnvVars() with light COLORFGBG = %s, want %s", result, ColorSchemeLight)
 	}
 
 	// Test with no environment variables set
-	os.Unsetenv("DARK_MODE")
-	os.Unsetenv("COLORFGBG")
+	t.Setenv("DARK_MODE", "")
+	t.Setenv("COLORFGBG", "")
 	if result := detectEnvVars(); result != ColorSchemeUnknown {
 		t.Errorf("detectEnvVars() with no env vars = %s, want %s", result, ColorSchemeUnknown)
 	}
-}
-
-// Mock for testing - we can't easily mock exec.Command, but we can test
-// that the functions don't panic and return valid values
-func TestDetectWindowsColorSchemeNoPanic(t *testing.T) {
-	t.Skip("Skipping Windows-specific test (requires mocking)")
-}
-
-func TestDetectLinuxColorSchemeNoPanic(t *testing.T) {
-	t.Skip("Skipping Linux-specific test (requires mocking)")
 }
 
 // Test that the ColorScheme type has the expected string values
@@ -134,5 +469,30 @@ func TestColorSchemeStringValues(t *testing.T) {
 	}
 	if string(ColorSchemeUnknown) != "unknown" {
 		t.Errorf("ColorSchemeUnknown string value = %s, want unknown", string(ColorSchemeUnknown))
+	}
+}
+
+// Mock for backward compatibility - these tests can be removed once all tests use runners
+func TestDetectDarwinColorScheme(t *testing.T) {
+	t.Skip("Use TestDetectDarwinColorSchemeWithRunner instead")
+}
+
+func TestDetectWindowsColorSchemeNoPanic(t *testing.T) {
+	t.Skip("Use TestDetectWindowsColorSchemeWithRunner instead")
+}
+
+func TestDetectLinuxColorSchemeNoPanic(t *testing.T) {
+	t.Skip("Use detectLinuxColorSchemeWithRunner tests instead")
+}
+
+// Test that the defaults reads are non-panicking
+func TestDetectDarwinColorSchemeNoPanic(t *testing.T) {
+	// This test just ensures the function doesn't panic on non-macOS systems
+	runner := newMockRunner()
+	runner.errors["defaults read -g AppleInterfaceStyle"] = errors.New("not on macOS")
+	result := detectDarwinColorSchemeWithRunner(runner)
+	// Should return unknown when defaults fails completely
+	if result != ColorSchemeUnknown {
+		t.Errorf("detectDarwinColorSchemeWithRunner() = %s, want %s", result, ColorSchemeUnknown)
 	}
 }

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -319,6 +319,7 @@ func (m *Model) viewSettings() string {
 	body := row(settingsFieldTool, "default tool", toolValue) + "\n" +
 		row(settingsFieldTheme, "theme", themes[m.settings.themeIndex].Name) + "  " +
 		themeSwatch(themes[m.settings.themeIndex]) + "\n" +
+		row(settingsFieldThemeAuto, "theme auto-detect", boolToString(m.settings.themeAuto)) + "\n" +
 		row(settingsFieldDensity, "list density", density) + "\n" +
 		row(settingsFieldLayout, "review layout", layout) + "\n" +
 		row(settingsFieldQuickClose, "after quick send", quickClose) + "\n" +

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -497,12 +497,10 @@ func storedTheme(st *store.Store) string {
 	return name
 }
 
-// storedThemeAuto reads whether auto theme detection is enabled from storage.
 func storedThemeAuto(st *store.Store) bool {
 	return themeAutoEnabled(st)
 }
 
-// themeAutoEnabled reads whether auto theme detection is enabled.
 func themeAutoEnabled(st *store.Store) bool {
 	val, err := st.Setting(themeAutoSetting)
 	if err != nil {
@@ -511,9 +509,6 @@ func themeAutoEnabled(st *store.Store) bool {
 	return val == "true" || val == "1"
 }
 
-// resolveTheme determines which theme to use based on auto-detection settings.
-// If auto is enabled, it detects the system color scheme and maps it to a theme.
-// Otherwise, it uses the stored theme preference.
 func resolveTheme(st *store.Store) string {
 	if themeAutoEnabled(st) {
 		scheme := sysstat.DetectSystemColorScheme()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -331,6 +331,7 @@ type settingsState struct {
 	enterFocuses    bool
 	comfortableRows bool
 	worktreeDefault bool
+	themeAuto       bool
 	// cliPicker is the sub-panel for which CLIs appear when creating sessions.
 	cliPicker bool
 	cliNames  []string
@@ -341,6 +342,7 @@ type settingsState struct {
 const (
 	settingsFieldTool = iota
 	settingsFieldTheme
+	settingsFieldThemeAuto
 	settingsFieldDensity
 	settingsFieldLayout
 	settingsFieldQuickClose
@@ -453,7 +455,8 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 	// A missing git binary only disables the diff view; everything else
 	// works without it, so the error surfaces on first use instead.
 	gitDriver, _ := git.New()
-	applyTheme(themes[themeIndex(storedTheme(st))])
+	themeName := resolveTheme(st)
+	applyTheme(themes[themeIndex(themeName)])
 	model := &Model{
 		cfg:                 cfg,
 		store:               st,
@@ -492,6 +495,31 @@ func storedTheme(st *store.Store) string {
 		return ""
 	}
 	return name
+}
+
+// storedThemeAuto reads whether auto theme detection is enabled from storage.
+func storedThemeAuto(st *store.Store) bool {
+	return themeAutoEnabled(st)
+}
+
+// themeAutoEnabled reads whether auto theme detection is enabled.
+func themeAutoEnabled(st *store.Store) bool {
+	val, err := st.Setting(themeAutoSetting)
+	if err != nil {
+		return false
+	}
+	return val == "true" || val == "1"
+}
+
+// resolveTheme determines which theme to use based on auto-detection settings.
+// If auto is enabled, it detects the system color scheme and maps it to a theme.
+// Otherwise, it uses the stored theme preference.
+func resolveTheme(st *store.Store) string {
+	if themeAutoEnabled(st) {
+		scheme := sysstat.DetectSystemColorScheme()
+		return sysstat.ThemeForColorScheme(scheme)
+	}
+	return storedTheme(st)
 }
 
 const collapsedSetting = "collapsed_groups"

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -7,8 +7,17 @@ import (
 	"time"
 
 	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/sysstat"
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+// boolToString converts a boolean to "true" or "false"
+func boolToString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
 
 // defaultTool is the CLI quick spawn launches: the settings choice when it
 // is still enabled, else the first enabled tool. A store error still yields
@@ -183,6 +192,7 @@ func (m *Model) openSettings() {
 		toolNames:      names,
 		toolIndex:      index,
 		themeIndex:     themeIndex(current.Name),
+		themeAuto:      storedThemeAuto(m.store),
 		layoutSplit:    m.defaultSplitLayout(),
 		quickCloseSend: m.quickCloseAfterSend(),
 		enterFocuses:   m.enterFocuses(),
@@ -249,6 +259,10 @@ func (m *Model) persistSettings() {
 		}
 	}
 	if err := m.store.SetSetting(themeSetting, themes[m.settings.themeIndex].Name); err != nil {
+		m.errBar.text = err.Error()
+	}
+	// Save theme_auto setting
+	if err := m.store.SetSetting(themeAutoSetting, boolToString(m.settings.themeAuto)); err != nil {
 		m.errBar.text = err.Error()
 	}
 	layout := "split"
@@ -391,6 +405,24 @@ func (m *Model) cycleSetting(step int) {
 		m.settings.themeIndex = (m.settings.themeIndex + step + len(themes)) % len(themes)
 		applyTheme(themes[m.settings.themeIndex])
 		SyncTerminalBackground()
+	case settingsFieldThemeAuto:
+		m.settings.themeAuto = !m.settings.themeAuto
+		// Re-apply theme based on new auto setting
+		if m.settings.themeAuto {
+			scheme := sysstat.DetectSystemColorScheme()
+			newTheme := sysstat.ThemeForColorScheme(scheme)
+			idx := themeIndex(newTheme)
+			m.settings.themeIndex = idx
+			applyTheme(themes[idx])
+			SyncTerminalBackground()
+		} else {
+			// When disabling auto, revert to the stored theme
+			storedName := storedTheme(m.store)
+			idx := themeIndex(storedName)
+			m.settings.themeIndex = idx
+			applyTheme(themes[idx])
+			SyncTerminalBackground()
+		}
 	case settingsFieldDensity:
 		m.settings.comfortableRows = !m.settings.comfortableRows
 	case settingsFieldLayout:

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -11,7 +11,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// boolToString converts a boolean to "true" or "false"
 func boolToString(b bool) string {
 	if b {
 		return "true"
@@ -407,7 +406,6 @@ func (m *Model) cycleSetting(step int) {
 		SyncTerminalBackground()
 	case settingsFieldThemeAuto:
 		m.settings.themeAuto = !m.settings.themeAuto
-		// Re-apply theme based on new auto setting
 		if m.settings.themeAuto {
 			scheme := sysstat.DetectSystemColorScheme()
 			newTheme := sysstat.ThemeForColorScheme(scheme)
@@ -416,7 +414,6 @@ func (m *Model) cycleSetting(step int) {
 			applyTheme(themes[idx])
 			SyncTerminalBackground()
 		} else {
-			// When disabling auto, revert to the stored theme
 			storedName := storedTheme(m.store)
 			idx := themeIndex(storedName)
 			m.settings.themeIndex = idx

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -338,8 +338,6 @@ var themes = []Theme{
 const themeSetting = "theme"
 const themeAutoSetting = "theme_auto"
 
-// themeIndex finds a theme by name, falling back to the default when the
-// stored name is unknown (a theme removed between releases).
 func themeIndex(name string) int {
 	for i, t := range themes {
 		if t.Name == name {

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -336,6 +336,7 @@ var themes = []Theme{
 }
 
 const themeSetting = "theme"
+const themeAutoSetting = "theme_auto"
 
 // themeIndex finds a theme by name, falling back to the default when the
 // stored name is unknown (a theme removed between releases).


### PR DESCRIPTION
Adds automatic theme switching based on the operating system's light/dark mode preference.

## Features
- Detect OS-level dark/light mode on macOS, Windows, and Linux
- New 'theme auto-detect' setting in Settings (s key)
- When enabled, automatically selects 'classic' (dark) or 'solarized light' theme
- When disabled, uses manually selected theme (default behavior)
- Toggle with left/right keys in Settings

## Platform Support
- **macOS**: Dark
- **Windows**: Registry query for 
- **Linux**: XDG Desktop Portal, gsettings, GTK theme detection, environment variables

## Implementation
- New package:  - Platform-specific detection logic
- New test file:  - Comprehensive tests
- Modified: , , , 

## Notes
- Opt-in feature (disabled by default)
- Non-invasive: when disabled, behavior is exactly as before
- Only affects agent-manager's own UI, not the agent CLIs
- Theme detection runs once at startup

Fixes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic theme selection based on the operating system’s light or dark mode preference.
  - Added a settings option to enable or disable automatic theme detection.
  - Automatic theme detection supports macOS, Windows, and Linux environments.
  - Disabling automatic selection restores the manually selected theme.
  - The automatic theme preference is saved between sessions.

- **Bug Fixes**
  - Added fallback behavior when system theme detection is unavailable, unsupported, or fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->