### PR TITLE
feat(ui): resume the agent when a session is restored

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,7 +31,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `v` | Revive a dead session, or every dead session under a group |
 | `V` | Revive every dead session in view |
 | `R` | Restart the selected session on an empty context: same name, group, directory and tool |
-| `a` / `u` | Archive / restore a session or group. Archive kills the process and keeps the last preview; restore unhides the dead row, `v` revives it |
+| `a` / `u` | Archive / restore a session or group. Archive kills the process and keeps the last preview; restore resumes it |
 | `d` | Delete session, or a group + its entire subtree |
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
 | `ctrl+r` | Review the selected session's changes: full-screen whole-file diffs, with `c` to comment a line and `C` to send the comments to the agent |

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -86,7 +86,7 @@ func helpSections() []helpSection {
 			{"R", "restart it on an empty context (same name, group, dir, tool)"},
 			{"x / X", "kill it / kill every live session (frees their RAM)"},
 			{"v / V", "revive it / revive every dead session (resumes the agent)"},
-			{"a / u", "archive / restore (archive kills; u unhides; v revives)"},
+			{"a / u", "archive / restore (archive kills, restore revives)"},
 			{"d", "delete it"},
 		}},
 		{title: "group under the cursor", rows: [][2]string{
@@ -97,7 +97,7 @@ func helpSections() []helpSection {
 			{"o", "open its default path in your editor"},
 			{"x / X", "kill every live session in it / everywhere"},
 			{"v / V", "revive every dead session in it / everywhere"},
-			{"a / u", "archive / restore the subtree (archive kills; u unhides; v revives)"},
+			{"a / u", "archive / restore the subtree (archive kills, restore revives)"},
 			{"d", "delete the group and its subtree"},
 		}},
 		{title: "quick prompt (space)", rows: [][2]string{

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -500,13 +500,13 @@ func (m *Model) restoreSelected() (tea.Model, tea.Cmd) {
 			path:     entry.group,
 			action:   actionRestore,
 			sessions: subtree,
-			label:    fmt.Sprintf("restore group %s (%d sessions)?", entry.group, len(subtree)),
+			label:    fmt.Sprintf("restore group %s (%d sessions)? resumes their agents.", entry.group, len(subtree)),
 		}
 	} else {
 		m.confirm = confirmTarget{
 			action:   actionRestore,
 			sessions: []store.Session{entry.sess},
-			label:    fmt.Sprintf("restore %s?", entry.sess.Name),
+			label:    fmt.Sprintf("restore %s? resumes its agent.", entry.sess.Name),
 		}
 	}
 	m.mode = modeConfirmDelete
@@ -642,6 +642,15 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if err := m.applyConfirmedArchived(false); err != nil {
 				m.errBar.text = err.Error()
 				return m, nil
+			}
+			for _, sess := range m.confirm.sessions {
+				if m.tmux.Exists(sess.ID) {
+					continue
+				}
+				if err := m.reviveSession(sess); err != nil {
+					m.reportLaunchError(err)
+					return m, nil
+				}
 			}
 			m.errBar.text = ""
 		case actionKill:

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -639,10 +639,6 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			m.errBar.text = ""
 		case actionRestore:
-			if err := m.applyConfirmedArchived(false); err != nil {
-				m.errBar.text = err.Error()
-				return m, nil
-			}
 			for _, sess := range m.confirm.sessions {
 				if m.tmux.Exists(sess.ID) {
 					continue
@@ -651,6 +647,10 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.reportLaunchError(err)
 					return m, nil
 				}
+			}
+			if err := m.applyConfirmedArchived(false); err != nil {
+				m.errBar.text = err.Error()
+				return m, nil
 			}
 			m.errBar.text = ""
 		case actionKill:

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -59,8 +59,8 @@ func TestCreateArchiveRestoreDelete(t *testing.T) {
 	if len(m.sessionRows()) != 1 {
 		t.Fatalf("after restore, active sessions = %d want 1", len(m.sessionRows()))
 	}
-	if m.tmux.Exists(sess.ID) {
-		t.Fatal("restore should not revive the tmux session")
+	if !m.tmux.Exists(sess.ID) {
+		t.Fatal("restore should revive the tmux session")
 	}
 
 	m.selectSessionRow(t, "alpha")
@@ -835,8 +835,8 @@ func TestArchiveGroupMovesWholeSubtree(t *testing.T) {
 		t.Fatalf("after restore, active sessions = %v want 2", names)
 	}
 	for _, sess := range m.sessionRows() {
-		if m.tmux.Exists(sess.ID) {
-			t.Fatalf("restore should not revive %s", sess.Name)
+		if !m.tmux.Exists(sess.ID) {
+			t.Fatalf("restore should revive %s", sess.Name)
 		}
 	}
 }

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -751,6 +751,41 @@ func TestArchiveRestoreClearStaleError(t *testing.T) {
 	}
 }
 
+func TestRestoreKeepsArchiveWhenReviveFails(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	createSession(t, m, "homeless", dir, "")
+	sess := m.sessionRows()[0]
+
+	m.selectSessionRow(t, "homeless")
+	m.archiveSelected()
+	_, cmd := m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m.applyCmd(t, cmd)
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove dir: %v", err)
+	}
+
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	m.selectSessionRow(t, "homeless")
+	m.restoreSelected()
+	_, cmd = m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	m.applyCmd(t, cmd)
+	if m.errBar.text == "" {
+		t.Fatal("restore without a working directory should error")
+	}
+	if m.tmux.Exists(sess.ID) {
+		t.Fatal("failed restore must not leave a tmux session")
+	}
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !got.Archived {
+		t.Fatal("failed restore must leave the session archived")
+	}
+}
+
 func TestArchiveAbortsWhenSnapshotFails(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## What changed

Confirming restore unhides the row and relaunches the agent through `reviveSession`. A session that still has a tmux window is left running.

## Why

Archive kills the process. Restore that only unhides a dead row is half the action: the next thing anyone does is `v`.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test` on the archive/restore/revive cases against an isolated tmux socket
- [ ] `go test -race ./...`
- [ ] Ran it against real sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Restoring archived sessions now automatically resumes them.
  - Restoring archived groups revives archived sessions within the group and recreates missing sessions.
  - Restore operations report launch errors and stop if a session cannot be resumed.

- **Bug Fixes**
  - Failed restores no longer create unavailable sessions and leave affected sessions archived.

- **Documentation**
  - Updated shortcut help and usage guidance to reflect the streamlined archive and restore workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->