### PR TITLE
fix(update): refetch when the release catalog stops short of the build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,9 @@ Cut from a clean worktree at the tag, with goreleaser run locally; there is
 no release workflow in CI.
 
 ```bash
-git tag v0.29.0 && git push origin v0.29.0
-git worktree add /tmp/amrel v0.29.0
+tag=v0.30.0                       # the release being cut
+git tag "$tag" && git push origin "$tag"
+git worktree add /tmp/amrel "$tag"
 cd /tmp/amrel && GITHUB_TOKEN="$(gh auth token)" AUR_KEY="$HOME/.ssh/aur_agent_manager" \
   goreleaser release --clean
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,11 @@ The notes carry more than the generated list of pull requests:
   pull requests, not only the generated list, and name what each one did.
 - **Thanks to whoever reported what got fixed, by handle.** A bug someone
   took the time to write up is why the fix exists, and the reporter is
-  usually not the author.
+  usually not the author. Credit the release a feature builds on, too, when
+  it extends someone else's work.
+
+A range with nobody outside the maintainer in it carries no thanks line;
+write the summary and leave it at that rather than manufacturing one.
 
 Write them into a file and publish with
 `goreleaser release --clean --release-notes=notes.md`, or edit the release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,39 @@ git worktree (`git worktree add`), or your edits get swept into someone
 else's commit. Branch from `origin/main` after a fetch, not from the local
 `main` ref.
 
+## Releases
+
+Cut from a clean worktree at the tag, with goreleaser run locally; there is
+no release workflow in CI.
+
+```bash
+git tag v0.29.0 && git push origin v0.29.0
+git worktree add /tmp/amrel v0.29.0
+cd /tmp/amrel && GITHUB_TOKEN="$(gh auth token)" AUR_KEY="$HOME/.ssh/aur_agent_manager" \
+  goreleaser release --clean
+```
+
+`AUR_KEY` is what publishes the Arch package: without it `git_url` templates
+to empty, goreleaser skips that step, and the release still reports success
+while the AUR package goes stale.
+
+The notes carry more than the generated list of pull requests:
+
+- **A summary in your own words**, at the top, saying what the release gives
+  someone who installs it. Two or three sentences, the change first and the
+  mechanism second. The generated list says which pull requests landed; it
+  does not say what is different now.
+- **Thanks to every contributor in the range, by handle.** Read the merged
+  pull requests, not only the generated list, and name what each one did.
+- **Thanks to whoever reported what got fixed, by handle.** A bug someone
+  took the time to write up is why the fix exists, and the reporter is
+  usually not the author.
+
+Write them into a file and publish with
+`goreleaser release --clean --release-notes=notes.md`, or edit the release
+afterwards with `gh release edit <tag> --notes-file`. Both keep the header
+and footer from `.goreleaser.yaml`.
+
 ## Layout
 
 - `main.go` dispatches subcommands (`rename`, `review-repo`, `review-base`,

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -119,7 +119,12 @@ func check(ctx context.Context, configDir, current string, force bool) (Result, 
 	cachePath := filepath.Join(configDir, cacheFile)
 	cached, haveCache := readCache(cachePath)
 	haveCatalog := haveCache && len(cached.Releases) > 0
-	if !force && haveCatalog && cacheFresh(cached, time.Now()) {
+	newest, _ := latestRelease(cached.Releases)
+	// A catalog that stops short of the running build was fetched before the
+	// release that is now installed, so however recently that was, it cannot
+	// name what the update brought. Updating within the interval lands in
+	// exactly that state, which is when the notes are read.
+	if !force && haveCatalog && cacheFresh(cached, time.Now()) && !Newer(current, newest) {
 		return resultFor(currentParts, cached.Releases), nil
 	}
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -172,6 +172,33 @@ func TestCheckUsesFreshCatalogWithoutNetwork(t *testing.T) {
 	}
 }
 
+// Updating inside the check interval leaves a catalog fetched before the
+// release now running, and the what's-new notice reads that catalog for the
+// changes the update brought. Freshness alone must not serve it.
+func TestCatalogBehindTheRunningBuildRefetches(t *testing.T) {
+	dir := t.TempDir()
+	seedCache(t, dir, cache{
+		CheckedAt: time.Now(),
+		Releases:  []Release{testRelease("v0.28.0", "the release before the one running")},
+	})
+
+	var calls atomic.Int32
+	server := releaseServer(t, &calls, "v0.29.0")
+	defer server.Close()
+	defer swapReleasesURL(server.URL)()
+
+	result, err := Check(context.Background(), dir, "v0.29.0")
+	if err != nil || calls.Load() != 1 {
+		t.Fatalf("err=%v calls=%d, want one fetch", err, calls.Load())
+	}
+	if got := releaseVersions(result.Releases); len(got) == 0 || got[0] != "v0.29.0" {
+		t.Fatalf("catalog is %v, want it to reach the running build", got)
+	}
+	if result.Latest != "" {
+		t.Fatalf("nothing is newer than the running build, got %q", result.Latest)
+	}
+}
+
 func TestUpToDateCatalogRetriesAfterTenMinutes(t *testing.T) {
 	dir := t.TempDir()
 	seedCache(t, dir, cache{

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -194,6 +194,11 @@ func TestCatalogBehindTheRunningBuildRefetches(t *testing.T) {
 	if got := releaseVersions(result.Releases); len(got) == 0 || got[0] != "v0.29.0" {
 		t.Fatalf("catalog is %v, want it to reach the running build", got)
 	}
+	// The notice is built from these lines, so reaching the release is only
+	// half of it: an entry with no changes leaves it as empty as before.
+	if got := result.Releases[0].Changes; len(got) != 1 || got[0] != "UI: Refreshed" {
+		t.Fatalf("changes are %q, want the fetched release's own", got)
+	}
 	if result.Latest != "" {
 		t.Fatalf("nothing is newer than the running build, got %q", result.Latest)
 	}


### PR DESCRIPTION
## What changed

The release check no longer serves a cached catalog that stops short of the running build. Freshness still governs everything else; a catalog missing the release you are on is stale whatever its timestamp says, because that release is the one being asked about.

AGENTS.md gains a **Releases** section: how a release is cut (clean worktree at the tag, goreleaser locally, `AUR_KEY` or the Arch package silently goes stale), and what the notes owe their readers — a summary in your own words, thanks to every contributor in the range by handle, and thanks to whoever reported what got fixed.

## Why

Updating inside the ten-minute check interval leaves the new build reading a catalog fetched before its own release existed, and the what's-new notice builds its body from that catalog. v0.29.0 greeted its first users with:

```
✦ Updated to 0.29.0
Updated from 0.28.0 to 0.29.0.
No generated change summary was found; r refreshes GitHub now.
```

The cache behind that had `checked_at 23:55:31` and `latest v0.28.0`; v0.29.0 published at 23:58:59. The window is small, but it is exactly the window an update lands in, which is when the notes get read.

Closes #299

## How it was verified

`TestCatalogBehindTheRunningBuildRefetches` seeds a catalog fetched a moment ago that ends at v0.28.0, runs the check as v0.29.0, and asserts one fetch and a catalog that reaches the running build. With the condition reverted it fails on `calls=0`.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] Ran it against real sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update checks now refresh release information when the installed version is newer than the cached catalog, ensuring accurate update results.
* **Documentation**
  * Added release guidance covering tagged publishing, Arch package configuration, release-note requirements, and contributor or bug reporter credits.
  * Documented commands for preparing release worktrees, running release automation, and publishing or editing release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->