### PR TITLE
fix(ui): name the worktree in the quick bar's unavailable notice

### DIFF
--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -894,7 +894,7 @@ func (m *Model) viewQuickBar(width int) string {
 			worktree := subtleStyle.Render("worktree off")
 			switch {
 			case !m.worktreeCapable(m.quickTargetDir()):
-				worktree = subtleStyle.Render(worktreeUnavailable)
+				worktree = subtleStyle.Render("worktree " + worktreeUnavailable)
 			case m.quickWorktreeOn():
 				worktree = lipgloss.NewStyle().Foreground(colorAccent2).Render("worktree on")
 			}

--- a/internal/ui/quick_test.go
+++ b/internal/ui/quick_test.go
@@ -631,6 +631,9 @@ func TestQuickWorktreeGatedInNonRepoGroup(t *testing.T) {
 	if hint := m.viewFooter(); !strings.Contains(hint, worktreeUnavailable) {
 		t.Fatalf("footer should mark worktree unavailable, got %q", hint)
 	}
+	if bar := m.viewQuickBar(120); !strings.Contains(bar, "worktree "+worktreeUnavailable) {
+		t.Fatalf("quick bar should name worktree as what is unavailable, got %q", bar)
+	}
 	m.quick.input.SetValue("do a thing")
 	m.submitQuick()
 	sessions, err := m.store.ListSessions(true)


### PR DESCRIPTION
The quick bar shows the worktree state next to the tool chip. On a non-repo target it read as a bare `unavailable (not a git repo)` sitting beside the tool name, so the notice looked like it was about the tool.

Now it reads `worktree unavailable (not a git repo)`, matching the `worktree off` / `worktree on` states rendered in the same slot. The footer legend and the spawn form already name the subject through their own labels, so the shared constant is unchanged and only the quick bar adds the prefix.

Covered by `TestQuickWorktreeGatedInNonRepoGroup`, which now asserts the rendered quick bar too. Full `go test ./...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the quick bar’s unavailable worktree label for consistency with other worktree statuses.
  * Improved messaging when worktree functionality is unavailable in non-Git repositories.

* **Tests**
  * Added coverage to verify the updated label and footer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->