### PR TITLE
feat(contrib): add cmux and desktop notification pipeline for session state changes

### DIFF
--- a/contrib/notifications/README.md
+++ b/contrib/notifications/README.md
@@ -15,7 +15,9 @@ writes per-session            am-status-notify (watcher, 2s poll;
 status files:                 systemd user service on Linux,
   waiting / working /         launchd agent on macOS)
   finished / idle                    │  on flip to waiting/finished:
-<hooks>/<session-id>.status          ▼  cmux-notify "Agent Manager" "<id> …"
+<hooks>/<session-id>.status          ▼  cmux-notify "<session name>" "<state>"
+                                     │  (name read from AM's state.db via
+                                     │  python3's sqlite3; falls back to id)
   Linux: ~/.config/agent-       cmux-notify (delivery module, per platform)
   manager/hooks/                     │
   macOS: ~/Library/Application       │  TARGETING (per event, fresh):
@@ -69,9 +71,9 @@ Explicitly **out of scope** (by design, not oversight):
 | Package file | Deployed at | Role |
 |---|---|---|
 | `linux/cmux-notify` | `~/.local/bin/cmux-notify` | **Delivery (Linux).** `cmux-notify [--workspace <id>] "title" "body"` · `--flush`. Targeting precedence: `--workspace` flag → `$CMUX_NOTIFY_WORKSPACE` env pin (empty = explicitly untargeted) → live probe of agent-manager's `CMUX_WORKSPACE_ID` in `/proc` → untargeted. Channels: cmux relay shim, then `notify-send`. 4-field TSV spool (title, body, relay route, workspace); flush replays per-event with stale-workspace fallback to untargeted. |
-| `linux/am-status-notify` | `~/.local/bin/am-status-notify` | **Watcher (Linux).** Polls `~/.config/agent-manager/hooks/*.status` every 2s; fires on flips to `waiting`/`finished`; seeds silently on first pass; flushes the spool each cycle; drops state for removed sessions. |
+| `linux/am-status-notify` | `~/.local/bin/am-status-notify` | **Watcher (Linux).** Polls `~/.config/agent-manager/hooks/*.status` every 2s; fires on flips to `waiting`/`finished`; seeds silently on first pass; flushes the spool each cycle; drops state for removed sessions. Notification **title is the session's name in Agent Manager** (read from `state.db` with python3's stdlib `sqlite3` — no `sqlite3` CLI dependency — falling back to the raw id), body is `Waiting for your input` / `Finished`. |
 | `linux/am-status-notify.service` | `~/.config/systemd/user/` | **Lifecycle (Linux).** `Restart=always`; linger enabled (`loginctl enable-linger <user>`) so it starts at boot. |
-| `macos/cmux-notify` | `~/.local/bin/cmux-notify` | **Delivery (macOS).** `cmux-notify "title" "body"` · `--flush`. Probes the agent-manager process for its TTY (`ps`) and `CMUX_WORKSPACE_ID`, writes OSC 777 (`ESC ] 777 ; notify ; title ; body BEL`) to that TTY. Spools only when the TTY write fails; flush retries a dead stored TTY once against the live-probed TTY. |
+| `macos/cmux-notify` | `~/.local/bin/cmux-notify` | **Delivery (macOS).** `cmux-notify "title" "body"` · `--flush`. Probes the agent-manager **TUI** process for its TTY (`ps`) and `CMUX_WORKSPACE_ID`, writes OSC 777 (`ESC ] 777 ; notify ; title ; body BEL`) to that TTY. `agent-manager mcp` children are excluded — their TTYs are tmux pane ptys and tmux swallows the escape. Spools when the write fails **or no TUI is running** (events then deliver when it reopens); flush retries a dead stored TTY once against the live-probed TTY. |
 | `macos/am-status-notify` | `~/.local/bin/am-status-notify` | **Watcher (macOS).** Identical logic, status dir is `~/Library/Application Support/agent-manager/hooks`. |
 | `macos/com.agentmanager.am-status-notify.plist` | `~/Library/LaunchAgents/` | **Lifecycle (macOS).** Template — `__HOME__` is substituted with the installing user's home at install time. `RunAtLoad` + `KeepAlive`, loaded with `launchctl bootstrap gui/<uid>`. |
 | `linux/install.sh` / `linux/uninstall.sh` | — | Install/remove the Linux pipeline (scripts, systemd unit, optional linger + Codex hints). |
@@ -122,6 +124,18 @@ line from `~/.codex/config.toml` if you added it.
 - **Spool discipline:** an event is only queued when every channel failed;
   replay preserves FIFO order; a stored target that died while queued gets
   one retry against the live-probed target before the event is re-queued.
+- **Notification content mirrors the native agents:** title is the session's
+  name in Agent Manager, body is the state phrase (`Waiting for your input` /
+  `Finished`) — the same shape as cmux's own Claude Code notifications
+  (`Claude Code` / `Claude is waiting for your input`), so managed and
+  native entries read identically in the panel. The name is read fresh from
+  Agent Manager's `state.db` per event via python3's stdlib `sqlite3`
+  (read-only WAL connection), so renames apply immediately and there is no
+  `sqlite3` CLI dependency; any lookup failure falls back to the raw id.
+- **macOS probe targets only the TUI:** `agent-manager mcp` child processes
+  hold tmux pane ptys, and tmux filters the escape — writing there loses the
+  event silently. When no TUI is running the event spools instead and
+  delivers when it reopens.
 - **Known upstream cmux quirks** (observed during verification, candidates
   for issues against manaflow-ai/cmux): orphaned remote-relay workspace
   binding after reconnect → focus-follows notification attribution; local

