### PR TITLE
feat(ui): open a session's directory in an editor with ctrl+o

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Arch Linux, mise, `go install`, prebuilt binaries, Windows (WSL2), and updating:
 agent-manager
 ```
 
-Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager and **Ctrl+R** opens its diff review. `agent-manager --version` prints the version.
+Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager, **Ctrl+R** opens its diff review and **Ctrl+O** opens its directory in your editor. `agent-manager --version` prints the version.
 
 Agent sessions live on a private tmux server named `agentmgr`, so they never mix with the tmux you run yourself and a `kill-server` on your own socket leaves them alone. To reach one from a plain shell, name that server: `tmux -L agentmgr ls`, then `tmux -L agentmgr attach -t am_<id>`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -85,7 +85,7 @@ Agent Manager takes the first of these it finds: `editor` in [config.toml](confi
 
 The line is run directly, never through a shell, so nothing in it is expanded and an `.envrc` that sets `EDITOR` cannot smuggle a command in behind it. Arguments are allowed, and quotes group one that carries a space: `editor = "code -n"`, `editor = "open -a 'Visual Studio Code'"`.
 
-Inside a session, attached or focused, `ctrl+o` opens that session's directory the same way. It costs an attach its client, so the manager steps back in once the editor is up.
+Inside a session, attached or focused, `ctrl+o` opens that session's directory the same way. It costs an attach its client, so the manager steps back into the session once a windowed editor is running, or once one that draws in the terminal exits. An editor that fails to start keeps the manager on screen, where you can read why.
 
 A known windowed editor (the six above, plus `open` and `xdg-open`) starts detached and the manager stays on screen, with the status line naming what opened. Everything else takes the terminal over the way an attach does and hands it back on exit — that way round because a terminal editor started detached would have nowhere to draw, while a windowed one launched this way only costs a repaint.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,6 +87,8 @@ The line is run directly, never through a shell, so nothing in it is expanded an
 
 Inside a session, attached or focused, `ctrl+o` opens that session's directory the same way. It costs an attach its client, so the manager steps back into the session once a windowed editor is running, or once one that draws in the terminal exits. An editor that fails to start keeps the manager on screen, where you can read why.
 
+Like `ctrl+q` and `ctrl+r`, the manager keeps `ctrl+o` for itself inside a session, so a program running in there stops seeing it: in a [terminal tab](#terminal-tabs), `nano` saves with `ctrl+s` instead.
+
 A known windowed editor (the six above, plus `open` and `xdg-open`) starts detached and the manager stays on screen, with the status line naming what opened. Everything else takes the terminal over the way an attach does and hands it back on exit — that way round because a terminal editor started detached would have nowhere to draw, while a windowed one launched this way only costs a repaint.
 
 ## Worktree sessions

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@
 agent-manager
 ```
 
-Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager and **Ctrl+R** opens its diff review. `agent-manager --version` prints the version.
+Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager, **Ctrl+R** opens its diff review and **Ctrl+O** opens its directory in your editor. `agent-manager --version` prints the version.
 
 Agent sessions live on a private tmux server named `agentmgr`, so they never mix with the tmux you run yourself and a `kill-server` on your own socket leaves them alone. To reach one from a plain shell, name that server: `tmux -L agentmgr ls`, then `tmux -L agentmgr attach -t am_<id>`.
 
@@ -20,6 +20,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `enter` | Focus session in place (keys go to the agent, list stays) / fold group |
 | `A` | Attach session full screen (Settings can swap it with `enter`) |
 | `ctrl+q` | Inside a session: back to the manager |
+| `ctrl+o` | Inside a session: open its directory in your editor |
 | `→` | Step into the row: focus the session, or open the group. In beta; Settings (`s`) can turn the pair off |
 | `←` | Step out: close the group, or — focused, with the caret at the start of the agent's prompt — back to the manager. This needs the tool's prompt marker (its `activity_cutoff`) on the caret's row, so a CLI without one keeps `←` entirely; anywhere else in the prompt it moves the caret as usual |
 | `K` / `J` (or `shift+↑` / `shift+↓`) | Reorder session or group among its visible siblings |
