### PR TITLE
feat: add Hermes Agent support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,6 +54,9 @@ body:
         - Codex
         - OpenCode
         - Grok Build
+        - Gemini CLI
+        - Pi
+        - Hermes Agent
         - A custom tool from my config
         - Not tool specific
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -30,7 +30,7 @@ Useful context when judging whether something is a vulnerability:
 - **tmux sessions.** The manager creates and drives sessions on its own tmux socket, and reads the visible text of each pane to derive status and render the preview. Pane content is treated as data, not commands.
 - **Process spawning.** Sessions launch the CLI command from your config (`[tools.<name>].command`) and its revive command. Anything you put in that config runs as you.
 - **Local state.** Config (`config.toml`) and state (`state.db`, SQLite) live in your OS user config directory. Session names, group paths, working directories, and review targets are stored there.
-- **Generated agent config.** Launching Claude Code, Codex, OpenCode, or Grok writes a generated settings or MCP config file so the agent gets status hooks and the agent-manager MCP tools.
+- **Generated agent config.** Launching Claude Code, Codex, OpenCode, Grok, Gemini, or an MCP-enabled Hermes tool writes or registers generated settings or MCP configuration so the agent gets status hooks and the agent-manager MCP tools.
 - **MCP server.** `agent-manager mcp` speaks stdio to the agent in its own session and exposes `rename`, `review_repo`, and `review_base`. It identifies the calling session from its environment.
 - **Git repositories.** Review mode runs read-only git commands against the repo a session declares or that ranking picks.
 - **Network.** One request a day to the GitHub Releases API to check for a newer version.
@@ -39,5 +39,5 @@ Findings that involve one of these crossing a trust boundary in a way the docs d
 
 ## Out of scope
 
-- Behavior of the AI agents themselves (Claude Code, Codex, OpenCode, Grok). Report those to their maintainers.
+- Behavior of the AI agents themselves (Claude Code, Codex, OpenCode, Grok, Gemini, Pi, Hermes). Report those to their maintainers.
 - Anything requiring an attacker to already have write access to your config file or your shell.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ![five prompts to five fresh agents without moving the cursor, one per CLI, then the blocked one answered and its diff opened](docs/demo.gif)
 
-Claude Code, Codex, OpenCode, Grok, Gemini CLI, and Pi run side by side. Each tool runs in its own persistent tmux session.
+Claude Code, Codex, OpenCode, Grok, Gemini CLI, Pi, and Hermes Agent run side by side. Each tool runs in its own persistent tmux session.
 
 agent-manager is a thin layer over the CLIs you already have. Each session launches your own installed tool as-is: your login, your subscription, your config files, your MCP servers, and every feature the tool ships all carry over, exactly as they behave in a plain terminal.
 
@@ -37,7 +37,7 @@ Not here yet: cost tracking, mouse-driven navigation, and agents that can talk t
 
 ## Supported tools
 
-Status detection supports **Claude Code**, **OpenCode**, **Codex**, **Grok Build**, **Gemini CLI**, and **Pi** by default. Other CLI tools can run as sessions. Add a `[tools.<name>]` block to give another tool live status rules (see [Configuration](docs/configuration.md)).
+Status detection supports **Claude Code**, **OpenCode**, **Codex**, **Grok Build**, **Gemini CLI**, **Pi**, and **Hermes Agent** by default. Other CLI tools can run as sessions. Add a `[tools.<name>]` block to give another tool live status rules (see [Configuration](docs/configuration.md)).
 
 ## Install
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,10 @@
 # Configuration
 
-Config lives in your OS user config dir (`~/Library/Application Support/agent-manager/config.toml` on macOS, `~/.config/agent-manager/config.toml` on Linux, with `XDG_CONFIG_HOME` honored when set) and is created on first run with defaults for Claude Code, OpenCode, Codex, Grok Build, Gemini CLI, and Pi.
+Config lives in your OS user config dir (`~/Library/Application Support/agent-manager/config.toml` on macOS, `~/.config/agent-manager/config.toml` on Linux, with `XDG_CONFIG_HOME` honored when set) and is created on first run with defaults for Claude Code, OpenCode, Codex, Grok Build, Gemini CLI, Pi, and Hermes Agent.
 
 The Pi defaults require Pi 0.76.0 or later because they use `--session-id`.
+
+The Hermes defaults are tested with Hermes Agent 0.20.0 and launch its classic REPL with `--cli`. This keeps the input, approval, and activity markers stable even when your Hermes preference selects its modern TUI.
 
 Top-level: `poll_interval` (default `"2s"`) sets how often panes are polled for status, preview, and stats.
 
@@ -24,7 +26,7 @@ Rules match top-down against the visible pane text; first match wins, and `defau
 
 **Status detection.** Optional per-tool fields refine it: `activity_cutoff` (regex locating the tool's input box, everything above it is turn content), `turn_end` (a turn-summary line marking the turn as over), `busy_line` (work that outlives its turn, such as background agents), `chrome_line`, `blocked_line`, and `trailing_note`. `status_source = "claude-hooks"` switches status to Claude Code hook events (see [Status](usage.md#status)). The generated config's `claude` and `opencode` blocks show all of them in use.
 
-**Revive.** `resume_by_id_command` resumes one exact conversation, with `{id}` replaced by the session's captured agent id. That id comes either from launching under an id the manager mints (`session_id_flag`, e.g. `--session-id`) or from reading back an id the tool minted itself (`session_store = "codex" | "opencode" | "gemini"`). `revive_command` is what `v` falls back to when no id is available, e.g. `claude --continue`.
+**Revive.** `resume_by_id_command` resumes one exact conversation, with `{id}` replaced by the session's captured agent id. That id comes either from launching under an id the manager mints (`session_id_flag`, e.g. `--session-id`) or from reading back an id the tool minted itself (`session_store = "codex" | "opencode" | "gemini" | "hermes"`). `revive_command` is what `v` falls back to when no id is available, e.g. `claude --continue`.
 
 **Forks.** `fork_command` creates a conversation from an existing session. Agent Manager replaces and shell-quotes these placeholders:
 
@@ -35,9 +37,8 @@ Rules match top-down against the visible pane text; first match wins, and `defau
 
 A `fork_command` references its source through `{id}` or `{session_file}`, so one of those two is required. Claude Code, Codex and Gemini CLI include default fork commands. A custom tool can omit `{new_id}` when its `session_store` captures the generated ID.
 
-**Prompts.** `prompt_flag` controls how the new-session form's optional prompt is embedded into the launch command. Tools that take the prompt as a positional argument (Claude Code: `claude 'the prompt'`) leave it empty; tools whose positional argument means something else declare the flag (OpenCode: `prompt_flag = "--prompt"`, since its positional argument is the project path). The prompt only shapes the launch command; revive (`v`) uses the revive commands untouched.
+**Prompts.** `prompt_flag` controls how the new-session form's optional prompt is embedded into the launch command. Tools that take the prompt as a positional argument (Claude Code: `claude 'the prompt'`) leave it empty; tools whose positional argument means something else declare the flag (OpenCode: `prompt_flag = "--prompt"`, since its positional argument is the project path). `prompt_mode = "send"` handles a persistent CLI that accepts no startup prompt: Agent Manager waits until `activity_cutoff` finds its input box, then submits the prompt there (Hermes uses this). Set it to `"argument"` if a custom Hermes wrapper accepts a launch argument instead. The prompt setting only affects a new launch; revive (`v`) uses the revive commands untouched.
 
-**MCP.** `mcp = "claude" | "codex" | "opencode" | "grok" | "gemini" | "none"` picks how the agent-manager MCP server is registered into the tool's sessions (see [MCP](usage.md#mcp-how-agents-discover-these-commands)). An empty value uses the tool's config key when it names a known style.
+**MCP.** `mcp = "claude" | "codex" | "opencode" | "grok" | "gemini" | "hermes" | "none"` picks how the agent-manager MCP server is registered into the tool's sessions (see [MCP](usage.md#mcp-how-agents-discover-these-commands)). An empty value uses the tool's config key when it names a known style. Hermes defaults to `none` because its MCP client is an optional install; after installing that extra through `hermes setup`, set `mcp = "hermes"` to opt in.
 
 State is stored next to the config in `state.db` (SQLite).
-

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,11 +51,11 @@ Navigation is keyboard-driven. The manager claims mouse reporting so the wheel s
 Press `space` to dock a prompt bar at the bottom of the sidebar. The target follows the cursor while the bar is open (`↑↓` still navigate):
 
 - On a **session** row, `enter` sends the typed text straight into the session's pane, so the agent gets it as a user message without you attaching. The bar clears and stays open, ready for the next answer; Settings (`s`) can make it close instead.
-- On a **group** row, `enter` spawns a new agent in that group with the prompt embedded, using the group's default path. The spawn tool starts at the Settings default and `tab` cycles it (claude ↔ opencode ↔ any configured tool); the footer shows the current pick. `alt+w` toggles whether the new agent spawns into its own git worktree, starting from the Settings default; the footer shows `worktree: on` or `worktree: off`, or `worktree: unavailable (not a git repo)` when the target directory cannot hold one. Answering an existing session ignores the toggle, since there is no new session to place in a worktree. The agent starts working on the prompt immediately.
+- On a **group** row, `enter` spawns a new agent in that group and submits the prompt at startup, using the group's default path. The spawn tool starts at the Settings default and `tab` cycles it (claude ↔ opencode ↔ any configured tool); the footer shows the current pick. `alt+w` toggles whether the new agent spawns into its own git worktree, starting from the Settings default; the footer shows `worktree: on` or `worktree: off`, or `worktree: unavailable (not a git repo)` when the target directory cannot hold one. Answering an existing session ignores the toggle, since there is no new session to place in a worktree. The agent starts working on the prompt immediately.
 
 `ctrl+v` pastes an image from the system clipboard as an `[Image #1]` chip at the caret. The image is saved under `agent-manager-pastes` in your temp directory, and on send each chip is swapped back for its path, so the paths reach the agent in the order and the places you pasted them. `backspace` next to a chip removes the whole chip, and an edit that swallows one releases its image. A clipboard holding text rather than an image pastes as text. Pasted images older than seven days are cleared at startup and once a day while the manager runs, so an agent can still open one from an earlier session while temp stays tidy.
 
-`esc` closes the bar. The new-session form's optional `prompt` field launches an agent the same way; tools whose CLI takes the prompt behind a flag declare it with `prompt_flag` (see [Configuration](configuration.md)).
+`esc` closes the bar. The new-session form's optional `prompt` field launches an agent the same way; tools whose CLI takes the prompt behind a flag declare it with `prompt_flag`, while a persistent CLI with no startup-prompt argument uses `prompt_mode = "send"` (see [Configuration](configuration.md)).
 
 ![answering a working Claude Code session from the prompt bar, without attaching](demo-space.gif)
 
@@ -93,9 +93,9 @@ Deleting (`d`) a session that holds a worktree removes the worktree and its bran
 
 ![ending every session under a group for the RAM, then reviving the whole subtree on its own conversations](demo-revive.gif)
 
