### PR TITLE
fix(ui): collapse a held T into one shell however slow the spawn is

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -136,6 +136,23 @@ func (d *Driver) run(args ...string) (string, error) {
 	return string(out), nil
 }
 
+// commandList joins commands into the single invocation tmux takes for a
+// whole list, where any argument ending in ";" ends one command and starts
+// the next, losing that character: a value that has to keep a trailing
+// semicolon writes it as \;. tmux stops at the first command that fails and
+// exits non-zero, so the list reports a failure the way a run per command
+// did.
+func commandList(commands ...[]string) []string {
+	var args []string
+	for _, command := range commands {
+		if len(args) > 0 {
+			args = append(args, ";")
+		}
+		args = append(args, command...)
+	}
+	return args
+}
+
 // afterCreateThemeLoad runs between Create loading the pane theme and writing
 // it, while Create holds the push lock. Nil in production; a test sets it to
 // drive a push against the held lock and prove the write ordering.
@@ -276,12 +293,8 @@ func (d *Driver) styleStatusBar(name string) error {
 		// terminal emulator, whose buffer carries content from prior attaches.
 		{"set-option", "-t", name, "mouse", "on"},
 	}
-	for _, args := range options {
-		if _, err := d.run(args...); err != nil {
-			return err
-		}
-	}
-	return nil
+	_, err = d.run(commandList(options...)...)
+	return err
 }
 
 func attachStatusRight(primary, secondary string) string {
@@ -311,12 +324,8 @@ func (d *Driver) EnsureBindings() error {
 		// Restore the standard fallback when the prefix shadows a direct binding.
 		{"bind-key", "-T", "prefix", "d", "detach-client"},
 	}
-	for _, args := range binds {
-		if _, err := d.run(args...); err != nil {
-			return err
-		}
-	}
-	return nil
+	_, err := d.run(commandList(binds...)...)
+	return err
 }
 
 // RefreshChrome re-applies the status bar chrome to a live session so a

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -717,4 +718,71 @@ func TestLifecycle(t *testing.T) {
 	if err := driver.Kill(id); err != nil {
 		t.Fatalf("Kill on missing session should be a no-op, got %v", err)
 	}
+}
+
+func TestCommandListSeparatesCommands(t *testing.T) {
+	if got := commandList(); got != nil {
+		t.Fatalf("no commands = %q, want nil", got)
+	}
+	if got := commandList([]string{"set-option", "@one", "alpha"}); !slices.Equal(got, []string{"set-option", "@one", "alpha"}) {
+		t.Fatalf("one command should reach tmux unchanged, got %q", got)
+	}
+	got := commandList(
+		[]string{"set-option", "@one", "alpha"},
+		[]string{"set-option", "@two", "beta"},
+		[]string{"set-option", "@three", "gamma"},
+	)
+	want := []string{
+		"set-option", "@one", "alpha", ";",
+		"set-option", "@two", "beta", ";",
+		"set-option", "@three", "gamma",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("commands should be separated by a lone %q, got %q", ";", got)
+	}
+}
+
+// The separator is what tmux itself reads, so the encoding has to hold against
+// a real server: a value carrying its own semicolon keeps it, and a command
+// that fails takes the rest of the list down with it.
+func TestCommandListRunsAgainstTmux(t *testing.T) {
+	driver := requireTmux(t)
+	id := "cmdlist" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "", nil, 0, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+	name := "am_" + id
+
+	if _, err := driver.run(commandList(
+		[]string{"set-option", "-t", name, "@first", `alpha\;`},
+		[]string{"set-option", "-t", name, "@second", "beta"},
+	)...); err != nil {
+		t.Fatalf("run command list: %v", err)
+	}
+	if got := sessionOption(t, name, "@first"); got != "alpha;" {
+		t.Fatalf("@first = %q, want the escaped semicolon kept", got)
+	}
+	if got := sessionOption(t, name, "@second"); got != "beta" {
+		t.Fatalf("@second = %q, want the command after the separator to run", got)
+	}
+
+	if _, err := driver.run(commandList(
+		[]string{"set-option", "-t", "am_no_such_session", "@third", "gamma"},
+		[]string{"set-option", "-t", name, "@fourth", "delta"},
+	)...); err == nil {
+		t.Fatal("a list whose first command fails should report the failure")
+	}
+	if got := sessionOption(t, name, "@fourth"); got != "" {
+		t.Fatalf("@fourth = %q, want the command after a failure skipped", got)
+	}
+}
+
+func sessionOption(t *testing.T, name, option string) string {
+	t.Helper()
+	out, err := tmuxCmd("show-options", "-v", "-t", name, option).CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -153,10 +153,7 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.showArchived = !m.showArchived
 		m.requestRefresh()
 	case "T", "shift+t":
-		if m.terminalKeyRepeat() {
-			return m, nil
-		}
-		return m.openTerminal()
+		return m.terminalKey()
 	case "o":
 		return m.openEditor()
 	case "e":

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -176,9 +176,10 @@ type Model struct {
 	// settle timers with an older gen are dropped so key-repeat cannot
 	// queue a second of tmux work after the user stops.
 	previewGen uint64
-	// terminalKeyAt is when T last arrived. Held down it autorepeats into a
-	// burst of keystrokes, and T is the only key that spawns on the
-	// keystroke itself rather than opening a form that would swallow them.
+	// terminalKeyAt is when the last T finished being handled. Held down it
+	// autorepeats into a burst of keystrokes, and T is the only key that
+	// spawns on the keystroke itself rather than opening a form that would
+	// swallow them.
 	terminalKeyAt time.Time
 
 	// bannerPhase advances the wordmark's current sweep and then rests, so

--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -9,9 +9,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// terminalKeyWindow is how long after a T keystroke another one reads as
-// autorepeat rather than a second request: comfortably longer than the
-// interval a held key repeats at, shorter than a deliberate second press.
+// terminalKeyWindow is how long after handling a T another one reads as
+// autorepeat rather than a second request: longer than the pause before a
+// held key starts repeating and than the interval it repeats at. It runs
+// from the end of the spawn, so the quiet gap between two deliberate
+// shells is this window plus the spawn.
 const terminalKeyWindow = 250 * time.Millisecond
 
 // shellTool finds the config block T spawns: the first one declaring
@@ -29,15 +31,22 @@ func (m *Model) isShell(toolName string) bool {
 	return m.cfg.Tools[toolName].Shell
 }
 
-// terminalKeyRepeat reports whether T arrived inside the burst a held key
-// sends. Each keystroke pushes the window out, so holding T spawns one
-// shell however long it is held. The other keys that create something open
-// a form first, which absorbs a burst on its own.
-func (m *Model) terminalKeyRepeat() bool {
-	now := time.Now()
-	repeated := now.Sub(m.terminalKeyAt) < terminalKeyWindow
-	m.terminalKeyAt = now
-	return repeated
+// terminalKey spawns a shell unless T arrived inside the burst a held key
+// sends. The window is measured from the end of the previous T's work, not
+// from its arrival: the spawn runs on the update path, so the keystroke a
+// burst queued behind it is only read once it finishes, and an interval
+// measured from arrival would be the spawn's own duration rather than the
+// gap the keyboard produced. Each keystroke pushes the window out, so
+// holding T spawns one shell however long it is held. The other keys that
+// create something open a form first, which absorbs a burst on its own.
+func (m *Model) terminalKey() (tea.Model, tea.Cmd) {
+	if time.Since(m.terminalKeyAt) < terminalKeyWindow {
+		m.terminalKeyAt = time.Now()
+		return m, nil
+	}
+	model, cmd := m.openTerminal()
+	m.terminalKeyAt = time.Now()
+	return model, cmd
 }
 
 // openTerminal spawns a shell tab in the group under the cursor. The block

--- a/internal/ui/terminal_test.go
+++ b/internal/ui/terminal_test.go
@@ -1,7 +1,9 @@
 package ui
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -202,10 +204,30 @@ func TestShellToolIsFoundByItsFlag(t *testing.T) {
 	}
 }
 
+// slowSpawn puts a tmux ahead of the real one on PATH that stalls
+// new-session, so a model built after it spawns as slowly as a loaded
+// machine does.
+func slowSpawn(t *testing.T, delay time.Duration) {
+	t.Helper()
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not installed")
+	}
+	dir := t.TempDir()
+	script := fmt.Sprintf("#!/bin/sh\ncase \" $* \" in *' new-session '*) sleep %.3f ;; esac\nexec %s \"$@\"\n", delay.Seconds(), realTmux)
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write slow tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 // Holding T autorepeats into a burst of keystrokes. T spawns on the
 // keystroke itself, so without a guard a held key fills the list with
-// shells and tmux windows nobody asked for.
+// shells and tmux windows nobody asked for. The spawn here takes longer
+// than the window, the way it does on a loaded machine, and the burst
+// queued behind it still has to collapse into one shell.
 func TestTerminalKeyIgnoresAutorepeat(t *testing.T) {
+	slowSpawn(t, terminalKeyWindow+50*time.Millisecond)
 	m := buildModel(t)
 	m.applyCmd(t, m.refreshCmd())
 


### PR DESCRIPTION
## What changed

`T` measures its autorepeat window from the end of the previous spawn rather than from the keystroke's arrival. The spawn runs on the update path, so a keystroke a burst queued behind it is only read once the previous session exists; timing from the end of that work reads the gap the keyboard produced, and a held `T` makes one shell whatever the spawn costs. The window constant now records that the quiet gap between two deliberate shells is the window plus the spawn.

`TestTerminalKeyIgnoresAutorepeat` puts a tmux ahead of the real one on PATH that stalls `new-session` for longer than the window, so the test spawns as slowly as a loaded machine and the burst still has to collapse into one shell.

Session creation sends its tmux work as command lists: the seven `set-option` calls that style the status bar and the five `bind-key` calls that install the bindings are two invocations. `commandList` documents that tmux ends a command at any argument ending in `;` and drops that character, and that a value needing a trailing semicolon writes it as `\;`.

## Why

Holding `T` filled the list with shells and tmux windows nobody asked for. The old window ran from the keystroke's arrival, so the interval it measured was the spawn's own duration; once a spawn ran past 250ms every repeat of a held key read as a deliberate press. The issue measured spawns of 559ms to 859ms on a loaded machine, where a held `T` produced five shells.

Closes #294

## How it was verified

```
gofmt -l .            # printed nothing
go vet ./...          # clean
env -u TMUX TMUX_TMPDIR=/tmp/am294 go test ./...        # ok, all 22 packages
env -u TMUX TMUX_TMPDIR=/tmp/am294 go test -race ./...  # ok, all 22 packages
```

The new test reproduces the bug against the code it replaces. Restoring `terminal.go` and `keys.go` from `origin/main` and running it:

```
--- FAIL: TestTerminalKeyIgnoresAutorepeat (2.57s)
    terminal_test.go:239: a held T made 5 shells, want 1
```

with the change in place it makes one shell.

The tmux command list semantics were checked against tmux 3.7b on an isolated socket. An argument ending in `;` ends the command and loses that character, `\;` keeps it, and an argument carrying an internal `;` inside quotes reaches tmux whole, which is what `EnsureBindings` relies on:

```
$ tmux set-option -t probe @one 'alpha;' set-option -t probe @two beta
$ tmux show-options -t probe -v @one   ->  alpha
$ tmux show-options -t probe -v @two   ->  beta
$ tmux set-option -t probe @esc 'gamma\;' ';' set-option -t probe @after delta
$ tmux show-options -t probe -v @esc   ->  gamma;
$ tmux list-keys -T root | grep C-r
bind-key -T root C-r if-shell -F "#{m:am-*,#{session_name}}" "set-option -g @am-request review ; detach-client" "send-keys C-r"
```

A failing command in a list stops the list and exits non-zero, so a list reports failure the way a run per command did:

```
$ tmux set-option -t probe @r1 yes ';' set-option -t nosuchsession @rbad yes ';' set-option -t probe @r2 yes
no such session: nosuchsession
exit=1
@r1=yes   @r2=invalid option: @r2
```

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [ ] Ran it against real sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated terminal-key presses from opening multiple shells, including when terminal startup is slow.
  * Improved handling of terminal key autorepeat bursts for more reliable behavior.
  * Streamlined tmux setup operations to run more efficiently in a single invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->