### PR TITLE
feat(ui): move a group to another group with m

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -575,6 +575,22 @@ func (s *Store) RenameGroup(oldPath, newPath string) error {
 	return tx.Commit()
 }
 
+// MoveGroup re-parents a group subtree under newParent ("" = root),
+// keeping its base name. Every descendant group and session follows.
+func (s *Store) MoveGroup(path, newParent string) error {
+	if path == "" {
+		return fmt.Errorf("group path cannot be empty")
+	}
+	if inSubtree(newParent, path) {
+		return fmt.Errorf("cannot move %s into its own subtree", path)
+	}
+	newPath := path[strings.LastIndex(path, "/")+1:]
+	if newParent != "" {
+		newPath = newParent + "/" + newPath
+	}
+	return s.RenameGroup(path, newPath)
+}
+
 // MoveSession reassigns a session to another group ("" = root), placing
 // it at the end of the destination.
 func (s *Store) MoveSession(id, group string) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -910,3 +910,101 @@ func TestBindAgentSessionIDOnlyBindsTheLaunchItAnswers(t *testing.T) {
 		t.Fatalf("conversation id = %q, want fresh", got.AgentSessionID)
 	}
 }
+
+func TestMoveGroupReparentsSubtree(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.CreateGroup("alpha/inner", "/srv/inner"); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := st.CreateGroup("beta", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := st.CreateSession(sample("a", "alpha/inner")); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := st.MoveGroup("alpha/inner", "beta"); err != nil {
+		t.Fatalf("MoveGroup: %v", err)
+	}
+	groups, err := st.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	var movedPath string
+	for _, group := range groups {
+		if group.Name == "alpha/inner" {
+			t.Fatal("old group path still present")
+		}
+		if group.Name == "beta/inner" {
+			movedPath = group.Path
+		}
+	}
+	if movedPath != "/srv/inner" {
+		t.Fatalf("beta/inner path = %q, want /srv/inner", movedPath)
+	}
+	sess, err := st.Get("a")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if sess.Group != "beta/inner" {
+		t.Fatalf("session group = %q, want beta/inner", sess.Group)
+	}
+}
+
+func TestMoveGroupToRoot(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.CreateGroup("alpha/inner", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := st.MoveGroup("alpha/inner", ""); err != nil {
+		t.Fatalf("MoveGroup: %v", err)
+	}
+	groups, err := st.Groups()
+	if err != nil {
+		t.Fatalf("groups: %v", err)
+	}
+	found := false
+	for _, group := range groups {
+		if group.Name == "inner" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("group inner missing at root")
+	}
+}
+
+func TestMoveGroupIntoOwnSubtreeFails(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.CreateGroup("alpha/inner", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := st.MoveGroup("alpha", "alpha/inner"); err == nil {
+		t.Fatal("moving a group into its own subtree should fail")
+	}
+	if err := st.MoveGroup("alpha", "alpha"); err == nil {
+		t.Fatal("moving a group into itself should fail")
+	}
+}
+
+func TestMoveGroupNameCollisionFails(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.CreateGroup("alpha/inner", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := st.CreateGroup("beta/inner", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := st.MoveGroup("alpha/inner", "beta"); err == nil {
+		t.Fatal("moving onto an existing sibling name should fail")
+	}
+}
+
+func TestMoveGroupSameParentIsNoop(t *testing.T) {
+	st := newTestStore(t)
+	if err := st.CreateGroup("alpha/inner", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := st.MoveGroup("alpha/inner", "alpha"); err != nil {
+		t.Fatalf("MoveGroup: %v", err)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -916,10 +916,19 @@ func TestMoveGroupReparentsSubtree(t *testing.T) {
 	if err := st.CreateGroup("alpha/inner", "/srv/inner"); err != nil {
 		t.Fatalf("create group: %v", err)
 	}
+	if err := st.CreateGroup("alpha/inner/deep", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
 	if err := st.CreateGroup("beta", ""); err != nil {
 		t.Fatalf("create group: %v", err)
 	}
+	if err := st.SetGroupWorktree("alpha/inner", "on"); err != nil {
+		t.Fatalf("set worktree: %v", err)
+	}
 	if err := st.CreateSession(sample("a", "alpha/inner")); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := st.CreateSession(sample("b", "alpha/inner/deep")); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
 	if err := st.MoveGroup("alpha/inner", "beta"); err != nil {
@@ -929,24 +938,34 @@ func TestMoveGroupReparentsSubtree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("groups: %v", err)
 	}
-	var movedPath string
+	byName := make(map[string]Group, len(groups))
 	for _, group := range groups {
-		if group.Name == "alpha/inner" {
-			t.Fatal("old group path still present")
+		if group.Name == "alpha/inner" || group.Name == "alpha/inner/deep" {
+			t.Fatalf("old group path %s still present", group.Name)
 		}
-		if group.Name == "beta/inner" {
-			movedPath = group.Path
+		byName[group.Name] = group
+	}
+	moved, ok := byName["beta/inner"]
+	if !ok {
+		t.Fatal("beta/inner missing")
+	}
+	if moved.Path != "/srv/inner" {
+		t.Fatalf("beta/inner path = %q, want /srv/inner", moved.Path)
+	}
+	if moved.Worktree != "on" {
+		t.Fatalf("beta/inner worktree = %q, want on", moved.Worktree)
+	}
+	if _, ok := byName["beta/inner/deep"]; !ok {
+		t.Fatal("beta/inner/deep missing")
+	}
+	for id, want := range map[string]string{"a": "beta/inner", "b": "beta/inner/deep"} {
+		sess, err := st.Get(id)
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
 		}
-	}
-	if movedPath != "/srv/inner" {
-		t.Fatalf("beta/inner path = %q, want /srv/inner", movedPath)
-	}
-	sess, err := st.Get("a")
-	if err != nil {
-		t.Fatalf("get: %v", err)
-	}
-	if sess.Group != "beta/inner" {
-		t.Fatalf("session group = %q, want beta/inner", sess.Group)
+		if sess.Group != want {
+			t.Fatalf("session %s group = %q, want %q", id, sess.Group, want)
+		}
 	}
 }
 

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -92,6 +92,7 @@ func helpSections() []helpSection {
 			{"↵", "fold / unfold"},
 			{"space", "quick prompt: spawn a new agent in the group"},
 			{"r", "edit it: name, default path, worktree"},
+			{"m", "move it, with its whole subtree, under another group"},
 			{"x / X", "kill every live session in it / everywhere"},
 			{"v / V", "revive every dead session in it / everywhere"},
 			{"a / u", "archive / restore the subtree"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -141,6 +141,7 @@ type Model struct {
 	settings  settingsState
 	help      helpState
 	moveID    string
+	movePath  string
 	repoPick  repoPickState
 
 	// Repo a human picked by hand per session, outranking the agent's

--- a/internal/ui/move.go
+++ b/internal/ui/move.go
@@ -1,16 +1,49 @@
 package ui
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 func (m *Model) openMove() {
-	sess, ok := m.selected()
-	if !ok {
+	row, ok := m.selectedRow()
+	if !ok || row.isRoot() {
 		return
 	}
-	m.moveID = sess.ID
-	m.rebuildGroupOptions(sess.Group)
+	if row.isGroup {
+		m.moveID = ""
+		m.movePath = row.group
+		m.rebuildGroupOptions(parentGroup(row.group))
+		m.pruneMoveTargets(row.group)
+	} else {
+		m.moveID = row.sess.ID
+		m.movePath = ""
+		m.rebuildGroupOptions(row.sess.Group)
+	}
 	m.mode = modeMove
 	m.errBar.text = ""
+}
+
+// pruneMoveTargets drops the moved group and its descendants from the
+// picker: a group cannot land inside its own subtree.
+func (m *Model) pruneMoveTargets(subtree string) {
+	selected := m.form.groups[m.form.groupIndex].path
+	options := make([]groupOption, 0, len(m.form.groups))
+	for _, opt := range m.form.groups {
+		if opt.path == subtree || strings.HasPrefix(opt.path, subtree+"/") {
+			continue
+		}
+		options = append(options, opt)
+	}
+	m.form.groups = options
+	m.form.groupIndex = 0
+	for i, opt := range options {
+		if opt.path == selected {
+			m.form.groupIndex = i
+			return
+		}
+	}
 }
 
 func (m *Model) handleMoveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -26,6 +59,9 @@ func (m *Model) handleMoveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "enter":
 		group := m.selectedGroupPath()
+		if m.movePath != "" {
+			return m.moveGroupTo(group)
+		}
 		if err := m.store.MoveSession(m.moveID, group); err != nil {
 			m.errBar.text = err.Error()
 			return m, nil
@@ -35,5 +71,26 @@ func (m *Model) handleMoveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.requestRefresh()
 		return m, nil
 	}
+	return m, nil
+}
+
+func (m *Model) moveGroupTo(parent string) (tea.Model, tea.Cmd) {
+	newPath := baseName(m.movePath)
+	if parent != "" {
+		newPath = parent + "/" + newPath
+	}
+	if newPath == m.movePath {
+		m.mode = modeList
+		return m, nil
+	}
+	if err := m.store.MoveGroup(m.movePath, parent); err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	m.renameGroupLocally(m.movePath, newPath, m.groupPaths[m.movePath], m.groupWorktrees[m.movePath])
+	m.relabelSubtree(newPath)
+	m.rebuildRows()
+	m.mode = modeList
+	m.requestRefresh()
 	return m, nil
 }

--- a/internal/ui/move.go
+++ b/internal/ui/move.go
@@ -8,7 +8,11 @@ import (
 
 func (m *Model) openMove() {
 	row, ok := m.selectedRow()
-	if !ok || row.isRoot() {
+	if !ok {
+		return
+	}
+	if row.isRoot() {
+		m.errBar.text = "root is the top level, not a group to move"
 		return
 	}
 	if row.isGroup {

--- a/internal/ui/move_test.go
+++ b/internal/ui/move_test.go
@@ -29,3 +29,54 @@ func TestMoveSession(t *testing.T) {
 		t.Fatalf("move failed: %+v", sessions)
 	}
 }
+
+func TestMoveGroupRow(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("alpha/inner", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := m.store.CreateGroup("beta", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "wanderer", dir, "alpha/inner")
+
+	m.selectGroupRow(t, "alpha/inner")
+	m.openMove()
+	if m.mode != modeMove {
+		t.Fatal("openMove on a group row should enter move mode")
+	}
+	for _, opt := range m.form.groups {
+		if opt.path == "alpha/inner" {
+			t.Fatal("picker offers the moved group itself")
+		}
+	}
+	pickGroup(t, m, "beta")
+	_, cmd := m.handleMoveKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m.applyCmd(t, cmd)
+
+	sessions := m.sessionRows()
+	if len(sessions) != 1 || sessions[0].Group != "beta/inner" {
+		t.Fatalf("group move failed: %+v", sessions)
+	}
+	if m.mode != modeList {
+		t.Fatal("should return to list mode")
+	}
+}
+
+func TestMoveGroupRowExcludesDescendants(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("alpha/inner/deep", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+
+	m.selectGroupRow(t, "alpha")
+	m.openMove()
+	for _, opt := range m.form.groups {
+		if opt.path == "alpha" || opt.path == "alpha/inner" || opt.path == "alpha/inner/deep" {
+			t.Fatalf("picker offers %q inside the moved subtree", opt.path)
+		}
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -488,7 +488,7 @@ func (m *Model) rowLegend() legendSection {
 			foldAction = "unfold"
 		}
 		return legendSection{title: "Group", pairs: [][2]string{
-			{"↵", foldAction}, {"r", "rename"},
+			{"↵", foldAction}, {"r", "rename"}, {"m", "move"},
 			{"x/X", "kill / all"}, {"v/V", "revive / all"},
 			{"a/u", "archive / restore"}, {"d", "delete"},
 		}}


### PR DESCRIPTION
m on a group row opens the same group picker sessions use, minus the moved subtree, preselected on the current parent. Enter re-parents the group; every descendant group and session follows via the rename cascade. Group default path and worktree setting carry over.

The picker refuses targets inside the moved subtree, moving to the same parent is a no-op, and a name collision at the destination surfaces as an error. Group footer legend and the ? key map list the new key.

Tested: store and UI unit tests, plus a live run of the built binary on an isolated tmux socket (moved a nested group to root and a root group under a sibling; verified in the DB and the rendered tree).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to move groups and their entire subtrees under another group or to the root.
  - Group moves preserve names and metadata while updating associated session paths.
  - Added the `m` keyboard shortcut and destination selection for moving groups.
  - Prevented invalid moves into a group’s own descendants or existing name conflicts.
- **Documentation**
  - Updated in-app help and group controls to describe group moving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->