### PR TITLE
fix(ui): render captured panes on a dark backdrop under light themes

### DIFF
--- a/internal/ui/capturebackdrop.go
+++ b/internal/ui/capturebackdrop.go
@@ -11,18 +11,20 @@ import (
 // backdrop alive across the capture's own SGR stream, where any reset would
 // otherwise let the light theme bleed through mid-line.
 
-// captureOnDark, captureOpen and captureBgSeq are rebuilt by applyTheme,
-// alongside every other package-level style.
+// captureOnDark, captureOpen and the component sequences are rebuilt by
+// applyTheme, alongside every other package-level style.
 var (
 	captureOnDark bool
 	captureOpen   string
+	captureFgSeq  string
 	captureBgSeq  string
 )
 
 func rebuildCaptureBackdrop(t Theme) {
 	captureOnDark = t.lightBackdrop()
+	captureFgSeq = fgSeq(themes[0].Text)
 	captureBgSeq = bgSeq(themes[0].Bg)
-	captureOpen = fgSeq(themes[0].Text) + captureBgSeq
+	captureOpen = captureFgSeq + captureBgSeq
 }
 
 // lightBackdrop reports whether the theme's backdrop is a light color, by
@@ -35,53 +37,78 @@ func (t Theme) lightBackdrop() bool {
 var sgrPattern = regexp.MustCompile(`\x1b\[[0-9;:]*m`)
 
 // reassertCaptureColors re-opens the capture backdrop after every SGR in
-// the line that returns the foreground or background to the terminal
-// default. The capture keeps every explicit color the agent set; only the
-// default cells move onto the backdrop.
+// the line that leaves the foreground or background at the terminal
+// default. Only the component actually left at default is re-opened, so an
+// explicit color set in the same sequence, or still open from an earlier
+// one, passes through untouched: `0;31` keeps its red foreground and gets
+// only the backdrop's background.
 func reassertCaptureColors(line string) string {
 	if !strings.Contains(line, "\x1b[") {
 		return line
 	}
 	return sgrPattern.ReplaceAllStringFunc(line, func(seq string) string {
-		if sgrDropsColors(seq[2 : len(seq)-1]) {
+		fg, bg := sgrDropsColors(seq[2 : len(seq)-1])
+		if fg && bg {
 			return seq + captureOpen
+		}
+		if fg {
+			return seq + captureFgSeq
+		}
+		if bg {
+			return seq + captureBgSeq
 		}
 		return seq
 	})
 }
 
-// sgrDropsColors reports whether an SGR parameter string resets all
-// attributes (0 or empty) or returns the foreground (39) or background
-// (49) to the default. Extended color introducers (38/48/58) carry their
-// arguments inline, so a 0-valued color component is skipped rather than
-// misread as a reset; colon-form arguments sit inside one semicolon part
-// and need no skipping.
-func sgrDropsColors(params string) bool {
+// sgrDropsColors reports, per component, whether an SGR parameter string
+// leaves the foreground or background at the terminal default: a reset
+// (0 or empty) or an explicit default (39/49) not followed by a color for
+// that component later in the same sequence. Extended color introducers
+// (38/48/58) carry their arguments inline, so a 0-valued color component
+// is skipped rather than misread as a reset; colon-form arguments sit
+// inside one semicolon part and need no skipping.
+func sgrDropsColors(params string) (fgDefault, bgDefault bool) {
 	if params == "" {
-		return true
+		return true, true
 	}
 	parts := strings.Split(params, ";")
 	for i := 0; i < len(parts); i++ {
 		head, _, _ := strings.Cut(parts[i], ":")
 		switch head {
-		case "", "0", "39", "49":
-			return true
+		case "", "0":
+			fgDefault, bgDefault = true, true
+		case "39":
+			fgDefault = true
+		case "49":
+			bgDefault = true
+		case "30", "31", "32", "33", "34", "35", "36", "37",
+			"90", "91", "92", "93", "94", "95", "96", "97":
+			fgDefault = false
+		case "40", "41", "42", "43", "44", "45", "46", "47",
+			"100", "101", "102", "103", "104", "105", "106", "107":
+			bgDefault = false
 		case "38", "48", "58":
+			switch head {
+			case "38":
+				fgDefault = false
+			case "48":
+				bgDefault = false
+			}
 			if strings.Contains(parts[i], ":") {
 				continue
 			}
-			if i+1 >= len(parts) {
-				return false
-			}
-			switch parts[i+1] {
-			case "5":
-				i += 2
-			case "2":
-				i += 4
+			if i+1 < len(parts) {
+				switch parts[i+1] {
+				case "5":
+					i += 2
+				case "2":
+					i += 4
+				}
 			}
 		}
 	}
-	return false
+	return fgDefault, bgDefault
 }
 
 // captureBlankRow is a full-width backdrop row for the panel rows below

--- a/internal/ui/capturebackdrop.go
+++ b/internal/ui/capturebackdrop.go
@@ -7,7 +7,8 @@ import (
 
 // Agent CLIs pick their colors for a dark terminal, so a light theme keeps
 // the manager chrome light and renders captured panes on a pinned dark
-// backdrop instead: the classic theme's surface. The helpers here keep that
+// backdrop instead: the classic theme's Bg, the tone a dark-theme terminal
+// itself would show behind the same capture. The helpers here keep that
 // backdrop alive across the capture's own SGR stream, where any reset would
 // otherwise let the light theme bleed through mid-line.
 

--- a/internal/ui/capturebackdrop.go
+++ b/internal/ui/capturebackdrop.go
@@ -1,0 +1,95 @@
+package ui
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Agent CLIs pick their colors for a dark terminal, so a light theme keeps
+// the manager chrome light and renders captured panes on a pinned dark
+// backdrop instead: the classic theme's surface. The helpers here keep that
+// backdrop alive across the capture's own SGR stream, where any reset would
+// otherwise let the light theme bleed through mid-line.
+
+// captureOnDark, captureOpen and captureBgSeq are rebuilt by applyTheme,
+// alongside every other package-level style.
+var (
+	captureOnDark bool
+	captureOpen   string
+	captureBgSeq  string
+)
+
+func rebuildCaptureBackdrop(t Theme) {
+	captureOnDark = t.lightBackdrop()
+	captureBgSeq = bgSeq(themes[0].Bg)
+	captureOpen = fgSeq(themes[0].Text) + captureBgSeq
+}
+
+// lightBackdrop reports whether the theme's backdrop is a light color, by
+// relative luminance of Bg.
+func (t Theme) lightBackdrop() bool {
+	r, g, b := hexRGB(t.Bg)
+	return 0.2126*float64(r)+0.7152*float64(g)+0.0722*float64(b) > 128
+}
+
+var sgrPattern = regexp.MustCompile(`\x1b\[[0-9;:]*m`)
+
+// reassertCaptureColors re-opens the capture backdrop after every SGR in
+// the line that returns the foreground or background to the terminal
+// default. The capture keeps every explicit color the agent set; only the
+// default cells move onto the backdrop.
+func reassertCaptureColors(line string) string {
+	if !strings.Contains(line, "\x1b[") {
+		return line
+	}
+	return sgrPattern.ReplaceAllStringFunc(line, func(seq string) string {
+		if sgrDropsColors(seq[2 : len(seq)-1]) {
+			return seq + captureOpen
+		}
+		return seq
+	})
+}
+
+// sgrDropsColors reports whether an SGR parameter string resets all
+// attributes (0 or empty) or returns the foreground (39) or background
+// (49) to the default. Extended color introducers (38/48/58) carry their
+// arguments inline, so a 0-valued color component is skipped rather than
+// misread as a reset; colon-form arguments sit inside one semicolon part
+// and need no skipping.
+func sgrDropsColors(params string) bool {
+	if params == "" {
+		return true
+	}
+	parts := strings.Split(params, ";")
+	for i := 0; i < len(parts); i++ {
+		head, _, _ := strings.Cut(parts[i], ":")
+		switch head {
+		case "", "0", "39", "49":
+			return true
+		case "38", "48", "58":
+			if strings.Contains(parts[i], ":") {
+				continue
+			}
+			if i+1 >= len(parts) {
+				return false
+			}
+			switch parts[i+1] {
+			case "5":
+				i += 2
+			case "2":
+				i += 4
+			}
+		}
+	}
+	return false
+}
+
+// captureBlankRow is a full-width backdrop row for the panel rows below
+// the capture, so the dark island covers the whole preview panel rather
+// than ending in a ragged edge at the agent's last line.
+func captureBlankRow(width int) string {
+	if width <= 0 {
+		return ""
+	}
+	return captureBgSeq + strings.Repeat(" ", width) + "\x1b[0m"
+}

--- a/internal/ui/capturebackdrop_test.go
+++ b/internal/ui/capturebackdrop_test.go
@@ -1,0 +1,106 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// lightThemeNames mirrors TestLightThemesPresent: the themes whose backdrop
+// is light, which the luminance split must classify exactly.
+var lightThemeNames = map[string]bool{
+	"solarized light":  true,
+	"catppuccin latte": true,
+	"tokyo night day":  true,
+	"gruvbox light":    true,
+	"rosé pine dawn":   true,
+	"paper":            true,
+}
+
+func TestLightBackdropClassification(t *testing.T) {
+	for _, theme := range themes {
+		if got, want := theme.lightBackdrop(), lightThemeNames[theme.Name]; got != want {
+			t.Errorf("%s: lightBackdrop() = %v, want %v (Bg %s)", theme.Name, got, want, theme.Bg)
+		}
+	}
+}
+
+func TestSGRDropsColors(t *testing.T) {
+	tests := []struct {
+		params string
+		want   bool
+	}{
+		{"", true},
+		{"0", true},
+		{"39", true},
+		{"49", true},
+		{"0;33", true},
+		{"1;31", false},
+		{"7", false},
+		{"38;5;0", false},
+		{"48;5;249", false},
+		{"38;2;0;0;0", false},
+		{"48;2;15;17;21", false},
+		{"38:2::0:0:0", false},
+		{"38;2;0;0;0;49", true},
+		{"1;38;5;39", false},
+		{"38;5;39", false},
+	}
+	for _, tt := range tests {
+		if got := sgrDropsColors(tt.params); got != tt.want {
+			t.Errorf("sgrDropsColors(%q) = %v, want %v", tt.params, got, tt.want)
+		}
+	}
+}
+
+func onLightTheme(t *testing.T) {
+	t.Helper()
+	applyTheme(themes[themeIndex("solarized light")])
+	t.Cleanup(func() { applyTheme(themes[0]) })
+	if !captureOnDark {
+		t.Fatal("captureOnDark not active on solarized light")
+	}
+}
+
+func TestReassertCaptureColors(t *testing.T) {
+	onLightTheme(t)
+	got := reassertCaptureColors("\x1b[31mred\x1b[0m plain")
+	if !strings.Contains(got, "\x1b[0m"+captureOpen) {
+		t.Errorf("reset not followed by capture colors: %q", got)
+	}
+	kept := "\x1b[38;2;0;0;0mblack"
+	if got := reassertCaptureColors(kept); got != kept {
+		t.Errorf("explicit color rewritten: %q", got)
+	}
+}
+
+func TestPreviewLineCaptureBackdrop(t *testing.T) {
+	onLightTheme(t)
+	line := previewLine("hi", 10)
+	if !strings.HasPrefix(line, captureOpen) {
+		t.Errorf("capture line does not open with backdrop colors: %q", line)
+	}
+	if !strings.Contains(line, captureBgSeq+strings.Repeat(" ", 8)+"\x1b[0m") {
+		t.Errorf("padding not painted with the backdrop: %q", line)
+	}
+}
+
+func TestPreviewLineDarkThemeUnchanged(t *testing.T) {
+	applyTheme(themes[0])
+	if got := previewLine("hi", 4); got != "hi  " {
+		t.Errorf("dark theme preview line rewritten: %q", got)
+	}
+}
+
+func TestCaptureBlankRow(t *testing.T) {
+	onLightTheme(t)
+	row := captureBlankRow(6)
+	if !strings.HasPrefix(row, captureBgSeq) || !strings.HasSuffix(row, "\x1b[0m") {
+		t.Errorf("blank row not wrapped in backdrop: %q", row)
+	}
+	if !strings.Contains(row, strings.Repeat(" ", 6)) {
+		t.Errorf("blank row not full width: %q", row)
+	}
+	if captureBlankRow(0) != "" {
+		t.Error("zero width blank row not empty")
+	}
+}

--- a/internal/ui/capturebackdrop_test.go
+++ b/internal/ui/capturebackdrop_test.go
@@ -27,27 +27,34 @@ func TestLightBackdropClassification(t *testing.T) {
 func TestSGRDropsColors(t *testing.T) {
 	tests := []struct {
 		params string
-		want   bool
+		fg, bg bool
 	}{
-		{"", true},
-		{"0", true},
-		{"39", true},
-		{"49", true},
-		{"0;33", true},
-		{"1;31", false},
-		{"7", false},
-		{"38;5;0", false},
-		{"48;5;249", false},
-		{"38;2;0;0;0", false},
-		{"48;2;15;17;21", false},
-		{"38:2::0:0:0", false},
-		{"38;2;0;0;0;49", true},
-		{"1;38;5;39", false},
-		{"38;5;39", false},
+		{"", true, true},
+		{"0", true, true},
+		{"39", true, false},
+		{"49", false, true},
+		{"0;33", false, true},
+		{"0;31", false, true},
+		{"0;41", true, false},
+		{"0;31;41", false, false},
+		{"1;31", false, false},
+		{"7", false, false},
+		{"38;5;0", false, false},
+		{"48;5;249", false, false},
+		{"38;2;0;0;0", false, false},
+		{"48;2;15;17;21", false, false},
+		{"38:2::0:0:0", false, false},
+		{"38;2;0;0;0;49", false, true},
+		{"48;5;1;39", true, false},
+		{"38;5;1;49", false, true},
+		{"39;31", false, false},
+		{"1;38;5;39", false, false},
+		{"38;5;39", false, false},
 	}
 	for _, tt := range tests {
-		if got := sgrDropsColors(tt.params); got != tt.want {
-			t.Errorf("sgrDropsColors(%q) = %v, want %v", tt.params, got, tt.want)
+		fg, bg := sgrDropsColors(tt.params)
+		if fg != tt.fg || bg != tt.bg {
+			t.Errorf("sgrDropsColors(%q) = (%v, %v), want (%v, %v)", tt.params, fg, bg, tt.fg, tt.bg)
 		}
 	}
 }
@@ -71,23 +78,13 @@ func TestReassertCaptureColors(t *testing.T) {
 	if got := reassertCaptureColors(kept); got != kept {
 		t.Errorf("explicit color rewritten: %q", got)
 	}
-}
-
-func TestPreviewLineCaptureBackdrop(t *testing.T) {
-	onLightTheme(t)
-	line := previewLine("hi", 10)
-	if !strings.HasPrefix(line, captureOpen) {
-		t.Errorf("capture line does not open with backdrop colors: %q", line)
+	// A reset combined with an explicit color keeps that color: only the
+	// component left at default moves onto the backdrop.
+	if got := reassertCaptureColors("\x1b[0;31mred"); got != "\x1b[0;31m"+captureBgSeq+"red" {
+		t.Errorf("combined reset+fg reasserted wrong components: %q", got)
 	}
-	if !strings.Contains(line, captureBgSeq+strings.Repeat(" ", 8)+"\x1b[0m") {
-		t.Errorf("padding not painted with the backdrop: %q", line)
-	}
-}
-
-func TestPreviewLineDarkThemeUnchanged(t *testing.T) {
-	applyTheme(themes[0])
-	if got := previewLine("hi", 4); got != "hi  " {
-		t.Errorf("dark theme preview line rewritten: %q", got)
+	if got := reassertCaptureColors("\x1b[48;5;1;39mtext"); got != "\x1b[48;5;1;39m"+captureFgSeq+"text" {
+		t.Errorf("explicit bg with default fg reasserted wrong components: %q", got)
 	}
 }
 

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -73,6 +73,7 @@ func (m *Model) attachCmd(id string) tea.Cmd {
 	if prepErr != nil {
 		m.errBar.text = prepErr.Error()
 	}
+	SyncAttachBackground()
 	return tea.ExecProcess(m.tmux.AttachCommand(id), func(err error) tea.Msg {
 		return attachDoneMsg{sessID: id, err: err}
 	})

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -692,9 +692,15 @@ func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 		lines = append(lines, contentLine{text: m.renderPaneRow(i, line, width), raw: true})
 	}
 	// Rows past the capture stay raw too: a painted tail under unpainted
-	// output would read as a box drawn around the agent's last line.
+	// output would read as a box drawn around the agent's last line. On the
+	// capture backdrop they carry its fill instead, so the dark island spans
+	// the whole panel.
 	for len(lines) < height {
-		lines = append(lines, contentLine{raw: true})
+		if captureOnDark {
+			lines = append(lines, contentLine{text: captureBlankRow(width), raw: true})
+		} else {
+			lines = append(lines, contentLine{raw: true})
+		}
 	}
 	return lines
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1188,6 +1188,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleQuickImageMsg(msg)
 
 	case attachDoneMsg:
+		// Undo the attach backdrop; the resume's WindowSizeMsg skips its own
+		// sync when the size is unchanged, so the detach restores it here.
+		SyncTerminalBackground()
 		// The attach client sized the window to the full terminal and tmux
 		// keeps that size on detach; shrink it back to the preview panel so
 		// the capture is not clipped on the right.
@@ -1240,6 +1243,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.errBar.text = msg.warn
+		SyncAttachBackground()
 		return m, tea.ExecProcess(m.tmux.AttachCommand(msg.sessID), func(err error) tea.Msg {
 			return attachDoneMsg{sessID: msg.sessID, err: err}
 		})

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -371,6 +371,7 @@ func applyTheme(t Theme) {
 	colorErrored = lipgloss.Color(t.Errored)
 	colorIdle = lipgloss.Color(t.Idle)
 
+	rebuildCaptureBackdrop(t)
 	rebuildStyles()
 }
 
@@ -391,6 +392,18 @@ func SyncTerminalBackground() {
 // when the manager exits.
 func ResetTerminalBackground() {
 	emitToTerminal("\x1b]111\x07")
+}
+
+// SyncAttachBackground repaints the terminal for a full-screen attach. On
+// a light theme the agent gets the capture backdrop's dark color — its
+// colors were picked for a dark terminal, same as in the preview panel.
+// attachDoneMsg restores the theme backdrop on detach. On a dark theme the
+// synced color already serves both, so nothing is emitted.
+func SyncAttachBackground() {
+	if !captureOnDark {
+		return
+	}
+	emitToTerminal("\x1b]11;" + themes[0].Bg + "\x07")
 }
 
 // emitToTerminal sends a control sequence to whatever is actually drawing

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -356,6 +356,9 @@ func previewLine(line string, width int) string {
 		}
 		return r
 	}, line)
+	if captureOnDark {
+		line = captureOpen + reassertCaptureColors(line)
+	}
 	w := ansi.StringWidth(line)
 	if w > width {
 		line = ansi.Truncate(line, width, "")
@@ -367,7 +370,11 @@ func previewLine(line string, width int) string {
 		line += "\x1b[0m"
 	}
 	if w < width {
-		line += strings.Repeat(" ", width-w)
+		if captureOnDark {
+			line += captureBgSeq + strings.Repeat(" ", width-w) + "\x1b[0m"
+		} else {
+			line += strings.Repeat(" ", width-w)
+		}
 	}
 	if !containsRTL(line) {
 		// Terminals that give format characters a cell (Windows Terminal

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -146,6 +146,24 @@ func TestPreviewLine(t *testing.T) {
 	}
 }
 
+func TestPreviewLineCaptureBackdrop(t *testing.T) {
+	onLightTheme(t)
+	line := previewLine("hi", 10)
+	if !strings.HasPrefix(line, captureOpen) {
+		t.Errorf("capture line does not open with backdrop colors: %q", line)
+	}
+	if !strings.Contains(line, captureBgSeq+strings.Repeat(" ", 8)+"\x1b[0m") {
+		t.Errorf("padding not painted with the backdrop: %q", line)
+	}
+}
+
+func TestPreviewLineDarkThemeUnchanged(t *testing.T) {
+	applyTheme(themes[0])
+	if got := previewLine("hi", 4); got != "hi  " {
+		t.Errorf("dark theme preview line rewritten: %q", got)
+	}
+}
+
 func TestTruncateRuneSafe(t *testing.T) {
 	hebrew := "/home/dev/פרויקטים/agent-manager"
 	tail := truncateTail(hebrew, 10)


### PR DESCRIPTION
Agent CLIs pick their colors for a dark terminal. Under a light manager theme the preview panel therefore rendered washed out and near-unreadable, and a full-screen attach put the agent on a light background.

## What this does
- **Preview panel**: captures render on a pinned dark island (the classic theme's surface). Every SGR in the capture that returns fg or bg to the terminal default re-opens the island colors; explicit agent colors pass through untouched. Panel rows below the capture carry the same fill, so the island spans the whole panel.
- **Attach**: on a light theme, attaching repaints the terminal backdrop (OSC 11) to the island color before the client takes over; detach restores the theme backdrop.
- **Dark themes**: render byte-for-byte as before (single boolean gate per row).

## Verification
- `go build`, `go vet`, full `go test ./...` pass; `BenchmarkListFrame` unchanged.
- Live-verified on an isolated tmux server with `solarized light`: captured bytes show default-fg text remapped to `38;2;198;204;214` on `48;2;15;17;21`, explicit `31` red preserved, tail rows dark-filled, manager chrome still light.

Groundwork for #245: with captures pinned dark, OS light-mode auto-detection can select a light theme without breaking the embedded CLIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved terminal background handling when attaching to sessions.
  - Light themes now preserve captured terminal colors and apply appropriate backdrop behavior.
  - Preview panels extend the capture backdrop across unused rows and columns.
  - Background settings are restored after leaving an attached session.

- **Bug Fixes**
  - Prevented theme changes and resets from incorrectly overriding captured colors.
  - Improved rendering consistency across light and dark themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->