### PR TITLE
feat(ui): kill the session when it is archived

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,7 +31,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `v` | Revive a dead session, or every dead session under a group |
 | `V` | Revive every dead session in view |
 | `R` | Restart the selected session on an empty context: same name, group, directory and tool |
-| `a` / `u` | Archive / restore a session or group. Archive kills the process and keeps the last preview |
+| `a` / `u` | Archive / restore a session or group. Archive kills the process and keeps the last preview; restore unhides the dead row, `v` revives it |
 | `d` | Delete session, or a group + its entire subtree |
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
 | `ctrl+r` | Review the selected session's changes: full-screen whole-file diffs, with `c` to comment a line and `C` to send the comments to the agent |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,7 +31,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `v` | Revive a dead session, or every dead session under a group |
 | `V` | Revive every dead session in view |
 | `R` | Restart the selected session on an empty context: same name, group, directory and tool |
-| `a` / `u` | Archive / restore a session, or a group and its entire subtree |
+| `a` / `u` | Archive / restore a session or group. Archive kills the process and keeps the last preview |
 | `d` | Delete session, or a group + its entire subtree |
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
 | `ctrl+r` | Review the selected session's changes: full-screen whole-file diffs, with `c` to comment a line and `C` to send the comments to the agent |

--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -35,7 +35,7 @@ func (m *Model) confirmTitle() string {
 // away, which decides whether the dialog reads as an alarm or as a move.
 func (m *Model) confirmDestructive() bool {
 	return m.confirm.action == actionKill || m.confirm.action == actionDelete ||
-		m.confirm.action == actionRestart
+		m.confirm.action == actionRestart || m.confirm.action == actionArchive
 }
 
 func (m *Model) viewConfirm() string {

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -86,7 +86,7 @@ func helpSections() []helpSection {
 			{"R", "restart it on an empty context (same name, group, dir, tool)"},
 			{"x / X", "kill it / kill every live session (frees their RAM)"},
 			{"v / V", "revive it / revive every dead session (resumes the agent)"},
-			{"a / u", "archive / restore (archive frees RAM)"},
+			{"a / u", "archive / restore (archive kills; u unhides; v revives)"},
 			{"d", "delete it"},
 		}},
 		{title: "group under the cursor", rows: [][2]string{
@@ -97,7 +97,7 @@ func helpSections() []helpSection {
 			{"o", "open its default path in your editor"},
 			{"x / X", "kill every live session in it / everywhere"},
 			{"v / V", "revive every dead session in it / everywhere"},
-			{"a / u", "archive / restore the subtree (archive frees RAM)"},
+			{"a / u", "archive / restore the subtree (archive kills; u unhides; v revives)"},
 			{"d", "delete the group and its subtree"},
 		}},
 		{title: "quick prompt (space)", rows: [][2]string{

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -86,7 +86,7 @@ func helpSections() []helpSection {
 			{"R", "restart it on an empty context (same name, group, dir, tool)"},
 			{"x / X", "kill it / kill every live session (frees their RAM)"},
 			{"v / V", "revive it / revive every dead session (resumes the agent)"},
-			{"a / u", "archive / restore"},
+			{"a / u", "archive / restore (archive frees RAM)"},
 			{"d", "delete it"},
 		}},
 		{title: "group under the cursor", rows: [][2]string{
@@ -97,7 +97,7 @@ func helpSections() []helpSection {
 			{"o", "open its default path in your editor"},
 			{"x / X", "kill every live session in it / everywhere"},
 			{"v / V", "revive every dead session in it / everywhere"},
-			{"a / u", "archive / restore the subtree"},
+			{"a / u", "archive / restore the subtree (archive frees RAM)"},
 			{"d", "delete the group and its subtree"},
 		}},
 		{title: "quick prompt (space)", rows: [][2]string{

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -471,13 +471,13 @@ func (m *Model) archiveSelected() (tea.Model, tea.Cmd) {
 			path:     entry.group,
 			action:   actionArchive,
 			sessions: subtree,
-			label:    fmt.Sprintf("archive group %s (%d sessions)?", entry.group, len(subtree)),
+			label:    fmt.Sprintf("archive group %s (%d sessions)? frees their RAM, t to find them.", entry.group, len(subtree)),
 		}
 	} else {
 		m.confirm = confirmTarget{
 			action:   actionArchive,
 			sessions: []store.Session{entry.sess},
-			label:    fmt.Sprintf("archive %s?", entry.sess.Name),
+			label:    fmt.Sprintf("archive %s? frees its RAM, t to find it.", entry.sess.Name),
 		}
 	}
 	m.mode = modeConfirmDelete
@@ -511,25 +511,6 @@ func (m *Model) restoreSelected() (tea.Model, tea.Cmd) {
 	}
 	m.mode = modeConfirmDelete
 	return m, nil
-}
-
-// archivalSnapshot captures pane content for every still-live session
-// in the confirm target, so the snapshot survives when the tmux window
-// is later killed or the session window is reused for a new agent.
-func (m *Model) archivalSnapshot() error {
-	for _, sess := range m.confirm.sessions {
-		if !m.tmux.Exists(sess.ID) {
-			continue
-		}
-		pane, err := m.tmux.CapturePane(sess.ID)
-		if err != nil || pane == "" {
-			continue
-		}
-		if err := m.setSnapshot(sess.ID, pane); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (m *Model) applyConfirmedArchived(archived bool) error {
@@ -621,9 +602,11 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "y", "enter":
 		switch m.confirm.action {
 		case actionArchive:
-			if err := m.archivalSnapshot(); err != nil {
-				m.errBar.text = err.Error()
-				return m, nil
+			for _, sess := range m.confirm.sessions {
+				if err := m.killSession(sess); err != nil {
+					m.errBar.text = err.Error()
+					return m, nil
+				}
 			}
 			if err := m.applyConfirmedArchived(true); err != nil {
 				m.errBar.text = err.Error()

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -513,6 +513,27 @@ func (m *Model) restoreSelected() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// snapshotLive stores the last pane of every still-live session. Archive
+// calls it before any kill so a capture failure cannot drop a frame.
+func (m *Model) snapshotLive(sessions []store.Session) error {
+	for _, sess := range sessions {
+		if !m.tmux.Exists(sess.ID) {
+			continue
+		}
+		pane, err := m.tmux.CapturePane(sess.ID)
+		if err != nil {
+			return err
+		}
+		if pane == "" {
+			continue
+		}
+		if err := m.setSnapshot(sess.ID, pane); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *Model) applyConfirmedArchived(archived bool) error {
 	if m.confirm.isGroup {
 		return m.store.SetGroupArchived(m.confirm.path, archived)
@@ -602,6 +623,10 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "y", "enter":
 		switch m.confirm.action {
 		case actionArchive:
+			if err := m.snapshotLive(m.confirm.sessions); err != nil {
+				m.errBar.text = err.Error()
+				return m, nil
+			}
 			for _, sess := range m.confirm.sessions {
 				if err := m.killSession(sess); err != nil {
 					m.errBar.text = err.Error()

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -40,6 +40,9 @@ func TestCreateArchiveRestoreDelete(t *testing.T) {
 	if len(m.sessionRows()) != 0 {
 		t.Fatalf("after archive, active sessions = %d want 0", len(m.sessionRows()))
 	}
+	if m.tmux.Exists(sess.ID) {
+		t.Fatal("archive should kill the tmux session")
+	}
 
 	m.showArchived = true
 	m.applyCmd(t, m.refreshCmd())
@@ -764,6 +767,9 @@ func TestArchiveAbortsWhenSnapshotFails(t *testing.T) {
 	if len(m.sessionRows()) != 1 {
 		t.Fatalf("failed snapshot must not archive, active sessions = %d want 1", len(m.sessionRows()))
 	}
+	if !m.tmux.Exists(m.sessionRows()[0].ID) {
+		t.Fatal("failed snapshot must not kill the tmux session")
+	}
 	active, err := m.store.ListSessions(false)
 	if err != nil {
 		t.Fatalf("list sessions: %v", err)
@@ -806,6 +812,11 @@ func TestArchiveGroupMovesWholeSubtree(t *testing.T) {
 	}
 	if names := sessionNames(m); len(names) != 2 {
 		t.Fatalf("archived view sessions = %v want 2", names)
+	}
+	for _, sess := range m.sessionRows() {
+		if m.tmux.Exists(sess.ID) {
+			t.Fatalf("archived session %s should be killed", sess.Name)
+		}
 	}
 
 	m.selectGroupRow(t, "proj")
@@ -878,6 +889,9 @@ func TestArchivedSessionKeepsPaneSnapshot(t *testing.T) {
 	}
 	if !strings.Contains(snapshot, "snapshot-marker") {
 		t.Fatalf("archive should persist the pane, snapshot = %q", snapshot)
+	}
+	if m.tmux.Exists(sess.ID) {
+		t.Fatal("archive should kill the tmux session")
 	}
 
 	m.showArchived = true

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -59,6 +59,9 @@ func TestCreateArchiveRestoreDelete(t *testing.T) {
 	if len(m.sessionRows()) != 1 {
 		t.Fatalf("after restore, active sessions = %d want 1", len(m.sessionRows()))
 	}
+	if m.tmux.Exists(sess.ID) {
+		t.Fatal("restore should not revive the tmux session")
+	}
 
 	m.selectSessionRow(t, "alpha")
 	m.prepareDelete()
@@ -830,6 +833,11 @@ func TestArchiveGroupMovesWholeSubtree(t *testing.T) {
 	}
 	if names := sessionNames(m); len(names) != 2 {
 		t.Fatalf("after restore, active sessions = %v want 2", names)
+	}
+	for _, sess := range m.sessionRows() {
+		if m.tmux.Exists(sess.ID) {
+			t.Fatalf("restore should not revive %s", sess.Name)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

Confirming archive now goes through `killSession`: the last pane is snapshotted, then the tmux window is gone. Restore still only unhides the row; `v` revives it.

The confirm dialog names the RAM cost, same voice as kill.

## Why

Archive hid the row and kept the preview, but the process kept running. #141 asked for the snapshot and the kill together.

Closes #141

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [ ] Ran it against real sessions

The archive tests drive a real tmux server on an isolated socket and now assert the window is gone after confirm, and still present if the snapshot write fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Archiving now terminates the associated session to free memory while preserving its last preview.
  - Archived sessions and groups can be restored from the archive view.
  - Archive confirmations now clearly indicate the destructive action and reversibility.

- **Bug Fixes**
  - Archive failures are reported immediately, and affected sessions remain running when preservation fails.

- **Documentation**
  - Updated help and usage guidance to explain archive behavior, memory benefits, and restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->