### PR TITLE
fix(fork): resolve {session_file} through the tool's own session store

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,15 +24,16 @@ Rules match top-down against the visible pane text; first match wins, and `defau
 
 **Status detection.** Optional per-tool fields refine it: `activity_cutoff` (regex locating the tool's input box, everything above it is turn content), `turn_end` (a turn-summary line marking the turn as over), `busy_line` (work that outlives its turn, such as background agents), `chrome_line`, `blocked_line`, and `trailing_note`. `status_source = "claude-hooks"` switches status to Claude Code hook events (see [Status](usage.md#status)). The generated config's `claude` and `opencode` blocks show all of them in use.
 
-**Revive.** `resume_by_id_command` resumes one exact conversation, with `{id}` replaced by the session's captured agent id. That id comes either from launching under an id the manager mints (`session_id_flag`, e.g. `--session-id`) or from reading back an id the tool minted itself (`session_store = "codex" | "opencode"`). `revive_command` is what `v` falls back to when no id is available, e.g. `claude --continue`.
+**Revive.** `resume_by_id_command` resumes one exact conversation, with `{id}` replaced by the session's captured agent id. That id comes either from launching under an id the manager mints (`session_id_flag`, e.g. `--session-id`) or from reading back an id the tool minted itself (`session_store = "codex" | "opencode" | "gemini"`). `revive_command` is what `v` falls back to when no id is available, e.g. `claude --continue`.
 
 **Forks.** `fork_command` creates a conversation from an existing session. Agent Manager replaces and shell-quotes these placeholders:
 
-- `{id}`: The source conversation ID. This placeholder is required.
+- `{id}`: The source conversation ID.
+- `{session_file}`: The source conversation's file on disk, for a tool that forks by loading a file (Gemini CLI: `gemini --session-file`). Available with `session_store = "gemini"`.
 - `{new_id}`: A new UUID that Agent Manager records for exact revival.
 - `{name}`: The new Agent Manager session name.
 
-Claude Code and Codex include default fork commands. A custom tool can omit `{new_id}` when its `session_store` captures the generated ID.
+A `fork_command` references its source through `{id}` or `{session_file}`, so one of those two is required. Claude Code, Codex and Gemini CLI include default fork commands. A custom tool can omit `{new_id}` when its `session_store` captures the generated ID.
 
 **Prompts.** `prompt_flag` controls how the new-session form's optional prompt is embedded into the launch command. Tools that take the prompt as a positional argument (Claude Code: `claude 'the prompt'`) leave it empty; tools whose positional argument means something else declare the flag (OpenCode: `prompt_flag = "--prompt"`, since its positional argument is the project path). The prompt only shapes the launch command; revive (`v`) uses the revive commands untouched.
 

--- a/internal/agentsession/capture.go
+++ b/internal/agentsession/capture.go
@@ -407,9 +407,21 @@ func captureGemini(root, cwd string, launchedAt time.Time, claimed map[string]bo
 	return pickEarliest(cands)
 }
 
-// GeminiSessionFile locates the on-disk session file gemini stores for a
-// conversation id, so a fork can hand it to `gemini --session-file`.
-func GeminiSessionFile(id string) (string, error) {
+// SupportsSessionFile reports whether a session store keeps conversations in
+// a file a fork can load, which is what the {session_file} placeholder needs.
+// gemini is the only store that does; codex and opencode fork by id.
+func SupportsSessionFile(sessionStore string) bool {
+	return sessionStore == "gemini"
+}
+
+// SessionFile locates the on-disk file holding a conversation, so a fork can
+// hand it to a command that loads a file instead of an id (`gemini
+// --session-file`). The tool's session_store selects the layout, so a tool
+// that stores nothing forkable is refused rather than read as gemini.
+func SessionFile(sessionStore, id string) (string, error) {
+	if !SupportsSessionFile(sessionStore) {
+		return "", fmt.Errorf("session_store %q keeps no session file to fork from", sessionStore)
+	}
 	return geminiSessionFileIn(geminiRoot(), id)
 }
 

--- a/internal/agentsession/capture_test.go
+++ b/internal/agentsession/capture_test.go
@@ -196,3 +196,19 @@ func TestGeminiSessionFileInResolvesByID(t *testing.T) {
 		t.Fatal("expected an error for an unknown conversation id")
 	}
 }
