### PR TITLE
fix(ui): mark a status message that worked as an outcome, not a failure

### DIFF
--- a/internal/ui/diffrender.go
+++ b/internal/ui/diffrender.go
@@ -897,10 +897,10 @@ func (m *Model) renderSideCell(fd *diff.FileDiff, hl *fileHL, index, width int, 
 
 func (m *Model) viewDiffStatus() string {
 	if m.errBar.text != "" {
-		return padRight(errStyle.Render(" ✖ "+m.errBar.text), m.width)
+		return padRight(m.statusMessage(" ✖", " ✔"), m.width)
 	}
 	if m.diff.notice != "" {
-		return padRight(lipgloss.NewStyle().Foreground(colorFinished).Render(" ✔ "+m.diff.notice), m.width)
+		return padRight(doneStyle.Render(" ✔ "+m.diff.notice), m.width)
 	}
 	if m.diff.sendConfirm {
 		count := len(m.diff.annotations[m.reviewKey()])

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -57,7 +57,7 @@ func (m *Model) flexCardWidth(title, body string, hint [][2]string) int {
 	measure(cardTitle(title))
 	measure(legendInline(hint, 1<<30))
 	if m.errBar.text != "" {
-		measure(errStyle.Render("⚠ " + m.errBar.text))
+		measure(m.statusMessage("⚠", "●"))
 	}
 	if m.width >= 28 && need > m.width-4 {
 		need = m.width - 4
@@ -89,7 +89,7 @@ func (m *Model) cardSized(width int, title, body string, hint [][2]string) strin
 		lines = append(lines, row(line))
 	}
 	if m.errBar.text != "" {
-		lines = append(lines, row(""), row(errStyle.Render("⚠ "+m.errBar.text)))
+		lines = append(lines, row(""), row(m.statusMessage("⚠", "●")))
 	}
 	lines = append(lines, row(""))
 	if len(hint) > 0 {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -231,8 +231,20 @@ type paneMirror struct {
 
 type errBar struct {
 	text  string
+	done  string
 	shown string
 	age   int
+}
+
+// worked reports whether the message on the bar is an action that went
+// through, so it can be styled as an outcome rather than a failure. Only
+// reportDone fills done, and any later write to text alone leaves it
+// behind, so a message says it worked or reads as a failure.
+func (e errBar) worked() bool { return e.text != "" && e.text == e.done }
+
+// reportDone puts an action that went through on the status bar.
+func (m *Model) reportDone(text string) {
+	m.errBar.text, m.errBar.done = text, text
 }
 
 // splitState is the horizontal sessions/sidebar split. ratio is the left
@@ -1121,7 +1133,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.indexReleaseRanges()
 			})
-			m.errBar.text = "already up to date"
+			m.reportDone("already up to date")
 			return m, nil
 		}
 		m.update.restartPath = msg.path
@@ -1304,7 +1316,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case editorOpenedMsg:
-		m.errBar.text = "opened " + msg.dir + " in " + msg.name
+		m.reportDone("opened " + msg.dir + " in " + msg.name)
 		return m, nil
 
 	case reattachPreparedMsg:
@@ -1382,7 +1394,7 @@ func (m *Model) updateNetRates(snap sysstat.Snapshot) {
 // ticks, so transient errors self-dismiss without any per-callsite timers.
 func (m *Model) ageError() {
 	if m.errBar.text == "" {
-		m.errBar.shown, m.errBar.age = "", 0
+		m.errBar = errBar{}
 		return
 	}
 	if m.errBar.text != m.errBar.shown {
@@ -1391,7 +1403,7 @@ func (m *Model) ageError() {
 	}
 	m.errBar.age++
 	if m.errBar.age >= 2 {
-		m.errBar.text, m.errBar.shown, m.errBar.age = "", "", 0
+		m.errBar = errBar{}
 	}
 }
 

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -624,7 +624,7 @@ func (m *Model) viewNotices() string {
 		tail = append(tail, lipgloss.NewStyle().Foreground(colorAccent).Render("↓ downloading "+m.update.latest+"…"))
 	}
 	if m.errBar.text != "" {
-		tail = append(tail, errStyle.Render("✕ "+m.errBar.text))
+		tail = append(tail, m.statusMessage("✕", "●"))
 	}
 	tail = append(tail, "")
 

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -39,6 +39,7 @@ var (
 	valueStyle  lipgloss.Style
 	labelStyle  lipgloss.Style
 	errStyle    lipgloss.Style
+	doneStyle   lipgloss.Style
 	keyStyle    lipgloss.Style
 
 	annotationStyle lipgloss.Style
@@ -68,6 +69,7 @@ func rebuildStyles() {
 	valueStyle = lipgloss.NewStyle().Foreground(colorText)
 	labelStyle = lipgloss.NewStyle().Foreground(colorSubtle)
 	errStyle = lipgloss.NewStyle().Foreground(colorErrored).Bold(true)
+	doneStyle = lipgloss.NewStyle().Foreground(colorFinished)
 	keyStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 
 	annotationStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)

--- a/internal/ui/toast_test.go
+++ b/internal/ui/toast_test.go
@@ -61,6 +61,76 @@ func TestStatusToastSitsTopRight(t *testing.T) {
 	}
 }
 
+// An editor that opened is an outcome, not a failure, all the way from the
+// key to the card the toast draws.
+func TestOpenedEditorReadsAsAnOutcome(t *testing.T) {
+	m := buildModel(t)
+	launched := captureEditor(t, "code")
+	dir := t.TempDir()
+	createSession(t, m, "agent", dir, "")
+	m.selectSessionRow(t, "agent")
+
+	_, cmd := m.openEditor()
+	m.applyCmd(t, cmd)
+	if len(*launched) == 0 {
+		t.Fatalf("the editor never launched, status = %q", m.errBar.text)
+	}
+	if want := doneStyle.Render("● " + m.errBar.text); m.statusLine() != want {
+		t.Fatalf("status line is %q, want the outcome styling %q", m.statusLine(), want)
+	}
+}
+
+// The same for an update check that found the current version installed:
+// the check ran, so the toast reports it rather than crossing it out.
+func TestUpToDateReadsAsAnOutcome(t *testing.T) {
+	m := shotModel()
+	updated, _ := m.Update(updateAppliedMsg{upToDate: true})
+	m = updated.(*Model)
+	if m.errBar.text != "already up to date" {
+		t.Fatalf("status text is %q", m.errBar.text)
+	}
+	if want := doneStyle.Render("● already up to date"); m.statusLine() != want {
+		t.Fatalf("status line is %q, want %q", m.statusLine(), want)
+	}
+}
+
+// Only the message that says it worked gets the outcome styling: a failure
+// written straight to the bar afterwards reads as one, whatever the bar
+// carried before.
+func TestFailureAfterAnOutcomeReadsAsAFailure(t *testing.T) {
+	m := shotModel()
+	m.reportDone("opened /tmp/project in code")
+	m.errBar.text = "git not found in PATH"
+	if want := errStyle.Render("✕ git not found in PATH"); m.statusLine() != want {
+		t.Fatalf("status line is %q, want %q", m.statusLine(), want)
+	}
+
+	// Dismissal takes the outcome with it, so the next message starts clean
+	// even when it repeats the words of the last one that worked.
+	m.reportDone("opened /tmp/project in code")
+	for range 3 {
+		m.ageError()
+	}
+	m.errBar.text = "opened /tmp/project in code"
+	if want := errStyle.Render("✕ opened /tmp/project in code"); m.statusLine() != want {
+		t.Fatalf("status line is %q, want %q", m.statusLine(), want)
+	}
+}
+
+// The review footer marks the same two states in its own glyphs.
+func TestReviewFooterMarksAnOutcome(t *testing.T) {
+	m := shotModel()
+	m.width = 80
+	m.reportDone("opened /tmp/project in code")
+	if got := ansi.Strip(m.viewDiffStatus()); !strings.HasPrefix(got, " ✔ ") {
+		t.Fatalf("review footer reads %q, want the outcome glyph", got)
+	}
+	m.errBar.text = "git not found in PATH"
+	if got := ansi.Strip(m.viewDiffStatus()); !strings.HasPrefix(got, " ✖ ") {
+		t.Fatalf("review footer reads %q, want the failure glyph", got)
+	}
+}
+
 // Splicing a card into a styled row must not shift the cells around it.
 func TestSpliceAtColumnKeepsWidth(t *testing.T) {
 	row := paint(keyStyle.Render("session ")+subtleStyle.Render("running"), 40, panelHex())

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -133,7 +133,7 @@ func (m *Model) statusLine() string {
 	// Errors outrank the focus notices: a scrolled or focused pane must
 	// not hide a failure report.
 	case m.mode == modeFocus && m.errBar.text != "":
-		return errStyle.Render("✕ " + m.errBar.text)
+		return m.statusMessage("✕", "●")
 	case m.scrolledBack():
 		return keyStyle.Render("scrolled ") +
 			subtleStyle.Render(fmt.Sprintf("%d lines back · wheel down or type to catch up", m.focusScroll))
@@ -147,12 +147,22 @@ func (m *Model) statusLine() string {
 		}
 		return keyStyle.Render("resize ") + subtleStyle.Render(hint)
 	case m.errBar.text != "":
-		return errStyle.Render("✕ " + m.errBar.text)
+		return m.statusMessage("✕", "●")
 	case m.diff.notice != "":
-		return lipgloss.NewStyle().Foreground(colorFinished).Render("● " + m.diff.notice)
+		return doneStyle.Render("● " + m.diff.notice)
 	default:
 		return ""
 	}
+}
+
+// statusMessage styles whatever sits on the status bar: an action that went
+// through reads as an outcome, everything else as a failure, in the glyphs
+// the calling surface marks the two with.
+func (m *Model) statusMessage(fail, done string) string {
+	if m.errBar.worked() {
+		return doneStyle.Render(done + " " + m.errBar.text)
+	}
+	return errStyle.Render(fail + " " + m.errBar.text)
 }
 
 // inGroupSubtree reports whether a session's group sits at or below the


### PR DESCRIPTION
## What changed

The status bar can say that a message reports something that worked. `reportDone` writes the text into `text` and `done`, and the bar reads as an outcome only while the two match, so a write to `text` alone keeps the failure styling that every other message in the package wants. Dismissal clears the pair.

Two messages report an action that went through, and both now say so: the editor launch (`opened <dir> in <editor>`) and `already up to date`. Every surface that renders the bar marks the two states in the glyphs it already used: `✕` / `●` on the toast and in the messages view, `✖` / `✔` in the review footer, `⚠` / `●` in dialogs. The green the review notice already rendered in is a shared `doneStyle`.

## Why

`o` opens the row's directory and the toast that follows read `✕ opened /Users/me/project in code`: a launch that worked, painted as a crash. The bar carried text and nothing else, so no surface could tell the two apart.

Closes #289

## How it was verified

Built the binary and drove it in a throwaway environment (own `HOME`, own tmux socket, a stub `code` on `PATH`), pressing `o` on a row and then `d` on root for a refusal. Read the escape codes straight off the pane:

```
38;2;133;178;111m ● opened /tmp/amfake/proj in code     <- finished green
38;2;204;105;105m ✕ root is the top level; ...          <- errored red
```

Four tests in `toast_test.go`: the editor launch end to end from the key through `Update` to the card, `already up to date`, a failure written after an outcome (which reads as a failure, including after the outcome self-dismissed), and the review footer's own glyph pair. Each fails on `main`'s rendering.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] Ran it against real sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Success and failure notifications now use distinct visual indicators.
  - Completed actions display the theme’s success styling across status messages, editor launches, updates, and review footers.
- **Bug Fixes**
  - Error messages consistently override earlier success states.
  - Dismissed notifications no longer affect subsequent status messages.
- **Tests**
  - Added coverage for success, failure, and repeated notification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->