### PR TITLE
feat(mcp): let agents operate managed terminals

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -131,7 +131,24 @@ Agents usually work in git worktrees, one branch per worktree, and those worktre
 
 ## MCP: how agents discover these commands
 
-Every session the manager spawns or revives carries the agent-manager MCP server, so MCP-capable agents see `rename`, `review_repo`, `review_base` and `review_mode` (which sets the diff scope review opens on) as native tools with descriptions telling them when to call each: no prompt injection, no per-project setup. The server lives in the same binary (`agent-manager mcp`, stdio) and identifies the calling session through its environment.
+Every session the manager spawns or revives carries the agent-manager MCP server, so MCP-capable agents see its session and terminal operations as native tools with descriptions telling them when to call each: no prompt injection, no per-project setup. The server lives in the same binary (`agent-manager mcp`, stdio) and identifies the calling session through its environment.
+
+| Tool | Action |
+|------|--------|
+| `rename` | Rename the calling session |
+| `review_repo` | Declare the repo or worktree under review |
+| `review_base` | Declare or clear the review base ref |
+| `review_mode` | Select the diff scope review opens with |
+| `list_terminals` | List active managed terminals and their current directories |
+| `create_terminal` | Open a terminal beside the calling agent, or in an explicit group or directory |
+| `send_terminal` | Submit a command or send exact keys to a running terminal |
+| `read_terminal` | Read the plain-text content currently visible in a terminal |
+
+`create_terminal` defaults to the calling agent's group and live pane directory. An explicit group uses that group's nearest inherited default path; an explicit directory wins over both. `send_terminal` accepts exactly one of a command, which is pasted and submitted with Enter, or a sequence of tmux key names such as `C-c`, `Up`, and `Enter`. `read_terminal` returns the current screen rather than unlimited scrollback.
+
+The server's MCP initialization instructions teach agents to use this workflow without waiting for an explicit request: list and reuse a terminal before long-running, output-heavy or continuously monitored work; create one only when needed; send the command; then read its screen until the result is clear. The same guidance is repeated in the individual tool descriptions for clients that expose tools but not server instructions. Short one-shot commands stay in the agent's normal execution path when a separate persistent terminal adds no value.
+
+Sending a command to a terminal executes it on the user's machine. Agents should treat `send_terminal` with the same care as typing into an attached shell: inspect the target returned by `list_terminals`, avoid destructive commands unless the user asked for them, and read the result before continuing.
 
 Registration is per tool. Claude gets a generated `--mcp-config` file. Codex gets `-c mcp_servers...` overrides. OpenCode gets an `OPENCODE_CONFIG` merge file. Grok and Gemini each get a one-time `mcp add --scope user` entry on their first launch.
 
@@ -218,4 +235,3 @@ The Computer block in the sessions panel shows machine gauges:
 Fifteen palettes ship. Nine dark: `classic`, `solarized dark`, `catppuccin mocha`, `tokyo night`, `gruvbox dark`, `nord`, `dracula`, `rosé pine`, and `monochrome`. Six light: `solarized light`, `catppuccin latte`, `tokyo night day`, `gruvbox light`, `rosé pine dawn`, and `paper`. The swatch strip beside the name previews the palette, and the theme applies as you step through it, so the picker is a live preview of the whole UI. The manager also matches the terminal's own background to the palette, so the window has no seam against it, and restores the terminal's background on exit. Your pick is saved with the rest of the state and restored on the next run.
 
 **theme follows OS** resolves the palette at startup from the environment's light/dark preference: the OS setting on macOS and Linux desktops, and the terminal's own background elsewhere, including over SSH. A theme already on the detected side stays; only a mismatch switches, to `classic` or `solarized light`. Your manual pick is kept separately, so turning the toggle off returns to it, and stepping the theme picker by hand turns the toggle off. Agent panes render on the theme's own backdrop, and the pane declares that background to the agent inside it, so an agent that auto-detects its palette resolves to the same side the manager is drawing. A session already running keeps the palette it resolved at launch until it is restarted.
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,10 +94,18 @@ func Path() (string, error) {
 }
 
 func Load() (Config, error) {
-	path, err := Path()
+	dir, err := Dir()
 	if err != nil {
 		return Config{}, err
 	}
+	return LoadDir(dir)
+}
+
+// LoadDir loads the configuration kept in dir. Session-scoped commands
+// already receive the manager's config directory, so they must not resolve
+// it again from a possibly different process environment.
+func LoadDir(dir string) (Config, error) {
+	path := filepath.Join(dir, "config.toml")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		if err := writeDefault(path); err != nil {
 			return Config{}, err
@@ -207,6 +215,21 @@ func (c Config) ToolNames() []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+// ShellTool returns the first shell block by name, making the choice stable
+// when a user configures more than one.
+func (c Config) ShellTool() (string, Tool, bool) {
+	chosen := ""
+	for name, tool := range c.Tools {
+		if tool.Shell && (chosen == "" || name < chosen) {
+			chosen = name
+		}
+	}
+	if chosen == "" {
+		return "", Tool{}, false
+	}
+	return chosen, c.Tools[chosen], true
 }
 
 func writeDefault(path string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -102,6 +103,32 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	}
 	if got := cfg.Tools["gemini"].SessionStore; got != "gemini" {
 		t.Fatalf("gemini session_store = %q want \"gemini\" (captures the fork's minted id)", got)
+	}
+}
+
+func TestLoadDirWritesDefaultInRequestedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if _, ok := cfg.Tools["terminal"]; !ok {
+		t.Fatal("default terminal tool is missing")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.toml")); err != nil {
+		t.Fatalf("config file: %v", err)
+	}
+}
+
+func TestShellToolUsesFlagAndStableName(t *testing.T) {
+	cfg := Config{Tools: map[string]Tool{
+		"terminal": {Command: "agent", Shell: false},
+		"zsh":      {Command: "zsh", Shell: true},
+		"bash":     {Command: "bash", Shell: true},
+	}}
+	name, tool, ok := cfg.ShellTool()
+	if !ok || name != "bash" || tool.Command != "bash" {
+		t.Fatalf("ShellTool = %q %+v %v, want bash", name, tool, ok)
 	}
 }
 

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -7,6 +7,7 @@ package mcpserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -31,10 +32,56 @@ type reviewModeArgs struct {
 	Scope string `json:"scope" jsonschema:"diff scope: uncommitted, branch (vs target), last_commit, or staged"`
 }
 
