### PR TITLE
feat(ui): hold a placeholder name until a new agent renames itself

### DIFF
--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -618,7 +618,7 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		agentSessionID = uuid.NewString()
 		base += " " + tool.SessionIDFlag + " " + agentSessionID
 	}
-	return m.launchNewSession(store.Session{
+	if err := m.launchNewSession(store.Session{
 		ID:    id,
 		Name:  name,
 		Tool:  toolName,
@@ -633,7 +633,18 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		PendingInputs:  pendingInputs,
 	}, tool, base, launchOptions{
 		rollbackWorktree: worktreeRepo != "",
-	})
+	}); err != nil {
+		return err
+	}
+	// The directive went out with the launch, so the row waits for the name
+	// the agent picks instead of showing the one generated for it.
+	if autoNamed {
+		if m.awaitedRenames == nil {
+			m.awaitedRenames = map[string]string{}
+		}
+		m.awaitedRenames[id] = name
+	}
+	return nil
 }
 
 func withPrompt(tool config.Tool, command, prompt string) string {

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -389,6 +389,29 @@ func TestLaunchPromptInjectsDirectiveOnlyForAutoNamedWithPrompt(t *testing.T) {
 	}
 }
 
+// Only a spawn that hands over the rename directive has a name to wait for;
+// one the user named itself is already at its final name.
+func TestSpawnAwaitsARenameOnlyWhenItAsksForOne(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+
+	if err := m.spawnSession("claude", "claude-aaaa", dir, "", "do things", true, false); err != nil {
+		t.Fatalf("auto-named spawn: %v", err)
+	}
+	if err := m.spawnSession("claude", "custom", dir, "", "do things", false, false); err != nil {
+		t.Fatalf("custom spawn: %v", err)
+	}
+	for _, sess := range m.sessions {
+		awaiting := m.awaitingRename(sess)
+		if sess.Name == "claude-aaaa" && !awaiting {
+			t.Fatal("an auto-named spawn should wait for the name its agent picks")
+		}
+		if sess.Name == "custom" && awaiting {
+			t.Fatal("a custom-named spawn was never asked to rename")
+		}
+	}
+}
+
 func TestSpawnMarksDeferredDirective(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -698,6 +698,7 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 				delete(m.pickedRepos, sess.ID)
+				delete(m.awaitedRenames, sess.ID)
 				if err := m.store.Delete(sess.ID); err != nil {
 					m.errBar.text = err.Error()
 					return m, nil

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -500,6 +500,40 @@ func (m *Model) sessionGlyph(sess store.Session) string {
 	return lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
 }
 
+// namePlaceholder stands in for the name a spawn generated while the agent
+// it asked to name itself has not answered, so the row settles on one name
+// instead of flashing a throwaway one first.
+const namePlaceholder = "…"
+
+// renameGrace caps the wait for that answer. It spans the whole way there,
+// the boot, the directive reaching the agent, and the command it runs, so it
+// is generous; past it the session keeps the name it was given.
+const renameGrace = time.Minute
+
+// awaitingRename drops the record it reads as soon as the wait is over, so
+// a session settling on its name needs nothing to sweep the map after it.
+func (m *Model) awaitingRename(sess store.Session) bool {
+	generated, awaited := m.awaitedRenames[sess.ID]
+	if !awaited {
+		return false
+	}
+	if sess.Name == generated && sess.Status != status.Dead &&
+		time.Since(sess.CreatedAt) < renameGrace {
+		return true
+	}
+	delete(m.awaitedRenames, sess.ID)
+	return false
+}
+
+// displayName is what every reading of a session prints, so the rail row and
+// the columns beside it never disagree about who an agent is.
+func (m *Model) displayName(sess store.Session) string {
+	if m.awaitingRename(sess) {
+		return namePlaceholder
+	}
+	return sess.Name
+}
+
 func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad, guides, trail, bg string) string {
 	sess := entry.sess
 	dot := m.sessionGlyph(sess)
@@ -507,7 +541,7 @@ func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad,
 	if selected {
 		nameStyle = lipgloss.NewStyle().Foreground(colorBright).Bold(true)
 	}
-	head := pad + guides + dot + " " + nameStyle.Render(sess.Name)
+	head := pad + guides + dot + " " + nameStyle.Render(m.displayName(sess))
 	focused := selected && m.mode == modeFocus
 	if focused {
 		head += " " + focusBadgeStyle.Render(" FOCUS ")
@@ -840,7 +874,7 @@ func (m *Model) viewDetail(width int) string {
 	// The branch a worktree session lives on is the fact that tells it apart
 	// from its siblings, so it rides beside the tool while the row has room,
 	// and the tool chip goes before the name does.
-	name := lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(sess.Name)
+	name := lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(m.displayName(sess))
 	withTool := name + "  " + chipStyle.Render(tool)
 	heads := []string{withTool, name}
 	if sess.WorktreeBranch != "" {
@@ -940,7 +974,7 @@ func (m *Model) viewGroupAgents(group string, width, height int) string {
 		}
 		tint := lipgloss.NewStyle().Foreground(statusColor(sess.Status))
 		rows = append(rows, rosterRow{
-			name:  tint.Render(statusGlyph(sess.Status)) + " " + valueStyle.Render(sess.Name),
+			name:  tint.Render(statusGlyph(sess.Status)) + " " + valueStyle.Render(m.displayName(sess)),
 			tool:  subtleStyle.Render(sess.Tool),
 			state: tint.Render(statusLabel(sess.Status)) + subtleStyle.Render(" · "+relSince(lastActivity(sess))),
 		})
@@ -1039,7 +1073,7 @@ func (m *Model) viewQuickBar(width int) string {
 			state := lipgloss.NewStyle().Foreground(statusColor(sess.Status)).
 				Render(statusGlyph(sess.Status) + " " + statusLabel(sess.Status))
 			target = fitColumns(
-				[]string{label("answer") + lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(sess.Name)},
+				[]string{label("answer") + lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(m.displayName(sess))},
 				[]string{state + " " + chipStyle.Render(sess.Tool), state, ""}, width)
 		}
 	}

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -532,6 +532,106 @@ func TestSelectedRowMetaUsesBrightNotSubtle(t *testing.T) {
 	}
 }
 
+// A spawn hands its agent the rename directive, so the row stands in for
+// the generated name until the agent answers, and settles on the generated
+// one as soon as that answer can no longer come.
+func TestSessionRowStandsInForAnAwaitedName(t *testing.T) {
+	const generated = "claude-ab12"
+	now := time.Now()
+	for _, tc := range []struct {
+		name    string
+		sess    store.Session
+		awaited bool
+		want    string
+	}{
+		{
+			name:    "waiting on the agent",
+			sess:    store.Session{ID: "s1", Name: generated, Tool: "claude", Status: status.Starting, CreatedAt: now},
+			awaited: true,
+			want:    namePlaceholder,
+		},
+		{
+			name:    "rename landed",
+			sess:    store.Session{ID: "s1", Name: "row-placeholder", Tool: "claude", Status: status.Working, CreatedAt: now},
+			awaited: true,
+			want:    "row-placeholder",
+		},
+		{
+			name:    "pane died before renaming",
+			sess:    store.Session{ID: "s1", Name: generated, Tool: "claude", Status: status.Dead, CreatedAt: now},
+			awaited: true,
+			want:    generated,
+		},
+		{
+			name:    "grace ran out",
+			sess:    store.Session{ID: "s1", Name: generated, Tool: "claude", Status: status.Working, CreatedAt: now.Add(-renameGrace - time.Second)},
+			awaited: true,
+			want:    generated,
+		},
+		{
+			name: "no directive was sent",
+			sess: store.Session{ID: "s1", Name: generated, Tool: "claude", Status: status.Starting, CreatedAt: now},
+			want: generated,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Model{}
+			if tc.awaited {
+				m.awaitedRenames = map[string]string{tc.sess.ID: generated}
+			}
+			row := ansi.Strip(m.renderTreeRow(treeRow{sess: tc.sess}, false, 80, 0, panelHex()))
+			if !strings.Contains(row, tc.want) {
+				t.Fatalf("row is missing %q:\n%s", tc.want, row)
+			}
+			if tc.want != generated && strings.Contains(row, generated) {
+				t.Fatalf("row still shows the generated name:\n%s", row)
+			}
+			if tc.want == namePlaceholder {
+				return
+			}
+			if strings.Contains(row, namePlaceholder) {
+				t.Fatalf("row still stands in for a name it has:\n%s", row)
+			}
+			if _, still := m.awaitedRenames[tc.sess.ID]; still {
+				t.Fatal("a wait that is over should drop what it was holding")
+			}
+		})
+	}
+}
+
+// The rail row is not the only place a name is printed, and the roster sits
+// beside it in the same frame, so every reading of a session stands in for
+// the awaited name together.
+func TestEveryReadingOfASessionStandsInForAnAwaitedName(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("backend", dir); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	const generated = "claude-ab12"
+	if err := m.spawnSession("claude", generated, dir, "backend", "do things", true, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+
+	type reading struct{ where, text string }
+	m.selectGroupRow(t, "backend")
+	readings := []reading{{"roster", ansi.Strip(m.viewGroupAgents("backend", 112, 10))}}
+	m.selectSessionRow(t, generated)
+	readings = append(readings, reading{"detail", strings.Split(ansi.Strip(m.viewDetail(112)), "\n")[0]})
+	m.openQuickMode()
+	readings = append(readings, reading{"quick bar", ansi.Strip(m.viewQuickBar(112))})
+
+	for _, shown := range readings {
+		if strings.Contains(shown.text, generated) {
+			t.Errorf("%s shows the generated name:\n%s", shown.where, shown.text)
+		}
+		if !strings.Contains(shown.text, namePlaceholder) {
+			t.Errorf("%s does not stand in for the awaited name:\n%s", shown.where, shown.text)
+		}
+	}
+}
+
 // A content separator stops at the pane's edge instead of crossing the seam.
 func TestContentRuleStopsAtSeam(t *testing.T) {
 	m := shotModel()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -165,6 +165,13 @@ type Model struct {
 	// declaration for as long as this manager runs.
 	pickedRepos map[string]string
 
+	// awaitedRenames holds the generated name a spawned session launched
+	// under, for as long as the agent it carries the rename directive to is
+	// still expected to answer. A rename that has not landed by the time
+	// this manager run ends is one that is never arriving, so the set is
+	// deliberately not persisted.
+	awaitedRenames map[string]string
+
 	width  int
 	height int
 	// sessionsSized flips after the first refresh shrinks sessions left

--- a/internal/ui/terminal_test.go
+++ b/internal/ui/terminal_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func shellCount(m *Model) int {
@@ -93,6 +95,26 @@ func TestOpenTerminalSpawnsShellInSelectedGroup(t *testing.T) {
 	}
 	if row, ok := m.selected(); !ok || row.ID != sess.ID {
 		t.Fatalf("cursor should land on the new terminal, selected = %+v", row)
+	}
+}
+
+// A shell gets no prompt and no rename directive, so the name it is given
+// is its real one and the row shows it from the first frame.
+func TestTerminalRowShowsItsNameImmediately(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("backend", t.TempDir()); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "backend")
+
+	sess := spawnTerminal(t, m)
+	if m.awaitingRename(sess) {
+		t.Fatalf("shell %q has no rename to wait for", sess.Name)
+	}
+	row := ansi.Strip(m.renderTreeRow(treeRow{sess: sess}, false, 80, 0, panelHex()))
+	if !strings.Contains(row, sess.Name) {
+		t.Fatalf("shell row is missing its name %q:\n%s", sess.Name, row)
 	}
 }
 


### PR DESCRIPTION
## What changed

A spawn that asks its agent to name itself launches under a generated name, and the manager now holds that name back until the agent answers. Every reading of the session shows the same stand-in while the wait is on: the rail row, the group roster beside it, the detail head, and the quick bar target, all through one `displayName`.

The wait ends the moment the rename lands, and the generated name takes over when no answer can come: the pane died, or a minute of grace covering the boot, the directive, and the command the agent runs has passed. Sessions the user named, shells, and terminals show their name from the first frame, because nothing was ever asked to rename them.

## Why

Quick prompts and built-in prompts always rename the agent right after creation, so the row flashed a throwaway name like `claude-ab12` and swapped it for the real one seconds later. The row now settles on one name.

Closes #158

## How it was verified

```
$ gofmt -l .
$ go vet ./...
$ env -u TMUX TMUX_TMPDIR=/tmp/am158 go test ./...
ok  	github.com/YoanWai/agent-manager	1.613s
...
ok  	github.com/YoanWai/agent-manager/internal/ui	143.923s
ok  	github.com/YoanWai/agent-manager/internal/update	(cached)
ok  	github.com/YoanWai/agent-manager/tools/badges	(cached)
```

`gofmt -l .` printed nothing and `go vet ./...` printed nothing. The suite drives real tmux sessions on the isolated `/tmp/am158` socket.

```
$ env -u TMUX TMUX_TMPDIR=/tmp/am158 go test -race ./...
ok  	github.com/YoanWai/agent-manager	3.645s
...
ok  	github.com/YoanWai/agent-manager/internal/ui	160.900s
ok  	github.com/YoanWai/agent-manager/internal/update	2.567s
ok  	github.com/YoanWai/agent-manager/tools/badges	2.718s
```

Tests covering the behaviour:

- `TestEveryReadingOfASessionStandsInForAnAwaitedName` spawns an auto-named session into a group and reads the roster, the detail head and the quick bar. Run against the code before this fix it failed on all three, each printing `claude-ab12` while the rail row printed the stand-in.
- `TestSessionRowStandsInForAnAwaitedName` walks the five states of a row: waiting on the agent, rename landed, pane dead, grace expired, and a spawn that was never asked to rename. Each case also asserts the wait drops what it was holding once it is over.
- `TestSpawnAwaitsARenameOnlyWhenItAsksForOne` covers the auto-named and user-named spawns.
- `TestTerminalRowShowsItsNameImmediately` covers a shell.

Re-run after rebasing onto `ac909b6`: `gofmt -l .`, `go vet ./...` and `go test -race ./...` are all green at `0228146`, the current head.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [ ] Ran it against real sessions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session naming while newly spawned sessions await an agent-selected name.
  * Added consistent placeholder and name handling across session lists, details, rosters, and quick access views.
  * Preserved immediate display of names for custom-named sessions and shell sessions.
  * Cleaned up pending naming state when sessions are renamed, expire, or are deleted.

* **Tests**
  * Added coverage for pending-name display, expiration, deletion, and custom naming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->