### PR TITLE
fix(tmux): show usable attach exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Arch Linux, mise, `go install`, prebuilt binaries, Windows (WSL2), and updating:
 agent-manager
 ```
 
-Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager, **Ctrl+R** opens its diff review and **Ctrl+O** opens its directory in your editor. `agent-manager --version` prints the version.
+Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager when your terminal and tmux leave it available; **Ctrl+\\** is an alternate under the same rule. **Ctrl+R** opens the session's diff review and **Ctrl+O** opens its directory in your editor. In a full-screen attach, the session footer also shows an inner tmux prefix followed by `d` when configured. When nested inside another tmux, send the inner prefix shown in the footer, then press `d`. If both tmux servers use the same prefix, invoke the outer tmux's `send-prefix` binding; if the outer tmux otherwise captures the inner prefix, configure it to forward that key. `agent-manager --version` prints the version.
 
 Agent sessions live on a private tmux server named `agentmgr`, so they never mix with the tmux you run yourself and a `kill-server` on your own socket leaves them alone. To reach one from a plain shell, name that server: `tmux -L agentmgr ls`, then `tmux -L agentmgr attach -t am_<id>`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@
 agent-manager
 ```
 
-Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager, **Ctrl+R** opens its diff review and **Ctrl+O** opens its directory in your editor. `agent-manager --version` prints the version.
+Sessions run inside tmux (`am_*` namespace), so they survive the manager quitting. Inside a session, **Ctrl+Q** detaches back to the manager when your terminal and tmux leave it available; **Ctrl+\\** is an alternate under the same rule. **Ctrl+R** opens the session's diff review and **Ctrl+O** opens its directory in your editor. In a full-screen attach, the session footer also shows an inner tmux prefix followed by `d` when configured. When nested inside another tmux, send the inner prefix shown in the footer, then press `d`. If both tmux servers use the same prefix, invoke the outer tmux's `send-prefix` binding; if the outer tmux otherwise captures the inner prefix, configure it to forward that key. `agent-manager --version` prints the version.
 
 Agent sessions live on a private tmux server named `agentmgr`, so they never mix with the tmux you run yourself and a `kill-server` on your own socket leaves them alone. To reach one from a plain shell, name that server: `tmux -L agentmgr ls`, then `tmux -L agentmgr attach -t am_<id>`.
 
@@ -19,7 +19,8 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `g` | New group (name, parent, default path) |
 | `enter` | Focus session in place (keys go to the agent, list stays) / fold group |
 | `A` | Attach session full screen (Settings can swap it with `enter`) |