--- a/contrib/notifications/README.md
+++ b/contrib/notifications/README.md
@@ -1,0 +1,129 @@
+# Agent Manager → cmux notifications
+
+Notifications from [Agent Manager](https://github.com/YoanWai/agent-manager)
+agent sessions, delivered to the **correct cmux workspace** — whether Agent
+Manager runs on the local Mac inside cmux, or on a remote Linux box reached
+through a cmux ssh workspace.
+
+Built and verified 2026-08-10/11. Two moving parts per platform, one
+integration point (Agent Manager's session status files):
+
+```
+Agent Manager                       this host                         target
+─────────────                       ──────────                        ──────
+writes per-session            am-status-notify (watcher, 2s poll;
+status files:                 systemd user service on Linux,
+  waiting / working /         launchd agent on macOS)
+  finished / idle                    │  on flip to waiting/finished:
+<hooks>/<session-id>.status          ▼  cmux-notify "Agent Manager" "<id> …"
+  Linux: ~/.config/agent-       cmux-notify (delivery module, per platform)
+  manager/hooks/                     │
+  macOS: ~/Library/Application       │  TARGETING (per event, fresh):
+  Support/agent-manager/hooks/       │  live probe of the agent-manager
+                                     │  process (its identity is the route)
+                                     ▼
+                          Linux:                          macOS:
+                          ┌───────────────────────┐       ┌────────────────────────┐
+                          │ cmux relay shim:      │       │ OSC 777 escape written │
+                          │ ~/.cmux/bin/cmux      │       │ to the agent-manager   │
+                          │ notify --workspace ID │       │ TTY; cmux raises it    │
+                          │ (ID probed from       │       │ natively, attributed   │
+                          │  /proc/<am>/environ   │       │ to the AM workspace    │
+                          │  CMUX_WORKSPACE_ID)   │       │ (CMUX_WORKSPACE_ID and │
+                          ├───────────────────────┤       │  TTY probed via ps)    │
+                          │ notify-send (desktop  │       └────────────────────────┘
+                          │ daemon, GNOME/KDE/….) │       single channel, no
+                          └───────────────────────┘       osascript side channel
+                                     │ both channels (Linux) / tty write (macOS) fail?
+                                     ▼
+                          spool FIFO (TSV, cap 200), replayed in order
+                          by later calls / --flush; stale targets retried
+                          once against the live-probed target
+```
+
+## Scope and compatibility — exactly this, nothing else
+
+| Path | Mechanism | Status |
+|---|---|---|
+| macOS, Agent Manager in a local **cmux** terminal | OSC 777 into the AM pane's pty → cmux pane ring, sidebar badge, notification panel, macOS banner, correct workspace attribution | ✅ verified live |
+| Linux desktop (Ubuntu/GNOME shown; KDE/Arch equivalent) | `notify-send` to the freedesktop notification daemon — **terminal-agnostic**, works no matter which terminal emulator Agent Manager runs in | ✅ verified on Ubuntu/GNOME |
+| Agent Manager on remote Linux via **cmux ssh workspace** | cmux relay shim with explicit `--workspace` targeting, discovered live per event | ✅ verified live (notification lands on the remote's workspace even while another workspace is focused) |
+| Codex per-turn pings (Linux) | `notify = ["<path>/cmux-notify", "Codex"]` in `~/.codex/config.toml`; codex's payload JSON is normalized to its `last-assistant-message`, one line, capped at 160 chars | ✅ deployed |
+
+Explicitly **out of scope** (by design, not oversight):
+
+- Terminal emulators other than cmux on macOS (iTerm2, Terminal.app, Kitty…).
+  Terminal.app has no escape-sequence notification API at all; iTerm2/Kitty
+  speak different dialects (OSC 9 / OSC 99). The delivery target is cmux.
+- `osascript`/Notification-Center banners on macOS. They arrive attributed to
+  "Script Editor", cannot focus the pane, and duplicate cmux's own banner.
+  Deliberately removed.
+- Per-agent wrapper scripts. The watcher covers every agent type Agent
+  Manager manages; Codex's native `notify` hook points directly at the
+  delivery module. Claude Code needs no configuration.
+- Headless Linux with no desktop session and no cmux workspace connected:
+  nothing can display there; events spool (cap 200) until a channel returns.
+
+## Files
+
+| Package file | Deployed at | Role |
+|---|---|---|
+| `linux/cmux-notify` | `~/.local/bin/cmux-notify` | **Delivery (Linux).** `cmux-notify [--workspace <id>] "title" "body"` · `--flush`. Targeting precedence: `--workspace` flag → `$CMUX_NOTIFY_WORKSPACE` env pin (empty = explicitly untargeted) → live probe of agent-manager's `CMUX_WORKSPACE_ID` in `/proc` → untargeted. Channels: cmux relay shim, then `notify-send`. 4-field TSV spool (title, body, relay route, workspace); flush replays per-event with stale-workspace fallback to untargeted. |
+| `linux/am-status-notify` | `~/.local/bin/am-status-notify` | **Watcher (Linux).** Polls `~/.config/agent-manager/hooks/*.status` every 2s; fires on flips to `waiting`/`finished`; seeds silently on first pass; flushes the spool each cycle; drops state for removed sessions. |
+| `linux/am-status-notify.service` | `~/.config/systemd/user/` | **Lifecycle (Linux).** `Restart=always`; linger enabled (`loginctl enable-linger <user>`) so it starts at boot. |
+| `macos/cmux-notify` | `~/.local/bin/cmux-notify` | **Delivery (macOS).** `cmux-notify "title" "body"` · `--flush`. Probes the agent-manager process for its TTY (`ps`) and `CMUX_WORKSPACE_ID`, writes OSC 777 (`ESC ] 777 ; notify ; title ; body BEL`) to that TTY. Spools only when the TTY write fails; flush retries a dead stored TTY once against the live-probed TTY. |
+| `macos/am-status-notify` | `~/.local/bin/am-status-notify` | **Watcher (macOS).** Identical logic, status dir is `~/Library/Application Support/agent-manager/hooks`. |
+| `macos/com.agentmanager.am-status-notify.plist` | `~/Library/LaunchAgents/` | **Lifecycle (macOS).** Template — `__HOME__` is substituted with the installing user's home at install time. `RunAtLoad` + `KeepAlive`, loaded with `launchctl bootstrap gui/<uid>`. |
+| `linux/install.sh` / `linux/uninstall.sh` | — | Install/remove the Linux pipeline (scripts, systemd unit, optional linger + Codex hints). |
+| `macos/install.sh` / `macos/uninstall.sh` | — | Install/remove the macOS pipeline (scripts, rendered plist, launchd load/bootout). |
+| `tests/test-interface-linux.sh` | — | **Test suite for the Linux delivery module.** 18 checks, fully sandboxed (temp `HOME`, fake relay that logs only on success, desktop channel off, workspace probe pinned empty). Covers targeting precedence, 4-field spool format, FIFO flush order, stale-workspace retry, mid-flush failure re-spool, spool cap, body normalization (JSON, 160-char cap, multiline collapse). |
+
+State (both platforms): `~/.local/state/cmux-notify/{spool,log}` —
+one decision line per event in `log`; `spool` exists only while events are
+queued. Watcher dedup state: `~/.local/state/am-status-notify/`.
+
+## Install
+
+Linux: `bash linux/install.sh` (scripts into `~/.local/bin`, systemd user
+unit enabled and started; prints the optional linger and Codex `notify`
+hints at the end).
+
+macOS (requires cmux): `bash macos/install.sh` (scripts into `~/.local/bin`,
+plist rendered with your `$HOME`, launchd agent loaded).
+
+Both watchers invoke the delivery module as `$HOME/.local/bin/cmux-notify` —
+if your distribution packages this elsewhere, adjust the path in the watcher
+scripts accordingly.
+
+## Uninstall
+
+`bash linux/uninstall.sh` or `bash macos/uninstall.sh` — removes scripts,
+service/plist, and state directories. On Linux, remove the Codex `notify =`
+line from `~/.codex/config.toml` if you added it.
+
+## Why it is built this way (design notes)
+
+- **Routing bug that started this:** cmux ssh workspaces each register a relay
+  on the remote host, but after reconnects the binding can go stale, and an
+  untargeted `cmux notify` then lands on whichever workspace is *focused*.
+  Proven with controlled focus experiments. Fix: explicit `--workspace`
+  targeting, with the id read live from the agent-manager process environment
+  per event — reconnects and id churn cannot strand it.
+- **macOS uses escape sequences, not the cmux CLI:** the local cmux socket
+  refuses connections from processes not started inside cmux
+  ("Access denied"), so a launchd watcher cannot use `cmux notify`. cmux is
+  libghostty-based and natively turns OSC 777 from the terminal stream into a
+  notification attributed to the emitting surface — writing to the AM pane's
+  TTY is both the native path and the correctly-attributed one.
+- **Linux uses `notify-send`, not escapes:** the freedesktop notification
+  daemon is the platform's terminal-agnostic mechanism; OSC 777 support
+  across Linux terminals is fragmented (urxvt/foot/contour/WezTerm yes,
+  stock VTE/GNOME Terminal, Kitty, xterm, Alacritty no).
+- **Spool discipline:** an event is only queued when every channel failed;
+  replay preserves FIFO order; a stored target that died while queued gets
+  one retry against the live-probed target before the event is re-queued.
+- **Known upstream cmux quirks** (observed during verification, candidates
+  for issues against manaflow-ai/cmux): orphaned remote-relay workspace
+  binding after reconnect → focus-follows notification attribution; local
+  `cmux notify --workspace` invoked from a non-cmux process appears to ignore
+  the workspace argument.

--- a/contrib/notifications/linux/am-status-notify
+++ b/contrib/notifications/linux/am-status-notify
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Watch Agent Manager session status files and send a notification when a
+# session flips to "waiting" or "finished". Covers every agent type Agent
+# Manager manages. Polls every 2s; first pass seeds state silently.
+# The delivery module auto-targets the cmux workspace running agent-manager
+# (live probe of the agent-manager process env) and also banners locally.
+# Each cycle also flushes the cmux-notify spool.
+DIR="$HOME/.config/agent-manager/hooks"
+STATE="$HOME/.local/state/am-status-notify"
+mkdir -p "$STATE"
+first=1
+while true; do
+  for f in "$DIR"/*.status; do
+    [ -e "$f" ] || continue
+    id=$(basename "$f" .status)
+    cur=$(cat "$f" 2>/dev/null) || continue
+    prev=$(cat "$STATE/$id" 2>/dev/null)
+    if [ "$cur" != "$prev" ]; then
+      printf %s "$cur" > "$STATE/$id"
+      if [ "$first" != 1 ]; then
+        case "$cur" in
+          waiting)  "$HOME/.local/bin/cmux-notify" "Agent Manager" "$id needs input" ;;
+          finished) "$HOME/.local/bin/cmux-notify" "Agent Manager" "$id finished" ;;
+        esac
+      fi
+    fi
+  done
+  # drop state for sessions whose status file was removed
+  for s in "$STATE"/*; do
+    [ -e "$s" ] || continue
+    id=$(basename "$s")
+    [ -e "$DIR/$id.status" ] || rm -f "$s"
+  done
+  "$HOME/.local/bin/cmux-notify" --flush
+  first=0
+  sleep 2
+done

--- a/contrib/notifications/linux/am-status-notify
+++ b/contrib/notifications/linux/am-status-notify
@@ -3,11 +3,26 @@
 # session flips to "waiting" or "finished". Covers every agent type Agent
 # Manager manages. Polls every 2s; first pass seeds state silently.
 # The delivery module auto-targets the cmux workspace running agent-manager
-# (live probe of the agent-manager process env) and also banners locally.
-# Each cycle also flushes the cmux-notify spool.
+# (live probe of the agent-manager process env) and also banners via
+# notify-send. Notification title is the session name from Agent Manager's
+# state.db (fallback: raw id). Each cycle also flushes the cmux-notify spool.
 DIR="$HOME/.config/agent-manager/hooks"
+DB="$HOME/.config/agent-manager/state.db"
 STATE="$HOME/.local/state/am-status-notify"
 mkdir -p "$STATE"
+
+session_name() { # session id -> human title from the AM store (fallback: id)
+  python3 - "$DB" "$1" <<'PY' 2>/dev/null
+import sqlite3, sys
+try:
+    db = sqlite3.connect("file:%s?mode=ro" % sys.argv[1], uri=True)
+    row = db.execute("SELECT name FROM sessions WHERE id = ?", (sys.argv[2],)).fetchone()
+    print(row[0] if row and row[0] else sys.argv[2])
+except Exception:
+    print(sys.argv[2])
+PY
+}
+
 first=1
 while true; do
   for f in "$DIR"/*.status; do
@@ -19,8 +34,8 @@ while true; do
       printf %s "$cur" > "$STATE/$id"
       if [ "$first" != 1 ]; then
         case "$cur" in
-          waiting)  "$HOME/.local/bin/cmux-notify" "Agent Manager" "$id needs input" ;;
-          finished) "$HOME/.local/bin/cmux-notify" "Agent Manager" "$id finished" ;;
+          waiting)  "$HOME/.local/bin/cmux-notify" "$(session_name "$id")" "Waiting for your input" ;;
+          finished) "$HOME/.local/bin/cmux-notify" "$(session_name "$id")" "Finished" ;;
         esac
       fi
     fi

--- a/contrib/notifications/linux/am-status-notify.service
+++ b/contrib/notifications/linux/am-status-notify.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Agent Manager status -> cmux notifications
+
+[Service]
+ExecStart=%h/.local/bin/am-status-notify
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=default.target

--- a/contrib/notifications/linux/cmux-notify
+++ b/contrib/notifications/linux/cmux-notify
@@ -1,0 +1,177 @@
+#!/bin/bash
+# cmux-notify — delivery module for agent notifications from this host.
+#
+# Interface:
+#   cmux-notify [--workspace <id>] "title" "body"
+#   cmux-notify --flush
+#
+# Targeting (which cmux workspace shows the notification):
+#   1. --workspace <id> flag, or $CMUX_NOTIFY_WORKSPACE when set
+#      (empty string = explicitly untargeted)
+#   2. auto: the workspace running agent-manager, read live from the
+#      agent-manager process environment (CMUX_WORKSPACE_ID) — fresh per
+#      event, so workspace-id churn across reconnects cannot strand it
+#   3. none found -> untargeted (cmux shows it on the active workspace)
+#
+# Channels (best effort, both attempted):
+#   1. cmux app via the remote relay (~/.cmux/bin/cmux shim; any live relay
+#      reaches the app — targeting is what matters, not which relay)
+#   2. local desktop via notify-send (GNOME banner on this machine)
+#
+# Bodies are normalized to native style: one line, capped at 160 chars;
+# a codex payload JSON body is reduced to its last-assistant-message.
+#
+# An event is spooled (TSV FIFO: title, body, route, workspace-override) only
+# when BOTH channels fail, and replayed in order by later calls / --flush.
+# Every event appends one decision line to $STATE_DIR/log.
+# CMUX_NOTIFY_DESKTOP=0 disables the desktop channel.
+set -u
+
+CMUX="$HOME/.cmux/bin/cmux"
+STATE_DIR="${CMUX_NOTIFY_STATE_DIR:-$HOME/.local/state/cmux-notify}"
+SPOOL="$STATE_DIR/spool"
+LOG="$STATE_DIR/log"
+MAX_SPOOL="${CMUX_NOTIFY_MAX_SPOOL:-200}"
+TARGET_WS=""
+WS_SOURCE=""
+
+if [ "${1:-}" = "--workspace" ]; then
+  TARGET_WS="${2:-}"
+  WS_SOURCE="flag"
+  shift 2
+fi
+
+logline() { # message...
+  mkdir -p "$STATE_DIR"
+  printf '%s %s\n' "$(date +%H:%M:%S)" "$*" >> "$LOG"
+}
+
+normalize_body() { # raw body -> short single line on stdout
+  python3 -c '
+import sys, json
+s = sys.argv[1].strip()
+if s.startswith("{"):
+    try:
+        d = json.loads(s)
+        s = d.get("last-assistant-message") or d.get("message") or s
+    except Exception:
+        pass
+s = " ".join(s.split())
+print(s[:160] + ("..." if len(s) > 160 else ""))
+' "$1" 2>/dev/null || printf '%s\n' "$1"
+}
+
+resolve_workspace() { # sets TARGET_WS/WS_SOURCE unless already set by flag
+  [ -n "$WS_SOURCE" ] && return 0
+  if [ "${CMUX_NOTIFY_WORKSPACE+x}" = x ]; then
+    TARGET_WS="$CMUX_NOTIFY_WORKSPACE"
+    WS_SOURCE="env-pin"
+    return 0
+  fi
+  local pid ws
+  for pid in $(pgrep -x agent-manager 2>/dev/null); do
+    ws=$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | sed -n 's/^CMUX_WORKSPACE_ID=//p' | head -1)
+    if [ -n "$ws" ]; then
+      TARGET_WS="$ws"
+      WS_SOURCE="agent-manager-probe"
+      return 0
+    fi
+  done
+  WS_SOURCE="untargeted"
+  return 1
+}
+
+relay_send() { # title body workspace -> 0 if delivered; prints relay JSON
+  [ -x "$CMUX" ] || return 1
+  local out wsargs=()
+  [ -n "${3:-}" ] && wsargs=(--workspace "$3")
+  out=$(timeout 8 "$CMUX" notify "${wsargs[@]}" --title "$1" --body "$2" 2>/dev/null) || return 1
+  printf '%s' "$out" | tr '\n\t' '  '
+}
+
+desktop_send() { # title body -> 0 if delivered to local desktop
+  [ "${CMUX_NOTIFY_DESKTOP:-1}" = "0" ] && return 1
+  command -v notify-send >/dev/null 2>&1 || return 1
+  export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$(id -u)/bus}"
+  notify-send "$1" "$2" >/dev/null 2>&1
+}
+
+spool_add() { # title body route workspace
+  mkdir -p "$STATE_DIR"
+  printf '%s\t%s\t%s\t%s\n' \
+    "$(printf '%s' "$1" | tr '\t\n' '  ')" \
+    "$(printf '%s' "$2" | tr '\t\n' '  ')" \
+    "$(printf '%s' "$3" | tr '\t\n' '  ')" \
+    "$(printf '%s' "$4" | tr '\t\n' '  ')" >> "$SPOOL"
+  local n
+  n=$(wc -l < "$SPOOL")
+  if [ "$n" -gt "$MAX_SPOOL" ]; then
+    tail -n "$MAX_SPOOL" "$SPOOL" > "$SPOOL.cap" && mv "$SPOOL.cap" "$SPOOL"
+  fi
+}
+
+flush() {
+  [ -s "$SPOOL" ] || return 0
+  mv "$SPOOL" "$SPOOL.flushing"
+  local failed=0 t b route ws
+  resolve_workspace 2>/dev/null
+  local live_ws="$TARGET_WS"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    # split on tabs manually: IFS-whitespace collapsing would eat empty fields
+    t=${line%%$'\t'*}; rest=${line#*$'\t'}
+    b=${rest%%$'\t'*}; rest=${rest#*$'\t'}
+    route=${rest%%$'\t'*}; ws=${rest#*$'\t'}
+    local eff_ws="${ws:-$live_ws}"
+    if [ "$failed" -eq 0 ] && CMUX_SOCKET_PATH="$route" relay_send "$t" "$b" "$eff_ws" >/dev/null; then
+      logline "flush delivered: $t"
+      continue
+    fi
+    # retry untargeted once (stored/pinned workspace may have died while spooled)
+    if [ "$failed" -eq 0 ] && [ -n "$eff_ws" ] && CMUX_SOCKET_PATH="$route" relay_send "$t" "$b" "" >/dev/null; then
+      logline "flush delivered untargeted (stale workspace $eff_ws): $t"
+      continue
+    fi
+    failed=1
+    printf '%s\t%s\t%s\t%s\n' "$t" "$b" "$route" "$ws" >> "$SPOOL.keep"
+  done < "$SPOOL.flushing"
+  rm -f "$SPOOL.flushing"
+  if [ -f "$SPOOL.keep" ]; then
+    if [ -f "$SPOOL" ]; then
+      cat "$SPOOL.keep" "$SPOOL" > "$SPOOL.merge" && mv "$SPOOL.merge" "$SPOOL"
+    else
+      mv "$SPOOL.keep" "$SPOOL"
+    fi
+  fi
+}
+
+if [ "${1:-}" = "--flush" ]; then
+  flush
+  exit 0
+fi
+
+title="${1:-cmux}"
+body=$(normalize_body "${2:-}")
+
+flush   # drain backlog first (cheap no-op when spool empty)
+resolve_workspace
+resp=""
+if resp=$(relay_send "$title" "$body" "$TARGET_WS"); then
+  logline "cmux ok [ws=${TARGET_WS:-none} via=$WS_SOURCE] {$resp} :: $title"
+  cmux_ok=0
+else
+  logline "cmux FAIL [ws=${TARGET_WS:-none} via=$WS_SOURCE] :: $title"
+  cmux_ok=1
+fi
+if desktop_send "$title" "$body"; then
+  logline "desktop ok :: $title"
+  desk_ok=0
+else
+  desk_ok=1
+fi
+if [ "$cmux_ok" -eq 0 ] || [ "$desk_ok" -eq 0 ]; then
+  exit 0
+fi
+spool_add "$title" "$body" "${CMUX_SOCKET_PATH:-}" "$TARGET_WS"
+logline "SPOOLED :: $title"
+echo "cmux-notify: no channel available - event spooled for later delivery" >&2

--- a/contrib/notifications/linux/install.sh
+++ b/contrib/notifications/linux/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Install the Linux notification pipeline: delivery module + watcher +
+# systemd user service.
+set -e
+cd "$(dirname "$0")"
+
+install -m755 cmux-notify am-status-notify "$HOME/.local/bin/"
+install -m644 am-status-notify.service "$HOME/.config/systemd/user/"
+systemctl --user daemon-reload
+systemctl --user enable --now am-status-notify
+
+echo "installed and started am-status-notify.service"
+echo "optional: loginctl enable-linger \$USER   # start at boot without login"
+echo "optional: per-turn Codex pings — add to ~/.codex/config.toml:"
+echo "  notify = [\"$HOME/.local/bin/cmux-notify\", \"Codex\"]"

--- a/contrib/notifications/linux/uninstall.sh
+++ b/contrib/notifications/linux/uninstall.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Uninstall the Linux notification pipeline installed by install.sh.
+set -e
+
+systemctl --user disable --now am-status-notify 2>/dev/null || true
+rm -f "$HOME/.config/systemd/user/am-status-notify.service"
+rm -f "$HOME/.local/bin/am-status-notify" "$HOME/.local/bin/cmux-notify"
+rm -rf "$HOME/.local/state/am-status-notify" "$HOME/.local/state/cmux-notify"
+systemctl --user daemon-reload
+echo "uninstalled am-status-notify"
+echo "note: remove the notify = [...] line from ~/.codex/config.toml if added"

--- a/contrib/notifications/macos/am-status-notify
+++ b/contrib/notifications/macos/am-status-notify
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Watch Agent Manager session status files and send a notification when a
+# session flips to "waiting" or "finished". Covers every agent type Agent
+# Manager manages. Polls every 2s; first pass seeds state silently.
+# The delivery module auto-targets the cmux workspace running agent-manager
+# (live probe of the agent-manager process env) and also banners locally.
+# Each cycle also flushes the cmux-notify spool.
+DIR="$HOME/Library/Application Support/agent-manager/hooks"
+STATE="$HOME/.local/state/am-status-notify"
+mkdir -p "$STATE"
+first=1
+while true; do
+  for f in "$DIR"/*.status; do
+    [ -e "$f" ] || continue
+    id=$(basename "$f" .status)
+    cur=$(cat "$f" 2>/dev/null) || continue
+    prev=$(cat "$STATE/$id" 2>/dev/null)
+    if [ "$cur" != "$prev" ]; then
+      printf %s "$cur" > "$STATE/$id"
+      if [ "$first" != 1 ]; then
+        case "$cur" in
+          waiting)  "$HOME/.local/bin/cmux-notify" "Agent Manager" "$id needs input" ;;
+          finished) "$HOME/.local/bin/cmux-notify" "Agent Manager" "$id finished" ;;
+        esac
+      fi
+    fi
+  done
+  # drop state for sessions whose status file was removed
+  for s in "$STATE"/*; do
+    [ -e "$s" ] || continue
+    id=$(basename "$s")
+    [ -e "$DIR/$id.status" ] || rm -f "$s"
+  done
+  "$HOME/.local/bin/cmux-notify" --flush
+  first=0
+  sleep 2
+done

--- a/contrib/notifications/macos/am-status-notify
+++ b/contrib/notifications/macos/am-status-notify
@@ -2,12 +2,27 @@
 # Watch Agent Manager session status files and send a notification when a
 # session flips to "waiting" or "finished". Covers every agent type Agent
 # Manager manages. Polls every 2s; first pass seeds state silently.
-# The delivery module auto-targets the cmux workspace running agent-manager
-# (live probe of the agent-manager process env) and also banners locally.
-# Each cycle also flushes the cmux-notify spool.
+# The delivery module targets the cmux workspace running agent-manager by
+# writing an OSC 777 escape to the agent-manager TTY (probed live per event).
+# Notification title is the session's name in Agent Manager (read from its
+# state.db; falls back to the raw id). Each cycle also flushes the spool.
 DIR="$HOME/Library/Application Support/agent-manager/hooks"
+DB="$HOME/Library/Application Support/agent-manager/state.db"
 STATE="$HOME/.local/state/am-status-notify"
 mkdir -p "$STATE"
+
+session_name() { # session id -> human title from the AM store (fallback: id)
+  python3 - "$DB" "$1" <<'PY' 2>/dev/null
+import sqlite3, sys
+try:
+    db = sqlite3.connect("file:%s?mode=ro" % sys.argv[1], uri=True)
+    row = db.execute("SELECT name FROM sessions WHERE id = ?", (sys.argv[2],)).fetchone()
+    print(row[0] if row and row[0] else sys.argv[2])
+except Exception:
+    print(sys.argv[2])
+PY
+}
+
 first=1
 while true; do
   for f in "$DIR"/*.status; do
@@ -19,8 +34,8 @@ while true; do
       printf %s "$cur" > "$STATE/$id"
       if [ "$first" != 1 ]; then
         case "$cur" in
-          waiting)  "$HOME/.local/bin/cmux-notify" "Agent Manager" "$id needs input" ;;
-          finished) "$HOME/.local/bin/cmux-notify" "Agent Manager" "$id finished" ;;
+          waiting)  "$HOME/.local/bin/cmux-notify" "$(session_name "$id")" "Waiting for your input" ;;
+          finished) "$HOME/.local/bin/cmux-notify" "$(session_name "$id")" "Finished" ;;
         esac
       fi
     fi

--- a/contrib/notifications/macos/cmux-notify
+++ b/contrib/notifications/macos/cmux-notify
@@ -53,11 +53,16 @@ print(s[:160] + ("..." if len(s) > 160 else ""))
 ' "$1" 2>/dev/null || printf '%s\n' "$1"
 }
 
-resolve_target() { # probe the live agent-manager process for its TTY (+ ws)
+resolve_target() { # probe the live agent-manager TUI for its TTY (+ ws)
   TARGET_TTY=""
   TARGET_WS=""
   local pid tty
   for pid in $(pgrep -x agent-manager 2>/dev/null); do
+    # skip `agent-manager mcp` children: their TTYs are tmux pane ptys,
+    # and tmux swallows the escape — only the TUI sits on a real cmux pty
+    case "$(ps -o command= -p "$pid" 2>/dev/null)" in
+      *" mcp") continue ;;
+    esac
     tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
     case "$tty" in
       ""|"??") continue ;;

--- a/contrib/notifications/macos/cmux-notify
+++ b/contrib/notifications/macos/cmux-notify
@@ -1,0 +1,153 @@
+#!/bin/bash
+# cmux-notify — delivery module for agent notifications from this host (macOS).
+#
+# Interface:
+#   cmux-notify "title" "body"
+#   cmux-notify --flush
+#
+# Delivery: a Ghostty-style escape (OSC 777 notify) written to the TTY of the
+# agent-manager process. The sequence enters cmux through that surface's pty,
+# so cmux itself raises the notification (pane ring, sidebar badge, panel
+# entry, macOS banner) attributed to the workspace running agent-manager —
+# correct routing with no cmux CLI access needed (the local socket refuses
+# processes not started inside cmux). This is the single, native channel:
+# no osascript/Notification Center side channel (those banners are attributed
+# to "Script Editor", can't focus the pane, and duplicate cmux's own banner).
+#
+# The target TTY is probed live per event (pgrep agent-manager -> ps tty),
+# so pane/workspace churn cannot strand it.
+#
+# Bodies are normalized to native style: one line, capped at 160 chars;
+# a codex payload JSON body is reduced to its last-assistant-message.
+#
+# An event is spooled (TSV FIFO: title, body, tty, workspace) only when the
+# TTY write fails, and replayed in order by later calls / --flush; a spooled
+# event whose stored TTY died is retried once on the live-probed TTY.
+# Every event appends one decision line to $STATE_DIR/log.
+set -u
+
+STATE_DIR="${CMUX_NOTIFY_STATE_DIR:-$HOME/.local/state/cmux-notify}"
+SPOOL="$STATE_DIR/spool"
+LOG="$STATE_DIR/log"
+MAX_SPOOL="${CMUX_NOTIFY_MAX_SPOOL:-200}"
+TARGET_TTY=""
+TARGET_WS=""
+
+logline() { # message...
+  mkdir -p "$STATE_DIR"
+  printf '%s %s\n' "$(date +%H:%M:%S)" "$*" >> "$LOG"
+}
+
+normalize_body() { # raw body -> short single line on stdout
+  python3 -c '
+import sys, json
+s = sys.argv[1].strip()
+if s.startswith("{"):
+    try:
+        d = json.loads(s)
+        s = d.get("last-assistant-message") or d.get("message") or s
+    except Exception:
+        pass
+s = " ".join(s.split())
+print(s[:160] + ("..." if len(s) > 160 else ""))
+' "$1" 2>/dev/null || printf '%s\n' "$1"
+}
+
+resolve_target() { # probe the live agent-manager process for its TTY (+ ws)
+  TARGET_TTY=""
+  TARGET_WS=""
+  local pid tty
+  for pid in $(pgrep -x agent-manager 2>/dev/null); do
+    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$tty" in
+      ""|"??") continue ;;
+    esac
+    [ -w "/dev/$tty" ] || continue
+    TARGET_TTY="/dev/$tty"
+    TARGET_WS=$(ps eww -p "$pid" 2>/dev/null | tr ' ' '\n' | sed -n 's/^CMUX_WORKSPACE_ID=//p' | head -1)
+    return 0
+  done
+  return 1
+}
+
+clean() { # strip ESC/BEL, flatten tabs/newlines
+  printf '%s' "$1" | tr -d '\033\007' | tr '\t\n' '  '
+}
+
+tty_send() { # title body tty -> 0 if written
+  [ -n "${3:-}" ] || return 1
+  printf '\033]777;notify;%s;%s\007' "$(clean "$1")" "$(clean "$2")" > "$3" 2>/dev/null
+}
+
+spool_add() { # title body tty workspace
+  mkdir -p "$STATE_DIR"
+  printf '%s\t%s\t%s\t%s\n' \
+    "$(printf '%s' "$1" | tr '\t\n' '  ')" \
+    "$(printf '%s' "$2" | tr '\t\n' '  ')" \
+    "$(printf '%s' "$3" | tr '\t\n' '  ')" \
+    "$(printf '%s' "$4" | tr '\t\n' '  ')" >> "$SPOOL"
+  local n
+  n=$(wc -l < "$SPOOL")
+  if [ "$n" -gt "$MAX_SPOOL" ]; then
+    tail -n "$MAX_SPOOL" "$SPOOL" > "$SPOOL.cap" && mv "$SPOOL.cap" "$SPOOL"
+  fi
+}
+
+flush() {
+  [ -s "$SPOOL" ] || return 0
+  mv "$SPOOL" "$SPOOL.flushing"
+  local failed=0 t b tty ws rest
+  resolve_target 2>/dev/null
+  local live_tty="$TARGET_TTY"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    # split on tabs manually: IFS-whitespace collapsing would eat empty fields
+    t=${line%%$'\t'*}; rest=${line#*$'\t'}
+    b=${rest%%$'\t'*}; rest=${rest#*$'\t'}
+    tty=${rest%%$'\t'*}; ws=${rest#*$'\t'}
+    local eff_tty="${tty:-$live_tty}"
+    if [ "$failed" -eq 0 ] && tty_send "$t" "$b" "$eff_tty"; then
+      logline "flush delivered: $t"
+      continue
+    fi
+    # retry on the live TTY once (stored TTY may have died while spooled)
+    if [ "$failed" -eq 0 ] && [ -n "$live_tty" ] && [ "$eff_tty" != "$live_tty" ] && tty_send "$t" "$b" "$live_tty"; then
+      logline "flush delivered via live tty (stale tty $eff_tty): $t"
+      continue
+    fi
+    failed=1
+    printf '%s\t%s\t%s\t%s\n' "$t" "$b" "$tty" "$ws" >> "$SPOOL.keep"
+  done < "$SPOOL.flushing"
+  rm -f "$SPOOL.flushing"
+  if [ -f "$SPOOL.keep" ]; then
+    if [ -f "$SPOOL" ]; then
+      cat "$SPOOL.keep" "$SPOOL" > "$SPOOL.merge" && mv "$SPOOL.merge" "$SPOOL"
+    else
+      mv "$SPOOL.keep" "$SPOOL"
+    fi
+  fi
+}
+
+if [ "${1:-}" = "--flush" ]; then
+  flush
+  exit 0
+fi
+
+title="${1:-cmux}"
+body=$(normalize_body "${2:-}")
+
+flush   # drain backlog first (cheap no-op when spool empty)
+resolve_target
+if tty_send "$title" "$body" "$TARGET_TTY"; then
+  logline "tty ok [tty=${TARGET_TTY:-none} ws=${TARGET_WS:-none}] :: $title"
+  tty_ok=0
+else
+  logline "tty FAIL [tty=${TARGET_TTY:-none} ws=${TARGET_WS:-none}] :: $title"
+  tty_ok=1
+fi
+if [ "$tty_ok" -eq 0 ]; then
+  exit 0
+fi
+spool_add "$title" "$body" "$TARGET_TTY" "$TARGET_WS"
+logline "SPOOLED :: $title"
+echo "cmux-notify: tty write failed - event spooled for later delivery" >&2

--- a/contrib/notifications/macos/com.agentmanager.am-status-notify.plist
+++ b/contrib/notifications/macos/com.agentmanager.am-status-notify.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agentmanager.am-status-notify</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__HOME__/.local/bin/am-status-notify</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+  <key>StandardOutPath</key>
+  <string>__HOME__/.local/state/am-status-notify.launchd.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/.local/state/am-status-notify.launchd.log</string>
+</dict>
+</plist>

--- a/contrib/notifications/macos/install.sh
+++ b/contrib/notifications/macos/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Install the macOS notification pipeline: delivery module + watcher +
+# launchd agent (plist template is rendered with the installing user's $HOME).
+# Requires cmux (https://github.com/manaflow-ai/cmux).
+set -e
+cd "$(dirname "$0")"
+
+LABEL=com.agentmanager.am-status-notify
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+install -m755 cmux-notify am-status-notify "$HOME/.local/bin/"
+sed "s|__HOME__|$HOME|g" "$LABEL.plist" > "$PLIST"
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+echo "installed and loaded $LABEL"

--- a/contrib/notifications/macos/uninstall.sh
+++ b/contrib/notifications/macos/uninstall.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Uninstall the macOS notification pipeline installed by install.sh.
+set -e
+
+LABEL=com.agentmanager.am-status-notify
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+rm -f "$HOME/Library/LaunchAgents/$LABEL.plist"
+rm -f "$HOME/.local/bin/am-status-notify" "$HOME/.local/bin/cmux-notify"
+rm -rf "$HOME/.local/state/am-status-notify" "$HOME/.local/state/cmux-notify"
+echo "uninstalled $LABEL"

--- a/contrib/notifications/tests/test-interface-linux.sh
+++ b/contrib/notifications/tests/test-interface-linux.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Interface tests for the Linux delivery module (linux/cmux-notify).
+# Sandboxed: each call runs with HOME=<tmp>, a fake relay, desktop disabled,
+# and CMUX_NOTIFY_WORKSPACE="" (empty pin = explicitly untargeted, and it
+# short-circuits the live agent-manager probe so tests never leak the real
+# workspace id).
+set -u
+SCRIPT="$HOME/.local/bin/cmux-notify"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf 'ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf 'FAIL %s\n' "$1"; }
+check(){ # name expected actual
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1"; printf '  expected: %s\n  actual:   %s\n' "$2" "$3"; fi
+}
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+STATE="$T/.local/state/cmux-notify"
+mkdir -p "$T/.cmux/bin"
+cat > "$T/.cmux/bin/cmux" <<EOF
+#!/bin/bash
+ec=\${CMUX_FAKE_EXIT:-0}
+case " \$* " in
+  *" FAILME "*) ec=1 ;;
+  *"--workspace W-DEAD"*) ec=1 ;;
+esac
+if [ "\$ec" = 0 ]; then
+  printf 'SOCK=%s %s\n' "\${CMUX_SOCKET_PATH:-none}" "\$*" >> "$T/relay.log"
+fi
+exit "\$ec"
+EOF
+chmod +x "$T/.cmux/bin/cmux"
+
+run() { # args... -> cmux-notify with sandbox env (CMUX_FAKE_EXIT pass-through)
+  HOME=$T CMUX_NOTIFY_DESKTOP=0 CMUX_NOTIFY_WORKSPACE="" \
+  CMUX_FAKE_EXIT="${CMUX_FAKE_EXIT:-0}" CMUX_NOTIFY_MAX_SPOOL="${CMUX_NOTIFY_MAX_SPOOL:-200}" \
+  bash "$SCRIPT" "$@" 2>/dev/null
+}
+reset() { rm -f "$T/relay.log"; rm -rf "$STATE"; }
+
+# 1. basic send, untargeted (empty pin)
+reset
+run "t1" "b1"
+check "basic untargeted send" "SOCK=none notify --title t1 --body b1" "$(cat "$T/relay.log")"
+
+# 2. env-pin targeting
+reset
+HOME=$T CMUX_NOTIFY_DESKTOP=0 CMUX_NOTIFY_WORKSPACE=W-42 bash "$SCRIPT" "t2" "b2" 2>/dev/null
+check "env-pin adds --workspace" "SOCK=none notify --workspace W-42 --title t2 --body b2" "$(cat "$T/relay.log")"
+
+# 3. flag targeting
+reset
+run --workspace W-99 "t3" "b3"
+check "flag adds --workspace" "SOCK=none notify --workspace W-99 --title t3 --body b3" "$(cat "$T/relay.log")"
+
+# 4. empty pin = explicitly untargeted (no probe leakage)
+reset
+run "t4" "b4"
+case "$(cat "$T/relay.log")" in *--workspace*) bad "empty pin stays untargeted" ;; *) ok "empty pin stays untargeted" ;; esac
+
+# 5. total failure spools 4-field TSV (empty route, empty ws)
+reset
+CMUX_FAKE_EXIT=1 run "first" "one"
+check "spool 4-field untargeted" "first	one		" "$(cat "$STATE/spool")"
+
+# 6. spooled event keeps its workspace
+reset
+HOME=$T CMUX_NOTIFY_DESKTOP=0 CMUX_NOTIFY_WORKSPACE=W-42 CMUX_FAKE_EXIT=1 \
+  bash "$SCRIPT" "r2" "b2" 2>/dev/null
+check "spool stores workspace" "r2	b2		W-42" "$(cat "$STATE/spool")"
+
+# 7. ws-replay: flush re-sends with the stored workspace (tab-collapse regression)
+reset
+mkdir -p "$STATE"; printf 'r2\tb2\t\tW-42\n' > "$STATE/spool"
+run --flush
+check "ws-replay uses stored workspace" "SOCK=none notify --workspace W-42 --title r2 --body b2" "$(cat "$T/relay.log")"
+
+# 8. flush drains in FIFO order
+reset
+mkdir -p "$STATE"; printf 'e1\tb1\t\t\ne2\tb2\t\t\n' > "$STATE/spool"
+run --flush
+check "flush FIFO order" "SOCK=none notify --title e1 --body b1
+SOCK=none notify --title e2 --body b2" "$(cat "$T/relay.log")"
+check "spool empty after flush" "" "$(cat "$STATE/spool" 2>/dev/null)"
+
+# 9. stale workspace falls back to untargeted once
+reset
+mkdir -p "$STATE"; printf 's\tb\t\tW-DEAD\n' > "$STATE/spool"
+run --flush
+check "stale ws retried untargeted" "SOCK=none notify --title s --body b" "$(cat "$T/relay.log")"
+check "stale ws not respooled" "" "$(cat "$STATE/spool" 2>/dev/null)"
+
+# 10. mid-flush failure respools remainder in order, unattempted
+reset
+mkdir -p "$STATE"; printf 'g1\tb1\t\t\nFAILME\tb2\t\t\ng2\tb3\t\t\n' > "$STATE/spool"
+run --flush
+check "mid-flush: head delivered" "SOCK=none notify --title g1 --body b1" "$(cat "$T/relay.log")"
+check "mid-flush: remainder respooled in order" "FAILME	b2		
+g2	b3		" "$(cat "$STATE/spool")"
+
+# 11. codex JSON body reduced to last-assistant-message
+reset
+run "codex" '{"type":"agent-turn-complete","last-assistant-message":"hello world"}'
+check "JSON body normalized" "SOCK=none notify --title codex --body hello world" "$(cat "$T/relay.log")"
+
+# 12. body collapsed to one line and capped at 160 (+"...")
+reset
+LONG=$(printf 'a%.0s' $(seq 1 200))
+run "cap" "$LONG"
+body=$(sed 's/.*--body //' "$T/relay.log")
+check "body capped at 160+ellipsis" "163" "${#body}"
+reset
+run "multi" "$(printf 'line1\nline2')"
+check "multiline collapsed" "SOCK=none notify --title multi --body line1 line2" "$(cat "$T/relay.log")"
+
+# 13. spool cap keeps newest MAX_SPOOL entries
+reset
+CMUX_NOTIFY_MAX_SPOOL=3; export CMUX_NOTIFY_MAX_SPOOL
+for i in 1 2 3 4 5; do CMUX_FAKE_EXIT=1 run "n$i" "x"; done
+check "spool capped at 3" "n4	x		
+n5	x		" "$(tail -2 "$STATE/spool")"
+check "spool has exactly 3 lines" "3" "$(wc -l < "$STATE/spool")"
+
+echo
+echo "pass=$PASS fail=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What changed

Adds `contrib/notifications/` — a self-contained notification pipeline that turns agent-manager's per-session status files (`waiting` / `working` / `finished` / `idle`) into correctly-routed notifications for users running agents under [cmux](https://github.com/manaflow-ai/cmux) (Ghostty-based macOS terminal), locally or over ssh, and for users at a Linux desktop.

Two components per platform, one integration point (the status files agent-manager already writes — no agent-specific configuration, covers every managed agent type):

- **Watcher** (`am-status-notify`): polls the status directory every 2s, fires on flips to `waiting`/`finished`, seeds silently on start, dedupes per session. Notification title is the session's name in agent-manager (read from `state.db` via python3 stdlib `sqlite3`, falling back to the raw id), body is `Waiting for your input` / `Finished` — mirroring cmux's native Claude Code notification shape. Lifecycle via systemd user unit (Linux) or launchd agent (macOS); `install.sh`/`uninstall.sh` for both.
- **Delivery module** (`cmux-notify`):
  - **macOS**: writes an OSC 777 escape to the agent-manager process's TTY (probed live via `ps`). cmux/libghostty raises it natively — pane ring, sidebar badge, notification panel, macOS banner — attributed to the correct workspace. Single channel; deliberately no `osascript` side channel (those banners are attributed to "Script Editor", can't focus the pane, and duplicate cmux's own).
  - **Linux**: `notify-send` to the freedesktop daemon (terminal-agnostic — works regardless of which terminal emulator agent-manager runs in), plus the cmux relay shim with explicit `--workspace` targeting for ssh workspaces, the workspace id read live from the agent-manager process environment per event.
  - Events spool to a TSV FIFO (cap 200) only when all channels fail, and replay in order; a stored target that died while queued gets one retry against the live-probed target.
- **Optional Codex per-turn pings** on Linux via codex's native `notify` hook pointing at the delivery module; payload JSON is normalized to `last-assistant-message`, one line, ≤160 chars.
- **Tests**: 18-check sandboxed interface suite for the Linux delivery module (targeting precedence, spool format, FIFO replay, stale-target retry, cap, body normalization).

Scope is deliberately narrow: macOS delivery targets cmux only (iTerm2/Terminal.app/Kitty speak different or no notification escapes); Linux desktop delivery is the terminal-agnostic daemon path, not per-terminal escapes; no per-agent wrappers — nothing reads agent internals beyond the status files.

## Why

cmux's CLI/relay path doesn't cover two shapes agent-manager users actually run: (1) agents on a remote host attached through a cmux *ssh workspace* — untargeted relay notifications land on whichever workspace is focused, and relay bindings go stale across reconnects; (2) a detached watcher on macOS can't use the cmux CLI at all (the local socket refuses processes not started inside cmux). The escape-sequence and explicit-targeting paths here solve both with mechanisms cmux/Ghostty and freedesktop already provide.

Closes #270

## How it was verified

- `tests/test-interface-linux.sh`: 18/18 pass on Ubuntu (sandboxed HOME, fake relay).
- Live matrix, all confirmed end-to-end: macOS cmux local workspace (notification attributed to the agent-manager workspace while another workspace was focused) · remote Ubuntu via cmux ssh workspace with explicit targeting (same focus test) · Ubuntu GNOME desktop banner · spool/replay across a disconnected interval.
- Independent review of the packaged scripts: PASS-WITH-NITS; both nits (install-time `$HOME` substitution, packaging note) addressed in this PR.
- Shell scripts are bash-3.2-compatible (macOS `/bin/bash`).
- Two upstream cmux quirks observed while verifying (documented in the package README; candidates for issues against manaflow-ai/cmux, not silently worked around): orphaned remote-relay workspace binding after reconnect → focus-follows attribution; local `cmux notify --workspace` from a non-cmux process appears to ignore the workspace argument.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] Ran it against real sessions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cross-platform Agent Manager notifications for Linux and macOS.
  - Alerts now appear when sessions enter `waiting` or `finished` states.
  - Added workspace-aware delivery through cmux and desktop notification channels.
  - Added queued delivery with retries and fallback handling when destinations are unavailable.
  - Added installation and uninstall scripts for both platforms, with automatic background service setup.

- **Documentation**
  - Added setup, usage, compatibility, state-management, and troubleshooting guidance.

- **Tests**
  - Added coverage for targeted delivery, queue replay, fallback behavior, formatting, and storage limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->