### PR TITLE
docs: require the CodeRabbit round before maintainer review, link the docs site

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -73,6 +73,8 @@ Two clauses are worth knowing as a contributor. Section 3 licenses the patent cl
 
 ## Review
 
+CodeRabbit reviews every pull request automatically, usually within minutes. Work through its findings first: fix what it got right, and reply on the comment when you disagree, so the thread records why. Maintainer review starts once the CodeRabbit round is handled; a PR with open, unanswered findings waits.
+
 @YoanWai reviews and merges everything (see [CODEOWNERS](CODEOWNERS)). Expect a first response within a few days.
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The tools you use alongside agents live in the same list: `T` opens a plain shel
 
 Not here yet: cost tracking, mouse-driven navigation, and agents that can talk to each other.
 
-**Jump to:** [Install](#install) · [Usage](#usage) · [Keys](docs/usage.md#keys) · [Diff review](docs/usage.md#diff-review) · [Configuration](docs/configuration.md)
+**Jump to:** [Install](#install) · [Usage](#usage) · [Keys](docs/usage.md#keys) · [Diff review](docs/usage.md#diff-review) · [Configuration](docs/configuration.md) · [Docs site](https://agent-manager.dev/docs/)
 
 ## Supported tools
 


### PR DESCRIPTION
## What changed

- CONTRIBUTING's Review section now sets the order: CodeRabbit's automatic review comes first, contributors resolve or answer its findings, and maintainer review starts once that round is handled.
- The README's jump line links the hosted docs site at https://agent-manager.dev/docs/ beside the in-repo references.

## Why

Recent PRs showed the pattern working well when contributors drive the CodeRabbit round themselves; writing it down makes the expectation visible before the first review. The docs site existed with no path to it from the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance explaining the automated pull request review process and how contributors should handle review findings.
  - Added a direct link to the documentation website in the project README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->