### PR TITLE
docs(agents): say how a summary reaches the release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,13 @@ The notes carry more than the generated list of pull requests:
 A range with nobody outside the maintainer in it carries no thanks line;
 write the summary and leave it at that rather than manufacturing one.
 
-Write them into a file and publish with
-`goreleaser release --clean --release-notes=notes.md`, or edit the release
-afterwards with `gh release edit <tag> --notes-file`. Both keep the header
-and footer from `.goreleaser.yaml`.
+`--release-notes=notes.md` replaces the generated list of pull requests
+rather than sitting above it, so a file passed that way has to carry the
+list itself. Publishing first and then editing is the simpler order: take
+what goreleaser published with `gh release view <tag> --json body -q .body`,
+put the summary and thanks above its `## What's Changed`, and send it back
+with `gh release edit <tag> --notes-file`. The header and footer from
+`.goreleaser.yaml` come along either way.
 
 ## Layout
 


### PR DESCRIPTION
## What changed

The Releases section said `--release-notes=notes.md` and `gh release edit` both keep the header and footer, which is true, and left out the part that matters: the file passed to `--release-notes` **replaces** the generated list of pull requests rather than sitting above it.

It now says so, and points at the simpler order: publish, read back what goreleaser wrote, put the summary and thanks above its `## What's Changed`, send it back with `gh release edit`.

## Why

Cutting v0.29.1 ran straight into it. The release went out carrying the summary and no changelog at all, and needed a second pass to put the pull request list back. The next person following that section would have done the same.

## How it was verified

Ran both halves while cutting v0.29.1: `--release-notes` published a body with no `## What's Changed`, and `gh release view --json body` piped through `gh release edit --notes-file` restored it with the summary above.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] Ran it against real sessions