-`v` relaunches a dead session under its old id, keeping its name, group, and history. When the manager holds that session's own conversation id, revive resumes **that exact conversation** through the tool's `resume_by_id_command`: `claude --resume {id}`, `codex resume {id}`, `opencode --session {id}`, `grok --resume {id}`, `gemini --resume {id}`, `pi --session {id}`.
+`v` relaunches a dead session under its old id, keeping its name, group, and history. When the manager holds that session's own conversation id, revive resumes **that exact conversation** through the tool's `resume_by_id_command`: `claude --resume {id}`, `codex resume {id}`, `opencode --session {id}`, `grok --resume {id}`, `gemini --resume {id}`, `pi --session {id}`, `hermes --cli --resume {id}`.
 
-The id arrives one of two ways: tools with a `session_id_flag` launch under an id the manager mints, and tools that mint their own are read back by a `session_store` capturer (`codex`, `opencode`). Without an id, revive falls back to `revive_command` (`claude --continue`), which resumes the working directory's most recent conversation, and the manager says so in the status line, since sessions sharing a directory would otherwise land on the wrong one. On a group row `v` revives every dead session under it, and `V` revives every dead session in view; both revive what they can and name the first failure rather than stopping.
+The id arrives one of two ways: tools with a `session_id_flag` launch under an id the manager mints, and tools that mint their own are read back by a `session_store` capturer (`codex`, `opencode`, `gemini`, `hermes`). Without an id, revive falls back to `revive_command` (`claude --continue`), which resumes the working directory's most recent conversation, and the manager says so in the status line, since sessions sharing a directory would otherwise land on the wrong one. On a group row `v` revives every dead session under it, and `V` revives every dead session in view; both revive what they can and name the first failure rather than stopping.
 
 ## Restarting a session on an empty context
 
@@ -150,7 +150,7 @@ The server's MCP initialization instructions teach agents to use this workflow w
 
 Sending a command to a terminal executes it on the user's machine. Agents should treat `send_terminal` with the same care as typing into an attached shell: inspect the target returned by `list_terminals`, avoid destructive commands unless the user asked for them, and read the result before continuing.
 
-Registration is per tool. Claude gets a generated `--mcp-config` file. Codex gets `-c mcp_servers...` overrides. OpenCode gets an `OPENCODE_CONFIG` merge file. Grok and Gemini each get a one-time `mcp add --scope user` entry on their first launch.
+Registration is per tool. Claude gets a generated `--mcp-config` file. Codex gets `-c mcp_servers...` overrides. OpenCode gets an `OPENCODE_CONFIG` merge file. Grok and Gemini each get a one-time `mcp add --scope user` entry on their first launch. Hermes can use its own one-time `mcp add` flow, but defaults to no registration because its MCP Python SDK is optional; after `hermes setup` installs that support, set `mcp = "hermes"` in its tool block.
 
 Pi does not include an MCP client. The `rename`, `review-repo`, and `review-base` commands still work inside Pi sessions.
 

--- a/internal/agentsession/capture.go
+++ b/internal/agentsession/capture.go
@@ -1,8 +1,8 @@
 // Package agentsession reads back the conversation id an agent CLI minted
 // for a session the manager launched, for tools that do not accept a
