### PR TITLE
fix(clipboard): copy through OSC 52 when the host has no display

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -356,6 +356,12 @@ func WriteText(text string) error {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdin = strings.NewReader(text)
 	if err := cmd.Run(); err != nil {
+		// A selected writer can still die at runtime: a stale SSH DISPLAY,
+		// a Wayland socket that is gone, a broken install. The terminal's
+		// clipboard is still reachable, so try it before reporting failure.
+		if osc52Err := writeTextOSC52(text); osc52Err == nil {
+			return nil
+		}
 		if ctx.Err() != nil {
 			return fmt.Errorf("%s: timed out", name)
 		}

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -4,6 +4,7 @@ package clipboard
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -13,6 +14,9 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/YoanWai/agent-manager/internal/termseq"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // ErrNoImage means the clipboard held no image when it was read.
@@ -40,6 +44,9 @@ var (
 	// wslProbe reports whether we are running under WSL (Windows clipboard
 	// bridge needed when Linux tools cannot see the host clipboard).
 	wslProbe = detectWSL
+	getenv   = os.Getenv
+	// emitSeq writes a control sequence to the terminal drawing the app.
+	emitSeq = termseq.Emit
 	// readNativeImage is set by platform files (darwin/linux) to an
 	// in-process pasteboard reader. Nil means "use the shell-tool path".
 	// Prefer native: spawning osascript/wl-paste is tens of ms each paste.
@@ -340,9 +347,9 @@ func SaveToTemp(data []byte, ext string) (string, error) {
 // it inherits keeps a capturing call waiting for EOF that never comes.
 // The timeout covers a writer that hangs before daemonizing.
 func WriteText(text string) error {
-	name, args, err := copyCommand()
-	if err != nil {
-		return err
+	name, args, ok := copyCommand()
+	if !ok {
+		return writeTextOSC52(text)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -357,26 +364,54 @@ func WriteText(text string) error {
 	return nil
 }
 
-// copyCommand picks the platform's clipboard writer.
-func copyCommand() (string, []string, error) {
+// copyCommand picks the platform's clipboard writer. The false return means
+// no local writer can reach a clipboard, which is the headless-host case
+// WriteText answers with OSC 52.
+func copyCommand() (string, []string, bool) {
 	switch goos {
 	case "darwin":
-		return "pbcopy", nil, nil
+		return "pbcopy", nil, true
 	case "windows":
-		return "clip", nil, nil
+		return "clip", nil, true
 	default:
 		if wslProbe() {
-			return "clip.exe", nil, nil
+			return "clip.exe", nil, true
+		}
+		// wl-copy, xclip and xsel all talk to a display server, so on a
+		// headless box an installed one is still a writer that fails at
+		// runtime with "Can't open display".
+		if !hasDisplay() {
+			return "", nil, false
 		}
 		if _, err := lookPath("wl-copy"); err == nil {
-			return "wl-copy", nil, nil
+			return "wl-copy", nil, true
 		}
 		if _, err := lookPath("xclip"); err == nil {
-			return "xclip", []string{"-selection", "clipboard"}, nil
+			return "xclip", []string{"-selection", "clipboard"}, true
 		}
 		if _, err := lookPath("xsel"); err == nil {
-			return "xsel", []string{"--clipboard", "--input"}, nil
+			return "xsel", []string{"--clipboard", "--input"}, true
 		}
-		return "", nil, errors.New("no clipboard tool found (install wl-copy, xclip or xsel)")
+		return "", nil, false
 	}
+}
+
+// hasDisplay reports whether a display server this process can reach exists.
+func hasDisplay() bool {
+	return getenv("WAYLAND_DISPLAY") != "" || getenv("DISPLAY") != ""
+}
+
+// osc52Limit caps the base64 payload, matching xterm's own OSC 52 ceiling.
+// Past it a terminal drops the sequence, so a copy that would be silently
+// lost is reported instead.
+const osc52Limit = 74994
+
+// writeTextOSC52 hands the text to the terminal that is drawing us, which
+// on a remote headless host is the only process with a real clipboard. The
+// app's mouse grab is no obstacle: that only bears on reading a selection.
+func writeTextOSC52(text string) error {
+	if encodedLen := base64.StdEncoding.EncodedLen(len(text)); encodedLen > osc52Limit {
+		return fmt.Errorf("selection is too large to send to the terminal clipboard (%d of %d bytes)", encodedLen, osc52Limit)
+	}
+	return emitSeq(ansi.SetSystemClipboard(text))
 }

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,6 +1,7 @@
 package clipboard
 
 import (
+	"encoding/base64"
 	"errors"
 	"os"
 	"path/filepath"
@@ -11,9 +12,19 @@ import (
 
 func restore() func() {
 	origGOOS, origLook, origRun, origToFile, origWSL, origNative := goos, lookPath, runCmd, runCmdToFile, wslProbe, readNativeImage
+	origEnv, origEmit := getenv, emitSeq
 	return func() {
 		goos, lookPath, runCmd, runCmdToFile, wslProbe, readNativeImage = origGOOS, origLook, origRun, origToFile, origWSL, origNative
+		getenv, emitSeq = origEnv, origEmit
 	}
+}
+
+// headlessLinux is the reported bug's environment: a Linux box with no
+// display server behind a terminal that does have a clipboard.
+func headlessLinux() {
+	goos = "linux"
+	wslProbe = func() bool { return false }
+	getenv = func(string) string { return "" }
 }
 
 func TestSaveImageDarwinPrefersNative(t *testing.T) {
@@ -383,6 +394,76 @@ func TestSweepStaleWithoutDirectory(t *testing.T) {
 	t.Setenv("TMPDIR", t.TempDir())
 	if err := SweepStale(7 * 24 * time.Hour); err != nil {
 		t.Fatalf("missing pastes dir is not an error: %v", err)
+	}
+}
+
+func TestWriteTextHeadlessUsesOSC52(t *testing.T) {
+	defer restore()()
+	headlessLinux()
+	var emitted string
+	emitSeq = func(seq string) error {
+		emitted = seq
+		return nil
+	}
+	if err := WriteText("hello"); err != nil {
+		t.Fatal(err)
+	}
+	want := "\x1b]52;c;" + base64.StdEncoding.EncodeToString([]byte("hello")) + "\x07"
+	if emitted != want {
+		t.Fatalf("emitted = %q, want %q", emitted, want)
+	}
+}
+
+// An installed xclip on a headless host is a writer that fails at runtime,
+// so the display check has to come before the lookups.
+func TestWriteTextHeadlessSkipsDisplayTools(t *testing.T) {
+	defer restore()()
+	headlessLinux()
+	lookPath = func(name string) (string, error) { return "/usr/bin/" + name, nil }
+	var emitted bool
+	emitSeq = func(string) error {
+		emitted = true
+		return nil
+	}
+	if err := WriteText("hello"); err != nil {
+		t.Fatal(err)
+	}
+	if !emitted {
+		t.Fatal("xclip on a displayless host should not win over OSC 52")
+	}
+}
+
+func TestCopyCommandPrefersDisplayTools(t *testing.T) {
+	defer restore()()
+	headlessLinux()
+	getenv = func(name string) string {
+		if name == "DISPLAY" {
+			return ":0"
+		}
+		return ""
+	}
+	lookPath = func(name string) (string, error) {
+		if name == "xclip" {
+			return "/usr/bin/xclip", nil
+		}
+		return "", errors.New("not found")
+	}
+	name, args, ok := copyCommand()
+	if !ok || name != "xclip" || strings.Join(args, " ") != "-selection clipboard" {
+		t.Fatalf("copyCommand() = %q %v %v", name, args, ok)
+	}
+}
+
+func TestWriteTextRejectsOversizedOSC52(t *testing.T) {
+	defer restore()()
+	headlessLinux()
+	emitSeq = func(string) error {
+		t.Fatal("an oversized payload must not reach the terminal")
+		return nil
+	}
+	err := WriteText(strings.Repeat("x", osc52Limit))
+	if err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("oversized copy error = %v", err)
 	}
 }
 

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -433,6 +433,56 @@ func TestWriteTextHeadlessSkipsDisplayTools(t *testing.T) {
 	}
 }
 
+// Every non-Linux platform keeps its writer exactly as before the OSC 52
+// fallback existed.
+func TestCopyCommandPlatformWriters(t *testing.T) {
+	defer restore()()
+	lookPath = func(name string) (string, error) { return "", errors.New("not found") }
+	getenv = func(string) string { return "" }
+
+	goos = "darwin"
+	wslProbe = func() bool { return false }
+	if name, _, ok := copyCommand(); !ok || name != "pbcopy" {
+		t.Fatalf("darwin writer = %q %v", name, ok)
+	}
+
+	goos = "windows"
+	if name, _, ok := copyCommand(); !ok || name != "clip" {
+		t.Fatalf("windows writer = %q %v", name, ok)
+	}
+
+	goos = "linux"
+	wslProbe = func() bool { return true }
+	if name, _, ok := copyCommand(); !ok || name != "clip.exe" {
+		t.Fatalf("WSL writer = %q %v", name, ok)
+	}
+}
+
+// A desktop Linux box with a display but no tool installed used to get the
+// "install wl-copy, xclip or xsel" error; now the terminal takes the copy.
+func TestWriteTextDisplayWithoutToolsFallsBackToOSC52(t *testing.T) {
+	defer restore()()
+	headlessLinux()
+	getenv = func(name string) string {
+		if name == "WAYLAND_DISPLAY" {
+			return "wayland-0"
+		}
+		return ""
+	}
+	lookPath = func(name string) (string, error) { return "", errors.New("not found") }
+	var emitted bool
+	emitSeq = func(string) error {
+		emitted = true
+		return nil
+	}
+	if err := WriteText("hello"); err != nil {
+		t.Fatal(err)
+	}
+	if !emitted {
+		t.Fatal("a display with no tools should fall back to OSC 52")
+	}
+}
+
 func TestCopyCommandPrefersDisplayTools(t *testing.T) {
 	defer restore()()
 	headlessLinux()

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -504,16 +505,70 @@ func TestCopyCommandPrefersDisplayTools(t *testing.T) {
 	}
 }
 
-func TestWriteTextRejectsOversizedOSC52(t *testing.T) {
+// 56244 raw bytes encode to 74992, the largest payload under the cap;
+// one more raw byte encodes to 74996 and crosses it.
+func TestWriteTextOSC52SizeBoundary(t *testing.T) {
 	defer restore()()
 	headlessLinux()
+	var emitted bool
 	emitSeq = func(string) error {
-		t.Fatal("an oversized payload must not reach the terminal")
+		emitted = true
 		return nil
 	}
-	err := WriteText(strings.Repeat("x", osc52Limit))
+	if err := WriteText(strings.Repeat("x", 56244)); err != nil {
+		t.Fatalf("largest fitting payload: %v", err)
+	}
+	if !emitted {
+		t.Fatal("largest fitting payload should reach the terminal")
+	}
+
+	emitted = false
+	err := WriteText(strings.Repeat("x", 56245))
 	if err == nil || !strings.Contains(err.Error(), "too large") {
 		t.Fatalf("oversized copy error = %v", err)
+	}
+	if emitted {
+		t.Fatal("an oversized payload must not reach the terminal")
+	}
+}
+
+// A stale SSH DISPLAY selects xclip, which then dies with "Can't open
+// display"; the copy must still land through OSC 52.
+func TestWriteTextNativeFailureFallsBackToOSC52(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("needs a unix shell script as the fake writer")
+	}
+	defer restore()()
+	headlessLinux()
+	getenv = func(name string) string {
+		if name == "DISPLAY" {
+			return "localhost:10.0"
+		}
+		return ""
+	}
+	binDir := t.TempDir()
+	fake := filepath.Join(binDir, "xclip")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\necho 'Error: Can't open display' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	lookPath = func(name string) (string, error) {
+		if name == "xclip" {
+			return fake, nil
+		}
+		return "", errors.New("not found")
+	}
+	var emitted string
+	emitSeq = func(seq string) error {
+		emitted = seq
+		return nil
+	}
+	if err := WriteText("hello"); err != nil {
+		t.Fatal(err)
+	}
+	want := "\x1b]52;c;" + base64.StdEncoding.EncodeToString([]byte("hello")) + "\x07"
+	if emitted != want {
+		t.Fatalf("emitted = %q, want %q", emitted, want)
 	}
 }
 

--- a/internal/clipboard/live_darwin_test.go
+++ b/internal/clipboard/live_darwin_test.go
@@ -1,0 +1,34 @@
+//go:build darwin
+
+package clipboard
+
+import (
+	"bytes"
+	"os/exec"
+	"testing"
+)
+
+// TestDarwinLiveCopy exercises the real pbcopy path end to end. Skipped in
+// CI where no pasteboard exists; locally it proves the platform writer kept
+// working after the OSC 52 fallback landed.
+func TestDarwinLiveCopy(t *testing.T) {
+	if _, err := exec.LookPath("pbpaste"); err != nil {
+		t.Skip("no pbpaste on this host")
+	}
+	original, _ := exec.Command("pbpaste").Output()
+	defer func() {
+		restoreCmd := exec.Command("pbcopy")
+		restoreCmd.Stdin = bytes.NewReader(original)
+		_ = restoreCmd.Run()
+	}()
+	if err := WriteText("agent-manager-live-copy-proof"); err != nil {
+		t.Skipf("pasteboard unavailable: %v", err)
+	}
+	out, err := exec.Command("pbpaste").Output()
+	if err != nil {
+		t.Skipf("pbpaste unavailable: %v", err)
+	}
+	if string(out) != "agent-manager-live-copy-proof" {
+		t.Fatalf("pbpaste = %q", out)
+	}
+}

--- a/internal/clipboard/live_darwin_test.go
+++ b/internal/clipboard/live_darwin_test.go
@@ -15,12 +15,17 @@ func TestDarwinLiveCopy(t *testing.T) {
 	if _, err := exec.LookPath("pbpaste"); err != nil {
 		t.Skip("no pbpaste on this host")
 	}
-	original, _ := exec.Command("pbpaste").Output()
-	defer func() {
+	original, err := exec.Command("pbpaste").Output()
+	if err != nil {
+		t.Skipf("cannot back up pasteboard: %v", err)
+	}
+	t.Cleanup(func() {
 		restoreCmd := exec.Command("pbcopy")
 		restoreCmd.Stdin = bytes.NewReader(original)
-		_ = restoreCmd.Run()
-	}()
+		if err := restoreCmd.Run(); err != nil {
+			t.Errorf("restore pasteboard: %v", err)
+		}
+	})
 	if err := WriteText("agent-manager-live-copy-proof"); err != nil {
 		t.Skipf("pasteboard unavailable: %v", err)
 	}

--- a/internal/termseq/termseq.go
+++ b/internal/termseq/termseq.go
@@ -1,0 +1,45 @@
+// Package termseq writes control sequences to whatever terminal is actually
+// drawing this process, tunnelling them past a hosting tmux when there is one.
+package termseq
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Out is the stream the sequences go to; tests point it elsewhere.
+var Out io.Writer = os.Stdout
+
+// inTmux reports whether a tmux is hosting this pane.
+var inTmux = func() bool { return os.Getenv("TMUX") != "" }
+
+// Emit sends a control sequence to the outer terminal. Under tmux only the
+// passthrough envelope goes out: tmux interprets sequences it recognises
+// against the pane instead of the window, and gates several of them behind
+// options a user may have turned off. EnablePassthrough must have opened the
+// envelope first.
+func Emit(seq string) error {
+	if inTmux() {
+		seq = Passthrough(seq)
+	}
+	_, err := io.WriteString(Out, seq)
+	return err
+}
+
+// Passthrough wraps a sequence in DCS tmux;…ST, doubling every ESC as tmux's
+// passthrough protocol requires.
+func Passthrough(seq string) string {
+	return "\x1bPtmux;" + strings.ReplaceAll(seq, "\x1b", "\x1b\x1b") + "\x1b\\"
+}
+
+// EnablePassthrough asks the hosting tmux, when there is one, to let this
+// pane's passthrough sequences reach the outer terminal. Off by default since
+// tmux 3.3, and without it every Emit above dies at the multiplexer.
+func EnablePassthrough() {
+	if !inTmux() {
+		return
+	}
+	_ = exec.Command("tmux", "set-option", "-p", "allow-passthrough", "on").Run()
+}

--- a/internal/termseq/termseq_test.go
+++ b/internal/termseq/termseq_test.go
@@ -1,0 +1,44 @@
+package termseq
+
+import (
+	"strings"
+	"testing"
+)
+
+func swap(tmux bool) (*strings.Builder, func()) {
+	origOut, origTmux := Out, inTmux
+	var sink strings.Builder
+	Out, inTmux = &sink, func() bool { return tmux }
+	return &sink, func() { Out, inTmux = origOut, origTmux }
+}
+
+// tmux forwards a passthrough payload after undoubling ESC bytes; a
+// sequence wrapped without the doubling reaches the terminal truncated at
+// its own first ESC.
+func TestPassthroughDoublesEscapes(t *testing.T) {
+	got := Passthrough("\x1b]11;#0f1115\x07")
+	want := "\x1bPtmux;\x1b\x1b]11;#0f1115\x07\x1b\\"
+	if got != want {
+		t.Fatalf("wrapped = %q, want %q", got, want)
+	}
+}
+
+func TestEmitWrapsOnlyUnderTmux(t *testing.T) {
+	sink, restore := swap(false)
+	defer restore()
+	if err := Emit("\x1b]111\x07"); err != nil {
+		t.Fatal(err)
+	}
+	if got := sink.String(); got != "\x1b]111\x07" {
+		t.Fatalf("bare emit = %q", got)
+	}
+
+	sink, restoreTmux := swap(true)
+	defer restoreTmux()
+	if err := Emit("\x1b]111\x07"); err != nil {
+		t.Fatal(err)
+	}
+	if got := sink.String(); got != "\x1bPtmux;\x1b\x1b]111\x07\x1b\\" {
+		t.Fatalf("tmux emit = %q", got)
+	}
+}

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -2,11 +2,10 @@ package ui
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
+	"github.com/YoanWai/agent-manager/internal/termseq"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -401,28 +400,13 @@ func ResetTerminalBackground() {
 // keeps blending its own — the exact ring the backdrop scheme exists to
 // avoid. EnableTerminalPassthrough must have opened the envelope first.
 func emitToTerminal(seq string) {
-	if os.Getenv("TMUX") != "" {
-		os.Stdout.WriteString(tmuxPassthrough(seq))
-		return
-	}
-	os.Stdout.WriteString(seq)
+	_ = termseq.Emit(seq)
 }
 
-// tmuxPassthrough wraps a sequence in DCS tmux;…ST, doubling every ESC as
-// tmux's passthrough protocol requires.
-func tmuxPassthrough(seq string) string {
-	return "\x1bPtmux;" + strings.ReplaceAll(seq, "\x1b", "\x1b\x1b") + "\x1b\\"
-}
-
-// EnableTerminalPassthrough asks the hosting tmux, when there is one, to
-// let this pane's passthrough sequences reach the outer terminal. Off by
-// default since tmux 3.3, and without it the backdrop sync above dies at
-// the multiplexer.
+// EnableTerminalPassthrough opens the tmux passthrough envelope the backdrop
+// sync and the clipboard fallback both write through.
 func EnableTerminalPassthrough() {
-	if os.Getenv("TMUX") == "" {
-		return
-	}
-	_ = exec.Command("tmux", "set-option", "-p", "allow-passthrough", "on").Run()
+	termseq.EnablePassthrough()
 }
 
 // bgSeq is the raw "set background" SGR for a hex color, for the few spots

--- a/internal/ui/theme_test.go
+++ b/internal/ui/theme_test.go
@@ -5,17 +5,6 @@ import (
 	"testing"
 )
 
-// tmux forwards a passthrough payload after undoubling ESC bytes; a
-// sequence wrapped without the doubling reaches the terminal truncated at
-// its own first ESC.
-func TestTmuxPassthroughDoublesEscapes(t *testing.T) {
-	got := tmuxPassthrough("\x1b]11;#0f1115\x07")
-	want := "\x1bPtmux;\x1b\x1b]11;#0f1115\x07\x1b\\"
-	if got != want {
-		t.Fatalf("wrapped = %q, want %q", got, want)
-	}
-}
-
 func relativeLuminance(hex string) float64 {
 	red, green, blue := hexRGB(hex)
 	channel := func(value int) float64 {


### PR DESCRIPTION
Fixes #244.

## Problem

Copy on a headless remote host failed with `no clipboard tool found (install wl-copy, xclip or xsel)`. Those tools all talk to a display server, so on a box with no `$DISPLAY`/`$WAYLAND_DISPLAY` there is nothing to install that would work; each fails at runtime with "Can't open display".

## Fix

`copyCommand` now checks for a reachable display before the tool lookups, so an installed-but-useless `xclip` cannot win on a headless host. When no local writer can reach a clipboard, `WriteText` hands the text to the terminal drawing the TUI via OSC 52 (`ESC ] 52 ; c ; base64 BEL`). Mouse reporting is no obstacle: the app's grab only bears on reading a selection, writing goes the other way.

Under tmux the sequence goes out wrapped in the DCS passthrough envelope the theme's background sync already opens at startup. tmux ships with `set-clipboard external`, and that setting drops a bare application OSC 52; the passthrough-wrapped one reaches the outer terminal verbatim, so the fallback works on default tmux config as well as the reporter's `set-clipboard on`. The wrapper moved into a new `internal/termseq` package shared by the clipboard fallback and the OSC 11 background sync.

Payloads whose base64 exceeds xterm's 74994-byte ceiling error out instead of being silently dropped by the terminal.

## Platform behavior

- darwin `pbcopy`, windows `clip`, WSL `clip.exe`: unchanged.
- Linux with a display and a tool: unchanged (`wl-copy`, then `xclip`, then `xsel`).
- Linux with a display and no tool: OSC 52 instead of the install error.
- Headless Linux: OSC 52 (the reported case).

## Verification

- Drove a real tmux 3.7b session (isolated socket) attached to a PTY and read the outer end: a bare OSC 52 is dropped by `set-clipboard external`, the passthrough-wrapped one arrives verbatim with no DCS residue, and the compiled `WriteText` fallback path produces exactly that arrival.
- Live darwin test writes through the real `pbcopy` and reads it back with `pbpaste` (skips where no pasteboard exists).
- Unit tests cover every `copyCommand` branch: darwin, windows, WSL, display+tool, display+no-tool, headless.
- `go build` and `go vet` pass for GOOS darwin, linux, windows; full `go test ./...` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard copying now works in headless environments through terminal-based fallback support.
  * Clipboard tools are selected more reliably based on platform and display availability.
  * Terminal output now supports tmux-compatible control sequences.

* **Bug Fixes**
  * Clipboard copying falls back gracefully when local tools are unavailable or fail.
  * Clipboard payloads are limited to supported terminal sequence sizes.

* **Tests**
  * Added coverage for platform selection, headless copying, terminal fallback, tmux output, and macOS clipboard integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->