### PR TITLE
probe: diagnose the notify test failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Arch Linux, mise, `go install`, prebuilt binaries, Windows (WSL2), and updating:
 agent-manager
 ```
 
-Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager and **Ctrl+R** opens its diff review. `agent-manager --version` prints the version.
+Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager, **Ctrl+R** opens its diff review and **Ctrl+O** opens its directory in your editor. `agent-manager --version` prints the version.
 
 Agent sessions live on a private tmux server named `agentmgr`, so they never mix with the tmux you run yourself and a `kill-server` on your own socket leaves them alone. To reach one from a plain shell, name that server: `tmux -L agentmgr ls`, then `tmux -L agentmgr attach -t am_<id>`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -85,7 +85,7 @@ Agent Manager takes the first of these it finds: `editor` in [config.toml](confi
 
 The line is run directly, never through a shell, so nothing in it is expanded and an `.envrc` that sets `EDITOR` cannot smuggle a command in behind it. Arguments are allowed, and quotes group one that carries a space: `editor = "code -n"`, `editor = "open -a 'Visual Studio Code'"`.
 
-Inside a session, attached or focused, `ctrl+o` opens that session's directory the same way. It costs an attach its client, so the manager steps back in once the editor is up.
+Inside a session, attached or focused, `ctrl+o` opens that session's directory the same way. It costs an attach its client, so the manager steps back into the session once a windowed editor is running, or once one that draws in the terminal exits. An editor that fails to start keeps the manager on screen, where you can read why.
 
 A known windowed editor (the six above, plus `open` and `xdg-open`) starts detached and the manager stays on screen, with the status line naming what opened. Everything else takes the terminal over the way an attach does and hands it back on exit — that way round because a terminal editor started detached would have nowhere to draw, while a windowed one launched this way only costs a repaint.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@
 agent-manager
 ```
 
-Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager and **Ctrl+R** opens its diff review. `agent-manager --version` prints the version.
+Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager, **Ctrl+R** opens its diff review and **Ctrl+O** opens its directory in your editor. `agent-manager --version` prints the version.
 
 Agent sessions live on a private tmux server named `agentmgr`, so they never mix with the tmux you run yourself and a `kill-server` on your own socket leaves them alone. To reach one from a plain shell, name that server: `tmux -L agentmgr ls`, then `tmux -L agentmgr attach -t am_<id>`.
 
@@ -20,6 +20,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `enter` | Focus session in place (keys go to the agent, list stays) / fold group |
 | `A` | Attach session full screen (Settings can swap it with `enter`) |
 | `ctrl+q` | Inside a session: back to the manager |
+| `ctrl+o` | Inside a session: open its directory in your editor |
 | `→` | Step into the row: focus the session, or open the group. In beta; Settings (`s`) can turn the pair off |
 | `←` | Step out: close the group, or — focused, with the caret at the start of the agent's prompt — back to the manager. This needs the tool's prompt marker (its `activity_cutoff`) on the caret's row, so a CLI without one keeps `←` entirely; anywhere else in the prompt it moves the caret as usual |
 | `K` / `J` (or `shift+↑` / `shift+↓`) | Reorder session or group among its visible siblings |