-// chosen id at launch (codex, opencode). Revive resumes that exact id
-// instead of the working directory's most recent conversation, which is
-// the wrong one whenever sessions share a directory.
+// chosen id at launch (codex, opencode, gemini, hermes). Revive resumes that
+// exact id instead of the working directory's most recent conversation, which
+// is the wrong one whenever sessions share a directory.
 package agentsession
 
 import (
@@ -10,16 +10,20 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 // clockSlack absorbs small differences between the manager's launch clock
@@ -42,6 +46,8 @@ const opencodeCLITimeout = 15 * time.Second
 // lets us stop before the transcript.
 const opencodeExportHeadBytes = 64 * 1024
 
+var hermesProfilePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,63}$`)
+
 // resolvePath canonicalizes a directory so a session launched via a
 // symlinked path (macOS /tmp -> /private/tmp) still matches the store
 // entry, which records the resolved path. Unresolvable paths compare raw.
@@ -54,10 +60,10 @@ func resolvePath(p string) string {
 
 // Capture returns the conversation id a tool wrote for a session launched
 // in cwd at or after launchedAt. sessionStore selects the on-disk format
-// ("codex" or "opencode"). claimed holds ids already bound to other
-// sessions, so two sessions started in one directory do not capture the
-// same conversation. It returns ok=false when no confident match exists
-// yet; the caller retries on the next poll.
+// ("codex", "opencode", "gemini" or "hermes"). claimed holds ids already
+// bound to other sessions, so two sessions started in one directory do not
+// capture the same conversation. It returns ok=false when no confident match
+// exists yet; the caller retries on the next poll.
 func Capture(sessionStore, cwd string, launchedAt time.Time, claimed map[string]bool) (string, bool) {
 	switch sessionStore {
 	case "codex":
@@ -66,9 +72,84 @@ func Capture(sessionStore, cwd string, launchedAt time.Time, claimed map[string]
 		return captureOpencode(cwd, launchedAt, claimed)
 	case "gemini":
 		return captureGemini(geminiRoot(), cwd, launchedAt, claimed)
+	case "hermes":
+		return captureHermes(hermesStateDB(), cwd, launchedAt, claimed)
 	default:
 		return "", false
 	}
+}
+
+func hermesStateDB() string {
+	root := strings.TrimSpace(os.Getenv("HERMES_HOME"))
+	if root != "" && filepath.Base(filepath.Dir(root)) == "profiles" {
+		return filepath.Join(root, "state.db")
+	}
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		root = filepath.Join(home, ".hermes")
+	}
+	if data, err := os.ReadFile(filepath.Join(root, "active_profile")); err == nil {
+		profile := strings.TrimSpace(string(data))
+		if profile != "default" && hermesProfilePattern.MatchString(profile) {
+			return filepath.Join(root, "profiles", profile, "state.db")
+		}
+	}
+	return filepath.Join(root, "state.db")
+}
+
+// captureHermes finds the CLI conversation Hermes created after first input.
+// Hermes records exact cwd and Unix creation time in state.db, which
+// distinguishes parallel sessions in the same project.
+func captureHermes(path, cwd string, launchedAt time.Time, claimed map[string]bool) (string, bool) {
+	if path == "" {
+		return "", false
+	}
+	if _, err := os.Stat(path); err != nil {
+		return "", false
+	}
+	dsn := url.URL{Scheme: "file", Path: filepath.ToSlash(path)}
+	query := dsn.Query()
+	query.Set("mode", "ro")
+	dsn.RawQuery = query.Encode()
+	db, err := sql.Open("sqlite", dsn.String())
+	if err != nil {
+		return "", false
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, cwd, started_at
+		FROM sessions
+		WHERE source = 'cli' AND started_at >= ?
+		ORDER BY started_at ASC
+		LIMIT 200`, float64(launchedAt.UnixNano())/float64(time.Second))
+	if err != nil {
+		return "", false
+	}
+	defer rows.Close()
+	wantCwd := resolvePath(cwd)
+	var cands []candidate
+	for rows.Next() {
+		var id string
+		var sessionCwd sql.NullString
+		var started float64
+		if rows.Scan(&id, &sessionCwd, &started) != nil {
+			return "", false
+		}
+		if id == "" || claimed[id] || !sessionCwd.Valid || resolvePath(sessionCwd.String) != wantCwd {
+			continue
+		}
+		cands = append(cands, candidate{id: id, modTime: time.Unix(0, int64(started*float64(time.Second)))})
+	}
+	if rows.Err() != nil {
+		return "", false
+	}
+	return pickEarliest(cands)
 }
 
 func codexRoot() string {

--- a/internal/agentsession/capture_test.go
+++ b/internal/agentsession/capture_test.go
@@ -1,11 +1,42 @@
 package agentsession
 
 import (
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+type hermesRow struct {
+	id, source, cwd string
+	started         time.Time
+}
+
+func writeHermesStore(t *testing.T, rows ...hermesRow) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE sessions (
+		id TEXT PRIMARY KEY,
+		source TEXT NOT NULL,
+		cwd TEXT,
+		started_at REAL NOT NULL
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		if _, err := db.Exec(`INSERT INTO sessions (id, source, cwd, started_at) VALUES (?, ?, ?, ?)`,
+			row.id, row.source, row.cwd, float64(row.started.UnixNano())/float64(time.Second)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return path
+}
 
 func writeFile(t *testing.T, path, content string, modTime time.Time) {
 	t.Helper()
@@ -136,6 +167,63 @@ func TestCaptureUnknownStore(t *testing.T) {
 	}
 }
 
+func TestCaptureHermesPicksSessionAfterLaunchInCwd(t *testing.T) {
+	launch := time.Now()
+	path := writeHermesStore(t,
+		hermesRow{"old", "cli", "/repo", launch.Add(-time.Hour)},
+		hermesRow{"just-before", "cli", "/repo", launch.Add(-time.Second)},
+		hermesRow{"other", "cli", "/elsewhere", launch.Add(time.Second)},
+		hermesRow{"tui", "tui", "/repo", launch.Add(time.Second)},
+		hermesRow{"ours", "cli", "/repo", launch.Add(2 * time.Second)},
+	)
+
+	id, ok := captureHermes(path, "/repo", launch, map[string]bool{})
+	if !ok || id != "ours" {
+		t.Fatalf("got id=%q ok=%v, want ours true", id, ok)
+	}
+}
+
+func TestCaptureHermesSkipsClaimed(t *testing.T) {
+	launch := time.Now()
+	path := writeHermesStore(t,
+		hermesRow{"first", "cli", "/repo", launch.Add(time.Second)},
+		hermesRow{"second", "cli", "/repo", launch.Add(2 * time.Second)},
+	)
+
+	id, ok := captureHermes(path, "/repo", launch, map[string]bool{"first": true})
+	if !ok || id != "second" {
+		t.Fatalf("got id=%q ok=%v, want second true", id, ok)
+	}
+}
+
+func TestHermesStateDBFollowsHermesHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HERMES_HOME", home)
+	if got := hermesStateDB(); got != filepath.Join(home, "state.db") {
+		t.Fatalf("hermesStateDB() = %q", got)
+	}
+}
+
+func TestHermesStateDBFollowsStickyProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HERMES_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "active_profile"), []byte("coder\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, "profiles", "coder", "state.db")
+	if got := hermesStateDB(); got != want {
+		t.Fatalf("hermesStateDB() = %q want %q", got, want)
+	}
+}
+
+func TestHermesStateDBKeepsExplicitProfileHome(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "profiles", "research")
+	t.Setenv("HERMES_HOME", home)
+	if got := hermesStateDB(); got != filepath.Join(home, "state.db") {
+		t.Fatalf("hermesStateDB() = %q", got)
+	}
+}
+
 // geminiSessionFixture is the header line of a gemini session file; the
 // capturer and resolver only read this first line.
 func geminiSessionFixture(sessionID, projectHash string) string {
@@ -200,7 +288,7 @@ func TestGeminiSessionFileInResolvesByID(t *testing.T) {
 // Only gemini keeps a conversation in a file a fork can load. Any other
 // store must be refused rather than read through the gemini layout.
 func TestSessionFileRefusesStoresWithoutAFile(t *testing.T) {
-	for _, sessionStore := range []string{"", "codex", "opencode", "weird"} {
+	for _, sessionStore := range []string{"", "codex", "opencode", "hermes", "weird"} {
 		if SupportsSessionFile(sessionStore) {
 			t.Errorf("SupportsSessionFile(%q) = true", sessionStore)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,10 @@ type Tool struct {
 	Shell         bool   `toml:"shell"`
 	ReviveCommand string `toml:"revive_command"`
 	PromptFlag    string `toml:"prompt_flag"`
+	// PromptMode controls how a new-session prompt reaches the tool. Empty
+	// embeds it in the launch command; "send" starts the interactive CLI
+	// first and submits the prompt when its input box appears.
+	PromptMode string `toml:"prompt_mode"`
 	// SessionIDFlag makes a new session launch with an id we choose (e.g.
 	// claude/grok/pi "--session-id <uuid>"), so revive can later resume that
 	// exact conversation deterministically.
@@ -37,12 +41,12 @@ type Tool struct {
 	// each value. {session_file} needs SessionStore to keep one ("gemini").
 	ForkCommand string `toml:"fork_command"`
 	// SessionStore names the built-in capturer that reads back the id a tool
-	// minted itself when it has no SessionIDFlag ("codex", "opencode" or
-	// "gemini").
+	// minted itself when it has no SessionIDFlag ("codex", "opencode",
+	// "gemini" or "hermes").
 	SessionStore string `toml:"session_store"`
 	// MCP picks how the agent-manager MCP server is registered into this
-	// tool's sessions: "claude", "codex", "opencode", "grok", "gemini" or
-	// "none".
+	// tool's sessions: "claude", "codex", "opencode", "grok", "gemini",
+	// "hermes" or "none".
 	// Empty uses the tool's config key when it names a known style.
 	MCP            string `toml:"mcp"`
 	StatusSource   string `toml:"status_source"`
@@ -161,10 +165,12 @@ func mergeTool(name string, user, def Tool) Tool {
 	fill(&user.Command, def.Command)
 	fill(&user.ReviveCommand, def.ReviveCommand)
 	fill(&user.PromptFlag, def.PromptFlag)
+	fill(&user.PromptMode, def.PromptMode)
 	fill(&user.SessionIDFlag, def.SessionIDFlag)
 	fill(&user.ResumeByIDCommand, def.ResumeByIDCommand)
 	fill(&user.ForkCommand, def.ForkCommand)
 	fill(&user.SessionStore, def.SessionStore)
+	fill(&user.MCP, def.MCP)
 	fill(&user.StatusSource, def.StatusSource)
 	fill(&user.DefaultStatus, def.DefaultStatus)
 	fill(&user.ActivityCutoff, def.ActivityCutoff)
@@ -410,6 +416,31 @@ rules = [
   { state = "working", pattern = "esc to cancel" },
   # error messages render with a "✕ " prefix
   { state = "errored", pattern = "(?m)^✕ " },
+]
+
+[tools.hermes]
+# The classic REPL exposes stable prompt markers for status and prompt delivery.
+command = "hermes --cli"
+# Hermes creates its session id on first input and records it in state.db.
+session_store = "hermes"
+resume_by_id_command = "hermes --cli --resume {id}"
+revive_command = "hermes --cli --continue"
+# Hermes only accepts startup text through chat -q, which is one-shot and
+# exits. Start the real REPL, then submit the prompt when its composer appears.
+prompt_mode = "send"
+# Hermes's MCP client is an optional install; enable mcp = "hermes" after
+# installing that extra if you want the agent-manager MCP tools.
+mcp = "none"
+default_status = "idle"
+activity_cutoff = "(?m)^\\s*(?:\\S+\\s+)?[❯>$#›»→]\\s"
+chrome_line = "^\\s*[─╭╮╰╯│]*\\s*$|^\\s*⚕ .*$"
+busy_line = "(?:▶|⚙|⛓) \\d+"
+rules = [
+  { state = "waiting", pattern = "↑/↓ to select, Enter to confirm" },
+  { state = "waiting", pattern = "type (?:password|secret).*ESC to skip" },
+  { state = "waiting", pattern = "type your answer (?:here )?and press Enter" },
+  { state = "waiting", pattern = "(?:Run setup now|Set up a provider now)\\? \\[Y/n\\]" },
+  { state = "working", pattern = "msg=interrupt · /queue · /bg · /steer · Ctrl\\+C cancel" },
 ]
 
 # The terminal tab "T" spawns: a shell in the group's directory, listed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,10 +24,7 @@ type Tool struct {
 	Shell         bool   `toml:"shell"`
 	ReviveCommand string `toml:"revive_command"`
 	PromptFlag    string `toml:"prompt_flag"`
-	// PromptMode controls how a new-session prompt reaches the tool. Empty
-	// embeds it in the launch command; "send" starts the interactive CLI
-	// first and submits the prompt when its input box appears.
-	PromptMode string `toml:"prompt_mode"`
+	PromptMode    string `toml:"prompt_mode"`
 	// SessionIDFlag makes a new session launch with an id we choose (e.g.
 	// claude/grok/pi "--session-id <uuid>"), so revive can later resume that
 	// exact conversation deterministically.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,6 +104,19 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if got := cfg.Tools["gemini"].SessionStore; got != "gemini" {
 		t.Fatalf("gemini session_store = %q want \"gemini\" (captures the fork's minted id)", got)
 	}
+	hermes := cfg.Tools["hermes"]
+	if hermes.Command != "hermes --cli" {
+		t.Fatalf("hermes command = %q", hermes.Command)
+	}
+	if hermes.PromptMode != "send" {
+		t.Fatalf("hermes prompt_mode = %q want send", hermes.PromptMode)
+	}
+	if hermes.SessionStore != "hermes" || hermes.ResumeByIDCommand != "hermes --cli --resume {id}" {
+		t.Fatalf("hermes resume config = %+v", hermes)
+	}
+	if hermes.MCP != "none" {
+		t.Fatalf("hermes mcp = %q want none (the Hermes MCP SDK is optional)", hermes.MCP)
+	}
 }
 
 func TestLoadDirWritesDefaultInRequestedDirectory(t *testing.T) {
@@ -226,6 +239,18 @@ func TestBackfillToolDefaults(t *testing.T) {
 	}
 }
 
+func TestBackfillHermesKeepsOptionalMCPDisabled(t *testing.T) {
+	cfg := Config{Tools: map[string]Tool{
+		"hermes": {Command: "hermes --cli"},
+	}}
+	if err := cfg.backfillToolDefaults(); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got := cfg.Tools["hermes"].MCP; got != "none" {
+		t.Fatalf("hermes mcp = %q want none", got)
+	}
+}
+
 func TestApplyDefaults(t *testing.T) {
 	var cfg Config
 	cfg.applyDefaults()
@@ -256,7 +281,7 @@ func TestDefaultResumeByIDFields(t *testing.T) {
 		t.Fatalf("pi resume_by_id_command = %q want \"pi --session {id}\"", got)
 	}
 	// Tools that mint their own id declare a store to capture it from.
-	for _, name := range []string{"codex", "opencode"} {
+	for _, name := range []string{"codex", "opencode", "hermes"} {
 		tool := cfg.Tools[name]
 		if tool.SessionStore != name {
 			t.Fatalf("%s session_store = %q want %q", name, tool.SessionStore, name)

--- a/internal/mcpreg/mcpreg.go
+++ b/internal/mcpreg/mcpreg.go
@@ -217,7 +217,7 @@ func ensureHermesRegistered(exe, hooksDir string) error {
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("hermes mcp add: %v: %s", err, out)
+		return fmt.Errorf("hermes mcp add: %w: %s", err, out)
 	}
 	entry, ok := readHermesMCPEntry()
 	if !ok || !validHermesMCPEntry(entry, exe) {

--- a/internal/mcpreg/mcpreg.go
+++ b/internal/mcpreg/mcpreg.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/tmux"
@@ -25,6 +26,7 @@ var knownStyles = map[string]bool{
 	"opencode": true,
 	"grok":     true,
 	"gemini":   true,
+	"hermes":   true,
 	"none":     true,
 }
 
@@ -80,6 +82,11 @@ func Apply(style, exe, hooksDir, command string, env map[string]string) (string,
 		return command, nil
 	case "gemini":
 		if err := ensureGeminiRegistered(exe, hooksDir); err != nil {
+			return "", err
+		}
+		return command, nil
+	case "hermes":
+		if err := ensureHermesRegistered(exe, hooksDir); err != nil {
 			return "", err
 		}
 		return command, nil
@@ -158,6 +165,68 @@ func ensureGeminiRegistered(exe, hooksDir string) error {
 		"-e", hooks.EnvSessionID+"=${"+hooks.EnvSessionID+"}",
 		serverName, exe, "mcp")
 	return ensureRegisteredOnce("gemini", exe, hooksDir, cmd)
+}
+
+type hermesMCPEntry struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args"`
+	Env     map[string]string `json:"env"`
+	Enabled *bool             `json:"enabled"`
+}
+
+func readHermesMCPEntry() (hermesMCPEntry, bool) {
+	cmd := exec.Command("hermes", "config", "get", "mcp_servers."+serverName, "--json")
+	for _, item := range os.Environ() {
+		if !strings.HasPrefix(item, hooks.EnvSessionID+"=") {
+			cmd.Env = append(cmd.Env, item)
+		}
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return hermesMCPEntry{}, false
+	}
+	var entry hermesMCPEntry
+	if json.Unmarshal(out, &entry) != nil {
+		return hermesMCPEntry{}, false
+	}
+	return entry, true
+}
+
+func validHermesMCPEntry(entry hermesMCPEntry, exe string) bool {
+	return entry.Command == exe && len(entry.Args) == 1 && entry.Args[0] == "mcp" &&
+		entry.Env[hooks.EnvSessionID] == "${"+hooks.EnvSessionID+"}" &&
+		(entry.Enabled == nil || *entry.Enabled)
+}
+
+// ensureHermesRegistered accepts the mcp-add defaults after Hermes verifies
+// the server. A stale entry adds an overwrite confirmation first.
+func ensureHermesRegistered(exe, hooksDir string) error {
+	marker := filepath.Join(hooksDir, "mcp-hermes-registered")
+	if content, err := os.ReadFile(marker); err == nil && string(content) == exe {
+		return nil
+	}
+	_, existed := readHermesMCPEntry()
+	cmd := exec.Command("hermes", "mcp", "add", serverName,
+		"--command", exe,
+		"--env", hooks.EnvSessionID+"=${"+hooks.EnvSessionID+"}",
+		"--args", "mcp")
+	if existed {
+		cmd.Stdin = strings.NewReader("y\n\n")
+	} else {
+		cmd.Stdin = strings.NewReader("\n")
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("hermes mcp add: %v: %s", err, out)
+	}
+	entry, ok := readHermesMCPEntry()
+	if !ok || !validHermesMCPEntry(entry, exe) {
+		return fmt.Errorf("hermes mcp add did not save an enabled agent-manager server: %s", out)
+	}
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(marker, []byte(exe), 0o644)
 }
 
 // ensureRegisteredOnce runs a tool's own mcp-add command once per binary

--- a/internal/mcpreg/mcpreg_test.go
+++ b/internal/mcpreg/mcpreg_test.go
@@ -2,6 +2,7 @@ package mcpreg
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -243,6 +244,32 @@ exit 1
 	marker, err := os.ReadFile(filepath.Join(dir, "mcp-hermes-registered"))
 	if err != nil || string(marker) != exe {
 		t.Fatalf("marker = %q err=%v", marker, err)
+	}
+}
+
+func TestEnsureHermesRegisteredWrapsExitError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Hermes executable is a shell script")
+	}
+	bin := t.TempDir()
+	script := `#!/bin/sh
+if [ "$1" = "config" ]; then
+  exit 1
+fi
+printf 'registration failed\n' >&2
+exit 7
+`
+	if err := os.WriteFile(filepath.Join(bin, "hermes"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	err := ensureHermesRegistered("/opt/bin/agent-manager", t.TempDir())
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error should wrap exec.ExitError, got %v", err)
+	}
+	if exitErr.ExitCode() != 7 {
+		t.Fatalf("exit code = %d, want 7", exitErr.ExitCode())
 	}
 }
 

--- a/internal/mcpreg/mcpreg_test.go
+++ b/internal/mcpreg/mcpreg_test.go
@@ -5,8 +5,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/hooks"
 )
 
 func TestStyleResolution(t *testing.T) {
@@ -18,6 +21,7 @@ func TestStyleResolution(t *testing.T) {
 		{"opencode", "", "opencode"},
 		{"grok", "", "grok"},
 		{"gemini", "", "gemini"},
+		{"hermes", "", "hermes"},
 		{"aider", "", "none"},
 		{"my-claude", "claude", "claude"},
 		{"claude", "none", "none"},
@@ -133,6 +137,112 @@ func TestApplyGeminiSkipsWhenMarkerMatches(t *testing.T) {
 	}
 	if command != "gemini" {
 		t.Fatalf("command = %q", command)
+	}
+}
+
+func TestApplyHermesSkipsWhenMarkerMatches(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "mcp-hermes-registered"), []byte("/opt/bin/agent-manager"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	command, err := Apply("hermes", "/opt/bin/agent-manager", dir, "hermes --cli", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command != "hermes --cli" {
+		t.Fatalf("command = %q", command)
+	}
+}
+
+func TestValidHermesMCPEntry(t *testing.T) {
+	enabled := true
+	entry := hermesMCPEntry{
+		Command: "/opt/bin/agent-manager",
+		Args:    []string{"mcp"},
+		Env:     map[string]string{"AGENT_MANAGER_SESSION_ID": "${AGENT_MANAGER_SESSION_ID}"},
+		Enabled: &enabled,
+	}
+	if !validHermesMCPEntry(entry, "/opt/bin/agent-manager") {
+		t.Fatal("valid Hermes MCP entry was rejected")
+	}
+	entry.Args = []string{"wrong"}
+	if validHermesMCPEntry(entry, "/opt/bin/agent-manager") {
+		t.Fatal("Hermes MCP entry with wrong args was accepted")
+	}
+}
+
+func TestApplyHermesRegistersAndVerifies(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Hermes executable is a shell script")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bin")
+	if err := os.Mkdir(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := `#!/bin/sh
+if [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  if [ -n "$AGENT_MANAGER_SESSION_ID" ]; then
+    touch "$FAKE_HERMES_LEAK"
+  fi
+  if [ -f "$FAKE_HERMES_STATE" ]; then
+    printf '{"command":"%s","args":["mcp"],"env":{"AGENT_MANAGER_SESSION_ID":"${AGENT_MANAGER_SESSION_ID}"},"enabled":true}\n' "$FAKE_HERMES_EXE"
+    exit 0
+  fi
+  exit 1
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "add" ]; then
+  printf '%s\n' "$@" > "$FAKE_HERMES_ARGS"
+  sed -n l > "$FAKE_HERMES_STDIN"
+  touch "$FAKE_HERMES_STATE"
+  exit 0
+fi
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(bin, "hermes"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := filepath.Join(dir, "registered")
+	argsPath := filepath.Join(dir, "args")
+	stdinPath := filepath.Join(dir, "stdin")
+	leakPath := filepath.Join(dir, "leaked")
+	exe := "/opt/bin/agent-manager"
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_HERMES_STATE", state)
+	t.Setenv("FAKE_HERMES_ARGS", argsPath)
+	t.Setenv("FAKE_HERMES_STDIN", stdinPath)
+	t.Setenv("FAKE_HERMES_LEAK", leakPath)
+	t.Setenv("FAKE_HERMES_EXE", exe)
+	t.Setenv(hooks.EnvSessionID, "parent-session")
+
+	command, err := Apply("hermes", exe, dir, "hermes --cli", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command != "hermes --cli" {
+		t.Fatalf("command = %q", command)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantArgs := "mcp\nadd\nagent-manager\n--command\n/opt/bin/agent-manager\n--env\nAGENT_MANAGER_SESSION_ID=${AGENT_MANAGER_SESSION_ID}\n--args\nmcp\n"
+	if string(args) != wantArgs {
+		t.Fatalf("hermes args = %q want %q", args, wantArgs)
+	}
+	stdin, err := os.ReadFile(stdinPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(stdin) != "$\n" {
+		t.Fatalf("hermes stdin = %q want one blank answer", stdin)
+	}
+	if _, err := os.Stat(leakPath); !os.IsNotExist(err) {
+		t.Fatal("config verification expanded the parent manager's session id")
+	}
+	marker, err := os.ReadFile(filepath.Join(dir, "mcp-hermes-registered"))
+	if err != nil || string(marker) != exe {
+		t.Fatalf("marker = %q err=%v", marker, err)
 	}
 }
 

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -368,6 +368,49 @@ func TestGeminiPanes(t *testing.T) {
 	}
 }
 
+// Hermes fixtures follow the classic prompt_toolkit interface in Hermes Agent
+// v0.20.0. Agent Manager launches --cli explicitly so user TUI preferences do
+// not change these status surfaces underneath the detector.
+func TestHermesPanes(t *testing.T) {
+	engine := defaultEngine(t)
+	cases := []struct {
+		name string
+		pane string
+		want string
+	}{
+		{"idle at prompt",
+			"Welcome to Hermes Agent\n  ⚕ hermes-4 │ ctx -- │ ⏲ 0s\n────────────────────────\n❯ ", Idle},
+		{"profile-prefixed prompt",
+			"  ⚕ hermes-4 │ ctx -- │ ⏲ 0s\n────────────────────────\ncoder ❯ ", Idle},
+		{"active turn",
+			"  ◇ cogitating...  (  4.2s)\n  ⚕ hermes-4 │ ctx -- │ ⏱ 4s\n────────────────────────\n⚕ ❯ msg=interrupt · /queue · /bg · /steer · Ctrl+C cancel", Working},
+		{"approval dialog",
+			"╭────────────────────────╮\n│ Run rm build.tmp?      │\n│ Allow once             │\n│ Deny                   │\n╰────────────────────────╯\n  ↑/↓ to select, Enter to confirm  (299s)\n⚠ ❯ ", Waiting},
+		{"clarify free text",
+			"╭────────────────────────╮\n│ Which target?          │\n╰────────────────────────╯\n  type your answer and press Enter\n✎ ❯ ", Waiting},
+		{"first-run setup",
+			"It looks like Hermes isn't configured yet -- no API keys or providers found.\nRun setup now? [Y/n] ", Waiting},
+		{"first-run provider setup",
+			"⚕ No inference provider is configured yet — let's fix that.\n  Set up a provider now? [Y/n]: ", Waiting},
+		{"background work",
+			"Started a background delegation.\n  ⚕ hermes-4 │ ctx -- │ ⛓ 2 │ ⏲ 8s\n────────────────────────\n❯ ", Working},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, _ := engine.Match("hermes", tc.pane); got != tc.want {
+				t.Fatalf("Match() = %q want %q", got, tc.want)
+			}
+		})
+	}
+
+	if got := engine.TurnEndedState("hermes", "╭────╮\n│ All done. │\n╰────╯\n  ⚕ hermes-4 │ ctx -- │ ⏲ 4s\n────────"); got != Finished {
+		t.Fatalf("completed turn = %q want finished", got)
+	}
+	if got := engine.TurnEndedState("hermes", "╭────╮\n│ Which target? │\n╰────╯\n  ⚕ hermes-4 │ ctx -- │ ⏲ 4s\n────────"); got != Waiting {
+		t.Fatalf("question turn = %q want waiting", got)
+	}
+}
+
 // Pi 0.83.0 fixtures cover its resting editor, active spinner, project-trust
 // selector, and final question or error directly above the editor.
 func TestPiPanes(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -45,6 +46,7 @@ type Session struct {
 	// session to leave can clean up the worktree and its am/ branch.
 	WorktreeRepo   string
 	WorktreeBranch string
+	PendingInputs  []string
 }
 
 // LaunchTime is when the agent now in the pane started: the last restart,
@@ -94,7 +96,8 @@ CREATE TABLE IF NOT EXISTS sessions (
 	archived       INTEGER NOT NULL DEFAULT 0,
 	created_at     INTEGER NOT NULL,
 	last_status_at INTEGER NOT NULL,
-	agent_session_id TEXT NOT NULL DEFAULT ''
+	agent_session_id TEXT NOT NULL DEFAULT '',
+	pending_inputs TEXT NOT NULL DEFAULT '[]'
 );
 CREATE TABLE IF NOT EXISTS groups (
 	name       TEXT PRIMARY KEY,
@@ -137,6 +140,7 @@ CREATE TABLE IF NOT EXISTS settings (
 		`ALTER TABLE groups ADD COLUMN worktree TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN agent_launched_at INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN retired_agent_session_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN pending_inputs TEXT NOT NULL DEFAULT '[]'`,
 	}
 	for _, migration := range migrations {
 		if _, err := s.db.Exec(migration); err != nil {
@@ -250,13 +254,17 @@ func (s *Store) CreateSession(sess Session) error {
 	if sess.LastStatusAt.IsZero() {
 		sess.LastStatusAt = sess.CreatedAt
 	}
-	_, err := s.db.Exec(
-		`INSERT INTO sessions (id, name, tool, cwd, group_name, status, archived, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, sort_order)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+	pendingInputs, err := json.Marshal(sess.PendingInputs)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(
+		`INSERT INTO sessions (id, name, tool, cwd, group_name, status, archived, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, pending_inputs, sort_order)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 		         (SELECT COALESCE(MAX(sort_order)+1, 0) FROM sessions WHERE group_name = ?))`,
 		sess.ID, sess.Name, sess.Tool, sess.Cwd, sess.Group, sess.Status,
 		boolToInt(sess.Archived), encodeTime(sess.CreatedAt), encodeTime(sess.LastStatusAt), sess.AgentSessionID,
-		sess.WorktreeRepo, sess.WorktreeBranch, sess.Group,
+		sess.WorktreeRepo, sess.WorktreeBranch, string(pendingInputs), sess.Group,
 	)
 	if err != nil {
 		return err
@@ -312,7 +320,7 @@ func (s *Store) AddGroup(name, path, worktree string) error {
 }
 
 func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
-	query := `SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id
+	query := `SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id, pending_inputs
 	          FROM sessions`
 	if !includeArchived {
 		query += ` WHERE archived = 0`
@@ -329,11 +337,15 @@ func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
 		var sess Session
 		var archived, acked int
 		var created, lastStatus, agentLaunched int64
+		var pendingInputs string
 		if err := rows.Scan(&sess.ID, &sess.Name, &sess.Tool, &sess.Cwd,
 			&sess.Group, &sess.Status, &archived, &acked, &created, &lastStatus,
 			&sess.AgentSessionID, &sess.WorktreeRepo, &sess.WorktreeBranch,
-			&agentLaunched, &sess.RetiredAgentSessionID); err != nil {
+			&agentLaunched, &sess.RetiredAgentSessionID, &pendingInputs); err != nil {
 			return nil, err
+		}
+		if err := json.Unmarshal([]byte(pendingInputs), &sess.PendingInputs); err != nil {
+			return nil, fmt.Errorf("decode pending inputs for session %s: %w", sess.ID, err)
 		}
 		sess.Archived = archived != 0
 		sess.Acked = acked != 0
@@ -349,14 +361,18 @@ func (s *Store) Get(id string) (Session, error) {
 	var sess Session
 	var archived, acked int
 	var created, lastStatus, agentLaunched int64
+	var pendingInputs string
 	err := s.db.QueryRow(
-		`SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id
+		`SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id, pending_inputs
 		 FROM sessions WHERE id = ?`, id,
 	).Scan(&sess.ID, &sess.Name, &sess.Tool, &sess.Cwd, &sess.Group,
 		&sess.Status, &archived, &acked, &created, &lastStatus, &sess.AgentSessionID,
-		&sess.WorktreeRepo, &sess.WorktreeBranch, &agentLaunched, &sess.RetiredAgentSessionID)
+		&sess.WorktreeRepo, &sess.WorktreeBranch, &agentLaunched, &sess.RetiredAgentSessionID, &pendingInputs)
 	if err != nil {
 		return Session{}, err
+	}
+	if err := json.Unmarshal([]byte(pendingInputs), &sess.PendingInputs); err != nil {
+		return Session{}, fmt.Errorf("decode pending inputs for session %s: %w", sess.ID, err)
 	}
 	sess.Archived = archived != 0
 	sess.Acked = acked != 0
@@ -364,6 +380,41 @@ func (s *Store) Get(id string) (Session, error) {
 	sess.LastStatusAt = decodeTime(lastStatus)
 	sess.AgentLaunchedAt = decodeTime(agentLaunched)
 	return sess, nil
+}
+
+func (s *Store) ConsumePendingInput(id, expected string) (bool, error) {
+	var encoded string
+	if err := s.db.QueryRow(`SELECT pending_inputs FROM sessions WHERE id = ?`, id).Scan(&encoded); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, fmt.Errorf("session %s: %w", id, ErrSessionGone)
+		}
+		return false, err
+	}
+	var inputs []string
+	if err := json.Unmarshal([]byte(encoded), &inputs); err != nil {
+		return false, fmt.Errorf("decode pending inputs for session %s: %w", id, err)
+	}
+	if len(inputs) == 0 || inputs[0] != expected {
+		return false, nil
+	}
+	remaining, err := json.Marshal(inputs[1:])
+	if err != nil {
+		return false, err
+	}
+	res, err := s.db.Exec(
+		`UPDATE sessions SET pending_inputs = ? WHERE id = ? AND pending_inputs = ?`,
+		string(remaining), id, encoded)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		return false, s.requireRowOrNoop(res, id)
+	}
+	return true, nil
 }
 
 func (s *Store) UpdateStatus(id, newStatus string) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -30,8 +30,8 @@ type Session struct {
 	CreatedAt    time.Time
 	LastStatusAt time.Time
 	// AgentSessionID is the agent CLI's own conversation id (claude/grok/
-	// gemini/pi session UUID, codex rollout id, opencode session id). Revive resumes
-	// this exact conversation instead of the cwd's most recent one.
+	// gemini/pi session UUID, codex rollout id, opencode/hermes session id).
+	// Revive resumes this exact conversation instead of the cwd's most recent one.
 	AgentSessionID string
 	// AgentLaunchedAt is when the agent process now in the pane started, which
 	// restart moves forward while CreatedAt keeps marking the row's birth.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -44,9 +44,10 @@ type Session struct {
 	// WorktreeRepo and WorktreeBranch are set for sessions running in a
 	// worktree Agent Manager created. Forks share these values so the last
 	// session to leave can clean up the worktree and its am/ branch.
-	WorktreeRepo   string
-	WorktreeBranch string
-	PendingInputs  []string
+	WorktreeRepo        string
+	WorktreeBranch      string
+	PendingInputs       []string
+	PendingInputClaimed bool
 }
 
 // LaunchTime is when the agent now in the pane started: the last restart,
@@ -97,7 +98,8 @@ CREATE TABLE IF NOT EXISTS sessions (
 	created_at     INTEGER NOT NULL,
 	last_status_at INTEGER NOT NULL,
 	agent_session_id TEXT NOT NULL DEFAULT '',
-	pending_inputs TEXT NOT NULL DEFAULT '[]'
+	pending_inputs TEXT NOT NULL DEFAULT '[]',
+	pending_claimed INTEGER NOT NULL DEFAULT 0
 );
 CREATE TABLE IF NOT EXISTS groups (
 	name       TEXT PRIMARY KEY,
@@ -141,6 +143,7 @@ CREATE TABLE IF NOT EXISTS settings (
 		`ALTER TABLE sessions ADD COLUMN agent_launched_at INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN retired_agent_session_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN pending_inputs TEXT NOT NULL DEFAULT '[]'`,
+		`ALTER TABLE sessions ADD COLUMN pending_claimed INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, migration := range migrations {
 		if _, err := s.db.Exec(migration); err != nil {
@@ -254,7 +257,7 @@ func (s *Store) CreateSession(sess Session) error {
 	if sess.LastStatusAt.IsZero() {
 		sess.LastStatusAt = sess.CreatedAt
 	}
-	pendingInputs, err := json.Marshal(sess.PendingInputs)
+	pendingInputs, err := encodePendingInputs(sess.PendingInputs)
 	if err != nil {
 		return err
 	}
@@ -264,7 +267,7 @@ func (s *Store) CreateSession(sess Session) error {
 		         (SELECT COALESCE(MAX(sort_order)+1, 0) FROM sessions WHERE group_name = ?))`,
 		sess.ID, sess.Name, sess.Tool, sess.Cwd, sess.Group, sess.Status,
 		boolToInt(sess.Archived), encodeTime(sess.CreatedAt), encodeTime(sess.LastStatusAt), sess.AgentSessionID,
-		sess.WorktreeRepo, sess.WorktreeBranch, string(pendingInputs), sess.Group,
+		sess.WorktreeRepo, sess.WorktreeBranch, pendingInputs, sess.Group,
 	)
 	if err != nil {
 		return err
@@ -320,7 +323,7 @@ func (s *Store) AddGroup(name, path, worktree string) error {
 }
 
 func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
-	query := `SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id, pending_inputs
+	query := `SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id, pending_inputs, pending_claimed
 	          FROM sessions`
 	if !includeArchived {
 		query += ` WHERE archived = 0`
@@ -335,13 +338,13 @@ func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
 	var sessions []Session
 	for rows.Next() {
 		var sess Session
-		var archived, acked int
+		var archived, acked, pendingClaimed int
 		var created, lastStatus, agentLaunched int64
 		var pendingInputs string
 		if err := rows.Scan(&sess.ID, &sess.Name, &sess.Tool, &sess.Cwd,
 			&sess.Group, &sess.Status, &archived, &acked, &created, &lastStatus,
 			&sess.AgentSessionID, &sess.WorktreeRepo, &sess.WorktreeBranch,
-			&agentLaunched, &sess.RetiredAgentSessionID, &pendingInputs); err != nil {
+			&agentLaunched, &sess.RetiredAgentSessionID, &pendingInputs, &pendingClaimed); err != nil {
 			return nil, err
 		}
 		if err := json.Unmarshal([]byte(pendingInputs), &sess.PendingInputs); err != nil {
@@ -349,6 +352,7 @@ func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
 		}
 		sess.Archived = archived != 0
 		sess.Acked = acked != 0
+		sess.PendingInputClaimed = pendingClaimed != 0
 		sess.CreatedAt = decodeTime(created)
 		sess.LastStatusAt = decodeTime(lastStatus)
 		sess.AgentLaunchedAt = decodeTime(agentLaunched)
@@ -359,15 +363,15 @@ func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
 
 func (s *Store) Get(id string) (Session, error) {
 	var sess Session
-	var archived, acked int
+	var archived, acked, pendingClaimed int
 	var created, lastStatus, agentLaunched int64
 	var pendingInputs string
 	err := s.db.QueryRow(
-		`SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id, pending_inputs
+		`SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id, pending_inputs, pending_claimed
 		 FROM sessions WHERE id = ?`, id,
 	).Scan(&sess.ID, &sess.Name, &sess.Tool, &sess.Cwd, &sess.Group,
 		&sess.Status, &archived, &acked, &created, &lastStatus, &sess.AgentSessionID,
-		&sess.WorktreeRepo, &sess.WorktreeBranch, &agentLaunched, &sess.RetiredAgentSessionID, &pendingInputs)
+		&sess.WorktreeRepo, &sess.WorktreeBranch, &agentLaunched, &sess.RetiredAgentSessionID, &pendingInputs, &pendingClaimed)
 	if err != nil {
 		return Session{}, err
 	}
@@ -376,34 +380,24 @@ func (s *Store) Get(id string) (Session, error) {
 	}
 	sess.Archived = archived != 0
 	sess.Acked = acked != 0
+	sess.PendingInputClaimed = pendingClaimed != 0
 	sess.CreatedAt = decodeTime(created)
 	sess.LastStatusAt = decodeTime(lastStatus)
 	sess.AgentLaunchedAt = decodeTime(agentLaunched)
 	return sess, nil
 }
 
-func (s *Store) ConsumePendingInput(id, expected string) (bool, error) {
-	var encoded string
-	if err := s.db.QueryRow(`SELECT pending_inputs FROM sessions WHERE id = ?`, id).Scan(&encoded); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return false, fmt.Errorf("session %s: %w", id, ErrSessionGone)
-		}
-		return false, err
-	}
-	var inputs []string
-	if err := json.Unmarshal([]byte(encoded), &inputs); err != nil {
-		return false, fmt.Errorf("decode pending inputs for session %s: %w", id, err)
-	}
-	if len(inputs) == 0 || inputs[0] != expected {
-		return false, nil
-	}
-	remaining, err := json.Marshal(inputs[1:])
+func (s *Store) ClaimPendingInput(id, expected string) (bool, error) {
+	encoded, inputs, claimed, err := s.pendingInputState(id)
 	if err != nil {
 		return false, err
 	}
+	if claimed || len(inputs) == 0 || inputs[0] != expected {
+		return false, nil
+	}
 	res, err := s.db.Exec(
-		`UPDATE sessions SET pending_inputs = ? WHERE id = ? AND pending_inputs = ?`,
-		string(remaining), id, encoded)
+		`UPDATE sessions SET pending_claimed = 1
+		 WHERE id = ? AND pending_inputs = ? AND pending_claimed = 0`, id, encoded)
 	if err != nil {
 		return false, err
 	}
@@ -415,6 +409,61 @@ func (s *Store) ConsumePendingInput(id, expected string) (bool, error) {
 		return false, s.requireRowOrNoop(res, id)
 	}
 	return true, nil
+}
+
+func (s *Store) ConsumeClaimedPendingInput(id, expected string) (bool, error) {
+	encoded, inputs, claimed, err := s.pendingInputState(id)
+	if err != nil {
+		return false, err
+	}
+	if !claimed || len(inputs) == 0 || inputs[0] != expected {
+		return false, nil
+	}
+	remaining, err := encodePendingInputs(inputs[1:])
+	if err != nil {
+		return false, err
+	}
+	res, err := s.db.Exec(
+		`UPDATE sessions SET pending_inputs = ?, pending_claimed = 0
+		 WHERE id = ? AND pending_inputs = ? AND pending_claimed = 1`,
+		remaining, id, encoded)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		return false, s.requireRowOrNoop(res, id)
+	}
+	return true, nil
+}
+
+func (s *Store) pendingInputState(id string) (string, []string, bool, error) {
+	var encoded string
+	var claimed int
+	if err := s.db.QueryRow(
+		`SELECT pending_inputs, pending_claimed FROM sessions WHERE id = ?`, id,
+	).Scan(&encoded, &claimed); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil, false, fmt.Errorf("session %s: %w", id, ErrSessionGone)
+		}
+		return "", nil, false, err
+	}
+	var inputs []string
+	if err := json.Unmarshal([]byte(encoded), &inputs); err != nil {
+		return "", nil, false, fmt.Errorf("decode pending inputs for session %s: %w", id, err)
+	}
+	return encoded, inputs, claimed != 0, nil
+}
+
+func encodePendingInputs(inputs []string) (string, error) {
+	if len(inputs) == 0 {
+		return "[]", nil
+	}
+	encoded, err := json.Marshal(inputs)
+	return string(encoded), err
 }
 
 func (s *Store) UpdateStatus(id, newStatus string) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -49,6 +49,50 @@ func TestCreateAndList(t *testing.T) {
 	}
 }
 
