### PR TITLE
feat(ui): pin shells in a Terminals block, with an inline option

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,6 +63,12 @@ Press `space` to dock a prompt bar at the bottom of the sidebar. The target foll
 
 The shell is the `[tools.terminal]` block in [config.toml](configuration.md). It ships with no command, which leaves the pane on `$SHELL`; set one to open a different shell. What marks it as a shell is `shell = true`, not its name, so a `[tools.terminal]` block you wrote yourself stays the agent CLI you meant it to be.
 
+### Where the shells sit
+
+Shells gather under a **Terminals** rule pinned to the foot of the list, holding every shell from every group, each row naming the group it belongs to. The tree scrolls above it; the block keeps at most half the list and scrolls inside itself once you have more shells than that. Settings (`s`) has a `terminal rows` row that switches it from `pinned` to `inline`, which puts every shell back among the agents in its own group, marked with `❯` where an agent carries its status dot.
+
+A group's dots and counts describe its agents either way, so the shell you left running a build never shows up as work in progress.
+
 **The keys that write into a pane refuse a shell.** `space` and the review screen's `C` both paste their text and press Enter, so on a shell a sentence meant for an agent would run as a command. Both say the row is a shell and send nothing; enter the session (`↵`) to type there, where what you type is plainly a command. `f` says the same, since a shell has no conversation to fork.
 
 A shell left on its empty command carries no session id, so `agent-manager rename` run inside one cannot find its session. Rename it from the list with `r`. Give the block a command and the pane gets an id like any other session.

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -241,7 +241,13 @@ func (m *Model) visibleReorderTarget(entry treeRow, delta int) (treeRow, bool) {
 	if delta < 0 {
 		step = -1
 	}
-	for i := m.cursor + step; i >= 0 && i < len(m.rows); i += step {
+	// The pinned block and the tree are separate orderings, so a reorder
+	// never pairs a row in one with a row in the other.
+	from, to := 0, len(m.treeRows())
+	if m.cursor >= to {
+		from, to = to, len(m.rows)
+	}
+	for i := m.cursor + step; i >= from && i < to; i += step {
 		candidate := m.rows[i]
 		if candidate.isRoot() {
 			// parentGroup("") is "" too, so root would match a top-level
@@ -427,6 +433,10 @@ const focusKeySetting = "focus_key"
 const quickCloseSetting = "quick_prompt_close"
 
 const worktreeSetting = "worktree_default"
+
+// terminalPlacementSetting is where shells sit: "pinned" gathers them in
+// their own block, "inline" leaves them among the agents in their group.
+const terminalPlacementSetting = "terminal_placement"
 
 // hiddenToolsSetting lists CLI tools omitted from new-session pickers
 // (comma-separated names). Empty means every configured tool is shown.

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -23,6 +23,8 @@ const (
 	railInset = railGutter - 1
 )
 
+const shellGlyph = "❯"
+
 // viewListFrame is the sessions rail beside the session content, both
 // painted surfaces rather than drawn panels.
 func (m *Model) viewListFrame() string {
@@ -132,6 +134,10 @@ func (m *Model) railLines(width, height int) []contentLine {
 	// while entries still have room under it: a rail that is all banner
 	// says nothing about the fleet.
 	const railBannerRows, railListMin = 3, 3
+	// Half the list at most, so the tree the block sits under keeps enough
+	// rows to still read as a tree.
+	shells := m.terminalSectionLines(width, listHeight/2)
+	listHeight -= len(shells)
 	room := func(cost int) bool { return listHeight-len(rows)-cost >= railListMin }
 	// Search heads the list it filters, so the query sits over the entries it
 	// is narrowing. It is also the field being typed into, so a rail too tight
@@ -154,11 +160,12 @@ func (m *Model) railLines(width, height int) []contentLine {
 				subtleStyle.Render("  ") + keyCap("t", "back to active")},
 			contentLine{})
 	}
-	rows = append(rows, m.entryLines(width, max(listHeight-len(rows), 0))...)
+	rows = append(rows, m.entryLines(m.treeRows(), 0, width, max(listHeight-len(rows), 0))...)
 	for len(rows) < listHeight {
 		rows = append(rows, contentLine{})
 	}
 	rows = rows[:listHeight]
+	rows = append(rows, shells...)
 	if meters != nil {
 		rows = append(rows, contentLine{rule: true})
 		for _, line := range meters {
@@ -168,16 +175,18 @@ func (m *Model) railLines(width, height int) []contentLine {
 	return rows
 }
 
-// entryLines renders the visible slice of the tree. Entries are two lines
-// tall, so the window is measured in lines rather than rows. Each line
-// carries the tone its entry painted, which the edge column matches.
-func (m *Model) entryLines(width, height int) []contentLine {
+// entryLines renders the visible slice of rows, which sit at offset in
+// m.rows so the cursor and the tree guides still resolve against the whole
+// list. Entries are two lines tall, so the window is measured in lines
+// rather than rows. Each line carries the tone its entry painted, which the
+// edge column matches.
+func (m *Model) entryLines(rows []treeRow, offset, width, height int) []contentLine {
 	// Root alone is still an empty list: it says what the rail holds, not
 	// what to do about it being empty.
-	if rest := m.rowsBelowRoot(); len(rest) == 0 {
+	if rest := rowsBelowRoot(rows); len(rest) == 0 {
 		var lines []contentLine
-		for _, entry := range m.rows {
-			for _, line := range splitLines(m.renderTreeRow(entry, m.cursor == 0, width, 0, panelHex())) {
+		for i, entry := range rows {
+			for _, line := range splitLines(m.renderTreeRow(entry, m.cursor == offset+i, width, offset+i, panelHex())) {
 				lines = append(lines, contentLine{text: line})
 			}
 		}
@@ -186,21 +195,21 @@ func (m *Model) entryLines(width, height int) []contentLine {
 		}
 		return lines
 	}
-	heights := make([]int, len(m.rows))
+	heights := make([]int, len(rows))
 	for i := range heights {
-		heights[i] = m.entryHeight(m.rows[i])
+		heights[i] = m.entryHeight(rows[i])
 	}
-	start, end := lineWindow(heights, m.cursor, height)
+	start, end := lineWindow(heights, m.cursor-offset, height)
 
 	var lines []contentLine
 	for i := start; i < end; i++ {
-		selected := i == m.cursor
-		entry := m.rows[i]
+		selected := offset+i == m.cursor
+		entry := rows[i]
 		tone := panelHex()
 		if selected || m.renamingRow(entry) {
 			tone = selectedHex()
 		}
-		for _, line := range splitLines(m.renderTreeRow(entry, selected, width, i, tone)) {
+		for _, line := range splitLines(m.renderTreeRow(entry, selected, width, offset+i, tone)) {
 			lines = append(lines, contentLine{text: line, tone: tone})
 		}
 	}
@@ -212,13 +221,30 @@ func (m *Model) entryLines(width, height int) []contentLine {
 		lines = append([]contentLine{{text: subtleStyle.Render(strings.Repeat(" ", railInset) + fmt.Sprintf("↑ %d more", start))}}, lines...)
 		spare--
 	}
-	if end < len(m.rows) && spare > 0 {
-		lines = append(lines, contentLine{text: subtleStyle.Render(strings.Repeat(" ", railInset) + fmt.Sprintf("↓ %d more", len(m.rows)-end))})
+	if end < len(rows) && spare > 0 {
+		lines = append(lines, contentLine{text: subtleStyle.Render(strings.Repeat(" ", railInset) + fmt.Sprintf("↓ %d more", len(rows)-end))})
 	}
 	if len(lines) > height {
 		lines = lines[:height]
 	}
 	return lines
+}
+
+// terminalSectionLines is the pinned Terminals block: a divider and the
+// shell rows under it, windowed like the tree so a long list of shells
+// scrolls inside the block instead of pushing the tree off screen. The
+// label is the first thing dropped when the rail is short, since a shell
+// row the cursor can reach outranks the heading over it.
+func (m *Model) terminalSectionLines(width, budget int) []contentLine {
+	if m.pinnedShells == 0 || budget < 1 {
+		return nil
+	}
+	at := len(m.rows) - m.pinnedShells
+	if budget == 1 {
+		return m.entryLines(m.rows[at:], at, width, 1)
+	}
+	head := contentLine{text: strings.Repeat(" ", railInset) + divider("Terminals", width-railInset)}
+	return append([]contentLine{head}, m.entryLines(m.rows[at:], at, width, budget-1)...)
 }
 
 // entryHeight is how many lines an entry paints: one in the compact list,
@@ -273,6 +299,21 @@ func lineWindow(heights []int, cursor, budget int) (int, int) {
 	return start, end
 }
 
+// emptyTreeReason is why the tree is bare, phrased to follow "no agents".
+// Ranked like the title chain above it: the narrowest view wins.
+func (m *Model) emptyTreeReason() string {
+	switch {
+	case strings.TrimSpace(m.search) != "":
+		return "match"
+	case m.statusFilter.active():
+		return "need " + m.statusFilter.label()
+	case m.showArchived:
+		return "archived"
+	default:
+		return "yet"
+	}
+}
+
 func (m *Model) emptyRailLines(width, height int) []string {
 	title := "no sessions yet"
 	hint := keyCap("n", "starts one")
@@ -287,6 +328,12 @@ func (m *Model) emptyRailLines(width, height int) []string {
 	if search := strings.TrimSpace(m.search); search != "" {
 		title = "no matches"
 		hint = subtleStyle.Render("for \"" + search + "\"")
+	}
+	// The Terminals block below can be full while the tree is bare, so the
+	// empty state says what is missing rather than claiming the rail holds
+	// nothing.
+	if m.pinnedShells > 0 {
+		title = "no agents " + m.emptyTreeReason()
 	}
 	titleLine := centerLine(
 		lipgloss.NewStyle().Bold(true).Foreground(colorBright).Render(title),
@@ -410,9 +457,20 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width, index int, bg
 	return m.renderSessionEntry(entry, selected, width, pad, guides, trail, bg)
 }
 
+// sessionGlyph is the mark ahead of a session's name. An inline shell takes
+// a caret rather than an idle dot it would never leave, but a pane that has
+// gone still has to say so.
+func (m *Model) sessionGlyph(sess store.Session) string {
+	resting := sess.Status != status.Dead && sess.Status != status.Errored
+	if resting && m.isShell(sess.Tool) && !m.pinnedShell(sess) {
+		return subtleStyle.Render(shellGlyph)
+	}
+	return lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
+}
+
 func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad, guides, trail, bg string) string {
 	sess := entry.sess
-	dot := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
+	dot := m.sessionGlyph(sess)
 	nameStyle := valueStyle
 	if selected {
 		nameStyle = lipgloss.NewStyle().Foreground(colorBright).Bold(true)
@@ -427,10 +485,16 @@ func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad,
 	if selected {
 		metaStyle = mutedStyle
 	}
+	// A pinned shell already sits under a Terminals heading, so its tool
+	// name is dead weight where the group it left behind is not.
+	detail := sess.Tool
+	if m.pinnedShell(sess) {
+		detail = displayGroup(sess.Group)
+	}
 	// A session names its state in words as well as in its dot; a group,
 	// whose row rolls several states together, is left to its dots.
 	meta := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusLabel(sess.Status)) +
-		metaStyle.Render(" · "+sess.Tool+" · "+relSince(lastActivity(sess)))
+		metaStyle.Render(" · "+detail+" · "+relSince(lastActivity(sess)))
 
 	if m.comfortableRows {
 		return stackedRow(head, metaIndent(pad, trail)+meta, width, bg)
@@ -798,7 +862,7 @@ func (m *Model) viewGroupAgents(group string, width, height int) string {
 	var rows []rosterRow
 	overflow := ""
 	shown := 0
-	for _, sess := range m.listedSessions() {
+	for _, sess := range m.listedAgents() {
 		if !inGroupSubtree(sess.Group, group) {
 			continue
 		}
@@ -959,14 +1023,14 @@ func joinHeaderPieces(sep string, pieces ...string) string {
 }
 
 // headerScope names what the list is showing. The count is of the same
-// sessions the rollup beside it breaks down, so the two lines always add
-// up; counting painted rows instead would drop everything folded inside
-// a collapsed group.
+// agents the rollup beside it breaks down, so the two lines always add up;
+// counting painted rows instead would drop everything folded inside a
+// collapsed group. Shells are left to their own block.
 func (m *Model) headerScope() string {
-	count := len(m.listedSessions())
-	label := " sessions"
+	count := len(m.listedAgents())
+	label := " agents"
 	if count == 1 {
-		label = " session"
+		label = " agent"
 	}
 	scope := subtleStyle.Render(" · active")
 	if m.showArchived {
@@ -994,10 +1058,10 @@ func (m *Model) headerAgents() string {
 }
 
 // viewStatusCounts is the fleet-at-a-glance strip: a tinted dot and count
-// per state present among the listed sessions.
+// per state present among the listed agents.
 func (m *Model) viewStatusCounts(compact bool) string {
 	counts := map[string]int{}
-	for _, sess := range m.listedSessions() {
+	for _, sess := range m.listedAgents() {
 		counts[sess.Status]++
 	}
 	var parts []string

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -146,7 +146,7 @@ func TestArchivedViewShowsOnlyArchivedSessions(t *testing.T) {
 func railText(t *testing.T, m *Model) []string {
 	t.Helper()
 	var out []string
-	for _, line := range m.entryLines(60, 20) {
+	for _, line := range m.entryLines(m.treeRows(), 0, 60, 20) {
 		out = append(out, strings.TrimRight(ansi.Strip(line.text), " "))
 	}
 	return out
@@ -254,7 +254,7 @@ func TestComfortableRowSurvivesShortRail(t *testing.T) {
 	}
 	m.selectSessionRow(t, "three")
 
-	lines := m.entryLines(60, 2)
+	lines := m.entryLines(m.treeRows(), 0, 60, 2)
 	if len(lines) != 2 {
 		t.Fatalf("entry lines = %d want 2", len(lines))
 	}

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -282,6 +282,10 @@ func (m *Model) viewSettings() string {
 	if m.settings.worktreeDefault {
 		worktreeDefault = "on"
 	}
+	terminals := "inline"
+	if m.settings.shellsPinned {
+		terminals = "pinned"
+	}
 	toolValue := ""
 	if len(m.settings.toolNames) > 0 {
 		toolValue = m.settings.toolNames[m.settings.toolIndex]
@@ -324,6 +328,7 @@ func (m *Model) viewSettings() string {
 		row(settingsFieldQuickClose, "after quick send", quickClose) + "\n" +
 		row(settingsFieldFocusKey, "session keys", focusKey) + "\n" +
 		row(settingsFieldWorktree, "spawn in worktree", worktreeDefault) + "\n" +
+		row(settingsFieldTerminals, "terminal rows", terminals) + "\n" +
 		actionRow(settingsFieldCLIs, "CLIs", "show or hide for new sessions") + "\n" +
 		bugRow + "\n" +
 		bugNote + "\n" +

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -64,8 +64,12 @@ type Model struct {
 	// without a broken store.
 	setSnapshot func(id, snapshot string) error
 
-	sessions       []store.Session
-	rows           []treeRow
+	sessions []store.Session
+	// rows is the flat list the cursor indexes. Its last pinnedShells entries
+	// are the Terminals block rather than part of the tree.
+	rows         []treeRow
+	pinnedShells int
+
 	groups         []string
 	groupPaths     map[string]string
 	groupWorktrees map[string]string
@@ -104,6 +108,10 @@ type Model struct {
 	// their meta on a second line instead of alongside the name. Every
 	// rail frame reads it, so it lives here instead of the store.
 	comfortableRows bool
+	// shellsPinned mirrors the persisted terminal placement: shells gather
+	// in their own block instead of sitting among the agents. rebuildRows
+	// reads it on every rebuild, so it lives here instead of the store.
+	shellsPinned bool
 	// watchedGen is previewGen as of the last poll pass, so a selection
 	// that has not moved since can be recognised as at rest.
 	watchedGen        uint64
@@ -331,6 +339,7 @@ type settingsState struct {
 	enterFocuses    bool
 	comfortableRows bool
 	worktreeDefault bool
+	shellsPinned    bool
 	// cliPicker is the sub-panel for which CLIs appear when creating sessions.
 	cliPicker bool
 	cliNames  []string
@@ -346,6 +355,7 @@ const (
 	settingsFieldQuickClose
 	settingsFieldFocusKey
 	settingsFieldWorktree
+	settingsFieldTerminals
 	settingsFieldCLIs
 	settingsFieldBugReport
 	settingsFieldUpdate
@@ -466,6 +476,7 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 		split:               splitState{ratio: loadSplitRatio(st)},
 		focusOnEnter:        storedFocusOnEnter(st),
 		comfortableRows:     storedComfortableRows(st),
+		shellsPinned:        storedShellsPinned(st),
 		mode:                modeList,
 		update:              updateInfo{version: version},
 		dismissed:           loadDismissed(st),
@@ -762,6 +773,19 @@ func (m *Model) listedSessions() []store.Session {
 		}
 	}
 	return listed
+}
+
+// listedAgents is listedSessions without the shells, for the rollups that
+// describe what a group is working on.
+func (m *Model) listedAgents() []store.Session {
+	listed := m.listedSessions()
+	agents := make([]store.Session, 0, len(listed))
+	for _, sess := range listed {
+		if !m.isShell(sess.Tool) {
+			agents = append(agents, sess)
+		}
+	}
+	return agents
 }
 
 func (m *Model) selected() (store.Session, bool) {
@@ -1300,11 +1324,22 @@ func (e treeRow) isRoot() bool { return e.isGroup && e.group == rootGroup }
 
 // rowsBelowRoot is the tree without its pinned row: empty means the rail
 // has nothing to list, however many rows it paints.
-func (m *Model) rowsBelowRoot() []treeRow {
-	if len(m.rows) > 0 && m.rows[0].isRoot() {
-		return m.rows[1:]
+func rowsBelowRoot(rows []treeRow) []treeRow {
+	if len(rows) > 0 && rows[0].isRoot() {
+		return rows[1:]
 	}
-	return m.rows
+	return rows
+}
+
+// treeRows is the list without the pinned shell block at its tail.
+func (m *Model) treeRows() []treeRow {
+	return m.rows[:len(m.rows)-m.pinnedShells]
+}
+
+// pinnedShell reports whether a session belongs in the Terminals block
+// rather than in its group.
+func (m *Model) pinnedShell(sess store.Session) bool {
+	return m.shellsPinned && m.isShell(sess.Tool)
 }
 
 func rowKey(entry treeRow) string {
@@ -1329,8 +1364,15 @@ func (m *Model) rebuildRows() {
 	// m.sessions arrives ordered by the store (group, sort_order), so
 	// per-group slices inherit the user's manual order.
 	sessionsByGroup := map[string][]store.Session{}
+	var shells []store.Session
 	for _, sess := range m.listedSessions() {
 		if query != "" && !matchesSearch(sess, query) {
+			continue
+		}
+		// Out of the group map as well as out of the tree, so a group whose
+		// only sessions are pinned reads as empty to the toggles that prune.
+		if m.pinnedShell(sess) {
+			shells = append(shells, sess)
 			continue
 		}
 		sessionsByGroup[sess.Group] = append(sessionsByGroup[sess.Group], sess)
@@ -1394,6 +1436,12 @@ func (m *Model) rebuildRows() {
 	for _, root := range children[""] {
 		walk(root, 0)
 	}
+	// Depth 0 closes every tree branch above the block, keeping its rows out
+	// of the guide columns.
+	for _, sess := range shells {
+		rows = append(rows, treeRow{sess: sess})
+	}
+	m.pinnedShells = len(shells)
 
 	m.rows = rows
 	if previousKey != "" {

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -154,6 +154,16 @@ func storedComfortableRows(st *store.Store) bool {
 	return chosen == "comfortable"
 }
 
+// storedShellsPinned reads the persisted terminal placement. Pinned is the
+// default; only an explicit "inline" leaves shells among the agents.
+func storedShellsPinned(st *store.Store) bool {
+	chosen, err := st.Setting(terminalPlacementSetting)
+	if err != nil {
+		return true
+	}
+	return chosen != "inline"
+}
+
 // enterFocuses reports which key opens a session where. Enter focuses the
 // preview and A attaches full screen by default; a stored "attach" choice
 // swaps the pair. Cached on the model because the footer reads it every
@@ -189,6 +199,7 @@ func (m *Model) openSettings() {
 
 		comfortableRows: m.comfortableRows,
 		worktreeDefault: m.defaultWorktree(),
+		shellsPinned:    m.shellsPinned,
 	}
 	m.mode = modeSettings
 }
@@ -238,6 +249,9 @@ func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) saveAndCloseSettings() (tea.Model, tea.Cmd) {
 	m.persistSettings()
+	// Placement changes the tree's shape, so the rail has to be rebuilt
+	// here rather than waiting for the next poll.
+	m.rebuildRows()
 	m.mode = modeList
 	return m, nil
 }
@@ -286,8 +300,16 @@ func (m *Model) persistSettings() {
 	if err := m.store.SetSetting(worktreeSetting, worktreeChoice); err != nil {
 		m.errBar.text = err.Error()
 	}
+	placement := "pinned"
+	if !m.settings.shellsPinned {
+		placement = "inline"
+	}
+	if err := m.store.SetSetting(terminalPlacementSetting, placement); err != nil {
+		m.errBar.text = err.Error()
+	}
 	m.focusOnEnter = m.settings.enterFocuses
 	m.comfortableRows = m.settings.comfortableRows
+	m.shellsPinned = m.settings.shellsPinned
 }
 
 func (m *Model) openCLIPicker() {
@@ -401,5 +423,7 @@ func (m *Model) cycleSetting(step int) {
 		m.settings.enterFocuses = !m.settings.enterFocuses
 	case settingsFieldWorktree:
 		m.settings.worktreeDefault = !m.settings.worktreeDefault
+	case settingsFieldTerminals:
+		m.settings.shellsPinned = !m.settings.shellsPinned
 	}
 }

--- a/internal/ui/statusfilter_test.go
+++ b/internal/ui/statusfilter_test.go
@@ -82,8 +82,8 @@ func TestStatusFilterKeyKeepsAttentionSessions(t *testing.T) {
 	if !strings.Contains(header, "ATTENTION") {
 		t.Fatalf("header missing ATTENTION badge:\n%s", header)
 	}
-	if !strings.Contains(header, "3 session") {
-		t.Fatalf("header count should match listed sessions:\n%s", header)
+	if !strings.Contains(header, "3 agents") {
+		t.Fatalf("header count should match the listed agents:\n%s", header)
 	}
 	footer := ansi.Strip(m.viewFooter())
 	if !strings.Contains(footer, "show all") {

--- a/internal/ui/terminal_test.go
+++ b/internal/ui/terminal_test.go
@@ -54,6 +54,8 @@ func terminalSession(t *testing.T, m *Model) store.Session {
 	return store.Session{}
 }
 
+// spawnTerminal returns the shell this call made, which openTerminal leaves
+// the cursor on; terminalSession would answer with the oldest one.
 func spawnTerminal(t *testing.T, m *Model) store.Session {
 	t.Helper()
 	_, cmd := m.openTerminal()
@@ -61,7 +63,11 @@ func spawnTerminal(t *testing.T, m *Model) store.Session {
 		t.Fatalf("terminal spawn reported %q", m.errBar.text)
 	}
 	m.applyCmd(t, cmd)
-	return terminalSession(t, m)
+	sess, ok := m.selected()
+	if !ok || !m.isShell(sess.Tool) {
+		t.Fatalf("spawn should leave the cursor on the new shell, got %+v", sess)
+	}
+	return sess
 }
 
 func TestOpenTerminalSpawnsShellInSelectedGroup(t *testing.T) {

--- a/internal/ui/terminals_section_test.go
+++ b/internal/ui/terminals_section_test.go
@@ -1,0 +1,428 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// rail is the sidebar alone. The content column repeats the selected
+// session's name in its detail head, so asserting against a whole frame
+// would pass on a row the rail never painted.
+func (m *Model) rail() string {
+	return ansi.Strip(railLinesText(m.railLines(40, m.listBodyHeight())))
+}
+
+func railRow(rail, needle string) int {
+	at := -1
+	for i, line := range strings.Split(rail, "\n") {
+		if !strings.Contains(line, needle) {
+			continue
+		}
+		if at >= 0 {
+			return -2
+		}
+		at = i
+	}
+	return at
+}
+
+func groupWithShell(t *testing.T, m *Model, group string) {
+	t.Helper()
+	if err := m.store.CreateGroup(group, t.TempDir()); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, group)
+}
+
+// Split is the default, so a shell leaves its group and gathers under the
+// Terminals divider at the foot of the rail.
+func TestTerminalsBlockPinsShells(t *testing.T) {
+	m := buildModel(t)
+	groupWithShell(t, m, "backend")
+	createSession(t, m, "agent-one", t.TempDir(), "backend")
+	m.selectGroupRow(t, "backend")
+	shell := spawnTerminal(t, m)
+
+	if m.pinnedShells != 1 {
+		t.Fatalf("pinnedShells = %d, want 1", m.pinnedShells)
+	}
+	last := m.rows[len(m.rows)-1]
+	if last.isGroup || last.sess.ID != shell.ID {
+		t.Fatalf("the shell should be the last row, got %+v", last)
+	}
+	if last.depth != 0 {
+		t.Fatalf("pinned depth = %d, want 0 so the tree's branches close above it", last.depth)
+	}
+
+	rail := m.rail()
+	divider, agent, shellAt := railRow(rail, "Terminals"), railRow(rail, "agent-one"), railRow(rail, shell.Name)
+	if divider < 0 || agent < 0 || shellAt < 0 {
+		t.Fatalf("rail is missing a row, or painted one twice (divider %d, agent %d, shell %d):\n%s", divider, agent, shellAt, rail)
+	}
+	if !(agent < divider && divider < shellAt) {
+		t.Fatalf("want the agent above the divider and the shell below it, got %d/%d/%d:\n%s", agent, divider, shellAt, rail)
+	}
+}
+
+// A pinned row trades its tool name, which the heading above it already
+// gives, for the group it came from.
+func TestPinnedShellNamesItsGroup(t *testing.T) {
+	m := buildModel(t)
+	groupWithShell(t, m, "backend")
+	shell := spawnTerminal(t, m)
+
+	rail := m.rail()
+	row := strings.Split(rail, "\n")[railRow(rail, shell.Name)]
+	if !strings.Contains(row, "backend") {
+		t.Fatalf("a pinned row should name its group:\n%s", row)
+	}
+	if strings.Contains(row, "· "+shell.Tool+" ·") {
+		t.Fatalf("the tool name is redundant under the heading:\n%s", row)
+	}
+}
+
+// The caret marks a shell only where it shares the list with agents.
+func TestShellGlyphIsInlineOnly(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	spawnTerminal(t, m)
+
+	if rail := m.rail(); strings.Contains(rail, shellGlyph) {
+		t.Fatalf("a pinned shell keeps its status dot:\n%s", rail)
+	}
+	m.shellsPinned = false
+	m.rebuildRows()
+	if rail := m.rail(); !strings.Contains(rail, shellGlyph) {
+		t.Fatalf("an inline shell should carry the caret:\n%s", rail)
+	}
+}
+
+// The caret says the shell is resting, so a shell whose pane has gone keeps
+// the glyph that says otherwise.
+func TestDeadInlineShellKeepsItsStatusGlyph(t *testing.T) {
+	m := buildModel(t)
+	m.shellsPinned = false
+	m.applyCmd(t, m.refreshCmd())
+	shell := spawnTerminal(t, m)
+
+	if glyph := ansi.Strip(m.sessionGlyph(shell)); glyph != shellGlyph {
+		t.Fatalf("a resting inline shell wears the caret, got %q", glyph)
+	}
+	for _, gone := range []string{status.Dead, status.Errored} {
+		shell.Status = gone
+		glyph := ansi.Strip(m.sessionGlyph(shell))
+		if glyph == shellGlyph {
+			t.Fatalf("a %s shell must not read as resting", gone)
+		}
+		if glyph != statusGlyph(gone) {
+			t.Fatalf("a %s shell should wear its own glyph, got %q", gone, glyph)
+		}
+	}
+}
+
+// Inline puts the shell back under its group.
+func TestInlinePlacementPutsShellsInTheTree(t *testing.T) {
+	m := buildModel(t)
+	groupWithShell(t, m, "backend")
+	shell := spawnTerminal(t, m)
+
+	m.shellsPinned = false
+	m.rebuildRows()
+
+	if m.pinnedShells != 0 {
+		t.Fatalf("pinnedShells = %d, want 0 once shells are inline", m.pinnedShells)
+	}
+	var row treeRow
+	for _, entry := range m.rows {
+		if !entry.isGroup && entry.sess.ID == shell.ID {
+			row = entry
+		}
+	}
+	if row.depth != 1 {
+		t.Fatalf("inline shell depth = %d, want 1 (under its group)", row.depth)
+	}
+	if rail := m.rail(); strings.Contains(rail, "Terminals") {
+		t.Fatalf("inline placement paints no divider:\n%s", rail)
+	}
+}
+
+// A group row describes the agents working in it, and so does the header,
+// so the two never contradict each other in the same frame.
+func TestRollupsCountAgentsOnly(t *testing.T) {
+	m := buildModel(t)
+	groupWithShell(t, m, "backend")
+	createSession(t, m, "agent-one", t.TempDir(), "backend")
+	m.selectGroupRow(t, "backend")
+	shell := spawnTerminal(t, m)
+
+	if got := m.groupSessionCount("backend"); got != 1 {
+		t.Fatalf("groupSessionCount = %d, want 1 agent", got)
+	}
+	total := 0
+	for _, count := range m.groupStatusCounts("backend") {
+		total += count
+	}
+	if total != 1 {
+		t.Fatalf("group status counts total = %d, want 1", total)
+	}
+	if header := ansi.Strip(m.headerScope()); !strings.HasPrefix(header, "1 agent") {
+		t.Fatalf("header = %q, want it to count the agent alone", header)
+	}
+	roster := ansi.Strip(m.viewGroupAgents("backend", 112, 10))
+	if !strings.Contains(roster, "agent-one") || strings.Contains(roster, shell.Name) {
+		t.Fatalf("the roster should hold the agent and not the shell:\n%s", roster)
+	}
+}
+
+// The block is not a reason to keep a group row that would paint nothing.
+func TestHideEmptyGroupsDropsAShellsOnlyGroup(t *testing.T) {
+	m := buildModel(t)
+	groupWithShell(t, m, "backend")
+	spawnTerminal(t, m)
+
+	if !hasGroupRow(m, "backend") {
+		t.Fatal("the group keeps its row while empty groups are shown")
+	}
+	m.hideEmptyGroups = true
+	m.rebuildRows()
+	if hasGroupRow(m, "backend") {
+		t.Fatal("a group whose only sessions are pinned has nothing under it to show")
+	}
+}
+
+func hasGroupRow(m *Model, group string) bool {
+	for _, entry := range m.rows {
+		if entry.isGroup && entry.group == group {
+			return true
+		}
+	}
+	return false
+}
+
+// The empty state speaks for the tree it replaces, not for the block that
+// is still full underneath it.
+func TestEmptyStateNamesTheTreesSubject(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	shell := spawnTerminal(t, m)
+
+	for _, probe := range []struct {
+		name  string
+		apply func()
+		want  string
+	}{
+		{"bare", func() {}, "no agents yet"},
+		{"search", func() { m.search = shell.Name }, "no agents match"},
+	} {
+		t.Run(probe.name, func(t *testing.T) {
+			probe.apply()
+			m.rebuildRows()
+			rail := m.rail()
+			if !strings.Contains(rail, probe.want) {
+				t.Fatalf("want %q while the block is full:\n%s", probe.want, rail)
+			}
+			if !strings.Contains(rail, "Terminals") {
+				t.Fatalf("the block should still be painted below it:\n%s", rail)
+			}
+		})
+	}
+}
+
+// A search reaches the block, so a query that matches no agent still shows
+// the shell it does match.
+func TestSearchFiltersTheBlock(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	shell := spawnTerminal(t, m)
+
+	m.search = shell.Name
+	m.rebuildRows()
+	if m.pinnedShells != 1 {
+		t.Fatalf("pinnedShells = %d, want the matching shell kept", m.pinnedShells)
+	}
+	m.search = "matches-nothing"
+	m.rebuildRows()
+	if m.pinnedShells != 0 {
+		t.Fatalf("pinnedShells = %d, want the block emptied by the query", m.pinnedShells)
+	}
+	if rail := m.rail(); strings.Contains(rail, "Terminals") {
+		t.Fatalf("an empty block paints no divider:\n%s", rail)
+	}
+}
+
+// An idle shell never needs attention, so the filter empties the block.
+func TestAttentionFilterEmptiesTheBlock(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "agent-one", t.TempDir(), "")
+	spawnTerminal(t, m)
+	m.selectSessionRow(t, "agent-one")
+
+	m.statusFilter = statusFilterAttention
+	m.rebuildRows()
+
+	if m.pinnedShells != 0 {
+		t.Fatalf("pinnedShells = %d, want 0", m.pinnedShells)
+	}
+	if rail := m.rail(); strings.Contains(rail, "Terminals") {
+		t.Fatalf("an empty block paints no divider:\n%s", rail)
+	}
+}
+
+// The cursor can walk into the block, and the row it lands on is painted in
+// the rail rather than only named by the detail head beside it.
+func TestCursorInTheBlockStaysPainted(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "agent-one", t.TempDir(), "")
+	first := spawnTerminal(t, m)
+	second := spawnTerminal(t, m)
+	if first.ID == second.ID {
+		t.Fatal("the two spawns should be different shells")
+	}
+
+	for _, shell := range []string{first.Name, second.Name} {
+		m.selectSessionRow(t, shell)
+		sess, ok := m.selected()
+		if !ok || sess.Name != shell {
+			t.Fatalf("selected() = %+v %v, want %s", sess, ok, shell)
+		}
+		for _, height := range []int{16, 24, 30, 44} {
+			m.height = height
+			if rail := m.rail(); railRow(rail, shell) < 0 {
+				t.Fatalf("selected shell %s is unpainted at height %d:\n%s", shell, height, rail)
+			}
+		}
+	}
+}
+
+// The block never takes more than half the list, and scrolls inside that
+// half rather than pushing the tree off screen.
+func TestBlockKeepsHalfTheListAtMost(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "agent-one", t.TempDir(), "")
+	for i := 0; i < 12; i++ {
+		spawnTerminal(t, m)
+	}
+	m.selectSessionRow(t, "agent-one")
+
+	const height = 30
+	lines := m.railLines(40, height)
+	if len(lines) != height {
+		t.Fatalf("rail painted %d lines, want %d", len(lines), height)
+	}
+	rail := ansi.Strip(railLinesText(lines))
+	if railRow(rail, "agent-one") < 0 {
+		t.Fatalf("the tree must survive a long block:\n%s", rail)
+	}
+	shown := strings.Count(rail, "terminal-")
+	if shown >= 12 {
+		t.Fatalf("all %d shells painted; the block should have windowed them:\n%s", shown, rail)
+	}
+	if !strings.Contains(rail, "more") {
+		t.Fatalf("a windowed block should offer its counter:\n%s", rail)
+	}
+}
+
+// The rail hands back exactly the rows it was given, whatever the block
+// costs. paintContent would pad or trim a wrong answer out of sight.
+func TestRailReturnsItsBudget(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "agent-one", t.TempDir(), "")
+	spawnTerminal(t, m)
+	spawnTerminal(t, m)
+
+	for _, height := range []int{3, 4, 6, 8, 10, 14, 34} {
+		for _, width := range []int{30, 60, 120} {
+			for _, searching := range []bool{false, true} {
+				m.searching = searching
+				if got := len(m.railLines(width, height)); got != height {
+					t.Fatalf("%dx%d searching=%v returned %d rows, want %d", width, height, searching, got, height)
+				}
+			}
+		}
+	}
+}
+
+// Where the rail cannot afford a heading, the shell rows outrank it.
+func TestShortRailDropsTheLabelNotTheRows(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	shell := spawnTerminal(t, m)
+
+	lines := m.terminalSectionLines(40, 1)
+	if len(lines) != 1 {
+		t.Fatalf("a one-row budget should paint one row, got %d", len(lines))
+	}
+	rail := ansi.Strip(railLinesText(lines))
+	if strings.Contains(rail, "Terminals") {
+		t.Fatalf("the heading should be the first thing dropped:\n%s", rail)
+	}
+	if !strings.Contains(rail, shell.Name) {
+		t.Fatalf("the shell row should survive:\n%s", rail)
+	}
+}
+
+// Reorder pairs a row with a sibling in its own block, never across the
+// divider, where a swap would write to the store invisibly.
+func TestReorderStaysInsideItsBlock(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "agent-one", t.TempDir(), "")
+	createSession(t, m, "agent-two", t.TempDir(), "")
+	first := spawnTerminal(t, m)
+	second := spawnTerminal(t, m)
+
+	m.selectSessionRow(t, second.Name)
+	target, ok := m.visibleReorderTarget(m.rows[m.cursor], -1)
+	if !ok || target.sess.ID != first.ID {
+		t.Fatalf("a shell should pair with the shell above it, got %+v %v", target, ok)
+	}
+
+	m.selectSessionRow(t, first.Name)
+	if target, ok := m.visibleReorderTarget(m.rows[m.cursor], -1); ok {
+		t.Fatalf("the first shell must not reach into the tree, got %+v", target.sess.Name)
+	}
+	m.selectSessionRow(t, "agent-two")
+	if target, ok := m.visibleReorderTarget(m.rows[m.cursor], 1); ok {
+		t.Fatalf("an agent must not pair across the divider, got %+v", target.sess.Name)
+	}
+}
+
+// The modal offers the row, and the choice survives a restart through the
+// store rather than only through the cached field.
+func TestTerminalPlacementPersists(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	spawnTerminal(t, m)
+
+	m.openSettings()
+	if body := ansi.Strip(m.viewSettings()); !strings.Contains(body, "terminal rows") || !strings.Contains(body, "pinned") {
+		t.Fatalf("settings should offer the placement row:\n%s", body)
+	}
+	for m.settings.field != settingsFieldTerminals {
+		m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyRight})
+	m.handleSettingsKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if chosen, err := m.store.Setting(terminalPlacementSetting); err != nil || chosen != "inline" {
+		t.Fatalf("stored placement = %q err %v, want inline", chosen, err)
+	}
+	if storedShellsPinned(m.store) {
+		t.Fatal("a fresh model should read the stored choice back as inline")
+	}
+	if m.shellsPinned {
+		t.Fatal("the model should mirror the stored choice")
+	}
+	if m.pinnedShells != 0 {
+		t.Fatalf("pinnedShells = %d, want the rail rebuilt on close", m.pinnedShells)
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -190,7 +190,7 @@ func inGroupSubtree(sessGroup, group string) bool {
 
 func (m *Model) groupSessionCount(path string) int {
 	count := 0
-	for _, sess := range m.listedSessions() {
+	for _, sess := range m.listedAgents() {
 		if inGroupSubtree(sess.Group, path) {
 			count++
 		}
@@ -231,8 +231,7 @@ func (m *Model) renamingRow(entry treeRow) bool {
 func (m *Model) renameRowInput(entry treeRow, width int) string {
 	lead := subtleStyle.Render("▾")
 	if !entry.isGroup {
-		lead = lipgloss.NewStyle().Foreground(statusColor(entry.sess.Status)).
-			Render(statusGlyph(entry.sess.Status))
+		lead = m.sessionGlyph(entry.sess)
 	}
 	if fieldWidth := width - 4; fieldWidth >= 5 {
 		m.rename.input.Width = fieldWidth
@@ -316,7 +315,7 @@ func (m *Model) groupStatusBreakdown(group string) string {
 
 func (m *Model) groupStatusCounts(group string) map[string]int {
 	counts := map[string]int{}
-	for _, sess := range m.listedSessions() {
+	for _, sess := range m.listedAgents() {
 		if inGroupSubtree(sess.Group, group) {
 			counts[sess.Status]++
 		}

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -338,7 +338,7 @@ func TestHeaderShowsUpdateBadgeBesideWordmark(t *testing.T) {
 	if !strings.Contains(header, "v0.9.0") || !strings.Contains(header, "available") {
 		t.Errorf("header missing update badge: %q", header)
 	}
-	if strings.Index(header, "available") > strings.Index(header, "sessions") {
+	if strings.Index(header, "available") > strings.Index(header, "agents") {
 		t.Errorf("badge should sit left, by the wordmark: %q", header)
 	}
 	m.update.latest = ""


### PR DESCRIPTION
Builds on #232. The UI half of #227: placement and rollups. The MCP tools stay with #227.

## Terminals block

Shells gather under a **Terminals** rule pinned to the foot of the rail, each row naming the group it belongs to, so the tree above stays agents only. The block keeps at most half the list and scrolls inside itself with its own `↑/↓ N more` counters. When the rail is too short for a heading, the label is the first thing dropped: a shell row the cursor can reach outranks the rule over it.

The rows stay in the one flat list the cursor indexes, so `enter`, `x`, `v`, `R`, `r`, `m`, `a`, `d` all work unchanged inside the block. `entryLines` now paints any slice at an offset, making the tree and the block the same painter windowed twice. Reorder pairs a row only with siblings in its own block.

## Inline option

Settings gains a **terminal rows** choice, `pinned` or `inline`, applied on close. Inline returns each shell to its group, wearing a `❯` caret where an agent carries its status dot; a dead or errored shell keeps the glyph that says so.

## Rollups describe agents

Group dots and counts, the group roster, the header count and its status strip all skip shells, so a shell left running a build never reads as work in progress, and the header always agrees with the root row it sits above. The header now reads **N agents**. A group whose only sessions are pinned reads as empty to the hide-empty-groups toggle, and the rail's empty state names what is missing ("no agents match") while the block below is still full.

## Testing

`gofmt -l .` clean, `go vet ./...` clean, `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./...` green. 15 new tests in `internal/ui/terminals_section_test.go` cover pinning and ordering, the group name on a pinned row, caret rules live and dead, agents-only rollups, the hide-empty-groups prune, the empty-state wording over a full block, search and the attention filter reaching the block, the cursor painted inside it, the half-list cap with windowing, the exact rail height budget, the short-rail label drop, reorder staying inside its block, and the setting persisting through the store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated **Terminals** section for shell sessions, with grouped rows and independent scrolling.
  - Shells are pinned by default, with an option in Settings to display them inline with their groups.
  - Terminal placement preferences are saved and applied immediately.
  - Agent counts and status summaries now exclude shell sessions.
  - Improved shell indicators, group metadata, filtering, empty states, and block-specific reordering.

- **Documentation**
  - Documented terminal placement options and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->