### PR TITLE
probe: notify flake rate on clean main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Vet
         run: go vet ./...
       - name: Test
-        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+        run: for i in 1 2 3 4; do echo "=== iteration $i"; go test -race -coverprofile=coverage.out -covermode=atomic ./internal/ui/ || echo "ITERATION $i FAILED"; done
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:


### PR DESCRIPTION
Throwaway; four coverage+race runs of internal/ui on an unchanged main to measure #292's failure rate. Closing once it reports.