+type listTerminalsArgs struct{}
+
+type createTerminalArgs struct {
+	Group     *string `json:"group,omitempty" jsonschema:"existing group path for the new terminal; pass an empty string for the root group; defaults to this agent's group"`
+	Directory string  `json:"directory,omitempty" jsonschema:"existing directory to open; defaults to the selected group's inherited path, then this agent's current directory"`
+}
+
+type sendTerminalArgs struct {
+	TerminalID string   `json:"terminal_id" jsonschema:"terminal id returned by list_terminals or create_terminal"`
+	Command    string   `json:"command,omitempty" jsonschema:"command text to paste and submit with Enter; provide exactly one of command or keys"`
+	Keys       []string `json:"keys,omitempty" jsonschema:"exact tmux key names to send in order, such as C-c, Up, or Enter; provide exactly one of keys or command"`
+}
+
+type readTerminalArgs struct {
+	TerminalID string `json:"terminal_id" jsonschema:"terminal id returned by list_terminals or create_terminal"`
+}
+
+type listTerminalsOutput struct {
+	Terminals []sessioncmd.Terminal `json:"terminals"`
+}
+
+type sendTerminalOutput struct {
+	TerminalID string `json:"terminal_id"`
+	Sent       string `json:"sent" jsonschema:"input kind sent: command or keys"`
+}
+
+type terminalCommands interface {
+	List(sessionID string) ([]sessioncmd.Terminal, error)
+	Create(sessionID string, opts sessioncmd.CreateTerminalOptions) (sessioncmd.Terminal, error)
+	Send(sessionID, terminalID, command string, keys []string) error
+	Read(sessionID, terminalID string) (sessioncmd.TerminalScreen, error)
+}
+
+const serverInstructions = `Use Agent Manager's terminal tools proactively for task-related shell work that should remain visible, persistent, or run alongside the conversation. Do not wait for the user to ask when these conditions apply.
+
+Before starting a long-running, output-heavy, or continuously monitored command such as a test suite, build, development server, or log tail, call list_terminals. Reuse a relevant running terminal when possible; otherwise call create_terminal in the current group and directory. Use send_terminal to submit the command, then call read_terminal to inspect its screen. Read again as needed while the command is running, and use send_terminal keys for interactive input or interruption.
+
+Do not create a new terminal for every short one-shot command when persistence or separate visibility adds no value. Sending a terminal command executes on the user's machine and follows the same safety and approval expectations as normal shell execution.`
+
 // NewServer builds the MCP server with every session tool registered.
 // Split from Run so tests can connect an in-process client.
 func NewServer(configDir, sessionID, version string) *mcp.Server {
-	server := mcp.NewServer(&mcp.Implementation{Name: "agent-manager", Version: version}, nil)
+	return newServer(configDir, sessionID, version, sessioncmd.NewTerminals(configDir))
+}
+
+func newServer(configDir, sessionID, version string, terminals terminalCommands) *mcp.Server {
+	server := mcp.NewServer(
+		&mcp.Implementation{Name: "agent-manager", Version: version},
+		&mcp.ServerOptions{Instructions: serverInstructions},
+	)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "rename",
@@ -83,7 +130,106 @@ func NewServer(configDir, sessionID, version string) *mcp.Server {
 		return textResult(sessioncmd.ReviewScope(configDir, sessionID, args.Scope))
 	})
 
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "list_terminals",
+		Description: "Call proactively before long-running, output-heavy, persistent, or parallel shell work to find a terminal you can reuse. " +
+			"Lists active managed terminals with ids, names, groups, current directories, statuses, and whether their tmux panes are running. " +
+			"Reuse a relevant running terminal when possible; otherwise call create_terminal. Use the returned id with send_terminal and read_terminal.",
+		Annotations: terminalToolAnnotations(true, false, false),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args listTerminalsArgs) (*mcp.CallToolResult, listTerminalsOutput, error) {
+		listed, err := terminals.List(sessionID)
+		if err != nil {
+			return nil, listTerminalsOutput{}, err
+		}
+		output := listTerminalsOutput{Terminals: listed}
+		return textContent(formatTerminalList(listed)), output, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "create_terminal",
+		Description: "After list_terminals finds no relevant running terminal, call this without waiting for the user to create one for long-running, output-heavy, persistent, or parallel shell work. " +
+			"Returns its id and opens by default in this agent's group and current directory. Set group to use another existing group and its inherited directory, or set directory explicitly. " +
+			"Then call send_terminal with the returned id.",
+		Annotations: terminalToolAnnotations(false, false, false),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args createTerminalArgs) (*mcp.CallToolResult, sessioncmd.Terminal, error) {
+		created, err := terminals.Create(sessionID, sessioncmd.CreateTerminalOptions{
+			Group:     args.Group,
+			Directory: args.Directory,
+		})
+		if err != nil {
+			return nil, sessioncmd.Terminal{}, err
+		}
+		return textContent("created " + formatTerminal(created)), created, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "send_terminal",
+		Description: "Call after list_terminals or create_terminal to run or control work in a managed terminal, keeping it visible and separate from the conversation. Provide exactly one of command or keys. " +
+			"A command is pasted and submitted with Enter, so it executes on the user's machine. " +
+			"Keys sends exact tmux key names for interactive control, such as [\"C-c\"] or [\"Up\", \"Enter\"]. Call read_terminal after sending to inspect the result.",
+		Annotations: terminalToolAnnotations(false, true, true),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args sendTerminalArgs) (*mcp.CallToolResult, sendTerminalOutput, error) {
+		if err := terminals.Send(sessionID, args.TerminalID, args.Command, args.Keys); err != nil {
+			return nil, sendTerminalOutput{}, err
+		}
+		sent := "keys"
+		if strings.TrimSpace(args.Command) != "" {
+			sent = "command"
+		}
+		output := sendTerminalOutput{TerminalID: args.TerminalID, Sent: sent}
+		return textContent(fmt.Sprintf("sent %s to terminal %s", sent, args.TerminalID)), output, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "read_terminal",
+		Description: "Call immediately after send_terminal to inspect the result, and call again as needed to monitor ongoing work. " +
+			"Returns the plain-text content currently visible in the managed terminal pane. This is the current screen, not the pane's full scrollback history.",
+		Annotations: terminalToolAnnotations(true, false, false),
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args readTerminalArgs) (*mcp.CallToolResult, sessioncmd.TerminalScreen, error) {
+		screen, err := terminals.Read(sessionID, args.TerminalID)
+		if err != nil {
+			return nil, sessioncmd.TerminalScreen{}, err
+		}
+		text := screen.Output
+		if text == "" {
+			text = "terminal screen is empty"
+		}
+		return textContent(text), screen, nil
+	})
+
 	return server
