### PR TITLE
docs: name the theme follows OS setting in the settings summaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ changelog:
 
 release:
   header: |
-    Run every AI coding agent from one terminal. Claude Code, Codex, OpenCode, Grok, and Gemini CLI run side by side, each in its own tmux session, with live status, a project tree, quick prompts, and full-file diff review. Runs on macOS and Linux, and on Windows inside WSL2. [See it running](https://github.com/YoanWai/agent-manager#agent-manager).
+    Run every AI coding agent from one terminal. Claude Code, Codex, OpenCode, Grok, Gemini CLI, and Pi run side by side, each in its own tmux session, with live status, a project tree, quick prompts, and full-file diff review. Runs on macOS and Linux, and on Windows inside WSL2. [See it running](https://github.com/YoanWai/agent-manager#agent-manager).
 
   footer: |
     ## Install

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The full reference, every key, the quick prompt, killing and reviving, diff revi
 | `ctrl+r` | Review the session's changes as full-file diffs; `c` comments a line, `C` sends the comments to the agent |
 | `x` / `v` | Kill a session to free its RAM / revive it on its own conversation |
 | `R` | Restart a session on an empty context: same name, group, directory and tool, fresh conversation |
-| `s` | Settings (default tool, theme, list density, review layout) |
+| `s` | Settings (default tool, theme or follow the OS light/dark mode, list density, review layout) |
 | `?` | The key map: every binding, grouped and scrollable, with `/` to search it |
 
 A session can spawn into its own git worktree (`<repo>-worktrees/<name>`, branch `am/<name>`), toggled on the `n` form, with `alt+w` in the quick prompt, or by default in Settings.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
 | `ctrl+r` | Review the selected session's changes: full-screen whole-file diffs, with `c` to comment a line and `C` to send the comments to the agent |
 | `F` | Fold / unfold every group |
-| `s` | Settings (quick-spawn tool, theme, list density, review layout, after quick send, session keys, worktree sessions, report a bug) |
+| `s` | Settings (quick-spawn tool, theme, theme follows OS, list density, review layout, after quick send, session keys, worktree sessions, report a bug) |
 | `\|` | Resize the split: `←→` nudge the divider, `enter` commits, `esc` cancels |
 | `t` | Toggle archived view |
 | `w` | Filter to sessions that need attention (`waiting`, `finished`, `errored`); press again to show all |


### PR DESCRIPTION
Adds the new theme follows OS toggle to the settings key rows in README.md and docs/usage.md, matching the feature shipped in #251. Swept the rest of both files against the current feature set; everything else already matches.