### PR TITLE
fix(ui): open the diff review with ctrl+r from focus mode

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -70,6 +70,9 @@ type diffState struct {
 
 	// Set when review opened from inside a session; leaving re-attaches it.
 	reattachID string
+
+	// Set when review opened from focus mode; leaving focuses again.
+	refocus bool
 }
 
 type diffLoadedMsg struct {
@@ -815,6 +818,8 @@ func (m *Model) handleDiffKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) closeDiff() tea.Cmd {
 	reattachID := m.diff.reattachID
+	refocus := m.diff.refocus
+	m.diff.refocus = false
 	m.mode = modeList
 	m.diff.active = false
 	m.diff.gen++
@@ -838,6 +843,10 @@ func (m *Model) closeDiff() tea.Cmd {
 	m.diff.reattachID = ""
 	if reattachID != "" {
 		return m.reattach(reattachID, m.diff.gen)
+	}
+	if refocus {
+		_, cmd := m.focusSelected()
+		return cmd
 	}
 	return nil
 }

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -196,9 +196,9 @@ func (m *Model) leaveFocus() tea.Cmd {
 }
 
 // handleFocusKey forwards every key into the focused pane. Ctrl+Q and
-// ctrl+\ are the reserved keys: they return to the list, mirroring detach
-// from a real attach, and every plain character - q included - reaches
-// the agent.
+// ctrl+\ return to the list and Ctrl+R opens the review, mirroring the
+// bindings a real attach gets, and every plain character - q included -
+// reaches the agent.
 func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.String() == "ctrl+q" || msg.String() == `ctrl+\` {
 		return m, m.leaveFocus()
@@ -206,6 +206,17 @@ func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	sess, ok := m.selected()
 	if !ok {
 		return m, m.leaveFocus()
+	}
+	// Ctrl+R opens the review, matching the binding a real attach gets;
+	// closing it focuses the session again rather than landing in the list.
+	if msg.String() == "ctrl+r" {
+		m.sel = focusSelection{}
+		m.copied = 0
+		cmd := m.openDiff()
+		if m.mode == modeDiff {
+			m.diff.refocus = true
+		}
+		return m, cmd
 	}
 	if msg.Type == tea.KeyLeft && !msg.Alt && m.arrowStep && m.caretAtInputStart(sess.ID, sess.Tool) {
 		return m, m.leaveFocus()

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -313,6 +313,37 @@ func TestFocusModeExitsWhenSessionDies(t *testing.T) {
 	}
 }
 
+// Ctrl+R while focused opens the review instead of reaching the pane, and
+// closing the review lands back in focus rather than the list.
+func TestFocusCtrlROpensReviewAndReturns(t *testing.T) {
+	m := buildModel(t)
+	dir := gitTestRepo(t)
+	createSession(t, m, "focusrev", dir, "")
+	m.selectSessionRow(t, "focusrev")
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+	if m.mode != modeFocus {
+		t.Fatalf("after enter, mode = %v, err = %q", m.mode, m.errBar.text)
+	}
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlR})
+	*m = *updated.(*Model)
+	m.drainCmds(t, cmd)
+	if m.mode != modeDiff || !m.diff.active {
+		t.Fatalf("ctrl+r in focus should open review, mode = %v, err = %q", m.mode, m.errBar.text)
+	}
+	if len(m.diff.set.Files) == 0 {
+		t.Fatalf("review opened empty, err = %q", m.diff.errText)
+	}
+
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	*m = *updated.(*Model)
+	if m.mode != modeFocus {
+		t.Fatalf("closing review should return to focus, mode = %v, err = %q", m.mode, m.errBar.text)
+	}
+}
+
 // Leaving focus must keep mouse reporting: handing it back would let a
 // wheel notch scroll the manager out of view from the list.
 func TestFocusExitKeepsMouse(t *testing.T) {

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -656,7 +656,7 @@ func (m *Model) contentLines(width, height int) []contentLine {
 // focusTopRule is the hairline that caps the focused pane, titled so the
 // mode names itself where the eye already is.
 func focusTopRule(width int) string {
-	title := " focused · ctrl+q back "
+	title := " focused · ctrl+q back · ctrl+r review "
 	rule := annotationStyle.Render(title)
 	rest := width - lipgloss.Width(title)
 	if rest > 0 {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -458,6 +458,7 @@ func (m *Model) viewFooter() string {
 		return legendBar([]legendSection{{title: "Focused", pairs: [][2]string{
 			{"typing", "goes to the agent"},
 			{"ctrl+q / ctrl+\\", "back to manager"},
+			{"ctrl+r", "review"},
 			{"drag / double / triple click", "copy"},
 		}}}, m.width)
 	}


### PR DESCRIPTION
## Problem

Focused a session, ctrl+r did nothing: the review never opened. Focus mode forwards every key into the pane with `send-keys`, which bypasses the tmux client binding that serves ctrl+r on a real attach. The help screen already listed ctrl+r as working while focused, and the focus footer never named the key at all.

## Fix

- `handleFocusKey` intercepts ctrl+r and opens the review directly.
- Closing the review returns to focus (new `diff.refocus` flag), the way the in-session ctrl+r path re-attaches (`diff.reattachID`). The list stays the destination for a review opened from the list.
- The focus footer and the pane's top hairline now name the key: `focused · ctrl+q back · ctrl+r review`.

## Tests

`TestFocusCtrlROpensReviewAndReturns`: focus a session in a git repo, ctrl+r opens the review with files loaded, esc lands back in focus. Fails before the fix, passes after. Full suite green with `-race` on an isolated tmux socket; `gofmt` and `go vet` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `Ctrl+R` shortcut to open the review view from focus mode.
  * Returning from the review view now restores focus to the active session.
  * Added visible `Ctrl+R review` guidance to focus-mode interfaces.

* **Bug Fixes**
  * Closing a review opened from focus mode now returns to the previously selected item instead of the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->