### PR TITLE
Fix quoted Codex status signals

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,7 +141,7 @@ func (c *Config) backfillToolDefaults() error {
 			c.Tools[name] = def
 			continue
 		}
-		c.Tools[name] = mergeTool(user, def)
+		c.Tools[name] = mergeTool(name, user, def)
 	}
 	return nil
 }
@@ -152,7 +152,7 @@ func (c *Config) backfillToolDefaults() error {
 // a hand-rolled agent block, and backfilling the flag onto one would take
 // the user's own tool out of the pickers and refuse to prompt it, without
 // saying so. A block is a shell only where its author wrote that.
-func mergeTool(user, def Tool) Tool {
+func mergeTool(name string, user, def Tool) Tool {
 	fill := func(dst *string, src string) {
 		if *dst == "" {
 			*dst = src
@@ -175,6 +175,18 @@ func mergeTool(user, def Tool) Tool {
 	fill(&user.BusyLine, def.BusyLine)
 	if len(user.Rules) == 0 {
 		user.Rules = def.Rules
+	} else if name == "codex" {
+		for i, rule := range user.Rules {
+			if rule.State != "working" || rule.Pattern != `(?m)esc to interrupt\b` {
+				continue
+			}
+			for _, current := range def.Rules {
+				if current.State == "working" {
+					user.Rules[i] = current
+					break
+				}
+			}
+		}
 	}
 	return user
 }
@@ -332,8 +344,9 @@ rules = [
   { state = "waiting", pattern = "(?m)^\\s*›\\s+\\d+\\." },
   { state = "waiting", pattern = "(?m)Press enter to (confirm|continue)\\b" },
   { state = "waiting", pattern = "(?m)enter to submit answer\\b" },
-  # active turn status line: "• Working (0s • esc to interrupt)" / "Analyzing"
-  { state = "working", pattern = "(?m)esc to interrupt\\b" },
+  # active status row is the final row above the input box; anchoring its full
+  # shape keeps an answer that quotes "esc to interrupt" from looking active
+  { state = "working", pattern = "(?m)^[ \\t]*(?:• )?[^\\n]*\\([\\dhms. ]+ [•·] esc to interrupt\\)(?: · [^\\n]*)?[ \\t]*\\n(?:[ \\t]+└[^\\n]*\\n(?:[ \\t]{4}[^\\n]*\\n)*)?[ \\t\\n]*\\z" },
   { state = "errored", pattern = "(?m)You've hit your usage limit" },
   { state = "errored", pattern = "(?im)^\\s*■.*\\berror\\b" },
 ]

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -120,6 +120,54 @@ func TestLoadDirWritesDefaultInRequestedDirectory(t *testing.T) {
 	}
 }
 
+func TestLoadDirUpgradesLegacyCodexWorkingRule(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	legacy := `
+[tools.codex]
+command = "codex"
+rules = [
+  { state = "working", pattern = "(?m)esc to interrupt\\b" },
+]
+`
+	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	rule := cfg.Tools["codex"].Rules[0]
+	if rule.Pattern == `(?m)esc to interrupt\b` {
+		t.Fatal("legacy Codex working rule was not upgraded")
+	}
+	if !strings.Contains(rule.Pattern, `\z`) {
+		t.Fatalf("upgraded Codex working rule is not scoped to the activity-region tail: %q", rule.Pattern)
+	}
+}
+
+func TestLoadDirPreservesCustomCodexWorkingRule(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	custom := `
+[tools.codex]
+command = "codex"
+rules = [
+  { state = "working", pattern = "my private status signal" },
+]
+`
+	if err := os.WriteFile(path, []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if got := cfg.Tools["codex"].Rules[0].Pattern; got != "my private status signal" {
+		t.Fatalf("custom Codex working rule = %q", got)
+	}
+}
+
 func TestShellToolUsesFlagAndStableName(t *testing.T) {
 	cfg := Config{Tools: map[string]Tool{
 		"terminal": {Command: "agent", Shell: false},

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -294,6 +294,12 @@ func TestCodexRealPanes(t *testing.T) {
 			"• Working (0s • esc to interrupt)\n\n› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Working},
 		{"codex active turn, other status verb", "codex",
 			"• Analyzing (12s • esc to interrupt)\n\n› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Working},
+		{"codex active turn with animations disabled", "codex",
+			"Working (12s • esc to interrupt)\n\n› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Working},
+		{"codex reconnecting turn with details", "codex",
+			"• Reconnecting... 3/5 (1m 04s • esc to interrupt)\n" +
+				"  └ Stream disconnected before completion\n\n" +
+				"› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Working},
 		{"codex numbered draft is not a dialog", "codex",
 			"• Working (0s • esc to interrupt)\n\n› 1. keep this as ordinary input\n  gpt-5.6-terra medium · /home/dev", Working},
 		{"codex option-shaped draft without footer is not a dialog", "codex",
@@ -530,6 +536,14 @@ func TestQuotedSignalsDoNotTrigger(t *testing.T) {
 				"✻ Crunched for 1m 5s\n────\n❯ \n────", Waiting},
 		{"claude real spinner during turn still working", "claude",
 			"  old output\n✻ Crunched for 2m 2s\n  streaming new answer\n✳ Drizzling… (6s · thinking)\n────\n❯ ", Working},
+		{"codex marker-less turn quoting interrupt hint", "codex",
+			"  Output:\n\n" +
+				"  tool:       mytool\n" +
+				"  result:     working\n" +
+				"  pattern:    esc to interrupt\n" +
+				"  default:    idle\n\n" +
+				"› Summarize recent commits\n" +
+				"  gpt-5.6-sol medium · /home/dev", Idle},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
@@ -392,6 +393,25 @@ func TestQuietPaneAfterWorkingDerivesFinished(t *testing.T) {
 	seedRegionHash(t, m, sess, pane)
 	if got := deriveStatus(t, m, sess, pane, true); got != status.Finished {
 		t.Fatalf("quiet pane after working should derive finished, got %q", got)
+	}
+}
+
+func TestQuietCodexPaneQuotingInterruptHintDerivesFinished(t *testing.T) {
+	disableQuietEndGrace(t)
+	m := buildModel(t)
+	cfg, err := config.Default()
+	if err != nil {
+		t.Fatalf("default config: %v", err)
+	}
+	m.poller.engine, err = status.NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("status engine: %v", err)
+	}
+	sess := store.Session{ID: "quiet-codex", Tool: "codex", Status: status.Working}
+	pane := "Output:\n\ntool: mytool\nresult: working\npattern: esc to interrupt\ndefault: idle\n\n› Summarize recent commits\n"
+	seedRegionHash(t, m, sess, pane)
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Finished {
+		t.Fatalf("quiet Codex pane quoting its interrupt hint should derive finished, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Scope Codex working detection to the complete live status row at the end of the activity region.
- Keep support for alternate status headers, reconnect details, inline messages, and disabled animations.
- Upgrade the exact legacy built-in Codex rule in existing configs while preserving custom rules.
- Add engine- and poller-level regressions for answers that quote `esc to interrupt`.

## Why

A marker-less Codex response could include the literal phrase `esc to interrupt` while the CLI was already Ready. The broad built-in regex matched that quoted text forever, preventing the quiet-region fallback from transitioning the session from working to finished.

## Impact

Finished Codex conversations that discuss status rules no longer remain falsely marked as working. Genuine live status rows still classify as working.

## Validation

- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...`
- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./internal/ui -count=1`
- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex activity detection to distinguish genuinely active sessions from quoted or incidental “esc to interrupt” text.
  * Correctly identifies animation-disabled and reconnecting Codex sessions as working.
  * Preserves custom Codex working-status rules when loading existing configurations.
  * Automatically upgrades legacy Codex activity rules for more accurate status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->