### PR TITLE
feat(ui): show a loader in the preview while a session starts

### DIFF
--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -697,6 +697,30 @@ func focusTopRule(width int) string {
 	return rule
 }
 
+// startupFrames turn a quarter arc around the circle the status marks are
+// drawn from, so a booting session animates in their geometric family while
+// standing clear of every mark that names a state: a frame caught mid-turn
+// cannot be read as one of them.
+var startupFrames = []string{"◜", "◝", "◞", "◟"}
+
+// startupLoader is the preview's line for a selected session that is coming
+// up, and "" for every other session. A launching agent leaves its pane
+// blank for as long as it takes to draw, and an empty preview under a live
+// row reads as a broken session rather than one on its way up. paneBooted
+// is the poller's own test for a pane nothing has drawn to, so the loader
+// clears on the first captured frame rather than waiting for the poll that
+// moves the row off the launch state. A focused pane keeps its own first
+// row: that is the screen the user is typing on, and its caret lives there.
+func (m *Model) startupLoader() string {
+	sess, ok := m.selected()
+	if !ok || m.mode == modeFocus || sess.Status != status.Starting || paneBooted(m.preview) {
+		return ""
+	}
+	frame := startupFrames[m.startupPhase%len(startupFrames)]
+	return lipgloss.NewStyle().Foreground(statusColor(status.Starting)).
+		Render(frame + " " + statusLabel(status.Starting))
+}
+
 // previewLines is the captured pane, filling every row under the detail
 // separator. The captured rows are marked raw and drawn without the
 // column's gutters: painting our backdrop behind an agent's own CLI colors
@@ -704,12 +728,17 @@ func focusTopRule(width int) string {
 // would put a margin around a terminal that has its own.
 func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 	var lines []contentLine
+	loader := m.startupLoader()
 	pane := paneExact(m.preview, height, width)
 	if len(pane) == 0 {
 		// No rows painted means nothing to hit-test: a box left over from
 		// the previous session would catch clicks on empty space.
 		m.pane.box = paneBox{}
-		return append(lines, contentLine{text: gutter + mutedStyle.Render("(no output yet)")})
+		notice := loader
+		if notice == "" {
+			notice = mutedStyle.Render("(no output yet)")
+		}
+		return append(lines, contentLine{text: gutter + notice})
 	}
 	// Record where these rows land so mouse hit-testing reads the same
 	// geometry the paint used.
@@ -721,6 +750,13 @@ func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 		ok:     true,
 	}
 	for i, line := range pane {
+		// The loader takes the pane's own first row rather than replacing the
+		// block, so the geometry recorded above is the geometry painted: a
+		// session whose pane stays blank keeps every click it would have had.
+		if i == 0 && loader != "" {
+			lines = append(lines, contentLine{text: previewLine(loader, width), raw: true})
+			continue
+		}
 		lines = append(lines, contentLine{text: m.renderPaneRow(i, line, width), raw: true})
 	}
 	// Rows past the capture stay raw too: a painted tail under unpainted

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -685,3 +685,140 @@ func TestFilterBadgesStackOverTheList(t *testing.T) {
 		}
 	}
 }
