### PR TITLE
test: anchor the tmux test servers so they survive between tests

### DIFF
--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -16,8 +16,13 @@ import (
 const testSocket = "amtmuxtest"
 
 // TestMain kills any leftover test server so each run starts and ends clean.
+// The anchor session then holds the server up for the whole run: tests kill
+// their sessions in cleanup, and a server whose last session dies begins an
+// exit-empty shutdown that takes the next test's fresh session down with it
+// ("server exited unexpectedly").
 func TestMain(m *testing.M) {
 	tmuxCmd("kill-server").Run()
+	tmuxCmd("new-session", "-d", "-s", "anchor").Run()
 	code := m.Run()
 	tmuxCmd("kill-server").Run()
 	os.Exit(code)

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -21,8 +22,17 @@ const testSocket = "amtmuxtest"
 // exit-empty shutdown that takes the next test's fresh session down with it
 // ("server exited unexpectedly").
 func TestMain(m *testing.M) {
+	// kill-server fails whenever no server is up, which is the normal case.
 	tmuxCmd("kill-server").Run()
-	tmuxCmd("new-session", "-d", "-s", "anchor").Run()
+	// Without tmux the run still starts: each test skips through its own
+	// requireTmux. With tmux, a run that could not plant the anchor would
+	// pass or flake on luck, so it stops instead.
+	if _, err := exec.LookPath("tmux"); err == nil {
+		if out, err := tmuxCmd("new-session", "-d", "-s", "anchor").CombinedOutput(); err != nil {
+			fmt.Fprintf(os.Stderr, "anchor session: %v: %s\n", err, out)
+			os.Exit(1)
+		}
+	}
 	code := m.Run()
 	tmuxCmd("kill-server").Run()
 	os.Exit(code)

--- a/internal/ui/main_test.go
+++ b/internal/ui/main_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -18,8 +19,17 @@ const testSocket = "amuitest"
 // ("server exited unexpectedly", the recurring CI failure in
 // TestFocusWatchReportsCursor).
 func TestMain(m *testing.M) {
+	// kill-server fails whenever no server is up, which is the normal case.
 	tmuxCmd("kill-server").Run()
-	tmuxCmd("new-session", "-d", "-s", "anchor").Run()
+	// Without tmux the run still starts: each test skips through its own
+	// requireTmux. With tmux, a run that could not plant the anchor would
+	// pass or flake on luck, so it stops instead.
+	if _, err := exec.LookPath("tmux"); err == nil {
+		if out, err := tmuxCmd("new-session", "-d", "-s", "anchor").CombinedOutput(); err != nil {
+			fmt.Fprintf(os.Stderr, "anchor session: %v: %s\n", err, out)
+			os.Exit(1)
+		}
+	}
 	code := m.Run()
 	tmuxCmd("kill-server").Run()
 	os.Exit(code)

--- a/internal/ui/main_test.go
+++ b/internal/ui/main_test.go
@@ -12,8 +12,14 @@ import (
 const testSocket = "amuitest"
 
 // TestMain kills any leftover test server so each run starts and ends clean.
+// The anchor session then holds the server up for the whole run: tests kill
+// their sessions in cleanup, and a server whose last session dies begins an
+// exit-empty shutdown that takes the next test's fresh session down with it
+// ("server exited unexpectedly", the recurring CI failure in
+// TestFocusWatchReportsCursor).
 func TestMain(m *testing.M) {
 	tmuxCmd("kill-server").Run()
+	tmuxCmd("new-session", "-d", "-s", "anchor").Run()
 	code := m.Run()
 	tmuxCmd("kill-server").Run()
 	os.Exit(code)


### PR DESCRIPTION
`TestFocusWatchReportsCursor` has failed four CI runs since August 1 (Aug 1, 2, 4, and PR 280's first run), always the same way: `tmux load-buffer ...: exit status 1: server exited unexpectedly`.

The mechanism is the one 3675f4a first diagnosed. Every test kills its tmux sessions in cleanup, and a server whose last session dies begins an exit-empty shutdown. A fresh session created on that socket inside the shutdown window lands on the dying server and goes down with it, so the next command on the new session reports `server exited unexpectedly`. 3675f4a isolated one source of dying servers (the backoff test's transient one), but every kill-last-session boundary on the shared socket still bounces the server, and `ReportsCursor` sits right after such a boundary. A PID check shows the bounce directly, even on a fast machine where the failure window is too narrow to hit:

```
-- without anchor --
pid before=54097 after=54250 bounced=yes
-- with anchor --
pid before=54275 after=54275 bounced=no
```

The fix: `TestMain` in both tmux-driving packages (`internal/ui`, `internal/tmux`) creates an `anchor` session right after the initial kill-server. The server always holds at least one session, so the shutdown window never opens; the final kill-server still tears everything down. Session names the driver uses all carry the `am_` prefix, so the anchor is invisible to every existing test.

Both suites pass on an isolated socket, and the full `go test ./...` is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment stability by keeping the terminal session available while individual tests run.
  * Ensured test cleanup continues to remove temporary sessions and shut down the test environment afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->