+func TestPendingInputsPersistAndConsumeInOrder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.db")
+	st, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	sess := sample("a", "g1")
+	sess.PendingInputs = []string{"first", "second"}
+	if err := st.CreateSession(sess); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	st, err = Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer st.Close()
+	got, err := st.Get("a")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !slices.Equal(got.PendingInputs, []string{"first", "second"}) {
+		t.Fatalf("pending inputs = %q", got.PendingInputs)
+	}
+	consumed, err := st.ConsumePendingInput("a", "second")
+	if err != nil || consumed {
+		t.Fatalf("consume out of order = %v, %v", consumed, err)
+	}
+	consumed, err = st.ConsumePendingInput("a", "first")
+	if err != nil || !consumed {
+		t.Fatalf("consume first = %v, %v", consumed, err)
+	}
+	got, err = st.Get("a")
+	if err != nil {
+		t.Fatalf("get after consume: %v", err)
+	}
+	if !slices.Equal(got.PendingInputs, []string{"second"}) {
+		t.Fatalf("remaining inputs = %q", got.PendingInputs)
+	}
+}
+
 func TestArchiveHidesFromActiveList(t *testing.T) {
 	st := newTestStore(t)
 	st.CreateSession(sample("a", "g1"))

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -76,11 +76,30 @@ func TestPendingInputsPersistAndConsumeInOrder(t *testing.T) {
 	if !slices.Equal(got.PendingInputs, []string{"first", "second"}) {
 		t.Fatalf("pending inputs = %q", got.PendingInputs)
 	}
-	consumed, err := st.ConsumePendingInput("a", "second")
-	if err != nil || consumed {
-		t.Fatalf("consume out of order = %v, %v", consumed, err)
+	claimed, err := st.ClaimPendingInput("a", "second")
+	if err != nil || claimed {
+		t.Fatalf("claim out of order = %v, %v", claimed, err)
 	}
-	consumed, err = st.ConsumePendingInput("a", "first")
+	claimed, err = st.ClaimPendingInput("a", "first")
+	if err != nil || !claimed {
+		t.Fatalf("claim first = %v, %v", claimed, err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close claimed store: %v", err)
+	}
+	st, err = Open(path)
+	if err != nil {
+		t.Fatalf("reopen claimed store: %v", err)
+	}
+	defer st.Close()
+	got, err = st.Get("a")
+	if err != nil {
+		t.Fatalf("get claimed: %v", err)
+	}
+	if !got.PendingInputClaimed {
+		t.Fatal("pending delivery claim did not survive reopen")
+	}
+	consumed, err := st.ConsumeClaimedPendingInput("a", "first")
 	if err != nil || !consumed {
 		t.Fatalf("consume first = %v, %v", consumed, err)
 	}
@@ -90,6 +109,9 @@ func TestPendingInputsPersistAndConsumeInOrder(t *testing.T) {
 	}
 	if !slices.Equal(got.PendingInputs, []string{"second"}) {
 		t.Fatalf("remaining inputs = %q", got.PendingInputs)
+	}
+	if got.PendingInputClaimed {
+		t.Fatal("delivery claim remained after consumption")
 	}
 }
 

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -600,6 +600,15 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 	deferDirective := autoNamed && !directiveEmbeddable(prompt)
 	prompt = launchPrompt(prompt, autoNamed)
 	base := withPrompt(tool, tool.Command, prompt)
+	var pendingInputs []string
+	if tool.PromptMode == "send" {
+		if prompt != "" {
+			pendingInputs = append(pendingInputs, prompt)
+		}
+	}
+	if deferDirective {
+		pendingInputs = append(pendingInputs, deferredRenameDirective)
+	}
 	// Tools that accept a chosen session id launch with one, so a later
 	// revive resumes this exact conversation rather than the directory's
 	// most recent one. Tools without the flag mint their own id, captured
@@ -622,16 +631,15 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		WorktreeRepo:   worktreeRepo,
 		WorktreeBranch: worktreeBranch,
 	}, tool, base, launchOptions{
-		deferDirective:   deferDirective,
+		pendingInputs:    pendingInputs,
 		rollbackWorktree: worktreeRepo != "",
 	})
 }
 