+
+// blankCapture is what tmux hands back for a session whose agent has not
+// painted yet: one empty row per pane line, not an empty capture.
+const blankCapture = "\n\n\n\n\n\n\n\n\n\n"
+
+func previewModel(sessionStatus, preview string) *Model {
+	return &Model{
+		width: 120, height: 40, mode: modeList, preview: preview,
+		rows: []treeRow{{sess: store.Session{ID: "boot", Name: "boot", Status: sessionStatus}}},
+	}
+}
+
+func previewText(m *Model) string {
+	var out []string
+	for _, line := range m.previewLines(80, 12, "  ") {
+		out = append(out, ansi.Strip(line.text))
+	}
+	return strings.Join(out, "\n")
+}
+
+// A launching agent paints nothing for a while, and the blank block that
+// leaves reads as a broken session; the preview says it is coming up. The
+// blank rows are still the session's pane, so they stay hit-testable.
+func TestPreviewShowsLoaderWhileSessionStarts(t *testing.T) {
+	m := previewModel(status.Starting, blankCapture)
+	if got := previewText(m); !strings.Contains(got, "starting up") {
+		t.Fatalf("preview should carry the launch loader, got %q", got)
+	}
+	if !m.pane.box.ok || m.pane.box.height != len(paneExact(blankCapture, 12, 80)) {
+		t.Fatalf("the loader must not cost the pane its geometry, box = %+v", m.pane.box)
+	}
+}
+
+// With no capture at all there are no pane rows to ride, so the loader
+// stands in for the empty-preview line.
+func TestPreviewShowsLoaderBeforeTheFirstCapture(t *testing.T) {
+	m := previewModel(status.Starting, "")
+	got := previewText(m)
+	if !strings.Contains(got, "starting up") {
+		t.Fatalf("preview should carry the launch loader, got %q", got)
+	}
+	if strings.Contains(got, "(no output yet)") {
+		t.Fatalf("a starting session should not read as empty, got %q", got)
+	}
+	if m.pane.box.ok {
+		t.Fatalf("no pane rows painted means nothing to hit-test, box = %+v", m.pane.box)
+	}
+}
+
+func TestPreviewLoaderClearsOnFirstFrame(t *testing.T) {
+	m := previewModel(status.Starting, "❯ hello\n")
+	got := previewText(m)
+	if strings.Contains(got, "starting up") {
+		t.Fatalf("a captured frame should replace the loader, got %q", got)
+	}
+	if !strings.Contains(got, "hello") {
+		t.Fatalf("preview should paint the captured frame, got %q", got)
+	}
+	if !m.pane.box.ok {
+		t.Fatalf("captured rows must stay hit-testable, box = %+v", m.pane.box)
+	}
+}
+
+// Only the launch state spins: a session that is up with a cleared pane, and
+// one that never came up at all, both keep the plain preview.
+func TestPreviewSkipsLoaderForSettledSessions(t *testing.T) {
+	live := previewModel(status.Idle, blankCapture)
+	if got := previewText(live); strings.Contains(got, "starting up") {
+		t.Fatalf("an idle session must not spin, got %q", got)
+	}
+	if !live.pane.box.ok {
+		t.Fatalf("an idle session keeps its pane rows, box = %+v", live.pane.box)
+	}
+	gone := previewModel(status.Dead, "")
+	if got := previewText(gone); !strings.Contains(got, "(no output yet)") {
+		t.Fatalf("a session that failed to start should read as empty, got %q", got)
+	}
+}
+
+// The loader animates on the preview tick the starting session already
+// earns, and cycles rather than running off the end of its frames.
+func TestPreviewLoaderTurnsOnThePreviewTick(t *testing.T) {
+	m := previewModel(status.Starting, blankCapture)
+	glyph := func() string {
+		line := strings.TrimSpace(previewText(m))
+		if line == "" {
+			t.Fatalf("preview painted nothing")
+		}
+		return string([]rune(line)[0])
+	}
+	seen := map[string]bool{}
+	first := glyph()
+	for i := 0; i < len(startupFrames); i++ {
+		seen[glyph()] = true
+		m.Update(previewTickMsg{})
+	}
+	if len(seen) != len(startupFrames) {
+		t.Fatalf("loader showed %d of %d frames over a full turn: %v", len(seen), len(startupFrames), seen)
+	}
+	if got := glyph(); got != first {
+		t.Fatalf("after a full turn the loader shows %q, want %q", got, first)
+	}
+}
+
+// The loader borrows no mark that already names a state: a frame caught
+// mid-turn would otherwise read as that state, and the detail head above
+// the preview is painting the real one.
+func TestPreviewLoaderFramesAreNotStatusMarks(t *testing.T) {
+	states := []string{status.Working, status.Starting, status.Waiting, status.Finished, status.Errored, status.Dead, status.Idle}
+	for _, frame := range startupFrames {
+		for _, state := range states {
+			if frame == statusGlyph(state) {
+				t.Fatalf("loader frame %q is the %s mark", frame, state)
+			}
+		}
+	}
+}
+
+// A focused pane is the screen the user types on, so it keeps its own first
+// row and the caret drawn there rather than the loader.
+func TestPreviewLeavesTheFocusedPaneAlone(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	m := previewModel(status.Starting, blankCapture)
+	m.mode = modeFocus
+	m.cursorOn = true
+	m.pane.cursor = paneCursor{ok: true}
+	first := m.previewLines(80, 12, "  ")[0].text
+	if strings.Contains(ansi.Strip(first), "starting up") {
+		t.Fatalf("the loader took the focused pane's first row: %q", first)
+	}
+	if !strings.Contains(first, "\x1b[") {
+		t.Fatalf("focused row 0 lost its caret: %q", first)
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -186,6 +186,11 @@ type Model struct {
 	// the frame is not repainted forever.
 	bannerPhase int
 
+	// startupPhase advances the preview's launch loader. It rides the
+	// preview tick, which already runs at its fast cadence while a session
+	// is starting, rather than adding a timer of its own.
+	startupPhase int
+
 	update updateInfo
 
 	// dismissed holds the notice ids the user closed for good; the set
@@ -1026,6 +1031,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case previewTickMsg:
+		m.startupPhase++
 		// Only the list keeps a live pane on screen; review and the modal
 		// screens have no preview to feed, so they skip the capture and
 		// just keep the timer alive.


### PR DESCRIPTION
## What changed

A selected session that is still coming up now spins an arc and reads "starting up" in the preview, on the pane's own first row, until the first captured frame takes that row back. The mark turns on the preview tick a starting session already runs at, and it is drawn from the circle the status marks share while staying clear of every mark that names a state, so a frame caught mid turn reads as motion rather than as a status. The pane keeps the geometry mouse hit-testing reads, and a focused pane keeps its own first row, where its caret lives.

## Why

Starting a session while its row is selected left the preview blank until the tool painted its first frame, so a live row sat over an empty block that read as a broken or empty session.

Closes #151

## How it was verified

```
$ gofmt -l .
$ go vet ./...
```
Both printed nothing.

```
$ env -u TMUX TMUX_TMPDIR=/tmp/am151 go test ./internal/ui -run TestPreview -v
--- PASS: TestPreviewShowsLoaderWhileSessionStarts
--- PASS: TestPreviewShowsLoaderBeforeTheFirstCapture
--- PASS: TestPreviewLoaderClearsOnFirstFrame
--- PASS: TestPreviewSkipsLoaderForSettledSessions
--- PASS: TestPreviewLoaderTurnsOnThePreviewTick
--- PASS: TestPreviewLoaderFramesAreNotStatusMarks
--- PASS: TestPreviewLeavesTheFocusedPaneAlone
```

Dropping the focus guard makes `TestPreviewLeavesTheFocusedPaneAlone` fail with the loader on the focused row and no caret on it, which is the regression it holds:

```
listview_test.go:819: the loader took the focused pane's first row:
"\x1b[38;2;208;131;65m◜ starting up\x1b[0m ..."
```

`env -u TMUX TMUX_TMPDIR=/tmp/am151 go test ./...` is green for every package, and so is the same run under `-race`, on this branch rebased onto `863cff6`.

Pane capture shapes were read from tmux 3.7b on an isolated socket: a pane cleared to a background colour with nothing drawn comes back as one SGR and blank rows, and `previewLine` resets before it pads, so a glyph free row paints no colour either way.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [ ] Ran it against real sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an animated startup loader for sessions while they initialize.
  - Loader appears in empty previews and replaces the first preview row when output is available.
  - Animation updates automatically while preserving pane layout and interactions.

- **Bug Fixes**
  - Loader is hidden for focused panes, settled sessions, and sessions without a selection.
  - Focused-pane caret behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
