### PR TITLE
feat(ui): label every filter over the sessions list instead of in the header

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -186,7 +186,7 @@ Each session's tmux pane is polled (default every 2s) to derive a status:
 | `idle` | Nothing running |
 | `dead` | The tmux session is gone |
 
-`w` narrows the list to sessions that need attention (`waiting`, `finished`, `errored`). Press again to show every status. The header badge and session counts follow the filter; folds open so matches are not hidden.
+`w` narrows the list to sessions that need attention (`waiting`, `finished`, `errored`). Press again to show every status. An `ATTENTION` badge sits over the list with the key that clears it, and the session counts follow the filter; folds open so matches are not hidden. The archived view (`t`) and hidden empty groups (`e`) label themselves the same way, so the list always names every filter it is under.
 
 ![the session tree, with a waiting agent's permission prompt in the preview](screenshot-sessions.png)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -186,7 +186,7 @@ Each session's tmux pane is polled (default every 2s) to derive a status:
 | `idle` | Nothing running |
 | `dead` | The tmux session is gone |
 
-`w` narrows the list to sessions that need attention (`waiting`, `finished`, `errored`). Press again to show every status. An `ATTENTION` badge sits over the list with the key that clears it, and the session counts follow the filter; folds open so matches are not hidden. The archived view (`t`) and hidden empty groups (`e`) label themselves the same way, so the list always names every filter it is under.
+`w` narrows the list to sessions that need attention (`waiting`, `finished`, `errored`). Press again to show every status. An `ATTENTION` badge sits over the list with the key that clears it, and the session counts follow the filter; folds open so matches are not hidden. The archived view (`t`) and hidden empty groups (`e`) label themselves the same way. The badges take whatever room the rail has: padded away from the entries on a tall terminal, tight against them on a short one, and yielding to the entries once the list is down to its last rows.
 
 ![the session tree, with a waiting agent's permission prompt in the preview](screenshot-sessions.png)
 

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -130,9 +130,9 @@ func (m *Model) railLines(width, height int) []contentLine {
 		listHeight, meters = height, nil
 	}
 	var rows []contentLine
-	// Both banners cost the list three rows each, so each one is only laid
-	// while entries still have room under it: a rail that is all banner
-	// says nothing about the fleet.
+	// A banner costs the list the rows it paints plus its padding, so each one
+	// is only laid while entries still have room under it: a rail that is all
+	// banner says nothing about the fleet.
 	const railBannerRows, railListMin = 3, 3
 	// Half the list at most, so the tree the block sits under keeps enough
 	// rows to still read as a tree.
@@ -152,13 +152,23 @@ func (m *Model) railLines(width, height int) []contentLine {
 		}
 	}
 	// The list starts straight under the pane's top edge; the empty state
-	// centers itself in the full list area instead.
-	if m.showArchived && room(railBannerRows) {
-		rows = append(rows, contentLine{})
-		rows = append(rows,
-			contentLine{text: strings.Repeat(" ", railInset) + scopeBadgeStyle.Render("ARCHIVED") +
-				subtleStyle.Render("  ") + keyCap("t", "back to active")},
-			contentLine{})
+	// centers itself in the full list area instead. Every filter the rail is
+	// under gets a badge here, since a narrowed list cannot show what it is
+	// leaving out. A rail too tight for the padded block keeps the bare
+	// badges, the way the search field does.
+	if badges := m.filterBadgeLines(); len(badges) > 0 {
+		lines := make([]contentLine, 0, len(badges))
+		for _, badge := range badges {
+			lines = append(lines, contentLine{text: badge})
+		}
+		switch {
+		case room(len(lines) + 2):
+			rows = append(rows, contentLine{})
+			rows = append(rows, lines...)
+			rows = append(rows, contentLine{})
+		case room(len(lines)):
+			rows = append(rows, lines...)
+		}
 	}
 	rows = append(rows, m.entryLines(m.treeRows(), 0, width, max(listHeight-len(rows), 0))...)
 	for len(rows) < listHeight {
@@ -173,6 +183,28 @@ func (m *Model) railLines(width, height int) []contentLine {
 		}
 	}
 	return rows
+}
+
+// filterBadgeLines is one badge per narrowing the rail is under, each next
+// to the key that lifts it. Ordered widest to narrowest: the archive is a
+// different fleet, the status filter hides sessions, hiding empty groups
+// only hides scaffolding.
+func (m *Model) filterBadgeLines() []string {
+	var lines []string
+	badge := func(label, key, action string) {
+		lines = append(lines, strings.Repeat(" ", railInset)+scopeBadgeStyle.Render(label)+
+			subtleStyle.Render("  ")+keyCap(key, action))
+	}
+	if m.showArchived {
+		badge("ARCHIVED", "t", "back to active")
+	}
+	if m.statusFilter.active() {
+		badge(strings.ToUpper(m.statusFilter.label()), "w", "show all")
+	}
+	if m.hideEmptyGroups {
+		badge("HIDE EMPTY", "e", "show empty")
+	}
+	return lines
 }
 
 // entryLines renders the visible slice of rows, which sit at offset in
@@ -1034,11 +1066,7 @@ func (m *Model) headerScope() string {
 	}
 	scope := subtleStyle.Render(" · active")
 	if m.showArchived {
-		scope = subtleStyle.Render(" · ") + scopeBadgeStyle.Render("ARCHIVED")
-	}
-	if m.statusFilter.active() {
-		scope += subtleStyle.Render(" · ") +
-			scopeBadgeStyle.Render(strings.ToUpper(m.statusFilter.label()))
+		scope = subtleStyle.Render(" · archived")
 	}
 	return valueStyle.Render(fmt.Sprintf("%d", count)) + subtleStyle.Render(label) + scope
 }

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -655,16 +655,32 @@ func TestFilterBadgesStackOverTheList(t *testing.T) {
 	m.showArchived, m.hideEmptyGroups = true, true
 	m.statusFilter = statusFilterAttention
 	rail := ansi.Strip(railLinesText(m.railLines(36, m.listBodyHeight())))
-	for _, want := range []string{
-		"ARCHIVED", "back to active",
-		"ATTENTION", "show all",
-		"HIDE EMPTY", "show empty",
-	} {
-		if !strings.Contains(rail, want) {
-			t.Errorf("rail missing %q:\n%s", want, rail)
+	var painted []string
+	for _, line := range strings.Split(rail, "\n") {
+		if strings.TrimSpace(line) != "" {
+			painted = append(painted, line)
+		}
+	}
+	// The badges are what the rail paints first, one filter per line with the
+	// key beside it, widest narrowing on top.
+	want := [][2]string{
+		{"ARCHIVED", "t back to active"},
+		{"ATTENTION", "w show all"},
+		{"HIDE EMPTY", "e show empty"},
+	}
+	if len(painted) < len(want) {
+		t.Fatalf("rail painted %d lines, want the %d badges first:\n%s", len(painted), len(want), rail)
+	}
+	for i, badge := range want {
+		line := painted[i]
+		if !strings.Contains(line, badge[0]) || !strings.Contains(line, badge[1]) {
+			t.Errorf("rail line %d = %q, want %q beside %q", i, line, badge[0], badge[1])
 		}
 	}
 	header := ansi.Strip(strings.Join(m.viewHeaderRows(), "\n"))
+	if !strings.Contains(header, "· archived") {
+		t.Errorf("header should keep the plain scope word:\n%s", header)
+	}
 	for _, unwanted := range []string{"ARCHIVED", "ATTENTION", "HIDE EMPTY"} {
 		if strings.Contains(header, unwanted) {
 			t.Errorf("header still carries the %s badge:\n%s", unwanted, header)

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -646,3 +646,28 @@ func gitRepoWithManyFiles(t *testing.T, n int) string {
 	}
 	return dir
 }
+
+// Every filter the list is under names itself over the list, beside the key
+// that lifts it, and the header stops repeating them.
+func TestFilterBadgesStackOverTheList(t *testing.T) {
+	m := shotModel()
+	m.width, m.height = 120, 40
+	m.showArchived, m.hideEmptyGroups = true, true
+	m.statusFilter = statusFilterAttention
+	rail := ansi.Strip(railLinesText(m.railLines(36, m.listBodyHeight())))
+	for _, want := range []string{
+		"ARCHIVED", "back to active",
+		"ATTENTION", "show all",
+		"HIDE EMPTY", "show empty",
+	} {
+		if !strings.Contains(rail, want) {
+			t.Errorf("rail missing %q:\n%s", want, rail)
+		}
+	}
+	header := ansi.Strip(strings.Join(m.viewHeaderRows(), "\n"))
+	for _, unwanted := range []string{"ARCHIVED", "ATTENTION", "HIDE EMPTY"} {
+		if strings.Contains(header, unwanted) {
+			t.Errorf("header still carries the %s badge:\n%s", unwanted, header)
+		}
+	}
+}

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -661,8 +661,6 @@ func TestFilterBadgesStackOverTheList(t *testing.T) {
 			painted = append(painted, line)
 		}
 	}
-	// The badges are what the rail paints first, one filter per line with the
-	// key beside it, widest narrowing on top.
 	want := [][2]string{
 		{"ARCHIVED", "t back to active"},
 		{"ATTENTION", "w show all"},

--- a/internal/ui/railfit_test.go
+++ b/internal/ui/railfit_test.go
@@ -44,6 +44,20 @@ func TestRailBannersLeaveRoomForEntries(t *testing.T) {
 	}
 }
 
+// A rail too short for the padded block keeps the badges themselves; only a
+// rail with no room for entries under them drops them altogether.
+func TestFilterBadgesSurviveShortRails(t *testing.T) {
+	for _, height := range []int{10, 14, 20} {
+		m := shotModel()
+		m.width, m.height = 120, height
+		m.showArchived = true
+		rail := ansi.Strip(railLinesText(m.railLines(36, m.listBodyHeight())))
+		if !strings.Contains(rail, "ARCHIVED") {
+			t.Errorf("height %d dropped the archived badge:\n%s", height, rail)
+		}
+	}
+}
+
 func railLinesText(lines []contentLine) string {
 	var b strings.Builder
 	for _, line := range lines {

--- a/internal/ui/statusfilter_test.go
+++ b/internal/ui/statusfilter_test.go
@@ -78,9 +78,17 @@ func TestStatusFilterKeyKeepsAttentionSessions(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Fatalf("attention list = %v want %v", got, want)
 	}
+	m.width, m.height = 120, 34
+	rail := ansi.Strip(railLinesText(m.railLines(36, m.listBodyHeight())))
+	if !strings.Contains(rail, "ATTENTION") {
+		t.Fatalf("rail missing ATTENTION badge:\n%s", rail)
+	}
+	if !strings.Contains(rail, "show all") {
+		t.Fatalf("rail badge should offer clearing the filter:\n%s", rail)
+	}
 	header := ansi.Strip(strings.Join(m.viewHeaderRows(), "\n"))
-	if !strings.Contains(header, "ATTENTION") {
-		t.Fatalf("header missing ATTENTION badge:\n%s", header)
+	if strings.Contains(header, "ATTENTION") {
+		t.Fatalf("filter badges belong over the list, not in the header:\n%s", header)
 	}
 	if !strings.Contains(header, "3 agents") {
 		t.Fatalf("header count should match the listed agents:\n%s", header)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -527,8 +527,7 @@ func (m *Model) viewLegend() legendSection {
 		foldAllAction = "unfold all"
 	}
 	// Ordered by what a narrow terminal must keep: moving around, making
-	// something, the filters whose state only the footer reports, then the
-	// keys a user already knows to look for.
+	// something, the filters, then the keys a user already knows to look for.
 	return legendSection{title: "View", quiet: true, pairs: [][2]string{
 		{"↑↓/jk", "navigate"}, {"n", "new"}, {"T", "terminal"}, {"g", "group"}, {"/", "search"},
 		{"t", archivedAction}, {"w", statusFilterAction}, {"e", emptyGroupsAction},


### PR DESCRIPTION
The archive named itself twice, once as a header badge and once over the list, while the attention filter showed only in the header and hidden empty groups showed nowhere at all. A filter narrows the list, so the list is where it belongs.

Every active filter now paints a badge over the entries, next to the key that lifts it:

```
  ARCHIVED   t back to active
  ATTENTION   w show all
  HIDE EMPTY   e show empty

   root                 ● 1
 ● Anna  finished · grok · 8d ago
```

The header keeps the count and a plain scope word (`6 agents · archived`), and the badges follow the rail's existing fit rules: padded block when there is room, bare badges on a tighter rail, dropped only when entries would have no room left under them.

Verified in the running TUI on an isolated tmux socket at 200 and 90 columns, with each filter alone and all three together; `gofmt`, `go vet` and `go test ./...` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Filter indicators for archived items, attention status, and hidden empty groups now appear together in the navigation rail.
  * Filter badges adapt to available space and remain visible on shorter layouts.
  * Reset and “show all” actions are displayed directly with the relevant filter badges.
  * Filter badges no longer repeat in the list header, keeping the interface clearer.

* **Documentation**
  * Updated status-filter guidance to explain how badges, archived views, counts, and list contents reflect active filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->