-// withPrompt embeds an optional starting prompt into a tool's launch
-// command; tools whose positional argument is not a prompt route it
-// through their prompt_flag.
+// withPrompt embeds a starting prompt into a tool's launch command unless
+// prompt_mode routes it through the live input box instead.
 func withPrompt(tool config.Tool, command, prompt string) string {
-	if prompt == "" {
+	if prompt == "" || tool.PromptMode == "send" {
 		return command
 	}
 	if tool.PromptFlag != "" {

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -630,14 +630,12 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		AgentSessionID: agentSessionID,
 		WorktreeRepo:   worktreeRepo,
 		WorktreeBranch: worktreeBranch,
+		PendingInputs:  pendingInputs,
 	}, tool, base, launchOptions{
-		pendingInputs:    pendingInputs,
 		rollbackWorktree: worktreeRepo != "",
 	})
 }
 
-// withPrompt embeds a starting prompt into a tool's launch command unless
-// prompt_mode routes it through the live input box instead.
 func withPrompt(tool config.Tool, command, prompt string) string {
 	if prompt == "" || tool.PromptMode == "send" {
 		return command

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -242,6 +242,10 @@ func TestFormPromptComposesWithSettings(t *testing.T) {
 	if got := withPrompt(tool, tool.Command, ""); got != "cat" {
 		t.Fatalf("empty prompt should leave the command untouched, got %q", got)
 	}
+	sent := config.Tool{Command: "hermes --cli", PromptMode: "send"}
+	if got := withPrompt(sent, sent.Command, "do it"); got != sent.Command {
+		t.Fatalf("send-mode prompt changed launch command to %q", got)
+	}
 }
 
 func TestFormLongDirKeepsCursorEndVisible(t *testing.T) {
@@ -441,6 +445,30 @@ func TestDeferredDirectiveSentWhenPaneReady(t *testing.T) {
 	}
 	if !strings.Contains(pane, "agent-manager rename") {
 		t.Fatalf("pane should hold the directive, got:\n%s", pane)
+	}
+}
+
+func TestSendModeSubmitsPromptAfterPaneReady(t *testing.T) {
+	m := buildModel(t)
+	if err := m.spawnSession("send-tool", "custom", t.TempDir(), "", "do the work", false, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	sess := m.sessionRows()[0]
+	deadline := time.Now().Add(5 * time.Second)
+	for m.poller.inputsPending(sess.ID) {
+		if time.Now().After(deadline) {
+			t.Fatal("startup prompt stayed queued after the input box appeared")
+		}
+		time.Sleep(100 * time.Millisecond)
+		m.applyCmd(t, m.refreshCmd())
+	}
+	pane, err := m.tmux.CapturePane(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(pane, "do the work") || !strings.Contains(pane, "This session is already named") {
+		t.Fatalf("pane did not receive the launch prompt:\n%s", pane)
 	}
 }
 

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -478,6 +478,69 @@ func TestSendModePromptSurvivesPollerRestart(t *testing.T) {
 	}
 }
 
+func TestSendModeReconcilesAmbiguousDeliveryWithoutResending(t *testing.T) {
+	m := buildModel(t)
+	if err := m.spawnSession("send-tool", "custom", t.TempDir(), "", "do not resend", false, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	sess := m.sessionRows()[0]
+	input := sessionPendingInputs(t, m, sess.ID)[0]
+	claimed, err := m.store.ClaimPendingInput(sess.ID, input)
+	if err != nil || !claimed {
+		t.Fatalf("claim pending input = %v, %v", claimed, err)
+	}
+	old := m.poller
+	m.poller = newPoller(m.store, m.tmux, m.engine, m.hooks, m.gitDrv,
+		old.statusSources, old.sessionStores, old.interval)
+	msg := m.poller.refreshOnce()
+	gotErr, ok := msg.(errMsg)
+	if !ok || !strings.Contains(gotErr.err.Error(), "ambiguous pending input") {
+		t.Fatalf("refresh result = %#v, want ambiguous-delivery error", msg)
+	}
+	if inputs := sessionPendingInputs(t, m, sess.ID); len(inputs) != 0 {
+		t.Fatalf("ambiguous input was not reconciled: %q", inputs)
+	}
+	pane, err := m.tmux.CapturePane(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(pane, "do not resend") {
+		t.Fatalf("ambiguous input was resent:\n%s", pane)
+	}
+}
+
+func TestSendModeSurfacesSendFailureAndDoesNotRetry(t *testing.T) {
+	m := buildModel(t)
+	if err := m.spawnSession("send-tool", "custom", t.TempDir(), "", "cannot deliver", false, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	sess, err := m.store.Get(m.sessionRows()[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.tmux.Kill(sess.ID); err != nil {
+		t.Fatal(err)
+	}
+	sent, err := m.poller.maybeSendPendingInput(sess, "❯ ", true)
+	if err == nil || !strings.Contains(err.Error(), "send pending input") || sent {
+		t.Fatalf("send result = %v, %v", sent, err)
+	}
+	claimed, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !claimed.PendingInputClaimed {
+		t.Fatal("failed delivery was not left in an ambiguous durable state")
+	}
+	sent, err = m.poller.maybeSendPendingInput(claimed, "", false)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous pending input") || !sent {
+		t.Fatalf("reconcile result = %v, %v", sent, err)
+	}
+	if inputs := sessionPendingInputs(t, m, sess.ID); len(inputs) != 0 {
+		t.Fatalf("ambiguous failed delivery was retried: %q", inputs)
+	}
+}
+
 func sessionPendingInputs(t *testing.T, m *Model, id string) []string {
 	t.Helper()
 	sess, err := m.store.Get(id)

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -398,7 +398,7 @@ func TestSpawnMarksDeferredDirective(t *testing.T) {
 	}
 	m.applyCmd(t, m.refreshCmd())
 	slashID := m.sessionRows()[0].ID
-	if !m.poller.directivePending(slashID) {
+	if !sessionHasPendingInput(t, m, slashID, deferredRenameDirective) {
 		t.Fatal("slash-prompt spawn should defer the directive")
 	}
 
@@ -413,7 +413,7 @@ func TestSpawnMarksDeferredDirective(t *testing.T) {
 		if sess.ID == slashID {
 			continue
 		}
-		if m.poller.directivePending(sess.ID) {
+		if sessionHasPendingInput(t, m, sess.ID, deferredRenameDirective) {
 			t.Fatalf("session %q should not defer a directive", sess.Name)
 		}
 	}
@@ -431,7 +431,7 @@ func TestDeferredDirectiveSentWhenPaneReady(t *testing.T) {
 	// already present in the pane is success; a missing mark before any
 	// send is not possible after spawnSession.
 	deadline := time.Now().Add(5 * time.Second)
-	for m.poller.directivePending(sess.ID) {
+	for sessionHasPendingInput(t, m, sess.ID, deferredRenameDirective) {
 		if time.Now().After(deadline) {
 			pane, _ := m.tmux.CapturePane(sess.ID)
 			t.Fatalf("directive never sent; pane:\n%s", pane)
@@ -448,17 +448,23 @@ func TestDeferredDirectiveSentWhenPaneReady(t *testing.T) {
 	}
 }
 
-func TestSendModeSubmitsPromptAfterPaneReady(t *testing.T) {
+func TestSendModePromptSurvivesPollerRestart(t *testing.T) {
 	m := buildModel(t)
 	if err := m.spawnSession("send-tool", "custom", t.TempDir(), "", "do the work", false, false); err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
-	m.applyCmd(t, m.refreshCmd())
 	sess := m.sessionRows()[0]
+	if !sessionHasPendingInput(t, m, sess.ID, "do the work") {
+		t.Fatal("launch prompt was not persisted before delivery")
+	}
+	old := m.poller
+	m.poller = newPoller(m.store, m.tmux, m.engine, m.hooks, m.gitDrv,
+		old.statusSources, old.sessionStores, old.interval)
+	m.applyCmd(t, m.refreshCmd())
 	deadline := time.Now().Add(5 * time.Second)
-	for m.poller.inputsPending(sess.ID) {
+	for len(sessionPendingInputs(t, m, sess.ID)) > 0 {
 		if time.Now().After(deadline) {
-			t.Fatal("startup prompt stayed queued after the input box appeared")
+			t.Fatal("startup prompt stayed queued after a poller restart and the input box appeared")
 		}
 		time.Sleep(100 * time.Millisecond)
 		m.applyCmd(t, m.refreshCmd())
@@ -470,6 +476,25 @@ func TestSendModeSubmitsPromptAfterPaneReady(t *testing.T) {
 	if !strings.Contains(pane, "do the work") || !strings.Contains(pane, "This session is already named") {
 		t.Fatalf("pane did not receive the launch prompt:\n%s", pane)
 	}
+}
+
+func sessionPendingInputs(t *testing.T, m *Model, id string) []string {
+	t.Helper()
+	sess, err := m.store.Get(id)
+	if err != nil {
+		t.Fatalf("get session %s: %v", id, err)
+	}
+	return sess.PendingInputs
+}
+
+func sessionHasPendingInput(t *testing.T, m *Model, id, want string) bool {
+	t.Helper()
+	for _, input := range sessionPendingInputs(t, m, id) {
+		if input == want || strings.Contains(input, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBuildLaunchCarriesSessionID(t *testing.T) {

--- a/internal/ui/helpers_test.go
+++ b/internal/ui/helpers_test.go
@@ -49,6 +49,12 @@ func buildModel(t *testing.T) *Model {
 				DefaultStatus:  status.Idle,
 				ActivityCutoff: "(?m)^❯",
 			},
+			"send-tool": {
+				Command:        `printf '❯ ' && cat`,
+				PromptMode:     "send",
+				DefaultStatus:  status.Idle,
+				ActivityCutoff: "(?m)^❯",
+			},
 			// Stands in for the agent CLIs, which turn on mouse tracking and
 			// scroll themselves instead of leaving history for tmux.
 			"mouse-tool": {

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -549,7 +549,7 @@ func TestRestartLaunchesAFreshConversation(t *testing.T) {
 	}
 }
 
-// A tool that mints its own conversation id (codex, opencode) has nothing to
+// A tool that mints its own conversation id has nothing to
 // hand the launch, so restart clears the binding and leaves the id for the
 // poller to capture once the new conversation lands.
 func TestRestartClearsCapturedConversationID(t *testing.T) {
@@ -1214,7 +1214,7 @@ func TestRestartLaunchIsAFreshStartForEveryShippedTool(t *testing.T) {
 			}
 		}
 		if tool.SessionIDFlag == "" {
-			// codex and opencode mint their own id; the poller captures it.
+			// Some tools mint their own id; the poller captures it.
 			if agentSessionID != "" || rest != "" {
 				t.Errorf("%s: restart handed an id to a tool that mints its own: %q", name, command)
 			}

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -41,10 +41,6 @@ type poller struct {
 	// captureErr holds a background id-capture failure to surface on the
 	// next poll, since that work no longer runs inline.
 	captureErr error
-	// Input queued until a freshly launched interactive CLI draws its input
-	// box. This carries rename directives that could not ride a launch prompt
-	// and prompts for tools that do not accept one in their command line.
-	pendingInputs map[string][]string
 
 	// captureBusy guards the single in-flight id-capture goroutine.
 	captureBusy atomic.Bool
@@ -94,69 +90,6 @@ func newPoller(st *store.Store, driver *tmux.Driver, engine *status.Engine, hook
 		poke:          make(chan struct{}, 1),
 		paneHashes:    map[string]uint64{},
 		quietSince:    map[string]time.Time{},
-		pendingInputs: map[string][]string{},
-	}
-}
-
-func (p *poller) markInputsPending(id string, inputs ...string) {
-	p.mu.Lock()
-	p.pendingInputs[id] = append(p.pendingInputs[id], inputs...)
-	p.mu.Unlock()
-}
-
-func (p *poller) directivePending(id string) bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	for _, input := range p.pendingInputs[id] {
-		if input == deferredRenameDirective {
-			return true
-		}
-	}
-	return false
-}
-
-func (p *poller) inputsPending(id string) bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return len(p.pendingInputs[id]) > 0
-}
-
-func (p *poller) nextPendingInput(id string) string {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if len(p.pendingInputs[id]) == 0 {
-		return ""
-	}
-	return p.pendingInputs[id][0]
-}
-
-func (p *poller) clearPendingInput(id string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	inputs := p.pendingInputs[id]
-	if len(inputs) <= 1 {
-		delete(p.pendingInputs, id)
-		return
-	}
-	p.pendingInputs[id] = inputs[1:]
-}
-
-// sweepPendingInputs drops queued input for sessions that no longer exist,
-// so a session deleted before its first input fires leaves nothing behind.
-func (p *poller) sweepPendingInputs(sessions []store.Session) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if len(p.pendingInputs) == 0 {
-		return
-	}
-	alive := make(map[string]struct{}, len(sessions))
-	for _, sess := range sessions {
-		alive[sess.ID] = struct{}{}
-	}
-	for id := range p.pendingInputs {
-		if _, ok := alive[id]; !ok {
-			delete(p.pendingInputs, id)
-		}
 	}
 }
 
@@ -337,7 +270,13 @@ func (p *poller) refreshOnce() tea.Msg {
 			// sample proves nothing, so it counts as alive.
 			agentAlive := !stat.OK || stat.Procs > 1
 			if pane, err := p.tmux.CapturePane(sess.ID); err == nil {
-				p.maybeSendPendingInput(sess, pane, agentAlive)
+				sent, err := p.maybeSendPendingInput(sess, pane, agentAlive)
+				if err != nil {
+					return errMsg{err}
+				}
+				if sent {
+					sessions[i].PendingInputs = sessions[i].PendingInputs[1:]
+				}
 				derived, err := p.derivePaneStatus(sess, pane, agentAlive, paneHashes)
 				if err != nil {
 					return errMsg{err}
@@ -384,7 +323,6 @@ func (p *poller) refreshOnce() tea.Msg {
 	}
 	p.startCaptureIfIdle(sessions, panes)
 	p.paneHashes = paneHashes
-	p.sweepPendingInputs(sessions)
 
 	groups, err := p.store.Groups()
 	if err != nil {
@@ -533,16 +471,18 @@ func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[stri
 // second message can safely follow a slash command on a later poll. A failed
 // send stays queued for retry. Tools without an activity_cutoff never look
 // ready and keep the input untouched.
-func (p *poller) maybeSendPendingInput(sess store.Session, pane string, agentAlive bool) {
-	if !agentAlive || !p.inputsPending(sess.ID) {
-		return
+func (p *poller) maybeSendPendingInput(sess store.Session, pane string, agentAlive bool) (bool, error) {
+	if !agentAlive || len(sess.PendingInputs) == 0 {
+		return false, nil
 	}
 	if _, ready := p.engine.ActivityRegion(sess.Tool, ansi.Strip(pane)); !ready {
-		return
+		return false, nil
 	}
-	if err := p.tmux.SendText(sess.ID, p.nextPendingInput(sess.ID)); err == nil {
-		p.clearPendingInput(sess.ID)
+	input := sess.PendingInputs[0]
+	if err := p.tmux.SendText(sess.ID, input); err != nil {
+		return false, nil
 	}
+	return p.store.ConsumePendingInput(sess.ID, input)
 }
 
 // applyPendingRename picks up a name the session's agent left via the

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -41,9 +41,10 @@ type poller struct {
 	// captureErr holds a background id-capture failure to surface on the
 	// next poll, since that work no longer runs inline.
 	captureErr error
-	// sessions whose rename directive could not ride the first prompt;
-	// sent as a message once the tool's input box appears
-	pendingDirective map[string]struct{}
+	// Input queued until a freshly launched interactive CLI draws its input
+	// box. This carries rename directives that could not ride a launch prompt
+	// and prompts for tools that do not accept one in their command line.
+	pendingInputs map[string][]string
 
 	// captureBusy guards the single in-flight id-capture goroutine.
 	captureBusy atomic.Bool
@@ -82,55 +83,79 @@ func paneBooted(pane string) bool {
 
 func newPoller(st *store.Store, driver *tmux.Driver, engine *status.Engine, hookManager *hooks.Manager, gitDriver *git.Driver, statusSources, sessionStores map[string]string, interval time.Duration) *poller {
 	return &poller{
-		store:            st,
-		tmux:             driver,
-		engine:           engine,
-		hooks:            hookManager,
-		gitDrv:           gitDriver,
-		statusSources:    statusSources,
-		sessionStores:    sessionStores,
-		interval:         interval,
-		poke:             make(chan struct{}, 1),
-		paneHashes:       map[string]uint64{},
-		quietSince:       map[string]time.Time{},
-		pendingDirective: map[string]struct{}{},
+		store:         st,
+		tmux:          driver,
+		engine:        engine,
+		hooks:         hookManager,
+		gitDrv:        gitDriver,
+		statusSources: statusSources,
+		sessionStores: sessionStores,
+		interval:      interval,
+		poke:          make(chan struct{}, 1),
+		paneHashes:    map[string]uint64{},
+		quietSince:    map[string]time.Time{},
+		pendingInputs: map[string][]string{},
 	}
 }
 
-func (p *poller) markDirectivePending(id string) {
+func (p *poller) markInputsPending(id string, inputs ...string) {
 	p.mu.Lock()
-	p.pendingDirective[id] = struct{}{}
+	p.pendingInputs[id] = append(p.pendingInputs[id], inputs...)
 	p.mu.Unlock()
 }
 
 func (p *poller) directivePending(id string) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	_, pending := p.pendingDirective[id]
-	return pending
+	for _, input := range p.pendingInputs[id] {
+		if input == deferredRenameDirective {
+			return true
+		}
+	}
+	return false
 }
 
-func (p *poller) clearDirective(id string) {
-	p.mu.Lock()
-	delete(p.pendingDirective, id)
-	p.mu.Unlock()
-}
-
-// sweepDirectives drops pending flags for sessions that no longer exist,
-// so a session deleted before its directive fired leaves nothing behind.
-func (p *poller) sweepDirectives(sessions []store.Session) {
+func (p *poller) inputsPending(id string) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if len(p.pendingDirective) == 0 {
+	return len(p.pendingInputs[id]) > 0
+}
+
+func (p *poller) nextPendingInput(id string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.pendingInputs[id]) == 0 {
+		return ""
+	}
+	return p.pendingInputs[id][0]
+}
+
+func (p *poller) clearPendingInput(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	inputs := p.pendingInputs[id]
+	if len(inputs) <= 1 {
+		delete(p.pendingInputs, id)
+		return
+	}
+	p.pendingInputs[id] = inputs[1:]
+}
+
+// sweepPendingInputs drops queued input for sessions that no longer exist,
+// so a session deleted before its first input fires leaves nothing behind.
+func (p *poller) sweepPendingInputs(sessions []store.Session) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.pendingInputs) == 0 {
 		return
 	}
 	alive := make(map[string]struct{}, len(sessions))
 	for _, sess := range sessions {
 		alive[sess.ID] = struct{}{}
 	}
-	for id := range p.pendingDirective {
+	for id := range p.pendingInputs {
 		if _, ok := alive[id]; !ok {
-			delete(p.pendingDirective, id)
+			delete(p.pendingInputs, id)
 		}
 	}
 }
@@ -312,7 +337,7 @@ func (p *poller) refreshOnce() tea.Msg {
 			// sample proves nothing, so it counts as alive.
 			agentAlive := !stat.OK || stat.Procs > 1
 			if pane, err := p.tmux.CapturePane(sess.ID); err == nil {
-				p.maybeSendDirective(sess, pane, agentAlive)
+				p.maybeSendPendingInput(sess, pane, agentAlive)
 				derived, err := p.derivePaneStatus(sess, pane, agentAlive, paneHashes)
 				if err != nil {
 					return errMsg{err}
@@ -359,7 +384,7 @@ func (p *poller) refreshOnce() tea.Msg {
 	}
 	p.startCaptureIfIdle(sessions, panes)
 	p.paneHashes = paneHashes
-	p.sweepDirectives(sessions)
+	p.sweepPendingInputs(sessions)
 
 	groups, err := p.store.Groups()
 	if err != nil {
@@ -410,14 +435,14 @@ func (p *poller) refreshOnce() tea.Msg {
 }
 
 // idMinting reports whether a live, not-yet-captured session belongs to a
-// tool that mints its own conversation id (codex, opencode).
+// tool that mints its own conversation id.
 func (p *poller) idMinting(sess store.Session, panes map[string]int) bool {
 	return !sess.Archived && panes[sess.ID] != 0 && sess.AgentSessionID == "" &&
 		p.sessionStores[sess.Tool] != ""
 }
 
 // startCaptureIfIdle runs id capture off the poll lock. Capturing an
-// opencode/codex id shells out to the tool's CLI, which can take seconds;
+// some ids shell out to the tool's CLI, which can take seconds;
 // doing it inside refreshOnce would hold runMu and stall every refresh,
 // including a freshly submitted session's first appearance. One pass runs at
 // a time, on a snapshot, and a pass that captures anything pokes a refresh so
@@ -448,9 +473,9 @@ func (p *poller) startCaptureIfIdle(sessions []store.Session, panes map[string]i
 	}()
 }
 
-// captureAgentSessionIDs binds each not-yet-captured id-minting session
-// (codex, opencode) to the conversation its CLI wrote, returning how many it
-// bound. Sessions are processed in launch order so the earliest one claims
+// captureAgentSessionIDs binds each not-yet-captured id-minting session to
+// the conversation its CLI wrote, returning how many it bound. Sessions are
+// processed in launch order so the earliest one claims
 // the earliest unclaimed conversation in its directory; a later session
 // started in the same directory then skips that one via claimed and captures
 // its own. Launch times carry nanosecond precision, so sessions launched a
@@ -503,21 +528,20 @@ func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[stri
 	return captured, nil
 }
 
-// maybeSendDirective delivers the deferred rename directive once the
-// tool's input box shows in the pane, proving the agent booted and can
-// take a message. Sent even mid-turn: tools queue typed input and
-// process it when the current turn ends. A failed send keeps the flag
-// for the next poll. Tools without an activity_cutoff never look ready,
-// so their sessions keep the placeholder name.
-func (p *poller) maybeSendDirective(sess store.Session, pane string, agentAlive bool) {
-	if !agentAlive || !p.directivePending(sess.ID) {
+// maybeSendPendingInput submits the next launch-time message once the tool's
+// input box proves it is ready. Tools queue input received mid-turn, so a
+// second message can safely follow a slash command on a later poll. A failed
+// send stays queued for retry. Tools without an activity_cutoff never look
+// ready and keep the input untouched.
+func (p *poller) maybeSendPendingInput(sess store.Session, pane string, agentAlive bool) {
+	if !agentAlive || !p.inputsPending(sess.ID) {
 		return
 	}
 	if _, ready := p.engine.ActivityRegion(sess.Tool, ansi.Strip(pane)); !ready {
 		return
 	}
-	if err := p.tmux.SendText(sess.ID, deferredRenameDirective); err == nil {
-		p.clearDirective(sess.ID)
+	if err := p.tmux.SendText(sess.ID, p.nextPendingInput(sess.ID)); err == nil {
+		p.clearPendingInput(sess.ID)
 	}
 }
 

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -466,23 +466,45 @@ func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[stri
 	return captured, nil
 }
 
-// maybeSendPendingInput submits the next launch-time message once the tool's
-// input box proves it is ready. Tools queue input received mid-turn, so a
-// second message can safely follow a slash command on a later poll. A failed
-// send stays queued for retry. Tools without an activity_cutoff never look
-// ready and keep the input untouched.
+// A durable claim makes automatic delivery at-most-once: after a process or
+// database failure, an ambiguous input is dropped and surfaced rather than
+// risking the same task or slash command running twice.
 func (p *poller) maybeSendPendingInput(sess store.Session, pane string, agentAlive bool) (bool, error) {
-	if !agentAlive || len(sess.PendingInputs) == 0 {
+	if len(sess.PendingInputs) == 0 {
+		return false, nil
+	}
+	input := sess.PendingInputs[0]
+	if sess.PendingInputClaimed {
+		consumed, err := p.store.ConsumeClaimedPendingInput(sess.ID, input)
+		if err != nil {
+			return false, fmt.Errorf("reconcile pending input for %s: %w", sess.Name, err)
+		}
+		if consumed {
+			return true, fmt.Errorf("skipped ambiguous pending input for %s to avoid duplicate delivery", sess.Name)
+		}
+		return false, nil
+	}
+	if !agentAlive {
 		return false, nil
 	}
 	if _, ready := p.engine.ActivityRegion(sess.Tool, ansi.Strip(pane)); !ready {
 		return false, nil
 	}
-	input := sess.PendingInputs[0]
-	if err := p.tmux.SendText(sess.ID, input); err != nil {
+	claimed, err := p.store.ClaimPendingInput(sess.ID, input)
+	if err != nil {
+		return false, fmt.Errorf("claim pending input for %s: %w", sess.Name, err)
+	}
+	if !claimed {
 		return false, nil
 	}
-	return p.store.ConsumePendingInput(sess.ID, input)
+	if err := p.tmux.SendText(sess.ID, input); err != nil {
+		return false, fmt.Errorf("send pending input to %s: %w", sess.Name, err)
+	}
+	consumed, err := p.store.ConsumeClaimedPendingInput(sess.ID, input)
+	if err != nil {
+		return false, fmt.Errorf("record pending input delivery for %s: %w", sess.Name, err)
+	}
+	return consumed, nil
 }
 
 // applyPendingRename picks up a name the session's agent left via the

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -8,7 +8,6 @@ import (
 )
 
 type launchOptions struct {
-	pendingInputs    []string
 	rollbackWorktree bool
 }
 
@@ -38,9 +37,6 @@ func (m *Model) launchNewSession(sess store.Session, tool config.Tool, baseComma
 		_ = m.hooks.Remove(sess.ID)
 		discardWorktree()
 		return err
-	}
-	if len(opts.pendingInputs) > 0 && m.poller != nil {
-		m.poller.markInputsPending(sess.ID, opts.pendingInputs...)
 	}
 	labelErr := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name))
 	m.sessions = append(m.sessions, sess)

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -8,7 +8,7 @@ import (
 )
 
 type launchOptions struct {
-	deferDirective   bool
+	pendingInputs    []string
 	rollbackWorktree bool
 }
 
@@ -39,8 +39,8 @@ func (m *Model) launchNewSession(sess store.Session, tool config.Tool, baseComma
 		discardWorktree()
 		return err
 	}
-	if opts.deferDirective && m.poller != nil {
-		m.poller.markDirectivePending(sess.ID)
+	if len(opts.pendingInputs) > 0 && m.poller != nil {
+		m.poller.markInputsPending(sess.ID, opts.pendingInputs...)
 	}
 	labelErr := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name))
 	m.sessions = append(m.sessions, sess)


### PR DESCRIPTION
## What changed

- add Hermes Agent as a built-in CLI, pinned to `hermes --cli` so its prompt and approval surfaces remain status-detectable
- deliver new-session and quick-spawn prompts through Hermes's live composer, since its only prompt argument is one-shot
- classify idle, working, waiting, finished, setup, approval, clarification, and background-work states
- capture the exact Hermes conversation ID from the active profile's SQLite store for deterministic revive
- support Hermes MCP registration as an explicit opt-in; the default stays `none` because the Homebrew package does not include Hermes's optional MCP SDK
- document the tool and extend the bug-report choices

## Why

Hermes can already run in a tmux pane, but treating it as a generic custom CLI loses startup prompts, reliable status, and exact resume. This makes the persistent interactive CLI behave like the other built-in agents without relying on the modern full-screen TUI's rendering details.

Hermes does not currently expose a conversation-fork command, so this PR deliberately leaves forking disabled.

## Validation

- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `gofmt -l .`
- live fresh-home smoke against Hermes Agent v0.20.0 / 2026.8.3, covering its provider-setup prompt, normal composer, submitted prompt, active-turn marker, and clean shutdown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Hermes Agent, including session revival, status detection, interactive prompts, and optional MCP integration.
  * Added support for Gemini CLI and Pi in related configuration and reporting workflows.
  * Prompts can now be sent after an interactive tool is ready, enabling quick-prompt spawning and reliable queued input delivery.

* **Documentation**
  * Updated setup, usage, security, and configuration documentation for supported tools and Hermes workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->