+}
+
+func terminalToolAnnotations(readOnly, destructive, openWorld bool) *mcp.ToolAnnotations {
+	return &mcp.ToolAnnotations{
+		ReadOnlyHint:    readOnly,
+		DestructiveHint: &destructive,
+		IdempotentHint:  readOnly,
+		OpenWorldHint:   &openWorld,
+	}
+}
+
+func formatTerminal(terminal sessioncmd.Terminal) string {
+	group := terminal.Group
+	if group == "" {
+		group = "root"
+	}
+	return fmt.Sprintf("%s (%s) in %s at %s", terminal.Name, terminal.ID, group, terminal.Directory)
+}
+
+func formatTerminalList(terminals []sessioncmd.Terminal) string {
+	if len(terminals) == 0 {
+		return "no managed terminals"
+	}
+	lines := make([]string, 0, len(terminals))
+	for _, terminal := range terminals {
+		lines = append(lines, fmt.Sprintf("- %s; status=%s; running=%t", formatTerminal(terminal), terminal.Status, terminal.Running))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func textContent(message string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: message}}}
 }
 
 func textResult(message string, err error) (*mcp.CallToolResult, any, error) {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,13 +10,51 @@ import (
 	"testing"
 
 	"github.com/YoanWai/agent-manager/internal/hooks"
+	"github.com/YoanWai/agent-manager/internal/sessioncmd"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+type fakeTerminalCommands struct {
+	listed      []sessioncmd.Terminal
+	created     sessioncmd.Terminal
+	screen      sessioncmd.TerminalScreen
+	createdOpts sessioncmd.CreateTerminalOptions
+	sentID      string
+	sentCommand string
+	sentKeys    []string
+	readID      string
+	err         error
+}
+
+func (f *fakeTerminalCommands) List(string) ([]sessioncmd.Terminal, error) {
+	return f.listed, f.err
+}
+
+func (f *fakeTerminalCommands) Create(_ string, opts sessioncmd.CreateTerminalOptions) (sessioncmd.Terminal, error) {
+	f.createdOpts = opts
+	return f.created, f.err
+}
+
+func (f *fakeTerminalCommands) Send(_ string, id, command string, keys []string) error {
+	f.sentID = id
+	f.sentCommand = command
+	f.sentKeys = append([]string(nil), keys...)
+	return f.err
+}
+
+func (f *fakeTerminalCommands) Read(_ string, id string) (sessioncmd.TerminalScreen, error) {
+	f.readID = id
+	return f.screen, f.err
+}
+
 func connect(t *testing.T, configDir, sessionID string) *mcp.ClientSession {
 	t.Helper()
+	return connectServer(t, NewServer(configDir, sessionID, "test"))
+}
+
+func connectServer(t *testing.T, server *mcp.Server) *mcp.ClientSession {
+	t.Helper()
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-	server := NewServer(configDir, sessionID, "test")
 	if _, err := server.Connect(context.Background(), serverTransport, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -28,12 +67,18 @@ func connect(t *testing.T, configDir, sessionID string) *mcp.ClientSession {
 	return session
 }
 
-func callText(t *testing.T, session *mcp.ClientSession, tool string, args map[string]any) (string, bool) {
+func callTool(t *testing.T, session *mcp.ClientSession, tool string, args map[string]any) *mcp.CallToolResult {
 	t.Helper()
 	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: tool, Arguments: args})
 	if err != nil {
 		t.Fatalf("CallTool %s: %v", tool, err)
 	}
+	return result
+}
+
+func callText(t *testing.T, session *mcp.ClientSession, tool string, args map[string]any) (string, bool) {
+	t.Helper()
+	result := callTool(t, session, tool, args)
 	var text strings.Builder
 	for _, content := range result.Content {
 		if tc, ok := content.(*mcp.TextContent); ok {
@@ -71,9 +116,159 @@ func TestListsAllTools(t *testing.T) {
 	for _, tool := range tools.Tools {
 		names[tool.Name] = true
 	}
-	for _, want := range []string{"rename", "review_repo", "review_base", "review_mode"} {
+	for _, want := range []string{
+		"rename", "review_repo", "review_base", "review_mode",
+		"list_terminals", "create_terminal", "send_terminal", "read_terminal",
+	} {
 		if !names[want] {
 			t.Fatalf("missing tool %q in %v", want, names)
+		}
+	}
+}
+
+func TestServerTeachesProactiveTerminalWorkflow(t *testing.T) {
+	session := connect(t, t.TempDir(), "abc123")
+	instructions := session.InitializeResult().Instructions
+	for _, want := range []string{
+		"Do not wait for the user",
+		"long-running",
+		"list_terminals",
+		"create_terminal",
+		"send_terminal",
+		"read_terminal",
+		"Reuse a relevant running terminal",
+	} {
+		if !strings.Contains(instructions, want) {
+			t.Fatalf("server instructions do not teach %q:\n%s", want, instructions)
+		}
+	}
+}
+
+func TestTerminalDescriptionsTeachWhenAndHowToChainTools(t *testing.T) {
+	session := connect(t, t.TempDir(), "abc123")
+	listed, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptions := map[string]string{}
+	for _, tool := range listed.Tools {
+		descriptions[tool.Name] = tool.Description
+	}
+	for tool, wants := range map[string][]string{
+		"list_terminals":  {"Call proactively", "Reuse", "create_terminal"},
+		"create_terminal": {"without waiting for the user", "send_terminal"},
+		"send_terminal":   {"create_terminal", "read_terminal", "executes on the user's machine"},
+		"read_terminal":   {"after send_terminal", "monitor ongoing work"},
+	} {
+		for _, want := range wants {
+			if !strings.Contains(descriptions[tool], want) {
+				t.Errorf("%s description does not contain %q: %s", tool, want, descriptions[tool])
+			}
+		}
+	}
+}
+
+func TestTerminalToolsExposeStructuredResultsAndForwardArguments(t *testing.T) {
+	group := "backend"
+	fake := &fakeTerminalCommands{
+		listed: []sessioncmd.Terminal{{
+			ID: "a1b2c3d4", Name: "terminal-a1b2", Group: group,
+			Directory: "/work", Status: "idle", Running: true,
+		}},
+		created: sessioncmd.Terminal{
+			ID: "e5f6a7b8", Name: "terminal-e5f6", Group: group,
+			Directory: "/tmp", Status: "starting", Running: true,
+		},
+		screen: sessioncmd.TerminalScreen{
+			Terminal: sessioncmd.Terminal{ID: "a1b2c3d4", Name: "terminal-a1b2", Running: true},
+			Output:   "build complete",
+		},
+	}
+	session := connectServer(t, newServer(t.TempDir(), "abc123", "test", fake))
+
+	listed := callTool(t, session, "list_terminals", map[string]any{})
+	if listed.IsError || listed.StructuredContent == nil {
+		t.Fatalf("list_terminals = %+v", listed)
+	}
+	if text, _ := callText(t, session, "list_terminals", map[string]any{}); !strings.Contains(text, "terminal-a1b2") {
+		t.Fatalf("list text = %q", text)
+	}
+
+	created := callTool(t, session, "create_terminal", map[string]any{"group": group, "directory": "/tmp"})
+	if created.IsError || created.StructuredContent == nil {
+		t.Fatalf("create_terminal = %+v", created)
+	}
+	if fake.createdOpts.Group == nil || *fake.createdOpts.Group != group || fake.createdOpts.Directory != "/tmp" {
+		t.Fatalf("create args = %+v", fake.createdOpts)
+	}
+
+	if text, isError := callText(t, session, "send_terminal", map[string]any{
+		"terminal_id": "a1b2c3d4", "command": "go test ./...",
+	}); isError || !strings.Contains(text, "sent command") {
+		t.Fatalf("send command = %q, isError=%v", text, isError)
+	}
+	if fake.sentID != "a1b2c3d4" || fake.sentCommand != "go test ./..." || len(fake.sentKeys) != 0 {
+		t.Fatalf("send command args = id %q command %q keys %v", fake.sentID, fake.sentCommand, fake.sentKeys)
+	}
+
+	if _, isError := callText(t, session, "send_terminal", map[string]any{
+		"terminal_id": "a1b2c3d4", "keys": []string{"C-c", "Enter"},
+	}); isError {
+		t.Fatal("send keys returned an error")
+	}
+	if fake.sentCommand != "" || strings.Join(fake.sentKeys, ",") != "C-c,Enter" {
+		t.Fatalf("send key args = command %q keys %v", fake.sentCommand, fake.sentKeys)
+	}
+
+	if text, isError := callText(t, session, "read_terminal", map[string]any{"terminal_id": "a1b2c3d4"}); isError || text != "build complete" {
+		t.Fatalf("read = %q, isError=%v", text, isError)
+	}
+	if fake.readID != "a1b2c3d4" {
+		t.Fatalf("read id = %q", fake.readID)
+	}
+}
+
+func TestTerminalToolAnnotationsDescribeLocalRisk(t *testing.T) {
+	session := connect(t, t.TempDir(), "abc123")
+	listed, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tools := map[string]*mcp.Tool{}
+	for _, tool := range listed.Tools {
+		tools[tool.Name] = tool
+	}
+	for _, name := range []string{"list_terminals", "read_terminal"} {
+		if annotations := tools[name].Annotations; annotations == nil || !annotations.ReadOnlyHint || annotations.OpenWorldHint == nil || *annotations.OpenWorldHint {
+			t.Fatalf("%s annotations = %+v", name, annotations)
+		}
+		if tools[name].OutputSchema == nil {
+			t.Fatalf("%s has no structured output schema", name)
+		}
+	}
+	if annotations := tools["create_terminal"].Annotations; annotations == nil || annotations.DestructiveHint == nil || *annotations.DestructiveHint {
+		t.Fatalf("create annotations = %+v", annotations)
+	}
+	if annotations := tools["send_terminal"].Annotations; annotations == nil || annotations.DestructiveHint == nil || !*annotations.DestructiveHint || annotations.OpenWorldHint == nil || !*annotations.OpenWorldHint {
+		t.Fatalf("send annotations = %+v", annotations)
+	}
+}
+
+func TestTerminalToolErrorsAreToolErrors(t *testing.T) {
+	fake := &fakeTerminalCommands{err: errors.New("terminal is not running")}
+	session := connectServer(t, newServer(t.TempDir(), "abc123", "test", fake))
+	for _, call := range []struct {
+		name string
+		args map[string]any
+	}{
+		{"list_terminals", map[string]any{}},
+		{"create_terminal", map[string]any{}},
+		{"send_terminal", map[string]any{"terminal_id": "a1", "command": "pwd"}},
+		{"read_terminal", map[string]any{"terminal_id": "a1"}},
+	} {
+		text, isError := callText(t, session, call.name, call.args)
+		if !isError || !strings.Contains(text, "not running") {
+			t.Fatalf("%s = %q, isError=%v", call.name, text, isError)
 		}
 	}
 }

--- a/internal/sessioncmd/sessioncmd.go
+++ b/internal/sessioncmd/sessioncmd.go
@@ -1,8 +1,7 @@
 // Package sessioncmd implements the session-scoped commands an agent uses
-// to talk to its running manager: naming the session and declaring review
-// targets. The CLI subcommands and the MCP server both call these, so
-// validation and behavior stay identical. Each command writes a mailbox
-// file the manager poller applies on its next cycle.
+// to talk to its running manager: naming the session, declaring review
+// targets, and operating managed terminals. The CLI subcommands and the MCP
+// server share this layer so validation and behavior stay identical.
 package sessioncmd
 
 import (

--- a/internal/sessioncmd/terminal.go
+++ b/internal/sessioncmd/terminal.go
@@ -241,7 +241,11 @@ func resolveTerminalDirectory(raw string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		dir = filepath.Join(home, strings.TrimPrefix(dir, "~/"))
+		if dir == "~" {
+			dir = home
+		} else {
+			dir = filepath.Join(home, strings.TrimPrefix(dir, "~/"))
+		}
 	}
 	abs, err := filepath.Abs(dir)
 	if err != nil {

--- a/internal/sessioncmd/terminal.go
+++ b/internal/sessioncmd/terminal.go
@@ -1,0 +1,330 @@
+package sessioncmd
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/YoanWai/agent-manager/internal/config"
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/tmux"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/google/uuid"
+)
+
+type Terminal struct {
+	ID        string `json:"id" jsonschema:"managed terminal session id"`
+	Name      string `json:"name" jsonschema:"terminal name shown in Agent Manager"`
+	Group     string `json:"group" jsonschema:"group path holding the terminal; empty is the root"`
+	Directory string `json:"directory" jsonschema:"terminal's current working directory, or its launch directory when stopped"`
+	Status    string `json:"status" jsonschema:"stored Agent Manager status"`
+	Running   bool   `json:"running" jsonschema:"whether the terminal currently has a live tmux pane"`
+}
+
+type TerminalScreen struct {
+	Terminal Terminal `json:"terminal"`
+	Output   string   `json:"output" jsonschema:"plain text currently visible in the terminal pane"`
+}
+
+type CreateTerminalOptions struct {
+	// Nil inherits the calling session's group; a pointer to an empty string
+	// deliberately targets the root group.
+	Group     *string
+	Directory string
+}
+
+type Terminals struct {
+	configDir string
+	newDriver func() (*tmux.Driver, error)
+}
+
+func NewTerminals(configDir string) *Terminals {
+	return newTerminals(configDir, tmux.New)
+}
+
+func newTerminals(configDir string, newDriver func() (*tmux.Driver, error)) *Terminals {
+	return &Terminals{configDir: configDir, newDriver: newDriver}
+}
+
+type terminalRuntime struct {
+	cfg    config.Config
+	store  *store.Store
+	driver *tmux.Driver
+}
+
+func (t *Terminals) open() (*terminalRuntime, error) {
+	cfg, err := config.LoadDir(t.configDir)
+	if err != nil {
+		return nil, err
+	}
+	driver, err := t.newDriver()
+	if err != nil {
+		return nil, err
+	}
+	st, err := store.Open(filepath.Join(t.configDir, "state.db"))
+	if err != nil {
+		return nil, err
+	}
+	return &terminalRuntime{cfg: cfg, store: st, driver: driver}, nil
+}
+
+func (r *terminalRuntime) caller(sessionID string) (store.Session, error) {
+	if err := validSession(sessionID); err != nil {
+		return store.Session{}, err
+	}
+	sess, err := r.store.Get(sessionID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.Session{}, fmt.Errorf("calling session %s no longer exists", sessionID)
+	}
+	return sess, err
+}
+
+func (r *terminalRuntime) terminal(id string) (store.Session, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return store.Session{}, errors.New("terminal_id is empty; call list_terminals to get one")
+	}
+	sess, err := r.store.Get(id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.Session{}, fmt.Errorf("terminal %s does not exist; call list_terminals for current ids", id)
+	}
+	if err != nil {
+		return store.Session{}, err
+	}
+	if !r.cfg.Tools[sess.Tool].Shell {
+		return store.Session{}, fmt.Errorf("session %s is an agent, not a terminal", id)
+	}
+	if sess.Archived {
+		return store.Session{}, fmt.Errorf("terminal %s is archived; restore it in Agent Manager first", id)
+	}
+	return sess, nil
+}
+
+func (r *terminalRuntime) info(sess store.Session, running bool) Terminal {
+	dir := sess.Cwd
+	if running {
+		if current, err := r.driver.PaneCurrentPath(sess.ID); err == nil {
+			dir = current
+		}
+	}
+	return Terminal{
+		ID:        sess.ID,
+		Name:      sess.Name,
+		Group:     sess.Group,
+		Directory: dir,
+		Status:    sess.Status,
+		Running:   running,
+	}
+}
+
+func (t *Terminals) List(sessionID string) ([]Terminal, error) {
+	runtime, err := t.open()
+	if err != nil {
+		return nil, err
+	}
+	defer runtime.store.Close()
+	if _, err := runtime.caller(sessionID); err != nil {
+		return nil, err
+	}
+	sessions, err := runtime.store.ListSessions(false)
+	if err != nil {
+		return nil, err
+	}
+	panes, err := runtime.driver.Panes()
+	if err != nil {
+		return nil, err
+	}
+	terminals := make([]Terminal, 0)
+	for _, sess := range sessions {
+		if !runtime.cfg.Tools[sess.Tool].Shell {
+			continue
+		}
+		_, running := panes[sess.ID]
+		terminals = append(terminals, runtime.info(sess, running))
+	}
+	return terminals, nil
+}
+
+func (t *Terminals) Create(sessionID string, opts CreateTerminalOptions) (Terminal, error) {
+	runtime, err := t.open()
+	if err != nil {
+		return Terminal{}, err
+	}
+	defer runtime.store.Close()
+	caller, err := runtime.caller(sessionID)
+	if err != nil {
+		return Terminal{}, err
+	}
+	toolName, tool, ok := runtime.cfg.ShellTool()
+	if !ok {
+		return Terminal{}, errors.New("no shell configured; add a tool block with shell = true to config.toml")
+	}
+	group, dir, err := runtime.createTarget(caller, opts)
+	if err != nil {
+		return Terminal{}, err
+	}
+	id := uuid.NewString()[:8]
+	sess := store.Session{
+		ID:     id,
+		Name:   toolName + "-" + id[:4],
+		Tool:   toolName,
+		Cwd:    dir,
+		Group:  group,
+		Status: status.Starting,
+	}
+	if err := runtime.driver.Create(sess.ID, sess.Cwd, tool.Command, nil, 0, 0); err != nil {
+		return Terminal{}, err
+	}
+	if err := runtime.store.CreateSession(sess); err != nil {
+		_ = runtime.driver.Kill(sess.ID)
+		return Terminal{}, err
+	}
+	_ = runtime.driver.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name))
+	return runtime.info(sess, true), nil
+}
+
+func (r *terminalRuntime) createTarget(caller store.Session, opts CreateTerminalOptions) (string, string, error) {
+	group := caller.Group
+	groups, err := r.store.Groups()
+	if err != nil {
+		return "", "", err
+	}
+	byName := make(map[string]store.Group, len(groups))
+	archived := make(map[string]bool, len(groups))
+	for _, candidate := range groups {
+		byName[candidate.Name] = candidate
+		archived[candidate.Name] = candidate.Archived
+	}
+	if opts.Group != nil {
+		group = strings.TrimSpace(*opts.Group)
+		if group != "" {
+			if _, ok := byName[group]; !ok {
+				return "", "", fmt.Errorf("group %q does not exist", group)
+			}
+		}
+	}
+	if group != "" && store.EffectivelyArchived(archived, group) {
+		return "", "", fmt.Errorf("group %q is archived; restore it in Agent Manager first", group)
+	}
+	if strings.TrimSpace(opts.Directory) != "" {
+		dir, err := resolveTerminalDirectory(opts.Directory)
+		return group, dir, err
+	}
+	if opts.Group != nil {
+		for current := group; current != ""; current = parentGroup(current) {
+			if candidate := byName[current].Path; candidate != "" {
+				if dir, err := resolveTerminalDirectory(candidate); err == nil {
+					return group, dir, nil
+				}
+			}
+		}
+	}
+	dir := caller.Cwd
+	if current, err := r.driver.PaneCurrentPath(caller.ID); err == nil {
+		dir = current
+	}
+	resolved, err := resolveTerminalDirectory(dir)
+	if err != nil {
+		return "", "", fmt.Errorf("no usable directory for terminal: %w", err)
+	}
+	return group, resolved, nil
+}
+
+func resolveTerminalDirectory(raw string) (string, error) {
+	dir := strings.TrimSpace(raw)
+	if dir == "~" || strings.HasPrefix(dir, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dir = filepath.Join(home, strings.TrimPrefix(dir, "~/"))
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("directory %s: %w", abs, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", abs)
+	}
+	return abs, nil
+}
+
+func parentGroup(group string) string {
+	if index := strings.LastIndex(group, "/"); index >= 0 {
+		return group[:index]
+	}
+	return ""
+}
+
+func sessionLabel(group, name string) string {
+	if group == "" {
+		return name
+	}
+	return group + " · " + name
+}
+
+func (t *Terminals) Send(sessionID, terminalID, command string, keys []string) error {
+	hasCommand := strings.TrimSpace(command) != ""
+	hasKeys := len(keys) > 0
+	if hasCommand == hasKeys {
+		return errors.New("provide exactly one of command or keys")
+	}
+	for _, key := range keys {
+		if key == "" {
+			return errors.New("keys cannot contain an empty value")
+		}
+	}
+	runtime, err := t.open()
+	if err != nil {
+		return err
+	}
+	defer runtime.store.Close()
+	if _, err := runtime.caller(sessionID); err != nil {
+		return err
+	}
+	terminal, err := runtime.terminal(terminalID)
+	if err != nil {
+		return err
+	}
+	if !runtime.driver.Exists(terminal.ID) {
+		return fmt.Errorf("terminal %s is not running; revive it in Agent Manager first", terminal.ID)
+	}
+	if hasCommand {
+		return runtime.driver.SendText(terminal.ID, command)
+	}
+	return runtime.driver.SendKeys(terminal.ID, keys...)
+}
+
+func (t *Terminals) Read(sessionID, terminalID string) (TerminalScreen, error) {
+	runtime, err := t.open()
+	if err != nil {
+		return TerminalScreen{}, err
+	}
+	defer runtime.store.Close()
+	if _, err := runtime.caller(sessionID); err != nil {
+		return TerminalScreen{}, err
+	}
+	terminal, err := runtime.terminal(terminalID)
+	if err != nil {
+		return TerminalScreen{}, err
+	}
+	if !runtime.driver.Exists(terminal.ID) {
+		return TerminalScreen{}, fmt.Errorf("terminal %s is not running; revive it in Agent Manager first", terminal.ID)
+	}
+	output, err := runtime.driver.CapturePane(terminal.ID)
+	if err != nil {
+		return TerminalScreen{}, err
+	}
+	return TerminalScreen{
+		Terminal: runtime.info(terminal, true),
+		Output:   strings.TrimRight(ansi.Strip(output), "\r\n"),
+	}, nil
+}

--- a/internal/sessioncmd/terminal_test.go
+++ b/internal/sessioncmd/terminal_test.go
@@ -73,7 +73,9 @@ default_status = "idle"
 		for _, sess := range sessions {
 			_ = driver.Kill(sess.ID)
 		}
-		_ = exec.Command("tmux", "-L", driver.SocketName(), "kill-server").Run()
+		if out, err := exec.Command("tmux", "-L", driver.SocketName(), "kill-server").CombinedOutput(); err != nil && !strings.Contains(string(out), "no server running") {
+			t.Errorf("kill test tmux server: %v: %s", err, strings.TrimSpace(string(out)))
+		}
 		_ = st.Close()
 	})
 	return h

--- a/internal/sessioncmd/terminal_test.go
+++ b/internal/sessioncmd/terminal_test.go
@@ -1,0 +1,226 @@
+package sessioncmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/tmux"
+	"github.com/google/uuid"
+)
+
+type terminalHarness struct {
+	driver    *tmux.Driver
+	store     *store.Store
+	terminals *Terminals
+	caller    store.Session
+}
+
+func newTerminalHarness(t *testing.T) *terminalHarness {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	configDir := t.TempDir()
+	configText := `[tools.terminal]
+command = ""
+shell = true
+default_status = "idle"
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(configText), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	driver, err := tmux.NewWithSocket("amtermtest-" + uuid.NewString()[:8])
+	if err != nil {
+		t.Fatalf("tmux driver: %v", err)
+	}
+	st, err := store.Open(filepath.Join(configDir, "state.db"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	callerDir := t.TempDir()
+	caller := store.Session{
+		ID:     uuid.NewString()[:8],
+		Name:   "calling-agent",
+		Tool:   "claude",
+		Cwd:    callerDir,
+		Group:  "backend",
+		Status: status.Idle,
+	}
+	if err := st.CreateGroup("backend", callerDir); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := driver.Create(caller.ID, caller.Cwd, "", nil, 80, 24); err != nil {
+		t.Fatalf("create caller pane: %v", err)
+	}
+	if err := st.CreateSession(caller); err != nil {
+		_ = driver.Kill(caller.ID)
+		t.Fatalf("create caller row: %v", err)
+	}
+	h := &terminalHarness{
+		driver: driver,
+		store:  st,
+		caller: caller,
+	}
+	h.terminals = newTerminals(configDir, func() (*tmux.Driver, error) { return driver, nil })
+	t.Cleanup(func() {
+		sessions, _ := st.ListSessions(true)
+		for _, sess := range sessions {
+			_ = driver.Kill(sess.ID)
+		}
+		_ = st.Close()
+	})
+	return h
+}
+
+func waitForTerminalOutput(t *testing.T, terminals *Terminals, callerID, terminalID, marker string) TerminalScreen {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		screen, err := terminals.Read(callerID, terminalID)
+		if err == nil && strings.Contains(screen.Output, marker) {
+			return screen
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	screen, err := terminals.Read(callerID, terminalID)
+	t.Fatalf("terminal never showed %q: output=%q err=%v", marker, screen.Output, err)
+	return TerminalScreen{}
+}
+
+func sameTerminalPath(left, right string) bool {
+	resolvedLeft, leftErr := filepath.EvalSymlinks(left)
+	resolvedRight, rightErr := filepath.EvalSymlinks(right)
+	return leftErr == nil && rightErr == nil && resolvedLeft == resolvedRight
+}
+
+func TestTerminalsCreateListSendAndReadWithRealTmux(t *testing.T) {
+	h := newTerminalHarness(t)
+	created, err := h.terminals.Create(h.caller.ID, CreateTerminalOptions{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.ID == "" || created.Name != "terminal-"+created.ID[:4] {
+		t.Fatalf("created identity = %+v", created)
+	}
+	if created.Group != h.caller.Group || !sameTerminalPath(created.Directory, h.caller.Cwd) || !created.Running {
+		t.Fatalf("created target = %+v, caller = %+v", created, h.caller)
+	}
+	stored, err := h.store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("stored terminal: %v", err)
+	}
+	if stored.Tool != "terminal" || stored.Status != status.Starting {
+		t.Fatalf("stored terminal = %+v", stored)
+	}
+
+	listed, err := h.terminals.List(h.caller.ID)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != created.ID || !listed[0].Running {
+		t.Fatalf("listed = %+v", listed)
+	}
+
+	const commandMarker = "terminal-command-marker"
+	if err := h.terminals.Send(h.caller.ID, created.ID, "printf '"+commandMarker+"\\n'", nil); err != nil {
+		t.Fatalf("Send command: %v", err)
+	}
+	screen := waitForTerminalOutput(t, h.terminals, h.caller.ID, created.ID, commandMarker)
+	if strings.Contains(screen.Output, "\x1b[") {
+		t.Fatalf("read output still carries ANSI escapes: %q", screen.Output)
+	}
+
+	const keyMarker = "terminal-keys-marker"
+	if err := h.terminals.Send(h.caller.ID, created.ID, "", []string{"printf '" + keyMarker + "\\n'", "Enter"}); err != nil {
+		t.Fatalf("Send keys: %v", err)
+	}
+	waitForTerminalOutput(t, h.terminals, h.caller.ID, created.ID, keyMarker)
+}
+
+func TestCreateTerminalResolvesExplicitGroupAndDirectory(t *testing.T) {
+	h := newTerminalHarness(t)
+	parentDir := t.TempDir()
+	explicitDir := t.TempDir()
+	if err := h.store.CreateGroup("platform", parentDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.store.CreateGroup("platform/api", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	group := "platform/api"
+	inherited, err := h.terminals.Create(h.caller.ID, CreateTerminalOptions{Group: &group})
+	if err != nil {
+		t.Fatalf("create inherited: %v", err)
+	}
+	if inherited.Group != group || !sameTerminalPath(inherited.Directory, parentDir) {
+		t.Fatalf("inherited target = %+v", inherited)
+	}
+
+	root := ""
+	explicit, err := h.terminals.Create(h.caller.ID, CreateTerminalOptions{Group: &root, Directory: explicitDir})
+	if err != nil {
+		t.Fatalf("create explicit: %v", err)
+	}
+	if explicit.Group != "" || !sameTerminalPath(explicit.Directory, explicitDir) {
+		t.Fatalf("explicit target = %+v", explicit)
+	}
+	if err := h.store.SetGroupArchived("platform", true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.terminals.Create(h.caller.ID, CreateTerminalOptions{Group: &group}); err == nil || !strings.Contains(err.Error(), "archived") {
+		t.Fatalf("archived group error = %v", err)
+	}
+
+	missing := "missing/group"
+	before, _ := h.store.ListSessions(false)
+	if _, err := h.terminals.Create(h.caller.ID, CreateTerminalOptions{Group: &missing}); err == nil || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("missing group error = %v", err)
+	}
+	after, _ := h.store.ListSessions(false)
+	if len(after) != len(before) {
+		t.Fatalf("failed create added a row: before=%d after=%d", len(before), len(after))
+	}
+}
+
+func TestTerminalCommandsRejectUnsafeTargetsAndInvalidInput(t *testing.T) {
+	h := newTerminalHarness(t)
+	terminal, err := h.terminals.Create(h.caller.ID, CreateTerminalOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name    string
+		command string
+		keys    []string
+	}{
+		{"neither", "", nil},
+		{"both", "pwd", []string{"Enter"}},
+		{"empty key", "", []string{""}},
+	} {
+		if err := h.terminals.Send(h.caller.ID, terminal.ID, test.command, test.keys); err == nil {
+			t.Fatalf("%s input was accepted", test.name)
+		}
+	}
+	if err := h.terminals.Send(h.caller.ID, h.caller.ID, "pwd", nil); err == nil || !strings.Contains(err.Error(), "not a terminal") {
+		t.Fatalf("agent target error = %v", err)
+	}
+	if err := h.driver.Kill(terminal.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.terminals.Send(h.caller.ID, terminal.ID, "pwd", nil); err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("dead send error = %v", err)
+	}
+	if _, err := h.terminals.Read(h.caller.ID, terminal.ID); err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("dead read error = %v", err)
+	}
+	if _, err := h.terminals.List(""); err == nil || !strings.Contains(err.Error(), "AGENT_MANAGER_SESSION_ID") {
+		t.Fatalf("missing caller error = %v", err)
+	}
+}

--- a/internal/sessioncmd/terminal_test.go
+++ b/internal/sessioncmd/terminal_test.go
@@ -73,6 +73,7 @@ default_status = "idle"
 		for _, sess := range sessions {
 			_ = driver.Kill(sess.ID)
 		}
+		_ = exec.Command("tmux", "-L", driver.SocketName(), "kill-server").Run()
 		_ = st.Close()
 	})
 	return h
@@ -141,6 +142,18 @@ func TestTerminalsCreateListSendAndReadWithRealTmux(t *testing.T) {
 		t.Fatalf("Send keys: %v", err)
 	}
 	waitForTerminalOutput(t, h.terminals, h.caller.ID, created.ID, keyMarker)
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("home directory: %v", err)
+	}
+	homeTerminal, err := h.terminals.Create(h.caller.ID, CreateTerminalOptions{Directory: "~"})
+	if err != nil {
+		t.Fatalf("Create in home: %v", err)
+	}
+	if !sameTerminalPath(homeTerminal.Directory, home) {
+		t.Fatalf("home terminal directory = %q, want %q", homeTerminal.Directory, home)
+	}
 }
 
 func TestCreateTerminalResolvesExplicitGroupAndDirectory(t *testing.T) {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -301,6 +301,14 @@ func (d *Driver) SendText(id, text string) error {
 	return d.pasteAndEnter(sessionName(id), text)
 }
 
+// SendKeys delivers exact tmux key names to a session. Keeping each key as
+// its own argv entry avoids routing agent-supplied input through a shell.
+func (d *Driver) SendKeys(id string, keys ...string) error {
+	args := []string{"send-keys", "-t", sessionName(id), "--"}
+	_, err := d.run(append(args, keys...)...)
+	return err
+}
+
 // Paste delivers text into the session's pane without submitting it. The
 // focus path uses this for clipboard pastes: sending the bytes as raw
 // keystrokes would turn every newline into an Enter press and submit the

--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -19,16 +19,7 @@ const terminalKeyWindow = 250 * time.Millisecond
 // keys off the block being called "terminal", so a user who already has a
 // [tools.terminal] block of their own keeps it as the agent CLI they wrote.
 func (m *Model) shellTool() (string, config.Tool, bool) {
-	chosen := ""
-	for name, tool := range m.cfg.Tools {
-		if tool.Shell && (chosen == "" || name < chosen) {
-			chosen = name
-		}
-	}
-	if chosen == "" {
-		return "", config.Tool{}, false
-	}
-	return chosen, m.cfg.Tools[chosen], true
+	return m.cfg.ShellTool()
 }
 
 // isShell reports whether a session's tool opens a shell rather than an


### PR DESCRIPTION
## What changed

Adds the four remaining terminal tools to the session-scoped Agent Manager MCP server:

- `list_terminals` returns active managed terminals with structured ids, names, groups, live directories, statuses, and pane liveness.
- `create_terminal` opens a managed shell beside the calling agent by default, or in an explicit existing group or directory.
- `send_terminal` submits one command or sends an exact tmux key sequence to a running managed terminal.
- `read_terminal` returns the terminal's current visible screen as ANSI-free text plus structured terminal metadata.

The implementation lives in `internal/sessioncmd`, keeping config/store/tmux validation separate from MCP schemas and presentation. Terminal identity remains the existing explicit `shell = true` config flag; these tools refuse agent panes, archived terminals/groups, stopped panes, invalid targets, and ambiguous command/key input.

The server now provides protocol-native initialization instructions that teach agents to use this workflow proactively for long-running, output-heavy, persistent, or parallel shell work: list and reuse, create only if needed, send, then read and monitor. The same chaining guidance appears in each tool description for clients that expose tools but ignore server instructions.

## Why

The UI already supports managed terminal sessions, but agents could not operate them. Builds, test suites, development servers, and log tails therefore competed with the conversation pane or disappeared into an unrelated shell. These tools keep that work persistent, visible in Agent Manager, and controllable by any MCP-capable agent.

Sending a command executes on the user's machine. The tool is marked destructive/open-world, its description states the trust boundary, and the docs require the same care and approval expectations as normal shell execution.

Closes #227

## Validation

- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...`
- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./...`
- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -count=10 ./internal/sessioncmd ./internal/mcpserver`
- `go build ./...`
- `go vet ./...`
- `gofmt -l .` (clean)
- `git diff --check` (clean)

The integration suite creates terminals on isolated real tmux sockets and verifies creation, listing, directory/group inheritance, submitted commands, exact key sequences, ANSI-free reads, rollback behavior, and safety rejections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP terminal management for listing, creating, sending commands or keys, and reading terminal output.
  * Added tmux-backed terminal sessions with shell selection and working-directory support.
  * Added guidance on terminal workflows and command safety to the MCP documentation.

* **Bug Fixes**
  * Improved terminal input handling and shell-tool selection.
  * Added clearer handling for archived, stopped, missing, unauthorized, or invalid terminal operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->