### PR TITLE
probe: is TestRefreshNotifiesWaitingTransitionOnce failing on a clean main?

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -71,3 +71,4 @@ the release catalog and editorial feed from GitHub. Normal background checks do
 no network or parsing work on the render path. The release catalog checks every
 10 minutes with an HTTP ETag, while the editorial feed's cache lasts 6 hours;
 both schedules are independent of the installed version.
+


### PR DESCRIPTION
Throwaway. A whitespace-only change on top of `origin/main` so CI runs the suite with nothing else in it, to tell #292 apart from the branch it was noticed on. Closing as soon as the job reports.