+
+// Only gemini keeps a conversation in a file a fork can load. Any other
+// store must be refused rather than read through the gemini layout.
+func TestSessionFileRefusesStoresWithoutAFile(t *testing.T) {
+	for _, sessionStore := range []string{"", "codex", "opencode", "weird"} {
+		if SupportsSessionFile(sessionStore) {
+			t.Errorf("SupportsSessionFile(%q) = true", sessionStore)
+		}
+		if _, err := SessionFile(sessionStore, "some-conversation"); err == nil {
+			t.Errorf("SessionFile(%q, ...) resolved a path", sessionStore)
+		}
+	}
+	if !SupportsSessionFile("gemini") {
+		t.Error(`SupportsSessionFile("gemini") = false`)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,10 +33,12 @@ type Tool struct {
 	// resumes the working directory's most recent conversation.
 	ResumeByIDCommand string `toml:"resume_by_id_command"`
 	// ForkCommand creates a new conversation from an existing one. Templates
-	// can use {id}, {new_id}, and {name}; Agent Manager quotes each value.
+	// can use {id}, {session_file}, {new_id}, and {name}; Agent Manager quotes
+	// each value. {session_file} needs SessionStore to keep one ("gemini").
 	ForkCommand string `toml:"fork_command"`
 	// SessionStore names the built-in capturer that reads back the id a tool
-	// minted itself when it has no SessionIDFlag ("codex" or "opencode").
+	// minted itself when it has no SessionIDFlag ("codex", "opencode" or
+	// "gemini").
 	SessionStore string `toml:"session_store"`
 	// MCP picks how the agent-manager MCP server is registered into this
 	// tool's sessions: "claude", "codex", "opencode", "grok", "gemini" or

--- a/internal/ui/fork.go
+++ b/internal/ui/fork.go
@@ -15,9 +15,10 @@ import (
 )
 
 // forkSessionFileResolver resolves a source conversation's on-disk session
-// file for tools whose fork loads a file instead of an id (gemini). A
-// variable so tests substitute a fixture without touching the real store.
-var forkSessionFileResolver = agentsession.GeminiSessionFile
+// file for tools whose fork loads a file instead of an id (gemini), keyed by
+// the tool's session_store. A variable so tests substitute a fixture without
+// touching the real store.
+var forkSessionFileResolver = agentsession.SessionFile
 
 type forkState struct {
 	source store.Session
@@ -97,7 +98,7 @@ func (m *Model) submitFork() (tea.Model, tea.Cmd) {
 	}
 	sessionFile := ""
 	if strings.Contains(tool.ForkCommand, "{session_file}") {
-		resolved, err := forkSessionFileResolver(source.AgentSessionID)
+		resolved, err := forkSessionFileResolver(tool.SessionStore, source.AgentSessionID)
 		if err != nil {
 			m.errBar.text = err.Error()
 			return m, nil
@@ -139,8 +140,12 @@ func validateForkSource(toolName string, tool config.Tool, source store.Session)
 	if tool.ForkCommand == "" {
 		return fmt.Errorf("tool %s has no fork_command", toolName)
 	}
-	if !strings.Contains(tool.ForkCommand, "{id}") && !strings.Contains(tool.ForkCommand, "{session_file}") {
+	usesSessionFile := strings.Contains(tool.ForkCommand, "{session_file}")
+	if !strings.Contains(tool.ForkCommand, "{id}") && !usesSessionFile {
 		return fmt.Errorf("tool %s fork_command must reference the source via {id} or {session_file}", toolName)
+	}
+	if usesSessionFile && !agentsession.SupportsSessionFile(tool.SessionStore) {
+		return fmt.Errorf("tool %s fork_command uses {session_file}, which needs session_store = \"gemini\"", toolName)
 	}
 	if source.AgentSessionID == "" {
 		return fmt.Errorf("%s has no captured conversation id", source.Name)

--- a/internal/ui/fork_test.go
+++ b/internal/ui/fork_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
@@ -207,6 +208,76 @@ func TestOpenForkRequiresConfiguredCommandAndConversationID(t *testing.T) {
 	}
 }
 
+// Every fork_command the manager ships has to satisfy its own validator, so
+// a placeholder can never outrun the session store that resolves it.
+func TestShippedForkCommandsValidate(t *testing.T) {
+	cfg, err := config.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Tools) < 6 {
+		t.Fatalf("built-in tools = %d, expected every shipped CLI", len(cfg.Tools))
+	}
+	source := store.Session{Name: "source", AgentSessionID: "source-conversation"}
+	forkable := 0
+	for name, tool := range cfg.Tools {
+		if tool.Shell || tool.ForkCommand == "" {
+			continue
+		}
+		forkable++
+		if err := validateForkSource(name, tool, source); err != nil {
+			t.Errorf("%s: %v", name, err)
+		}
+	}
+	if forkable == 0 {
+		t.Fatal("no shipped tool defines a fork_command")
+	}
+}
+
+// {session_file} only resolves for a store that keeps conversations in a
+// file. A tool without one would otherwise fork against a gemini path.
+func TestOpenForkRejectsSessionFileWithoutAFileBackedStore(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	source := store.Session{
+		ID:             "claude-source",
+		Name:           "source",
+		Tool:           "claude",
+		Cwd:            dir,
+		Status:         status.Idle,
+		AgentSessionID: "claude-conversation",
+	}
+	if err := m.store.CreateSession(source); err != nil {
+		t.Fatal(err)
+	}
+	loadStoredRows(t, m)
+	m.selectSessionRow(t, "source")
+
+	previousResolver := forkSessionFileResolver
+	forkSessionFileResolver = func(sessionStore, id string) (string, error) {
+		t.Errorf("resolver called for session store %q, id %q", sessionStore, id)
+		return "", nil
+	}
+	t.Cleanup(func() { forkSessionFileResolver = previousResolver })
+
+	tool := m.cfg.Tools["claude"]
+	if tool.SessionStore != "" {
+		t.Fatalf("claude session_store = %q, want empty", tool.SessionStore)
+	}
+	tool.ForkCommand = "claude --session-file {session_file}"
+	m.cfg.Tools["claude"] = tool
+
+	m.openFork()
+
+	if m.mode == modeFork {
+		t.Fatal("fork opened for a tool whose store keeps no session file")
+	}
+	if !strings.Contains(m.errBar.text, "{session_file}") ||
+		!strings.Contains(m.errBar.text, `session_store = "gemini"`) {
+		t.Fatalf("err = %q, want it to name the placeholder and the store it needs", m.errBar.text)
+	}
+}
+
 func TestOpenForkRejectsGroup(t *testing.T) {
 	m := buildModel(t)
 	if err := m.store.CreateGroup("work", ""); err != nil {
@@ -312,7 +383,10 @@ func TestForkGeminiResolvesSessionFile(t *testing.T) {
 
 	const sourceFile = "/store/gemini/session-source.jsonl"
 	previousResolver := forkSessionFileResolver
-	forkSessionFileResolver = func(id string) (string, error) {
+	forkSessionFileResolver = func(sessionStore, id string) (string, error) {
+		if sessionStore != "gemini" {
+			t.Errorf("resolver session store = %q, want gemini", sessionStore)
+		}
 		if id != source.AgentSessionID {
 			t.Errorf("resolver id = %q, want %q", id, source.AgentSessionID)
 		}
@@ -323,6 +397,7 @@ func TestForkGeminiResolvesSessionFile(t *testing.T) {
 	argsFile := filepath.Join(t.TempDir(), "fork-args")
 	tool := m.cfg.Tools["gemini"]
 	tool.ForkCommand = "printf '%s\\n' {session_file} > " + tmux.ShellQuote(argsFile) + "; cat"
+	tool.SessionStore = "gemini"
 	tool.MCP = "none"
 	m.cfg.Tools["gemini"] = tool
 
@@ -390,13 +465,14 @@ func TestForkGeminiResolverFailureReportsError(t *testing.T) {
 	m.selectSessionRow(t, "source")
 
 	previousResolver := forkSessionFileResolver
-	forkSessionFileResolver = func(id string) (string, error) {
+	forkSessionFileResolver = func(_, id string) (string, error) {
 		return "", fmt.Errorf("no gemini session file found for conversation %s", id)
 	}
 	t.Cleanup(func() { forkSessionFileResolver = previousResolver })
 
 	tool := m.cfg.Tools["gemini"]
 	tool.ForkCommand = "gemini --session-file {session_file}"
+	tool.SessionStore = "gemini"
 	m.cfg.Tools["gemini"] = tool
 
 	before := len(m.sessionRows())


### PR DESCRIPTION
Closes #228.

## What changed

`{session_file}` now resolves through the session store the tool declares. `agentsession.SessionFile(sessionStore, id)` dispatches on `session_store`, and `gemini` is the store that keeps a conversation in a file a fork can load.

Validation accepts the placeholder only for such a store, so a `fork_command` that uses `{session_file}` without one reports it when `f` is pressed, before the fork form opens:

```
tool weird fork_command uses {session_file}, which needs session_store = "gemini"
```

## Why

`submitFork` resolved the placeholder with `agentsession.GeminiSessionFile` for every tool, so a custom tool in `config.toml` that used `{session_file}` forked against a Gemini conversation path.

## Docs

`docs/configuration.md` lists `{session_file}` among the fork placeholders with the store it needs, records that a `fork_command` references its source through `{id}` or `{session_file}`, and names `gemini` alongside `codex` and `opencode` as a session store.

## Verification

`gofmt -l .` prints nothing, `go vet ./...` and `go build ./...` are clean, and `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./...` passes on an isolated socket.

New tests:

- `TestOpenForkRejectsSessionFileWithoutAFileBackedStore` drives `openFork` on a real model and asserts the resolver is never reached for a tool whose store keeps no file.
- `TestShippedForkCommandsValidate` runs every built-in `fork_command` through the validator, so a placeholder cannot outrun the store that resolves it.
- `TestSessionFileRefusesStoresWithoutAFile` covers the dispatcher directly.

`TestForkGeminiResolvesSessionFile` still launches a real tmux session and confirms the resolved path reaches the command line intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for using Gemini as a session store.
  - Fork commands can now reference sessions with either `{id}` or `{session_file}`.
  - Gemini includes a default fork command, while custom tools may omit `{new_id}` when their session store captures generated IDs.

- **Bug Fixes**
  - Added validation to prevent `{session_file}` fork commands when the configured session store cannot access session files.
  - Improved configuration guidance and error handling for session-based forks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->