@@ -83,6 +84,8 @@ A shell left on its empty command carries no session id, so `agent-manager renam
 Agent Manager takes the first of these it finds: `editor` in [config.toml](configuration.md), `$AGENT_MANAGER_EDITOR`, a GUI editor on `PATH` (`code`, `cursor`, `windsurf`, `zed`, `subl`, `idea`), then `$VISUAL` or `$EDITOR`. The environment comes last because it usually names the editor you set for git commit messages rather than the one a project should open in.
 
 The line is run directly, never through a shell, so nothing in it is expanded and an `.envrc` that sets `EDITOR` cannot smuggle a command in behind it. Arguments are allowed, and quotes group one that carries a space: `editor = "code -n"`, `editor = "open -a 'Visual Studio Code'"`.
+
+Inside a session, attached or focused, `ctrl+o` opens that session's directory the same way. It costs an attach its client, so the manager steps back in once the editor is up.
 
 A known windowed editor (the six above, plus `open` and `xdg-open`) starts detached and the manager stays on screen, with the status line naming what opened. Everything else takes the terminal over the way an attach does and hands it back on exit — that way round because a terminal editor started detached would have nowhere to draw, while a windowed one launched this way only costs a repaint.
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -25,7 +25,6 @@ const defaultSocket = "agentmgr"
 // just detached from.
 const requestOption = "@am_request"
 
-// The requests those bindings leave behind.
 const (
 	RequestReview = "review"
 	RequestEditor = "editor"
@@ -403,8 +402,8 @@ func sanitizeFormat(s string) string {
 	return strings.ReplaceAll(s, "#", "##")
 }
 
-// PendingRequest names what an in-session binding asked for before
-// detaching, empty when none did. A missing tmux server means no request.
+// A missing tmux server means no request rather than an error: the
+// manager outlives the sessions it opens.
 func (d *Driver) PendingRequest() (string, error) {
 	out, err := exec.Command(d.bin, d.args("show-option", "-gqv", requestOption)...).CombinedOutput()
 	if err != nil {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -20,9 +20,16 @@ const prefix = "am_"
 // otherwise share a server with the live agents and take them all down at once.
 const defaultSocket = "agentmgr"
 
-// reviewOption is the global tmux user option the in-session Ctrl+R binding
-// sets to signal the manager to open review for the session it just detached.
-const reviewOption = "@am_review"
+// requestOption is the global tmux user option the in-session bindings set
+// on their way out, naming what the manager should do with the session they
+// just detached from.
+const requestOption = "@am_request"
+
+// The requests those bindings leave behind.
+const (
+	RequestReview = "review"
+	RequestEditor = "editor"
+)
 
 type Driver struct {
 	bin    string
@@ -253,7 +260,7 @@ func (d *Driver) styleStatusBar(name string) error {
 		// The default status-right-length of 40 truncates the hint before the
 		// Ctrl+R part, so widen it to fit the whole footer.
 		{"set-option", "-t", name, "status-right-length", "80"},
-		{"set-option", "-t", name, "status-right", " agent-manager · Ctrl+q = back · Ctrl+r = review "},
+		{"set-option", "-t", name, "status-right", " agent-manager · Ctrl+q = back · Ctrl+r = review · Ctrl+o = editor "},
 		{"set-option", "-t", name, "status-style", "bg=colour236,fg=colour249"},
 		// hide the "0:windowname*" window list; it reads as noise here
 		{"set-option", "-t", name, "window-status-format", ""},
@@ -270,15 +277,20 @@ func (d *Driver) styleStatusBar(name string) error {
 	return nil
 }
 
-// EnsureBindings installs the server-global Ctrl+Q / Ctrl+\ detach and
-// Ctrl+R review bindings. All only act inside am_* sessions; elsewhere the
-// key passes through to the pane. Idempotent, so it is safe to re-run for
-// sessions that predate a binding.
+// EnsureBindings installs the server-global Ctrl+Q / Ctrl+\ detach, Ctrl+R
+// review and Ctrl+O editor bindings. All only act inside am_* sessions;
+// elsewhere the key passes through to the pane. Idempotent, so it is safe to
+// re-run for sessions that predate a binding.
 func (d *Driver) EnsureBindings() error {
+	inSession := "#{m:" + prefix + "*,#{session_name}}"
+	request := func(name string) string {
+		return "set-option -g " + requestOption + " " + name + " ; detach-client"
+	}
 	binds := [][]string{
-		{"bind-key", "-n", "C-q", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "detach-client", "send-keys C-q"},
-		{"bind-key", "-n", `C-\`, "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "detach-client", `send-keys C-\\`},
-		{"bind-key", "-n", "C-r", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "set-option -g " + reviewOption + " 1 ; detach-client", "send-keys C-r"},
+		{"bind-key", "-n", "C-q", "if-shell", "-F", inSession, "detach-client", "send-keys C-q"},
+		{"bind-key", "-n", `C-\`, "if-shell", "-F", inSession, "detach-client", `send-keys C-\\`},
+		{"bind-key", "-n", "C-r", "if-shell", "-F", inSession, request(RequestReview), "send-keys C-r"},
+		{"bind-key", "-n", "C-o", "if-shell", "-F", inSession, request(RequestEditor), "send-keys C-o"},
 	}
 	for _, args := range binds {
 		if _, err := d.run(args...); err != nil {
@@ -391,22 +403,22 @@ func sanitizeFormat(s string) string {
 	return strings.ReplaceAll(s, "#", "##")
 }
 
-// ReviewRequested reports whether the in-session Ctrl+R binding set the
-// review marker before detaching. A missing tmux server means no request.
-func (d *Driver) ReviewRequested() (bool, error) {
-	out, err := exec.Command(d.bin, d.args("show-option", "-gqv", reviewOption)...).CombinedOutput()
+// PendingRequest names what an in-session binding asked for before
+// detaching, empty when none did. A missing tmux server means no request.
+func (d *Driver) PendingRequest() (string, error) {
+	out, err := exec.Command(d.bin, d.args("show-option", "-gqv", requestOption)...).CombinedOutput()
 	if err != nil {
 		if noServer(string(out)) {
-			return false, nil
+			return "", nil
 		}
-		return false, fmt.Errorf("tmux show-option %s: %w: %s", reviewOption, err, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("tmux show-option %s: %w: %s", requestOption, err, strings.TrimSpace(string(out)))
 	}
-	return strings.TrimSpace(string(out)) == "1", nil
+	return strings.TrimSpace(string(out)), nil
 }
 
-// ClearReviewRequest unsets the review marker so it fires once per request.
-func (d *Driver) ClearReviewRequest() error {
-	_, err := d.run("set-option", "-gu", reviewOption)
+// ClearRequest unsets the marker so a request is carried out once.
+func (d *Driver) ClearRequest() error {
+	_, err := d.run("set-option", "-gu", requestOption)
 	return err
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -294,7 +294,7 @@ func TestCreateDeliversLongCommand(t *testing.T) {
 	t.Fatalf("long launch command truncated or failed; wrote %d bytes, want %d; pane:\n%s", len(got), len(payload), pane)
 }
 
-func TestReviewRequestRoundTrip(t *testing.T) {
+func TestDetachRequestRoundTrip(t *testing.T) {
 	driver := requireTmux(t)
 	// A live server is needed for global options to stick.
 	id := "rev" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
@@ -302,39 +302,41 @@ func TestReviewRequestRoundTrip(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	t.Cleanup(func() { driver.Kill(id) })
-	t.Cleanup(func() { driver.ClearReviewRequest() })
+	t.Cleanup(func() { driver.ClearRequest() })
 
-	if err := driver.ClearReviewRequest(); err != nil {
-		t.Fatalf("ClearReviewRequest: %v", err)
+	if err := driver.ClearRequest(); err != nil {
+		t.Fatalf("ClearRequest: %v", err)
 	}
-	requested, err := driver.ReviewRequested()
+	request, err := driver.PendingRequest()
 	if err != nil {
-		t.Fatalf("ReviewRequested: %v", err)
+		t.Fatalf("PendingRequest: %v", err)
 	}
-	if requested {
-		t.Fatal("no request expected on a clean marker")
-	}
-
-	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
-		t.Fatalf("set marker: %v", err)
-	}
-	requested, err = driver.ReviewRequested()
-	if err != nil {
-		t.Fatalf("ReviewRequested: %v", err)
-	}
-	if !requested {
-		t.Fatal("marker set to 1 should read as requested")
+	if request != "" {
+		t.Fatalf("no request expected on a clean marker, got %q", request)
 	}
 
-	if err := driver.ClearReviewRequest(); err != nil {
-		t.Fatalf("ClearReviewRequest: %v", err)
-	}
-	requested, err = driver.ReviewRequested()
-	if err != nil {
-		t.Fatalf("ReviewRequested: %v", err)
-	}
-	if requested {
-		t.Fatal("clear should drop the marker")
+	for _, want := range []string{RequestReview, RequestEditor} {
+		if _, err := tmuxCmd("set-option", "-g", requestOption, want).CombinedOutput(); err != nil {
+			t.Fatalf("set marker: %v", err)
+		}
+		request, err = driver.PendingRequest()
+		if err != nil {
+			t.Fatalf("PendingRequest: %v", err)
+		}
+		if request != want {
+			t.Fatalf("marker reads as %q, want %q", request, want)
+		}
+
+		if err := driver.ClearRequest(); err != nil {
+			t.Fatalf("ClearRequest: %v", err)
+		}
+		request, err = driver.PendingRequest()
+		if err != nil {
+			t.Fatalf("PendingRequest: %v", err)
+		}
+		if request != "" {
+			t.Fatalf("clear should drop the marker, got %q", request)
+		}
 	}
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -302,7 +302,11 @@ func TestDetachRequestRoundTrip(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	t.Cleanup(func() { driver.Kill(id) })
-	t.Cleanup(func() { driver.ClearRequest() })
+	t.Cleanup(func() {
+		if err := driver.ClearRequest(); err != nil {
+			t.Errorf("ClearRequest: %v", err)
+		}
+	})
 
 	if err := driver.ClearRequest(); err != nil {
 		t.Fatalf("ClearRequest: %v", err)

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/diff"
 	"github.com/YoanWai/agent-manager/internal/git"
 	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -461,9 +462,9 @@ func TestInSessionReviewRemembersOriginAndReattaches(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+	t.Cleanup(func() { m.tmux.ClearRequest() })
 
-	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
 	updated, _ := m.Update(attachDoneMsg{})
@@ -531,12 +532,12 @@ func TestReattachAcknowledgesFinished(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+	t.Cleanup(func() { m.tmux.ClearRequest() })
 
 	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
 		t.Fatalf("set finished: %v", err)
 	}
-	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
 	updated, _ := m.Update(attachDoneMsg{})

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -462,7 +462,7 @@ func TestInSessionReviewRemembersOriginAndReattaches(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
@@ -532,7 +532,7 @@ func TestReattachAcknowledgesFinished(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
 		t.Fatalf("set finished: %v", err)

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -467,7 +467,7 @@ func TestInSessionReviewRemembersOriginAndReattaches(t *testing.T) {
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
-	updated, _ := m.Update(attachDoneMsg{})
+	updated, _ := m.Update(attachDoneMsg{sessID: sess.ID})
 	*m = *updated.(*Model)
 
 	if m.mode != modeDiff {
@@ -540,7 +540,7 @@ func TestReattachAcknowledgesFinished(t *testing.T) {
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
-	updated, _ := m.Update(attachDoneMsg{})
+	updated, _ := m.Update(attachDoneMsg{sessID: sess.ID})
 	*m = *updated.(*Model)
 	if m.mode != modeDiff {
 		t.Fatalf("expected review, mode = %v, err = %q", m.mode, m.errBar.text)

--- a/internal/ui/editor.go
+++ b/internal/ui/editor.go
@@ -43,11 +43,15 @@ var (
 	}
 )
 
-// The status line waits on this rather than announcing the editor from
-// openEditor, so a launch that fails is never reported as one that opened.
-type editorOpenedMsg struct {
+// editorDoneMsg ends an editor request. The status line waits on it rather
+// than announcing the editor from openEditor, so a launch that fails is
+// never reported as one that opened: name and dir are filled once a
+// windowed editor is running, and err carries a launch that failed or a
+// terminal editor that exited badly.
+type editorDoneMsg struct {
 	name string
 	dir  string
+	err  error
 }
 
 func (m *Model) openEditor() (tea.Model, tea.Cmd) {
@@ -68,10 +72,7 @@ func (m *Model) openEditor() (tea.Model, tea.Cmd) {
 	m.errBar.text = ""
 	if !detachedEditors[editorName(line)] {
 		return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
-			if err != nil {
-				return errMsg{err}
-			}
-			return nil
+			return editorDoneMsg{err: err}
 		})
 	}
 	return m, startEditorCmd(cmd, editorName(line), dir)
@@ -82,9 +83,9 @@ func (m *Model) openEditor() (tea.Model, tea.Cmd) {
 func startEditorCmd(cmd *exec.Cmd, name, dir string) tea.Cmd {
 	return func() tea.Msg {
 		if err := startEditor(cmd); err != nil {
-			return errMsg{err}
+			return editorDoneMsg{err: err}
 		}
-		return editorOpenedMsg{name: name, dir: dir}
+		return editorDoneMsg{name: name, dir: dir}
 	}
 }
 

--- a/internal/ui/editor.go
+++ b/internal/ui/editor.go
@@ -47,11 +47,14 @@ var (
 // than announcing the editor from openEditor, so a launch that fails is
 // never reported as one that opened: name and dir are filled once a
 // windowed editor is running, and err carries a launch that failed or a
-// terminal editor that exited badly.
+// terminal editor that exited badly. tookScreen marks the editor the
+// manager handed the terminal to, which comes back without the mouse
+// reporting and background the manager had set on it.
 type editorDoneMsg struct {
-	name string
-	dir  string
-	err  error
+	name       string
+	dir        string
+	err        error
+	tookScreen bool
 }
 
 func (m *Model) openEditor() (tea.Model, tea.Cmd) {
@@ -72,7 +75,7 @@ func (m *Model) openEditor() (tea.Model, tea.Cmd) {
 	m.errBar.text = ""
 	if !detachedEditors[editorName(line)] {
 		return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
-			return editorDoneMsg{err: err}
+			return editorDoneMsg{err: err, tookScreen: true}
 		})
 	}
 	return m, startEditorCmd(cmd, editorName(line), dir)

--- a/internal/ui/editor_test.go
+++ b/internal/ui/editor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/YoanWai/agent-manager/internal/config"
+	"github.com/YoanWai/agent-manager/internal/tmux"
 )
 
 // captureEditor swaps both editor seams: PATH answers only for the names
@@ -240,5 +241,138 @@ func TestOpenEditorNamesADirectoryThatIsGone(t *testing.T) {
 	}
 	if !strings.HasSuffix(m.errBar.text, gone) {
 		t.Fatalf("status line should name the directory, got %q", m.errBar.text)
+	}
+}
+
+// Ctrl+O inside an attach leaves a request behind and detaches: the manager
+// opens the editor for the session it was in, then hands that session its
+// client back.
+func TestAttachDoneOpensEditorAndReturnsToTheSession(t *testing.T) {
+	m := buildModel(t)
+	launched := captureEditor(t, "code")
+	dir := t.TempDir()
+	createSession(t, m, "editme", dir, "")
+	m.selectSessionRow(t, "editme")
+	sess, ok := m.selected()
+	if !ok {
+		t.Fatal("no session selected")
+	}
+	t.Cleanup(func() { m.tmux.ClearRequest() })
+
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	updated, cmd := m.Update(attachDoneMsg{sessID: sess.ID})
+	*m = *updated.(*Model)
+	if cmd == nil {
+		t.Fatalf("the request produced no launch, err = %q", m.errBar.text)
+	}
+	if m.editorReturnID != sess.ID {
+		t.Fatalf("return armed for %q, want %q", m.editorReturnID, sess.ID)
+	}
+	request, err := m.tmux.PendingRequest()
+	if err != nil {
+		t.Fatalf("PendingRequest: %v", err)
+	}
+	if request != "" {
+		t.Fatalf("carrying the request out should consume it, got %q", request)
+	}
+
+	done, isDone := cmd().(editorDoneMsg)
+	if !isDone || done.err != nil {
+		t.Fatalf("editor launch reported %#v", done)
+	}
+	if want := []string{"code", resolved(t, dir)}; !slices.Equal(*launched, want) {
+		t.Fatalf("launched %v, want %v", *launched, want)
+	}
+
+	updated, cmd = m.Update(done)
+	*m = *updated.(*Model)
+	if m.editorReturnID != "" {
+		t.Fatalf("the return should be consumed, still holds %q", m.editorReturnID)
+	}
+	if cmd == nil {
+		t.Fatal("the session should get its client back")
+	}
+	prepared, isPrepared := cmd().(reattachPreparedMsg)
+	if !isPrepared || prepared.sessID != sess.ID {
+		t.Fatalf("want a reattach for %q, got %#v", sess.ID, prepared)
+	}
+}
+
+// A request the manager cannot carry out leaves nothing armed: the next
+// editor opened from the list must not drag the session back on screen.
+func TestAttachDoneRefusedEditorArmsNoReturn(t *testing.T) {
+	m := buildModel(t)
+	captureEditor(t)
+	createSession(t, m, "editme", t.TempDir(), "")
+	m.selectSessionRow(t, "editme")
+	t.Cleanup(func() { m.tmux.ClearRequest() })
+
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	updated, cmd := m.Update(attachDoneMsg{})
+	*m = *updated.(*Model)
+	if cmd != nil {
+		t.Fatal("a refused request should return no command")
+	}
+	if m.editorReturnID != "" {
+		t.Fatalf("nothing launched, so nothing to return from, got %q", m.editorReturnID)
+	}
+	if !strings.Contains(m.errBar.text, "no editor found") {
+		t.Fatalf("status line should say why, got %q", m.errBar.text)
+	}
+}
+
+// An editor that draws in the terminal takes the screen and hands it back
+// on exit, so the request arms the return the same way a windowed one does.
+func TestAttachDoneTerminalEditorArmsTheReturn(t *testing.T) {
+	m := buildModel(t)
+	launched := captureEditor(t)
+	m.cfg.Editor = "my-own-edit-wrapper"
+	createSession(t, m, "editme", t.TempDir(), "")
+	m.selectSessionRow(t, "editme")
+	sess, ok := m.selected()
+	if !ok {
+		t.Fatal("no session selected")
+	}
+	t.Cleanup(func() { m.tmux.ClearRequest() })
+
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	updated, cmd := m.Update(attachDoneMsg{sessID: sess.ID})
+	*m = *updated.(*Model)
+	if cmd == nil {
+		t.Fatalf("the request produced no launch, err = %q", m.errBar.text)
+	}
+	if len(*launched) != 0 {
+		t.Fatalf("a terminal editor must not start detached, got %v", *launched)
+	}
+	if m.editorReturnID != sess.ID {
+		t.Fatalf("return armed for %q, want %q", m.editorReturnID, sess.ID)
+	}
+}
+
+// An editor that failed to start keeps the list: going back into the
+// session would hide the only account of what went wrong.
+func TestEditorFailureKeepsTheListAndItsReason(t *testing.T) {
+	m := buildModel(t)
+	captureEditor(t, "code")
+	createSession(t, m, "editme", t.TempDir(), "")
+	m.selectSessionRow(t, "editme")
+	m.editorReturnID = m.sessionRows()[0].ID
+
+	updated, cmd := m.Update(editorDoneMsg{err: errors.New("exec: \"code\": file does not exist")})
+	*m = *updated.(*Model)
+	if cmd != nil {
+		t.Fatal("a failed editor should not hand the session back its client")
+	}
+	if m.editorReturnID != "" {
+		t.Fatalf("the return should be dropped, still holds %q", m.editorReturnID)
+	}
+	if !strings.Contains(m.errBar.text, "does not exist") {
+		t.Fatalf("status line should carry the failure, got %q", m.errBar.text)
 	}
 }

--- a/internal/ui/editor_test.go
+++ b/internal/ui/editor_test.go
@@ -307,12 +307,13 @@ func TestAttachDoneRefusedEditorArmsNoReturn(t *testing.T) {
 	captureEditor(t)
 	createSession(t, m, "editme", t.TempDir(), "")
 	m.selectSessionRow(t, "editme")
+	sess := m.sessionRows()[0]
 	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
-	updated, cmd := m.Update(attachDoneMsg{})
+	updated, cmd := m.Update(attachDoneMsg{sessID: sess.ID})
 	*m = *updated.(*Model)
 	if cmd != nil {
 		t.Fatal("a refused request should return no command")
@@ -374,5 +375,47 @@ func TestEditorFailureKeepsTheListAndItsReason(t *testing.T) {
 	}
 	if !strings.Contains(m.errBar.text, "does not exist") {
 		t.Fatalf("status line should carry the failure, got %q", m.errBar.text)
+	}
+}
+
+// The cursor is not where the request came from: a poll handled ahead of
+// the attach's own message can move it. The request follows the session
+// that detached, and refuses rather than acting on another one.
+func TestAttachDoneEditorFollowsTheSessionThatDetached(t *testing.T) {
+	m := buildModel(t)
+	launched := captureEditor(t, "code")
+	attachedDir := t.TempDir()
+	createSession(t, m, "attached", attachedDir, "")
+	createSession(t, m, "elsewhere", t.TempDir(), "")
+	attached := m.sessionRows()[0]
+	if attached.Name != "attached" {
+		t.Fatalf("first row is %q", attached.Name)
+	}
+	m.selectSessionRow(t, "elsewhere")
+	clearRequestOnCleanup(t, m)
+
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	updated, cmd := m.Update(attachDoneMsg{sessID: attached.ID})
+	*m = *updated.(*Model)
+	m.applyCmd(t, cmd)
+
+	if want := []string{"code", resolved(t, attachedDir)}; !slices.Equal(*launched, want) {
+		t.Fatalf("launched %v, want the attached session's directory %v", *launched, want)
+	}
+
+	// A session that left the list takes its request with it.
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	*launched = nil
+	updated, cmd = m.Update(attachDoneMsg{sessID: "gone"})
+	*m = *updated.(*Model)
+	if cmd != nil || len(*launched) != 0 {
+		t.Fatalf("a session that is gone should launch nothing, got %v", *launched)
+	}
+	if !strings.Contains(m.errBar.text, "left the list") {
+		t.Fatalf("status line should say why, got %q", m.errBar.text)
 	}
 }

--- a/internal/ui/editor_test.go
+++ b/internal/ui/editor_test.go
@@ -257,7 +257,7 @@ func TestAttachDoneOpensEditorAndReturnsToTheSession(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
@@ -307,7 +307,7 @@ func TestAttachDoneRefusedEditorArmsNoReturn(t *testing.T) {
 	captureEditor(t)
 	createSession(t, m, "editme", t.TempDir(), "")
 	m.selectSessionRow(t, "editme")
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
@@ -337,7 +337,7 @@ func TestAttachDoneTerminalEditorArmsTheReturn(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -198,9 +198,9 @@ func (m *Model) leaveFocus() tea.Cmd {
 }
 
 // handleFocusKey forwards every key into the focused pane. Ctrl+Q and
-// ctrl+\ return to the list and Ctrl+R opens the review, mirroring the
-// bindings a real attach gets, and every plain character - q included -
-// reaches the agent.
+// ctrl+\ return to the list, Ctrl+R opens the review and Ctrl+O the editor,
+// mirroring the bindings a real attach gets, and every plain character - q
+// included - reaches the agent.
 func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.String() == "ctrl+q" || msg.String() == `ctrl+\` {
 		return m, m.leaveFocus()
@@ -208,6 +208,12 @@ func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	sess, ok := m.selected()
 	if !ok {
 		return m, m.leaveFocus()
+	}
+	// Ctrl+O opens the session's directory in an editor, matching the
+	// binding a real attach gets. A windowed editor leaves the focus where
+	// it is; one that draws in the terminal takes it back on exit.
+	if msg.String() == "ctrl+o" {
+		return m.openEditor()
 	}
 	// Ctrl+R opens the review, matching the binding a real attach gets;
 	// closing it focuses the session again rather than landing in the list.

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -344,6 +345,39 @@ func TestFocusCtrlROpensReviewAndReturns(t *testing.T) {
 	}
 }
 
+// Ctrl+O opens the focused session's directory the way the list's o does,
+// and a windowed editor leaves the focus where it was.
+func TestFocusCtrlOOpensEditor(t *testing.T) {
+	m := buildModel(t)
+	launched := captureEditor(t, "code")
+	dir := t.TempDir()
+	createSession(t, m, "focusedit", dir, "")
+	m.selectSessionRow(t, "focusedit")
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+	if m.mode != modeFocus {
+		t.Fatalf("after enter, mode = %v, err = %q", m.mode, m.errBar.text)
+	}
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlO})
+	*m = *updated.(*Model)
+	if cmd == nil {
+		t.Fatalf("ctrl+o in focus returned no launch, err = %q", m.errBar.text)
+	}
+	m.applyCmd(t, cmd)
+
+	if want := []string{"code", resolved(t, dir)}; !slices.Equal(*launched, want) {
+		t.Fatalf("launched %v, want %v", *launched, want)
+	}
+	if m.mode != modeFocus {
+		t.Fatalf("a windowed editor should leave the focus alone, mode = %v", m.mode)
+	}
+	if !strings.Contains(m.errBar.text, "code") {
+		t.Fatalf("status line should name the editor, got %q", m.errBar.text)
+	}
+}
+
 // Leaving focus must keep mouse reporting: handing it back would let a
 // wheel notch scroll the manager out of view from the list.
 func TestFocusExitKeepsMouse(t *testing.T) {
@@ -457,7 +491,7 @@ func TestFocusPasteKeepsPromptInComposer(t *testing.T) {
 // This test verifies the handler returns no mouse-enable command.
 func TestDetachNoMouseReArm(t *testing.T) {
 	m := buildModel(t)
-	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+	t.Cleanup(func() { m.tmux.ClearRequest() })
 
 	_, cmd := m.Update(attachDoneMsg{})
 	if cmd != nil {

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -491,7 +491,7 @@ func TestFocusPasteKeepsPromptInComposer(t *testing.T) {
 // This test verifies the handler returns no mouse-enable command.
 func TestDetachNoMouseReArm(t *testing.T) {
 	m := buildModel(t)
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	_, cmd := m.Update(attachDoneMsg{})
 	if cmd != nil {

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -378,6 +378,33 @@ func TestFocusCtrlOOpensEditor(t *testing.T) {
 	}
 }
 
+// An editor that took the terminal hands it back without the mouse
+// reporting focus mode armed, so the pane's wheel and drag would be dead
+// on return.
+func TestFocusEditorThatTookTheScreenRearmsMouse(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "screenedit", t.TempDir(), "")
+	m.selectSessionRow(t, "screenedit")
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+
+	updated, cmd := m.Update(editorDoneMsg{tookScreen: true})
+	*m = *updated.(*Model)
+	if cmd == nil {
+		t.Fatal("returning from a terminal editor issued no mouse command")
+	}
+	if !batchContains(cmd(), tea.EnableMouseCellMotion()) {
+		t.Fatalf("mouse reporting was not re-armed: %T", cmd())
+	}
+
+	// A windowed editor never took the terminal, so it has nothing to undo.
+	updated, cmd = m.Update(editorDoneMsg{name: "code", dir: "/tmp"})
+	*m = *updated.(*Model)
+	if cmd != nil {
+		t.Fatalf("a windowed editor should leave the terminal alone, got %T", cmd())
+	}
+}
+
 // Leaving focus must keep mouse reporting: handing it back would let a
 // wheel notch scroll the manager out of view from the list.
 func TestFocusExitKeepsMouse(t *testing.T) {

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -115,6 +115,7 @@ func helpSections() []helpSection {
 			{"ctrl+q", "back to the manager (ctrl+\\ too)"},
 			{"←", "focused: back to the manager, at the prompt's start"},
 			{"ctrl+r", "review the session's diff, esc returns"},
+			{"ctrl+o", "open its directory in an editor"},
 			{"wheel", "focused: scroll the pane's history, type to catch up"},
 			{"drag", "focused: select pane text and copy it"},
 			{"double click", "focused: copy the word"},

--- a/internal/ui/helpers_test.go
+++ b/internal/ui/helpers_test.go
@@ -111,6 +111,17 @@ func (m *Model) applyCmd(t *testing.T, cmd tea.Cmd) {
 	*m = *updated.(*Model)
 }
 
+// clearRequestOnCleanup drops the server-global detach marker when the test
+// ends: one left behind reaches every later test that reads it.
+func clearRequestOnCleanup(t *testing.T, m *Model) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := m.tmux.ClearRequest(); err != nil {
+			t.Errorf("ClearRequest: %v", err)
+		}
+	})
+}
+
 func (m *Model) sessionRows() []store.Session {
 	var sessions []store.Session
 	for _, r := range m.rows {

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -216,7 +216,7 @@ func TestAttachDoneOpensReviewWhenMarkerSet(t *testing.T) {
 	}
 	createSession(t, m, "reviewme", t.TempDir(), "")
 	m.selectSessionRow(t, "reviewme")
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -216,9 +216,9 @@ func TestAttachDoneOpensReviewWhenMarkerSet(t *testing.T) {
 	}
 	createSession(t, m, "reviewme", t.TempDir(), "")
 	m.selectSessionRow(t, "reviewme")
-	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+	t.Cleanup(func() { m.tmux.ClearRequest() })
 
-	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
 	updated, _ := m.Update(attachDoneMsg{})
@@ -227,12 +227,12 @@ func TestAttachDoneOpensReviewWhenMarkerSet(t *testing.T) {
 		t.Fatalf("marker set should enter review, mode = %v, err = %q", m.mode, m.errBar.text)
 	}
 
-	requested, err := m.tmux.ReviewRequested()
+	request, err := m.tmux.PendingRequest()
 	if err != nil {
-		t.Fatalf("ReviewRequested: %v", err)
+		t.Fatalf("PendingRequest: %v", err)
 	}
-	if requested {
-		t.Fatal("opening review should consume the marker")
+	if request != "" {
+		t.Fatalf("opening review should consume the marker, got %q", request)
 	}
 }
 
@@ -240,7 +240,7 @@ func TestAttachDoneStaysInListWithoutMarker(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "plainexit", t.TempDir(), "")
 	m.selectSessionRow(t, "plainexit")
-	if err := m.tmux.ClearReviewRequest(); err != nil {
+	if err := m.tmux.ClearRequest(); err != nil {
 		t.Fatalf("clear marker: %v", err)
 	}
 

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -216,12 +216,13 @@ func TestAttachDoneOpensReviewWhenMarkerSet(t *testing.T) {
 	}
 	createSession(t, m, "reviewme", t.TempDir(), "")
 	m.selectSessionRow(t, "reviewme")
+	sess := m.sessionRows()[0]
 	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
-	updated, _ := m.Update(attachDoneMsg{})
+	updated, _ := m.Update(attachDoneMsg{sessID: sess.ID})
 	*m = *updated.(*Model)
 	if m.mode != modeDiff {
 		t.Fatalf("marker set should enter review, mode = %v, err = %q", m.mode, m.errBar.text)

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -688,7 +688,7 @@ func (m *Model) contentLines(width, height int) []contentLine {
 // focusTopRule is the hairline that caps the focused pane, titled so the
 // mode names itself where the eye already is.
 func focusTopRule(width int) string {
-	title := " focused · ctrl+q back · ctrl+r review "
+	title := " focused · ctrl+q back · ctrl+r review · ctrl+o editor "
 	rule := annotationStyle.Render(title)
 	rest := width - lipgloss.Width(title)
 	if rest > 0 {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -157,6 +157,9 @@ type Model struct {
 	moveID     string
 	movePath   string
 	repoPick   repoPickState
+	// editorReturnID is the session an editor request detached from, so the
+	// attach it cost can be resumed once the editor is up.
+	editorReturnID string
 
 	// Repo a human picked by hand per session, outranking the agent's
 	// declaration for as long as this manager runs.
@@ -1291,32 +1294,60 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.requestRefresh()
 			return m, nil
 		}
-		// Ctrl+R inside the session sets a marker before detaching; consume
-		// it here and jump straight to review for the session just attached.
-		requested, err := m.tmux.ReviewRequested()
+		// Ctrl+R and Ctrl+O inside the session leave a marker before
+		// detaching; consume it here and carry it out for the session just
+		// attached.
+		request, err := m.tmux.PendingRequest()
 		if err != nil {
 			m.errBar.text = err.Error()
-		} else if requested {
-			// A failed clear leaves the marker set, which would reopen review
-			// on every later detach, so surface it and stay in the list rather
-			// than letting openDiff reset m.errBar.text and hide it.
-			if clearErr := m.tmux.ClearReviewRequest(); clearErr != nil {
+		} else if request != "" {
+			// A failed clear leaves the marker set, which would replay the
+			// request on every later detach, so surface it and stay in the
+			// list rather than letting the request reset m.errBar.text and
+			// hide it.
+			if clearErr := m.tmux.ClearRequest(); clearErr != nil {
 				m.errBar.text = clearErr.Error()
 				m.requestRefresh()
 				return m, nil
 			}
 			sess, ok := m.selected()
-			cmd := m.openDiff()
-			if ok && m.mode == modeDiff {
-				m.diff.reattachID = sess.ID
+			switch request {
+			case tmux.RequestReview:
+				cmd := m.openDiff()
+				if ok && m.mode == modeDiff {
+					m.diff.reattachID = sess.ID
+				}
+				return m, cmd
+			case tmux.RequestEditor:
+				_, cmd := m.openEditor()
+				// The request cost the session its client, so the manager
+				// goes back into it once the editor is up, or once a
+				// terminal editor closes. A refused launch returns no
+				// command and stays in the list with its reason.
+				if ok && cmd != nil {
+					m.editorReturnID = sess.ID
+				}
+				return m, cmd
 			}
-			return m, cmd
 		}
 		m.requestRefresh()
 		return m, nil
 
-	case editorOpenedMsg:
-		m.reportDone("opened " + msg.dir + " in " + msg.name)
+	case editorDoneMsg:
+		if msg.err != nil {
+			// Going back into the session would hide the only account of
+			// what went wrong, so a failed editor keeps the list.
+			m.errBar.text = msg.err.Error()
+			m.editorReturnID = ""
+			return m, nil
+		}
+		if msg.name != "" {
+			m.reportDone("opened " + msg.dir + " in " + msg.name)
+		}
+		if id := m.editorReturnID; id != "" {
+			m.editorReturnID = ""
+			return m, m.reattach(id, m.diff.gen)
+		}
 		return m, nil
 
 	case reattachPreparedMsg:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1310,11 +1310,21 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.requestRefresh()
 				return m, nil
 			}
+			// Both requests act on the row under the cursor, and the cursor
+			// is not where the request came from: a poll handled ahead of
+			// this message rebuilds the rows, and a filter can drop the
+			// session that detached out of the list entirely.
+			m.focusSession(msg.sessID)
 			sess, ok := m.selected()
+			if !ok || sess.ID != msg.sessID {
+				m.errBar.text = "the session that asked for it has left the list"
+				m.requestRefresh()
+				return m, nil
+			}
 			switch request {
 			case tmux.RequestReview:
 				cmd := m.openDiff()
-				if ok && m.mode == modeDiff {
+				if m.mode == modeDiff {
 					m.diff.reattachID = sess.ID
 				}
 				return m, cmd
@@ -1324,7 +1334,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// goes back into it once the editor is up, or once a
 				// terminal editor closes. A refused launch returns no
 				// command and stays in the list with its reason.
-				if ok && cmd != nil {
+				if cmd != nil {
 					m.editorReturnID = sess.ID
 				}
 				return m, cmd

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1334,21 +1334,31 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case editorDoneMsg:
+		var resume tea.Cmd
+		if msg.tookScreen {
+			// The terminal comes back from an editor the way it comes back
+			// from an attach: painted in the editor's background, and
+			// without the mouse reporting focus mode armed on the way in.
+			SyncTerminalBackground()
+			if m.mode == modeFocus {
+				resume = tea.EnableMouseCellMotion
+			}
+		}
 		if msg.err != nil {
 			// Going back into the session would hide the only account of
 			// what went wrong, so a failed editor keeps the list.
 			m.errBar.text = msg.err.Error()
 			m.editorReturnID = ""
-			return m, nil
+			return m, resume
 		}
 		if msg.name != "" {
 			m.reportDone("opened " + msg.dir + " in " + msg.name)
 		}
 		if id := m.editorReturnID; id != "" {
 			m.editorReturnID = ""
-			return m, m.reattach(id, m.diff.gen)
+			return m, tea.Batch(resume, m.reattach(id, m.diff.gen))
 		}
-		return m, nil
+		return m, resume
 
 	case reattachPreparedMsg:
 		if msg.diffGen != m.diff.gen || m.diff.active {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -419,7 +419,10 @@ func (m *Model) viewFooter() string {
 			{"typing", "goes to the agent"},
 			{"ctrl+q / ctrl+\\", "back to manager"},
 			{"ctrl+r", "review"},
-			{"drag / double / triple click", "copy"},
+			{"ctrl+o", "editor"},
+			// The footer holds one row: the word and line gestures are in
+			// the key map, where there is room to name all three.
+			{"drag / click", "copy"},
 		}
 		if m.pane.mouse {
 			pairs = append(pairs, [2]string{"click / alt+drag", "agent UI"})


### PR DESCRIPTION
Stacked on #291 (base is `fix/toast-severity`, so the diff here is this change alone; GitHub retargets it to `main` when #291 merges).

## What changed

`ctrl+o` opens the session's directory in an editor from inside a session, both focused and attached, next to the `ctrl+q` and `ctrl+r` pair that already work in there.

Focused, `handleFocusKey` takes the key before the pane does. Attached, tmux owns the keyboard, so a root binding leaves a marker and detaches, the way `ctrl+r` already does. The two markers become one request that names what it wants (`@am_request review` / `editor`): one option, one place in the manager where a request is carried out, and room for the next one.

The manager goes back into the session once the editor is up, or once one that draws in the terminal exits, so the request costs the attach a repaint and nothing else. A launch that failed keeps the list instead, since under the attach its account of what went wrong would never be seen.

The tmux footer, the focus footer, the key map and the docs all name the key. The focus footer holds one row, so its copy gestures now read `drag / click`; the word and line ones stay in the key map, which has room for all three.

## Why

`o` reaches the row under the cursor, and inside a session every plain character belongs to the agent. The person closest to wanting the key was the one who could not press it.

Closes #290

## How it was verified

Drove the built binary in a throwaway environment (own `HOME`, own tmux socket, a stub `code` that logs its arguments, `AGENT_MANAGER_EDITOR=myed` for a terminal editor that holds the screen for three seconds). All four paths:

| where | editor | what happened |
|---|---|---|
| attached | windowed | detached, `code` logged `/private/tmp/amfake/proj`, back in the session |
| attached | terminal | detached, the editor held the screen, back in the session when it exited |
| focused | windowed | green `● opened /private/tmp/amfake/proj in code`, focus kept |
| focused | terminal | the editor held the screen, focus restored on exit |

`tmux -L agentmgr list-keys -T root` carries the binding:

```
bind-key -T root C-o if-shell -F "#{m:am_*,#{session_name}}" "set-option -g @am_request editor ; detach-client" "send-keys C-o"
```

`ctrl+r` from an attach still opens the review and `esc` still goes back in, and the marker is consumed once per press (a second `ctrl+o` in the same attach opened the editor again).

Tests: the focus key, the attach request for both editor classes, a refused request arming no return, a failed editor keeping the list, and the request marker's round trip through tmux for both values. The focus and attach tests fail without their handler.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] Ran it against real sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Press **Ctrl+O** to open the current or selected session’s directory in your configured editor.
  * After editing, the app returns you to the originating session when possible.
  * Added editor shortcuts, status indicators, and help text across session views.

* **Bug Fixes**
  * Improved editor launch, completion, terminal-state restoration, and error handling.

* **Documentation**
  * Updated the README and usage guide with the new **Ctrl+O** shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->