-| `ctrl+q` | Inside a session: back to the manager |
+| `ctrl+q` / `ctrl+\` | Inside a session: back to the manager when the terminal and tmux leave the key available |
+| tmux prefix, then `d` | Inside a full-screen attach: back to the manager when the prefix reaches the inner tmux |
 | `ctrl+o` | Inside a session: open its directory in your editor |
 | `→` | Step into the row: focus the session, or open the group. In beta; Settings (`s`) can turn the pair off |
 | `←` | Step out: close the group, or — focused, with the caret at the start of the agent's prompt — back to the manager. This needs the tool's prompt marker (its `activity_cutoff`) on the caret's row, so a CLI without one keeps `←` entirely; anywhere else in the prompt it moves the caret as usual |

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -254,12 +254,20 @@ func (d *Driver) installSessionUX(name string) error {
 // styleStatusBar sets a session's status bar chrome, leaving status-left (the
 // name label) untouched so re-styling a live session keeps its label.
 func (d *Driver) styleStatusBar(name string) error {
+	primary, err := d.run("show-options", "-t", name, "-v", "prefix")
+	if err != nil {
+		return err
+	}
+	secondary, err := d.run("show-options", "-t", name, "-v", "prefix2")
+	if err != nil {
+		return err
+	}
 	options := [][]string{
 		{"set-option", "-t", name, "status", "on"},
-		// The default status-right-length of 40 truncates the hint before the
-		// Ctrl+R part, so widen it to fit the whole footer.
-		{"set-option", "-t", name, "status-right-length", "80"},
-		{"set-option", "-t", name, "status-right", " agent-manager · Ctrl+q = back · Ctrl+r = review · Ctrl+o = editor "},
+		// The default status-right-length of 40 truncates the hints, so widen it
+		// to fit the whole footer, including the configured-prefix fallback.
+		{"set-option", "-t", name, "status-right-length", "100"},
+		{"set-option", "-t", name, "status-right", attachStatusRight(strings.TrimSpace(primary), strings.TrimSpace(secondary))},
 		{"set-option", "-t", name, "status-style", "bg=colour236,fg=colour249"},
 		// hide the "0:windowname*" window list; it reads as noise here
 		{"set-option", "-t", name, "window-status-format", ""},
@@ -276,10 +284,20 @@ func (d *Driver) styleStatusBar(name string) error {
 	return nil
 }
 
-// EnsureBindings installs the server-global Ctrl+Q / Ctrl+\ detach, Ctrl+R
-// review and Ctrl+O editor bindings. All only act inside am_* sessions;
-// elsewhere the key passes through to the pane. Idempotent, so it is safe to
-// re-run for sessions that predate a binding.
+func attachStatusRight(primary, secondary string) string {
+	exits := make([]string, 0, 2)
+	if primary != "C-q" && secondary != "C-q" {
+		exits = append(exits, "Ctrl+q")
+	}
+	for _, candidate := range []string{primary, secondary} {
+		if candidate != "" && candidate != "None" {
+			exits = append(exits, candidate+" d")
+			break
+		}
+	}
+	return " agent-manager · Ctrl+r = review · Ctrl+o = editor · " + strings.Join(exits, " / ") + " = back "
+}
+
 func (d *Driver) EnsureBindings() error {
 	inSession := "#{m:" + prefix + "*,#{session_name}}"
 	request := func(name string) string {
@@ -290,6 +308,8 @@ func (d *Driver) EnsureBindings() error {
 		{"bind-key", "-n", `C-\`, "if-shell", "-F", inSession, "detach-client", `send-keys C-\\`},
 		{"bind-key", "-n", "C-r", "if-shell", "-F", inSession, request(RequestReview), "send-keys C-r"},
 		{"bind-key", "-n", "C-o", "if-shell", "-F", inSession, request(RequestEditor), "send-keys C-o"},
+		// Restore the standard fallback when the prefix shadows a direct binding.
+		{"bind-key", "-T", "prefix", "d", "detach-client"},
 	}
 	for _, args := range binds {
 		if _, err := d.run(args...); err != nil {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -344,7 +344,38 @@ func TestDetachRequestRoundTrip(t *testing.T) {
 	}
 }
 
-func TestRefreshChromeKeepsLabelAndAddsReviewHint(t *testing.T) {
+func TestEnsureBindingsRestoresPrefixDetach(t *testing.T) {
+	driver := requireTmux(t)
+	t.Cleanup(func() {
+		if out, err := tmuxCmd("bind-key", "-T", "prefix", "d", "detach-client").CombinedOutput(); err != nil {
+			t.Errorf("restore prefix d: %v: %s", err, out)
+		}
+	})
+	if out, err := tmuxCmd("unbind-key", "-T", "prefix", "d").CombinedOutput(); err != nil {
+		t.Fatalf("unbind prefix d: %v: %s", err, out)
+	}
+
+	if err := driver.EnsureBindings(); err != nil {
+		t.Fatalf("EnsureBindings: %v", err)
+	}
+	bound, err := tmuxCmd("list-keys", "-T", "prefix").CombinedOutput()
+	if err != nil {
+		t.Fatalf("list prefix d: %v: %s", err, bound)
+	}
+	found := false
+	for _, line := range strings.Split(string(bound), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 5 && fields[0] == "bind-key" && fields[1] == "-T" && fields[2] == "prefix" && fields[3] == "d" && fields[4] == "detach-client" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("prefix d should detach, got %q", bound)
+	}
+}
+
+func TestRefreshChromeKeepsLabelAndAddsSessionHints(t *testing.T) {
 	driver := requireTmux(t)
 	id := "chr" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
 	if err := driver.Create(id, "/tmp", "", nil, 0, 0); err != nil {
@@ -354,6 +385,9 @@ func TestRefreshChromeKeepsLabelAndAddsReviewHint(t *testing.T) {
 
 	if err := driver.SetLabel(id, "my-session"); err != nil {
 		t.Fatalf("SetLabel: %v", err)
+	}
+	if out, err := tmuxCmd("set-option", "-t", "am_"+id, "prefix", `C-\`).CombinedOutput(); err != nil {
+		t.Fatalf("set prefix: %v: %s", err, out)
 	}
 	if err := driver.RefreshChrome(id); err != nil {
 		t.Fatalf("RefreshChrome: %v", err)
@@ -366,11 +400,81 @@ func TestRefreshChromeKeepsLabelAndAddsReviewHint(t *testing.T) {
 	if !strings.Contains(string(right), "Ctrl+r = review") {
 		t.Fatalf("footer should advertise review, got %q", right)
 	}
+	if !strings.Contains(string(right), `C-\ d = back`) {
+		t.Fatalf("footer should advertise the configured-prefix escape, got %q", right)
+	}
+	if !strings.Contains(string(right), `Ctrl+q / C-\ d = back`) {
+		t.Fatalf("footer should advertise the available direct escape, got %q", right)
+	}
+	if out, err := tmuxCmd("set-option", "-t", "am_"+id, "prefix", "C-q").CombinedOutput(); err != nil {
+		t.Fatalf("set conflicting prefix: %v: %s", err, out)
+	}
+	if err := driver.RefreshChrome(id); err != nil {
+		t.Fatalf("RefreshChrome with conflicting prefix: %v", err)
+	}
+	right, err = tmuxCmd("display-message", "-p", "-t", "am_"+id, "#{T:status-right}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("conflicting status-right: %v", err)
+	}
+	if strings.Contains(string(right), "Ctrl+q /") {
+		t.Fatalf("footer should hide a direct shortcut claimed by the prefix, got %q", right)
+	}
+	if !strings.Contains(string(right), "C-q d = back") {
+		t.Fatalf("footer should retain the prefix escape, got %q", right)
+	}
+	if out, err := tmuxCmd("set-option", "-t", "am_"+id, "prefix", `C-\`).CombinedOutput(); err != nil {
+		t.Fatalf("restore primary prefix: %v: %s", err, out)
+	}
+	if out, err := tmuxCmd("set-option", "-t", "am_"+id, "prefix2", "C-q").CombinedOutput(); err != nil {
+		t.Fatalf("set conflicting secondary prefix: %v: %s", err, out)
+	}
+	if err := driver.RefreshChrome(id); err != nil {
+		t.Fatalf("RefreshChrome with conflicting secondary prefix: %v", err)
+	}
+	right, err = tmuxCmd("display-message", "-p", "-t", "am_"+id, "#{T:status-right}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("secondary-prefix status-right: %v", err)
+	}
+	if strings.Contains(string(right), "Ctrl+q /") {
+		t.Fatalf("footer should hide a direct shortcut claimed by prefix2, got %q", right)
+	}
+	if !strings.Contains(string(right), `C-\ d = back`) {
+		t.Fatalf("footer should retain the primary-prefix escape, got %q", right)
+	}
+	if out, err := tmuxCmd("set-option", "-t", "am_"+id, "prefix", "None").CombinedOutput(); err != nil {
+		t.Fatalf("disable prefix: %v: %s", err, out)
+	}
+	if err := driver.RefreshChrome(id); err != nil {
+		t.Fatalf("RefreshChrome without prefix: %v", err)
+	}
+	right, err = tmuxCmd("display-message", "-p", "-t", "am_"+id, "#{T:status-right}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("prefix-free status-right: %v", err)
+	}
+	if strings.Contains(string(right), "Ctrl+q") {
+		t.Fatalf("footer should hide a direct shortcut claimed by prefix2, got %q", right)
+	}
+	if !strings.Contains(string(right), "C-q d = back") {
+		t.Fatalf("footer should show prefix2 when the primary prefix is disabled, got %q", right)
+	}
+	if out, err := tmuxCmd("set-option", "-t", "am_"+id, "prefix2", "None").CombinedOutput(); err != nil {
+		t.Fatalf("disable secondary prefix: %v: %s", err, out)
+	}
+	if err := driver.RefreshChrome(id); err != nil {
+		t.Fatalf("RefreshChrome without either prefix: %v", err)
+	}
+	right, err = tmuxCmd("display-message", "-p", "-t", "am_"+id, "#{T:status-right}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("prefix-free status-right: %v", err)
+	}
+	if strings.Contains(string(right), "None d") || !strings.Contains(string(right), "Ctrl+q = back") {
+		t.Fatalf("footer should retain only the direct escape without prefixes, got %q", right)
+	}
 	length, err := tmuxCmd("show-option", "-t", "am_"+id, "-v", "status-right-length").CombinedOutput()
 	if err != nil {
 		t.Fatalf("status-right-length: %v", err)
 	}
-	if strings.TrimSpace(string(length)) != "80" {
+	if strings.TrimSpace(string(length)) != "100" {
 		t.Fatalf("status-right-length should fit the footer, got %q", length)
 	}
 	left, err := tmuxCmd("display-message", "-p", "-t", "am_"+id, "#{T:status-left}").CombinedOutput()


### PR DESCRIPTION
## What changed

- show the usable `Ctrl+Q` and configured-prefix detach routes in the attached-session footer
- hide `Ctrl+Q` when either `prefix` or `prefix2` claims it, and omit the prefix route when both are disabled
- restore the standard prefix-table `d` detach binding on the private server
- document `Ctrl+Q`, `Ctrl+\`, prefix-then-`d`, and accurate nested-tmux forwarding for matching and differing prefixes
- cover removed bindings plus primary, secondary, conflicting, and disabled prefix states with real tmux tests

## Why

When `C-\` is a tmux prefix, tmux consumes it before the root-table binding. If the terminal also reserves `Ctrl+Q`, neither direct shortcut is available. Restoring and displaying a configured inner prefix followed by `d` fixes that trap for a normal attach. For nested attaches, the documentation now distinguishes sending a different inner prefix directly from using the outer tmux `send-prefix` binding when both prefixes match, including explicit forwarding when the outer layer otherwise captures the key.

## Verification

- manually reproduced the reported prefix collision on an isolated tmux socket
- independently black-box tested normal and nested behavior on tmux 3.2a and 3.7b
- `env -u TMUX TMUX_TMPDIR=/tmp/am265p2 go test -count=5 -run "Test(EnsureBindingsRestoresPrefixDetach|RefreshChromeKeepsLabelAndAddsSessionHints|DetachRequestRoundTrip)" ./internal/tmux`
- `env -u TMUX TMUX_TMPDIR=/tmp/am265final go test -count=1 -race ./...`
- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- final documentation-only review revision: `git diff --check`

Fixes #265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified when Ctrl+Q and Ctrl+\ detach shortcuts are available.
  - Added guidance for detaching from full-screen and nested tmux sessions using prefix commands.

- **Bug Fixes**
  - Restored the standard tmux prefix-plus-`d` detach binding when missing.
  - Improved the tmux status footer with configured prefix keys and context-aware detach instructions.

- **Tests**
  - Added coverage for tmux detach-binding restoration and session hint display across different prefix configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->