@@ -83,6 +84,8 @@ A shell left on its empty command carries no session id, so `agent-manager renam
 Agent Manager takes the first of these it finds: `editor` in [config.toml](configuration.md), `$AGENT_MANAGER_EDITOR`, a GUI editor on `PATH` (`code`, `cursor`, `windsurf`, `zed`, `subl`, `idea`), then `$VISUAL` or `$EDITOR`. The environment comes last because it usually names the editor you set for git commit messages rather than the one a project should open in.
 
 The line is run directly, never through a shell, so nothing in it is expanded and an `.envrc` that sets `EDITOR` cannot smuggle a command in behind it. Arguments are allowed, and quotes group one that carries a space: `editor = "code -n"`, `editor = "open -a 'Visual Studio Code'"`.
+
+Inside a session, attached or focused, `ctrl+o` opens that session's directory the same way. It costs an attach its client, so the manager steps back in once the editor is up.
 
 A known windowed editor (the six above, plus `open` and `xdg-open`) starts detached and the manager stays on screen, with the status line naming what opened. Everything else takes the terminal over the way an attach does and hands it back on exit — that way round because a terminal editor started detached would have nowhere to draw, while a windowed one launched this way only costs a repaint.
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -25,7 +25,6 @@ const defaultSocket = "agentmgr"
 // just detached from.
 const requestOption = "@am_request"
 
-// The requests those bindings leave behind.
 const (
 	RequestReview = "review"
 	RequestEditor = "editor"
@@ -403,8 +402,8 @@ func sanitizeFormat(s string) string {
 	return strings.ReplaceAll(s, "#", "##")
 }
 
-// PendingRequest names what an in-session binding asked for before
-// detaching, empty when none did. A missing tmux server means no request.
+// A missing tmux server means no request rather than an error: the
+// manager outlives the sessions it opens.
 func (d *Driver) PendingRequest() (string, error) {
 	out, err := exec.Command(d.bin, d.args("show-option", "-gqv", requestOption)...).CombinedOutput()
 	if err != nil {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -20,9 +20,16 @@ const prefix = "am_"
 // otherwise share a server with the live agents and take them all down at once.
 const defaultSocket = "agentmgr"
 
-// reviewOption is the global tmux user option the in-session Ctrl+R binding
-// sets to signal the manager to open review for the session it just detached.
-const reviewOption = "@am_review"
+// requestOption is the global tmux user option the in-session bindings set
+// on their way out, naming what the manager should do with the session they
+// just detached from.
+const requestOption = "@am_request"
+
+// The requests those bindings leave behind.
+const (
+	RequestReview = "review"
+	RequestEditor = "editor"
+)
 
 type Driver struct {
 	bin    string
@@ -253,7 +260,7 @@ func (d *Driver) styleStatusBar(name string) error {
 		// The default status-right-length of 40 truncates the hint before the
 		// Ctrl+R part, so widen it to fit the whole footer.
 		{"set-option", "-t", name, "status-right-length", "80"},
-		{"set-option", "-t", name, "status-right", " agent-manager · Ctrl+q = back · Ctrl+r = review "},
+		{"set-option", "-t", name, "status-right", " agent-manager · Ctrl+q = back · Ctrl+r = review · Ctrl+o = editor "},
 		{"set-option", "-t", name, "status-style", "bg=colour236,fg=colour249"},
 		// hide the "0:windowname*" window list; it reads as noise here
 		{"set-option", "-t", name, "window-status-format", ""},
@@ -270,15 +277,20 @@ func (d *Driver) styleStatusBar(name string) error {
 	return nil
 }
 
-// EnsureBindings installs the server-global Ctrl+Q / Ctrl+\ detach and
-// Ctrl+R review bindings. All only act inside am_* sessions; elsewhere the
-// key passes through to the pane. Idempotent, so it is safe to re-run for
-// sessions that predate a binding.
+// EnsureBindings installs the server-global Ctrl+Q / Ctrl+\ detach, Ctrl+R
+// review and Ctrl+O editor bindings. All only act inside am_* sessions;
+// elsewhere the key passes through to the pane. Idempotent, so it is safe to
+// re-run for sessions that predate a binding.
 func (d *Driver) EnsureBindings() error {
+	inSession := "#{m:" + prefix + "*,#{session_name}}"
+	request := func(name string) string {
+		return "set-option -g " + requestOption + " " + name + " ; detach-client"
+	}
 	binds := [][]string{
-		{"bind-key", "-n", "C-q", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "detach-client", "send-keys C-q"},
-		{"bind-key", "-n", `C-\`, "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "detach-client", `send-keys C-\\`},
-		{"bind-key", "-n", "C-r", "if-shell", "-F", "#{m:" + prefix + "*,#{session_name}}", "set-option -g " + reviewOption + " 1 ; detach-client", "send-keys C-r"},
+		{"bind-key", "-n", "C-q", "if-shell", "-F", inSession, "detach-client", "send-keys C-q"},
+		{"bind-key", "-n", `C-\`, "if-shell", "-F", inSession, "detach-client", `send-keys C-\\`},
+		{"bind-key", "-n", "C-r", "if-shell", "-F", inSession, request(RequestReview), "send-keys C-r"},
+		{"bind-key", "-n", "C-o", "if-shell", "-F", inSession, request(RequestEditor), "send-keys C-o"},
 	}
 	for _, args := range binds {
 		if _, err := d.run(args...); err != nil {
@@ -391,22 +403,22 @@ func sanitizeFormat(s string) string {
 	return strings.ReplaceAll(s, "#", "##")
 }
 
-// ReviewRequested reports whether the in-session Ctrl+R binding set the
-// review marker before detaching. A missing tmux server means no request.
-func (d *Driver) ReviewRequested() (bool, error) {
-	out, err := exec.Command(d.bin, d.args("show-option", "-gqv", reviewOption)...).CombinedOutput()
+// PendingRequest names what an in-session binding asked for before
+// detaching, empty when none did. A missing tmux server means no request.
+func (d *Driver) PendingRequest() (string, error) {
+	out, err := exec.Command(d.bin, d.args("show-option", "-gqv", requestOption)...).CombinedOutput()
 	if err != nil {
 		if noServer(string(out)) {
-			return false, nil
+			return "", nil
 		}
-		return false, fmt.Errorf("tmux show-option %s: %w: %s", reviewOption, err, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("tmux show-option %s: %w: %s", requestOption, err, strings.TrimSpace(string(out)))
 	}
-	return strings.TrimSpace(string(out)) == "1", nil
+	return strings.TrimSpace(string(out)), nil
 }
 
-// ClearReviewRequest unsets the review marker so it fires once per request.
-func (d *Driver) ClearReviewRequest() error {
-	_, err := d.run("set-option", "-gu", reviewOption)
+// ClearRequest unsets the marker so a request is carried out once.
+func (d *Driver) ClearRequest() error {
+	_, err := d.run("set-option", "-gu", requestOption)
 	return err
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -294,7 +294,7 @@ func TestCreateDeliversLongCommand(t *testing.T) {
 	t.Fatalf("long launch command truncated or failed; wrote %d bytes, want %d; pane:\n%s", len(got), len(payload), pane)
 }
 
-func TestReviewRequestRoundTrip(t *testing.T) {
+func TestDetachRequestRoundTrip(t *testing.T) {
 	driver := requireTmux(t)
 	// A live server is needed for global options to stick.
 	id := "rev" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
@@ -302,39 +302,41 @@ func TestReviewRequestRoundTrip(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	t.Cleanup(func() { driver.Kill(id) })
-	t.Cleanup(func() { driver.ClearReviewRequest() })
+	t.Cleanup(func() { driver.ClearRequest() })
 
-	if err := driver.ClearReviewRequest(); err != nil {
-		t.Fatalf("ClearReviewRequest: %v", err)
+	if err := driver.ClearRequest(); err != nil {
+		t.Fatalf("ClearRequest: %v", err)
 	}
-	requested, err := driver.ReviewRequested()
+	request, err := driver.PendingRequest()
 	if err != nil {
-		t.Fatalf("ReviewRequested: %v", err)
+		t.Fatalf("PendingRequest: %v", err)
 	}
-	if requested {
-		t.Fatal("no request expected on a clean marker")
-	}
-
-	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
-		t.Fatalf("set marker: %v", err)
-	}
-	requested, err = driver.ReviewRequested()
-	if err != nil {
-		t.Fatalf("ReviewRequested: %v", err)
-	}
-	if !requested {
-		t.Fatal("marker set to 1 should read as requested")
+	if request != "" {
+		t.Fatalf("no request expected on a clean marker, got %q", request)
 	}
 
-	if err := driver.ClearReviewRequest(); err != nil {
-		t.Fatalf("ClearReviewRequest: %v", err)
-	}
-	requested, err = driver.ReviewRequested()
-	if err != nil {
-		t.Fatalf("ReviewRequested: %v", err)
-	}
-	if requested {
-		t.Fatal("clear should drop the marker")
+	for _, want := range []string{RequestReview, RequestEditor} {
+		if _, err := tmuxCmd("set-option", "-g", requestOption, want).CombinedOutput(); err != nil {
+			t.Fatalf("set marker: %v", err)
+		}
+		request, err = driver.PendingRequest()
+		if err != nil {
+			t.Fatalf("PendingRequest: %v", err)
+		}
+		if request != want {
+			t.Fatalf("marker reads as %q, want %q", request, want)
+		}
+
+		if err := driver.ClearRequest(); err != nil {
+			t.Fatalf("ClearRequest: %v", err)
+		}
+		request, err = driver.PendingRequest()
+		if err != nil {
+			t.Fatalf("PendingRequest: %v", err)
+		}
+		if request != "" {
+			t.Fatalf("clear should drop the marker, got %q", request)
+		}
 	}
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -302,7 +302,11 @@ func TestDetachRequestRoundTrip(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	t.Cleanup(func() { driver.Kill(id) })
-	t.Cleanup(func() { driver.ClearRequest() })
+	t.Cleanup(func() {
+		if err := driver.ClearRequest(); err != nil {
+			t.Errorf("ClearRequest: %v", err)
+		}
+	})
 
 	if err := driver.ClearRequest(); err != nil {
 		t.Fatalf("ClearRequest: %v", err)

--- a/internal/ui/diffrender.go
+++ b/internal/ui/diffrender.go
@@ -897,10 +897,10 @@ func (m *Model) renderSideCell(fd *diff.FileDiff, hl *fileHL, index, width int, 
 
 func (m *Model) viewDiffStatus() string {
 	if m.errBar.text != "" {
-		return padRight(errStyle.Render(" ✖ "+m.errBar.text), m.width)
+		return padRight(m.statusMessage(" ✖", " ✔"), m.width)
 	}
 	if m.diff.notice != "" {
-		return padRight(lipgloss.NewStyle().Foreground(colorFinished).Render(" ✔ "+m.diff.notice), m.width)
+		return padRight(doneStyle.Render(" ✔ "+m.diff.notice), m.width)
 	}
 	if m.diff.sendConfirm {
 		count := len(m.diff.annotations[m.reviewKey()])

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/diff"
 	"github.com/YoanWai/agent-manager/internal/git"
 	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -461,9 +462,9 @@ func TestInSessionReviewRemembersOriginAndReattaches(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+	t.Cleanup(func() { m.tmux.ClearRequest() })
 
-	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
 	updated, _ := m.Update(attachDoneMsg{})
@@ -531,12 +532,12 @@ func TestReattachAcknowledgesFinished(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+	t.Cleanup(func() { m.tmux.ClearRequest() })
 
 	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
 		t.Fatalf("set finished: %v", err)
 	}
-	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
 	updated, _ := m.Update(attachDoneMsg{})

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -462,7 +462,7 @@ func TestInSessionReviewRemembersOriginAndReattaches(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
@@ -532,7 +532,7 @@ func TestReattachAcknowledgesFinished(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if err := m.store.UpdateStatus(sess.ID, status.Finished); err != nil {
 		t.Fatalf("set finished: %v", err)

--- a/internal/ui/editor.go
+++ b/internal/ui/editor.go
@@ -43,11 +43,15 @@ var (
 	}
 )
 
-// The status line waits on this rather than announcing the editor from
-// openEditor, so a launch that fails is never reported as one that opened.
-type editorOpenedMsg struct {
+// editorDoneMsg ends an editor request. The status line waits on it rather
+// than announcing the editor from openEditor, so a launch that fails is
+// never reported as one that opened: name and dir are filled once a
+// windowed editor is running, and err carries a launch that failed or a
+// terminal editor that exited badly.
+type editorDoneMsg struct {
 	name string
 	dir  string
+	err  error
 }
 
 func (m *Model) openEditor() (tea.Model, tea.Cmd) {
@@ -68,10 +72,7 @@ func (m *Model) openEditor() (tea.Model, tea.Cmd) {
 	m.errBar.text = ""
 	if !detachedEditors[editorName(line)] {
 		return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
-			if err != nil {
-				return errMsg{err}
-			}
-			return nil
+			return editorDoneMsg{err: err}
 		})
 	}
 	return m, startEditorCmd(cmd, editorName(line), dir)
@@ -82,9 +83,9 @@ func (m *Model) openEditor() (tea.Model, tea.Cmd) {
 func startEditorCmd(cmd *exec.Cmd, name, dir string) tea.Cmd {
 	return func() tea.Msg {
 		if err := startEditor(cmd); err != nil {
-			return errMsg{err}
+			return editorDoneMsg{err: err}
 		}
-		return editorOpenedMsg{name: name, dir: dir}
+		return editorDoneMsg{name: name, dir: dir}
 	}
 }
 

--- a/internal/ui/editor_test.go
+++ b/internal/ui/editor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/YoanWai/agent-manager/internal/config"
+	"github.com/YoanWai/agent-manager/internal/tmux"
 )
 
 // captureEditor swaps both editor seams: PATH answers only for the names
@@ -240,5 +241,138 @@ func TestOpenEditorNamesADirectoryThatIsGone(t *testing.T) {
 	}
 	if !strings.HasSuffix(m.errBar.text, gone) {
 		t.Fatalf("status line should name the directory, got %q", m.errBar.text)
+	}
+}
+
+// Ctrl+O inside an attach leaves a request behind and detaches: the manager
+// opens the editor for the session it was in, then hands that session its
+// client back.
+func TestAttachDoneOpensEditorAndReturnsToTheSession(t *testing.T) {
+	m := buildModel(t)
+	launched := captureEditor(t, "code")
+	dir := t.TempDir()
+	createSession(t, m, "editme", dir, "")
+	m.selectSessionRow(t, "editme")
+	sess, ok := m.selected()
+	if !ok {
+		t.Fatal("no session selected")
+	}
+	t.Cleanup(func() { m.tmux.ClearRequest() })
+
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	updated, cmd := m.Update(attachDoneMsg{sessID: sess.ID})
+	*m = *updated.(*Model)
+	if cmd == nil {
+		t.Fatalf("the request produced no launch, err = %q", m.errBar.text)
+	}
+	if m.editorReturnID != sess.ID {
+		t.Fatalf("return armed for %q, want %q", m.editorReturnID, sess.ID)
+	}
+	request, err := m.tmux.PendingRequest()
+	if err != nil {
+		t.Fatalf("PendingRequest: %v", err)
+	}
+	if request != "" {
+		t.Fatalf("carrying the request out should consume it, got %q", request)
+	}
+
+	done, isDone := cmd().(editorDoneMsg)
+	if !isDone || done.err != nil {
+		t.Fatalf("editor launch reported %#v", done)
+	}
+	if want := []string{"code", resolved(t, dir)}; !slices.Equal(*launched, want) {
+		t.Fatalf("launched %v, want %v", *launched, want)
+	}
+
+	updated, cmd = m.Update(done)
+	*m = *updated.(*Model)
+	if m.editorReturnID != "" {
+		t.Fatalf("the return should be consumed, still holds %q", m.editorReturnID)
+	}
+	if cmd == nil {
+		t.Fatal("the session should get its client back")
+	}
+	prepared, isPrepared := cmd().(reattachPreparedMsg)
+	if !isPrepared || prepared.sessID != sess.ID {
+		t.Fatalf("want a reattach for %q, got %#v", sess.ID, prepared)
+	}
+}
+
+// A request the manager cannot carry out leaves nothing armed: the next
+// editor opened from the list must not drag the session back on screen.
+func TestAttachDoneRefusedEditorArmsNoReturn(t *testing.T) {
+	m := buildModel(t)
+	captureEditor(t)
+	createSession(t, m, "editme", t.TempDir(), "")
+	m.selectSessionRow(t, "editme")
+	t.Cleanup(func() { m.tmux.ClearRequest() })
+
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	updated, cmd := m.Update(attachDoneMsg{})
+	*m = *updated.(*Model)
+	if cmd != nil {
+		t.Fatal("a refused request should return no command")
+	}
+	if m.editorReturnID != "" {
+		t.Fatalf("nothing launched, so nothing to return from, got %q", m.editorReturnID)
+	}
+	if !strings.Contains(m.errBar.text, "no editor found") {
+		t.Fatalf("status line should say why, got %q", m.errBar.text)
+	}
+}
+
+// An editor that draws in the terminal takes the screen and hands it back
+// on exit, so the request arms the return the same way a windowed one does.
+func TestAttachDoneTerminalEditorArmsTheReturn(t *testing.T) {
+	m := buildModel(t)
+	launched := captureEditor(t)
+	m.cfg.Editor = "my-own-edit-wrapper"
+	createSession(t, m, "editme", t.TempDir(), "")
+	m.selectSessionRow(t, "editme")
+	sess, ok := m.selected()
+	if !ok {
+		t.Fatal("no session selected")
+	}
+	t.Cleanup(func() { m.tmux.ClearRequest() })
+
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	updated, cmd := m.Update(attachDoneMsg{sessID: sess.ID})
+	*m = *updated.(*Model)
+	if cmd == nil {
+		t.Fatalf("the request produced no launch, err = %q", m.errBar.text)
+	}
+	if len(*launched) != 0 {
+		t.Fatalf("a terminal editor must not start detached, got %v", *launched)
+	}
+	if m.editorReturnID != sess.ID {
+		t.Fatalf("return armed for %q, want %q", m.editorReturnID, sess.ID)
+	}
+}
+
+// An editor that failed to start keeps the list: going back into the
+// session would hide the only account of what went wrong.
+func TestEditorFailureKeepsTheListAndItsReason(t *testing.T) {
+	m := buildModel(t)
+	captureEditor(t, "code")
+	createSession(t, m, "editme", t.TempDir(), "")
+	m.selectSessionRow(t, "editme")
+	m.editorReturnID = m.sessionRows()[0].ID
+
+	updated, cmd := m.Update(editorDoneMsg{err: errors.New("exec: \"code\": file does not exist")})
+	*m = *updated.(*Model)
+	if cmd != nil {
+		t.Fatal("a failed editor should not hand the session back its client")
+	}
+	if m.editorReturnID != "" {
+		t.Fatalf("the return should be dropped, still holds %q", m.editorReturnID)
+	}
+	if !strings.Contains(m.errBar.text, "does not exist") {
+		t.Fatalf("status line should carry the failure, got %q", m.errBar.text)
 	}
 }

--- a/internal/ui/editor_test.go
+++ b/internal/ui/editor_test.go
@@ -257,7 +257,7 @@ func TestAttachDoneOpensEditorAndReturnsToTheSession(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
@@ -307,7 +307,7 @@ func TestAttachDoneRefusedEditorArmsNoReturn(t *testing.T) {
 	captureEditor(t)
 	createSession(t, m, "editme", t.TempDir(), "")
 	m.selectSessionRow(t, "editme")
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
@@ -337,7 +337,7 @@ func TestAttachDoneTerminalEditorArmsTheReturn(t *testing.T) {
 	if !ok {
 		t.Fatal("no session selected")
 	}
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestEditor).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -198,9 +198,9 @@ func (m *Model) leaveFocus() tea.Cmd {
 }
 
 // handleFocusKey forwards every key into the focused pane. Ctrl+Q and
-// ctrl+\ return to the list and Ctrl+R opens the review, mirroring the
-// bindings a real attach gets, and every plain character - q included -
-// reaches the agent.
+// ctrl+\ return to the list, Ctrl+R opens the review and Ctrl+O the editor,
+// mirroring the bindings a real attach gets, and every plain character - q
+// included - reaches the agent.
 func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.String() == "ctrl+q" || msg.String() == `ctrl+\` {
 		return m, m.leaveFocus()
@@ -208,6 +208,12 @@ func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	sess, ok := m.selected()
 	if !ok {
 		return m, m.leaveFocus()
+	}
+	// Ctrl+O opens the session's directory in an editor, matching the
+	// binding a real attach gets. A windowed editor leaves the focus where
+	// it is; one that draws in the terminal takes it back on exit.
+	if msg.String() == "ctrl+o" {
+		return m.openEditor()
 	}
 	// Ctrl+R opens the review, matching the binding a real attach gets;
 	// closing it focuses the session again rather than landing in the list.

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -344,6 +345,39 @@ func TestFocusCtrlROpensReviewAndReturns(t *testing.T) {
 	}
 }
 
+// Ctrl+O opens the focused session's directory the way the list's o does,
+// and a windowed editor leaves the focus where it was.
+func TestFocusCtrlOOpensEditor(t *testing.T) {
+	m := buildModel(t)
+	launched := captureEditor(t, "code")
+	dir := t.TempDir()
+	createSession(t, m, "focusedit", dir, "")
+	m.selectSessionRow(t, "focusedit")
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+	if m.mode != modeFocus {
+		t.Fatalf("after enter, mode = %v, err = %q", m.mode, m.errBar.text)
+	}
+
+	updated, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlO})
+	*m = *updated.(*Model)
+	if cmd == nil {
+		t.Fatalf("ctrl+o in focus returned no launch, err = %q", m.errBar.text)
+	}
+	m.applyCmd(t, cmd)
+
+	if want := []string{"code", resolved(t, dir)}; !slices.Equal(*launched, want) {
+		t.Fatalf("launched %v, want %v", *launched, want)
+	}
+	if m.mode != modeFocus {
+		t.Fatalf("a windowed editor should leave the focus alone, mode = %v", m.mode)
+	}
+	if !strings.Contains(m.errBar.text, "code") {
+		t.Fatalf("status line should name the editor, got %q", m.errBar.text)
+	}
+}
+
 // Leaving focus must keep mouse reporting: handing it back would let a
 // wheel notch scroll the manager out of view from the list.
 func TestFocusExitKeepsMouse(t *testing.T) {
@@ -457,7 +491,7 @@ func TestFocusPasteKeepsPromptInComposer(t *testing.T) {
 // This test verifies the handler returns no mouse-enable command.
 func TestDetachNoMouseReArm(t *testing.T) {
 	m := buildModel(t)
-	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+	t.Cleanup(func() { m.tmux.ClearRequest() })
 
 	_, cmd := m.Update(attachDoneMsg{})
 	if cmd != nil {

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -491,7 +491,7 @@ func TestFocusPasteKeepsPromptInComposer(t *testing.T) {
 // This test verifies the handler returns no mouse-enable command.
 func TestDetachNoMouseReArm(t *testing.T) {
 	m := buildModel(t)
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	_, cmd := m.Update(attachDoneMsg{})
 	if cmd != nil {

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -115,6 +115,7 @@ func helpSections() []helpSection {
 			{"ctrl+q", "back to the manager (ctrl+\\ too)"},
 			{"←", "focused: back to the manager, at the prompt's start"},
 			{"ctrl+r", "review the session's diff, esc returns"},
+			{"ctrl+o", "open its directory in an editor"},
 			{"wheel", "focused: scroll the pane's history, type to catch up"},
 			{"drag", "focused: select pane text and copy it"},
 			{"double click", "focused: copy the word"},

--- a/internal/ui/helpers_test.go
+++ b/internal/ui/helpers_test.go
@@ -111,6 +111,17 @@ func (m *Model) applyCmd(t *testing.T, cmd tea.Cmd) {
 	*m = *updated.(*Model)
 }
 
+// clearRequestOnCleanup drops the server-global detach marker when the test
+// ends: one left behind reaches every later test that reads it.
+func clearRequestOnCleanup(t *testing.T, m *Model) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := m.tmux.ClearRequest(); err != nil {
+			t.Errorf("ClearRequest: %v", err)
+		}
+	})
+}
+
 func (m *Model) sessionRows() []store.Session {
 	var sessions []store.Session
 	for _, r := range m.rows {

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -216,7 +216,7 @@ func TestAttachDoneOpensReviewWhenMarkerSet(t *testing.T) {
 	}
 	createSession(t, m, "reviewme", t.TempDir(), "")
 	m.selectSessionRow(t, "reviewme")
-	t.Cleanup(func() { m.tmux.ClearRequest() })
+	clearRequestOnCleanup(t, m)
 
 	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -216,9 +216,9 @@ func TestAttachDoneOpensReviewWhenMarkerSet(t *testing.T) {
 	}
 	createSession(t, m, "reviewme", t.TempDir(), "")
 	m.selectSessionRow(t, "reviewme")
-	t.Cleanup(func() { m.tmux.ClearReviewRequest() })
+	t.Cleanup(func() { m.tmux.ClearRequest() })
 
-	if _, err := tmuxCmd("set-option", "-g", "@am_review", "1").CombinedOutput(); err != nil {
+	if _, err := tmuxCmd("set-option", "-g", "@am_request", tmux.RequestReview).CombinedOutput(); err != nil {
 		t.Fatalf("set marker: %v", err)
 	}
 	updated, _ := m.Update(attachDoneMsg{})
@@ -227,12 +227,12 @@ func TestAttachDoneOpensReviewWhenMarkerSet(t *testing.T) {
 		t.Fatalf("marker set should enter review, mode = %v, err = %q", m.mode, m.errBar.text)
 	}
 
-	requested, err := m.tmux.ReviewRequested()
+	request, err := m.tmux.PendingRequest()
 	if err != nil {
-		t.Fatalf("ReviewRequested: %v", err)
+		t.Fatalf("PendingRequest: %v", err)
 	}
-	if requested {
-		t.Fatal("opening review should consume the marker")
+	if request != "" {
+		t.Fatalf("opening review should consume the marker, got %q", request)
 	}
 }
 
@@ -240,7 +240,7 @@ func TestAttachDoneStaysInListWithoutMarker(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "plainexit", t.TempDir(), "")
 	m.selectSessionRow(t, "plainexit")
-	if err := m.tmux.ClearReviewRequest(); err != nil {
+	if err := m.tmux.ClearRequest(); err != nil {
 		t.Fatalf("clear marker: %v", err)
 	}
 

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -688,7 +688,7 @@ func (m *Model) contentLines(width, height int) []contentLine {
 // focusTopRule is the hairline that caps the focused pane, titled so the
 // mode names itself where the eye already is.
 func focusTopRule(width int) string {
-	title := " focused · ctrl+q back · ctrl+r review "
+	title := " focused · ctrl+q back · ctrl+r review · ctrl+o editor "
 	rule := annotationStyle.Render(title)
 	rest := width - lipgloss.Width(title)
 	if rest > 0 {

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -57,7 +57,7 @@ func (m *Model) flexCardWidth(title, body string, hint [][2]string) int {
 	measure(cardTitle(title))
 	measure(legendInline(hint, 1<<30))
 	if m.errBar.text != "" {
-		measure(errStyle.Render("⚠ " + m.errBar.text))
+		measure(m.statusMessage("⚠", "●"))
 	}
 	if m.width >= 28 && need > m.width-4 {
 		need = m.width - 4
@@ -89,7 +89,7 @@ func (m *Model) cardSized(width int, title, body string, hint [][2]string) strin
 		lines = append(lines, row(line))
 	}
 	if m.errBar.text != "" {
-		lines = append(lines, row(""), row(errStyle.Render("⚠ "+m.errBar.text)))
+		lines = append(lines, row(""), row(m.statusMessage("⚠", "●")))
 	}
 	lines = append(lines, row(""))
 	if len(hint) > 0 {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -231,8 +231,20 @@ type paneMirror struct {
 
 type errBar struct {
 	text  string
+	done  string
 	shown string
 	age   int
+}
+
+// worked reports whether the message on the bar is an action that went
+// through, so it can be styled as an outcome rather than a failure. Only
+// reportDone fills done, and any later write to text alone leaves it
+// behind, so a message says it worked or reads as a failure.
+func (e errBar) worked() bool { return e.text != "" && e.text == e.done }
+
+// reportDone puts an action that went through on the status bar.
+func (m *Model) reportDone(text string) {
+	m.errBar.text, m.errBar.done = text, text
 }
 
 // splitState is the horizontal sessions/sidebar split. ratio is the left
@@ -1121,7 +1133,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.indexReleaseRanges()
 			})
-			m.errBar.text = "already up to date"
+			m.reportDone("already up to date")
 			return m, nil
 		}
 		m.update.restartPath = msg.path
@@ -1304,7 +1316,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case editorOpenedMsg:
-		m.errBar.text = "opened " + msg.dir + " in " + msg.name
+		m.reportDone("opened " + msg.dir + " in " + msg.name)
 		return m, nil
 
 	case reattachPreparedMsg:
@@ -1382,7 +1394,7 @@ func (m *Model) updateNetRates(snap sysstat.Snapshot) {
 // ticks, so transient errors self-dismiss without any per-callsite timers.
 func (m *Model) ageError() {
 	if m.errBar.text == "" {
-		m.errBar.shown, m.errBar.age = "", 0
+		m.errBar = errBar{}
 		return
 	}
 	if m.errBar.text != m.errBar.shown {
@@ -1391,7 +1403,7 @@ func (m *Model) ageError() {
 	}
 	m.errBar.age++
 	if m.errBar.age >= 2 {
-		m.errBar.text, m.errBar.shown, m.errBar.age = "", "", 0
+		m.errBar = errBar{}
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -157,6 +157,9 @@ type Model struct {
 	moveID     string
 	movePath   string
 	repoPick   repoPickState
+	// editorReturnID is the session an editor request detached from, so the
+	// attach it cost can be resumed once the editor is up.
+	editorReturnID string
 
 	// Repo a human picked by hand per session, outranking the agent's
 	// declaration for as long as this manager runs.
@@ -1291,32 +1294,60 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.requestRefresh()
 			return m, nil
 		}
-		// Ctrl+R inside the session sets a marker before detaching; consume
-		// it here and jump straight to review for the session just attached.
-		requested, err := m.tmux.ReviewRequested()
+		// Ctrl+R and Ctrl+O inside the session leave a marker before
+		// detaching; consume it here and carry it out for the session just
+		// attached.
+		request, err := m.tmux.PendingRequest()
 		if err != nil {
 			m.errBar.text = err.Error()
-		} else if requested {
-			// A failed clear leaves the marker set, which would reopen review
-			// on every later detach, so surface it and stay in the list rather
-			// than letting openDiff reset m.errBar.text and hide it.
-			if clearErr := m.tmux.ClearReviewRequest(); clearErr != nil {
+		} else if request != "" {
+			// A failed clear leaves the marker set, which would replay the
+			// request on every later detach, so surface it and stay in the
+			// list rather than letting the request reset m.errBar.text and
+			// hide it.
+			if clearErr := m.tmux.ClearRequest(); clearErr != nil {
 				m.errBar.text = clearErr.Error()
 				m.requestRefresh()
 				return m, nil
 			}
 			sess, ok := m.selected()
-			cmd := m.openDiff()
-			if ok && m.mode == modeDiff {
-				m.diff.reattachID = sess.ID
+			switch request {
+			case tmux.RequestReview:
+				cmd := m.openDiff()
+				if ok && m.mode == modeDiff {
+					m.diff.reattachID = sess.ID
+				}
+				return m, cmd
+			case tmux.RequestEditor:
+				_, cmd := m.openEditor()
+				// The request cost the session its client, so the manager
+				// goes back into it once the editor is up, or once a
+				// terminal editor closes. A refused launch returns no
+				// command and stays in the list with its reason.
+				if ok && cmd != nil {
+					m.editorReturnID = sess.ID
+				}
+				return m, cmd
 			}
-			return m, cmd
 		}
 		m.requestRefresh()
 		return m, nil
 
-	case editorOpenedMsg:
-		m.reportDone("opened " + msg.dir + " in " + msg.name)
+	case editorDoneMsg:
+		if msg.err != nil {
+			// Going back into the session would hide the only account of
+			// what went wrong, so a failed editor keeps the list.
+			m.errBar.text = msg.err.Error()
+			m.editorReturnID = ""
+			return m, nil
+		}
+		if msg.name != "" {
+			m.reportDone("opened " + msg.dir + " in " + msg.name)
+		}
+		if id := m.editorReturnID; id != "" {
+			m.editorReturnID = ""
+			return m, m.reattach(id, m.diff.gen)
+		}
 		return m, nil
 
 	case reattachPreparedMsg:

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -624,7 +624,7 @@ func (m *Model) viewNotices() string {
 		tail = append(tail, lipgloss.NewStyle().Foreground(colorAccent).Render("↓ downloading "+m.update.latest+"…"))
 	}
 	if m.errBar.text != "" {
-		tail = append(tail, errStyle.Render("✕ "+m.errBar.text))
+		tail = append(tail, m.statusMessage("✕", "●"))
 	}
 	tail = append(tail, "")
 

--- a/internal/ui/notify_test.go
+++ b/internal/ui/notify_test.go
@@ -159,6 +159,9 @@ func TestRefreshNotifiesWaitingTransitionOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if got, err := m.store.Get(sess.ID); err == nil {
+		t.Logf("DIAG after pin: status=%q acked=%v", got.Status, got.Acked)
+	}
 	rec := &notifyRecorder{}
 	m.poller.notifyFn = rec.fn()
 
@@ -170,7 +173,13 @@ func TestRefreshNotifiesWaitingTransitionOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if got, err := m.store.Get(sess.ID); err == nil {
+		t.Logf("DIAG before refresh: status=%q", got.Status)
+	}
 	m.applyCmd(t, m.refreshCmd())
+	if got, err := m.store.Get(sess.ID); err == nil {
+		t.Logf("DIAG after refresh: status=%q calls=%v", got.Status, rec.all())
+	}
 	calls := waitForCalls(t, rec, 1)
 	if calls[0] != (notify.Event{Session: "needy", Tool: "claude-hooked", Kind: notify.Waiting}) {
 		t.Fatalf("want one waiting notification titled with the session name, got %v", calls)

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -39,6 +39,7 @@ var (
 	valueStyle  lipgloss.Style
 	labelStyle  lipgloss.Style
 	errStyle    lipgloss.Style
+	doneStyle   lipgloss.Style
 	keyStyle    lipgloss.Style
 
 	annotationStyle lipgloss.Style
@@ -68,6 +69,7 @@ func rebuildStyles() {
 	valueStyle = lipgloss.NewStyle().Foreground(colorText)
 	labelStyle = lipgloss.NewStyle().Foreground(colorSubtle)
 	errStyle = lipgloss.NewStyle().Foreground(colorErrored).Bold(true)
+	doneStyle = lipgloss.NewStyle().Foreground(colorFinished)
 	keyStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 
 	annotationStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)

--- a/internal/ui/toast_test.go
+++ b/internal/ui/toast_test.go
@@ -61,6 +61,76 @@ func TestStatusToastSitsTopRight(t *testing.T) {
 	}
 }
 
+// An editor that opened is an outcome, not a failure, all the way from the
+// key to the card the toast draws.
+func TestOpenedEditorReadsAsAnOutcome(t *testing.T) {
+	m := buildModel(t)
+	launched := captureEditor(t, "code")
+	dir := t.TempDir()
+	createSession(t, m, "agent", dir, "")
+	m.selectSessionRow(t, "agent")
+
+	_, cmd := m.openEditor()
+	m.applyCmd(t, cmd)
+	if len(*launched) == 0 {
+		t.Fatalf("the editor never launched, status = %q", m.errBar.text)
+	}
+	if want := doneStyle.Render("● " + m.errBar.text); m.statusLine() != want {
+		t.Fatalf("status line is %q, want the outcome styling %q", m.statusLine(), want)
+	}
+}
+
+// The same for an update check that found the current version installed:
+// the check ran, so the toast reports it rather than crossing it out.
+func TestUpToDateReadsAsAnOutcome(t *testing.T) {
+	m := shotModel()
+	updated, _ := m.Update(updateAppliedMsg{upToDate: true})
+	m = updated.(*Model)
+	if m.errBar.text != "already up to date" {
+		t.Fatalf("status text is %q", m.errBar.text)
+	}
+	if want := doneStyle.Render("● already up to date"); m.statusLine() != want {
+		t.Fatalf("status line is %q, want %q", m.statusLine(), want)
+	}
+}
+
+// Only the message that says it worked gets the outcome styling: a failure
+// written straight to the bar afterwards reads as one, whatever the bar
+// carried before.
+func TestFailureAfterAnOutcomeReadsAsAFailure(t *testing.T) {
+	m := shotModel()
+	m.reportDone("opened /tmp/project in code")
+	m.errBar.text = "git not found in PATH"
+	if want := errStyle.Render("✕ git not found in PATH"); m.statusLine() != want {
+		t.Fatalf("status line is %q, want %q", m.statusLine(), want)
+	}
+
+	// Dismissal takes the outcome with it, so the next message starts clean
+	// even when it repeats the words of the last one that worked.
+	m.reportDone("opened /tmp/project in code")
+	for range 3 {
+		m.ageError()
+	}
+	m.errBar.text = "opened /tmp/project in code"
+	if want := errStyle.Render("✕ opened /tmp/project in code"); m.statusLine() != want {
+		t.Fatalf("status line is %q, want %q", m.statusLine(), want)
+	}
+}
+
+// The review footer marks the same two states in its own glyphs.
+func TestReviewFooterMarksAnOutcome(t *testing.T) {
+	m := shotModel()
+	m.width = 80
+	m.reportDone("opened /tmp/project in code")
+	if got := ansi.Strip(m.viewDiffStatus()); !strings.HasPrefix(got, " ✔ ") {
+		t.Fatalf("review footer reads %q, want the outcome glyph", got)
+	}
+	m.errBar.text = "git not found in PATH"
+	if got := ansi.Strip(m.viewDiffStatus()); !strings.HasPrefix(got, " ✖ ") {
+		t.Fatalf("review footer reads %q, want the failure glyph", got)
+	}
+}
+
 // Splicing a card into a styled row must not shift the cells around it.
 func TestSpliceAtColumnKeepsWidth(t *testing.T) {
 	row := paint(keyStyle.Render("session ")+subtleStyle.Render("running"), 40, panelHex())

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -419,7 +419,10 @@ func (m *Model) viewFooter() string {
 			{"typing", "goes to the agent"},
 			{"ctrl+q / ctrl+\\", "back to manager"},
 			{"ctrl+r", "review"},
-			{"drag / double / triple click", "copy"},
+			{"ctrl+o", "editor"},
+			// The footer holds one row: the word and line gestures are in
+			// the key map, where there is room to name all three.
+			{"drag / click", "copy"},
 		}
 		if m.pane.mouse {
 			pairs = append(pairs, [2]string{"click / alt+drag", "agent UI"})

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -133,7 +133,7 @@ func (m *Model) statusLine() string {
 	// Errors outrank the focus notices: a scrolled or focused pane must
 	// not hide a failure report.
 	case m.mode == modeFocus && m.errBar.text != "":
-		return errStyle.Render("✕ " + m.errBar.text)
+		return m.statusMessage("✕", "●")
 	case m.scrolledBack():
 		return keyStyle.Render("scrolled ") +
 			subtleStyle.Render(fmt.Sprintf("%d lines back · wheel down or type to catch up", m.focusScroll))
@@ -147,12 +147,22 @@ func (m *Model) statusLine() string {
 		}
 		return keyStyle.Render("resize ") + subtleStyle.Render(hint)
 	case m.errBar.text != "":
-		return errStyle.Render("✕ " + m.errBar.text)
+		return m.statusMessage("✕", "●")
 	case m.diff.notice != "":
-		return lipgloss.NewStyle().Foreground(colorFinished).Render("● " + m.diff.notice)
+		return doneStyle.Render("● " + m.diff.notice)
 	default:
 		return ""
 	}
+}
+
+// statusMessage styles whatever sits on the status bar: an action that went
+// through reads as an outcome, everything else as a failure, in the glyphs
+// the calling surface marks the two with.
+func (m *Model) statusMessage(fail, done string) string {
+	if m.errBar.worked() {
+		return doneStyle.Render(done + " " + m.errBar.text)
+	}
+	return errStyle.Render(fail + " " + m.errBar.text)
 }
 
 // inGroupSubtree reports whether a session's group sits at or below the


### PR DESCRIPTION
Throwaway, closing as soon as CI reports. Logs the stored status around the refresh so #292's failure can be read instead of guessed.