### PR TITLE
fix(ui): expand a pane row's tabs into the cells it painted

### DIFF
--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -195,7 +195,7 @@ func TestFocusScrollRecapturesAfterPreviewResize(t *testing.T) {
 	}
 	updated, _ = m.Update(recapture())
 	m = updated.(*Model)
-	if got, want := len(paneExact(m.preview, m.previewPaneHeight())), m.previewPaneHeight(); got != want {
+	if got, want := len(paneExact(m.preview, m.previewPaneHeight(), m.previewPaneWidth())), m.previewPaneHeight(); got != want {
 		t.Fatalf("scroll frame has %d rows, want %d", got, want)
 	}
 	if !strings.Contains(m.preview, "history-line-") {
@@ -238,7 +238,7 @@ func TestFocusScrollKeepsDeepHistoryFrame(t *testing.T) {
 	}
 	updated, _ := m.Update(msg)
 	m = updated.(*Model)
-	if got, want := len(paneExact(m.preview, m.previewPaneHeight())), m.previewPaneHeight(); got != want {
+	if got, want := len(paneExact(m.preview, m.previewPaneHeight(), m.previewPaneWidth())), m.previewPaneHeight(); got != want {
 		t.Fatalf("deep frame has %d rows, want %d", got, want)
 	}
 	if !strings.Contains(m.preview, "history-line-") {

--- a/internal/ui/focussel.go
+++ b/internal/ui/focussel.go
@@ -108,7 +108,7 @@ func (m *Model) paneCell(x, y int) (row, col int, ok bool) {
 // same slice the renderer paints, so selection indices line up with what
 // is on screen.
 func (m *Model) paneTextLines() []string {
-	rows := paneExact(m.preview, m.pane.box.height)
+	rows := paneExact(m.preview, m.pane.box.height, m.pane.box.width)
 	out := make([]string, len(rows))
 	for i, row := range rows {
 		out[i] = ansi.Strip(previewDangerSeqs.ReplaceAllString(row, ""))

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -514,3 +514,38 @@ func TestCursorPastEndOfLine(t *testing.T) {
 		t.Fatalf("cursor changed the line text: %q", plain)
 	}
 }
+
+// tmux reports the caret and takes the mouse in painted cells, so on a row
+// `go test` wrote the tab's cells have to count for the caret and the
+// selection the same way they count for the paint.
+func TestTabbedRowSharesItsColumns(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	const width = 30
+	m := paneAt(t, "ok  \tgithub.com/x/y\t1.5s")
+	m.pane.box.width = width
+	rows := paneExact(m.preview, m.pane.box.height, width)
+
+	// Column 8 is where the pane paints the package name's first letter.
+	m.pane.cursor = paneCursor{x: 8, y: 0, ok: true}
+	row := m.renderPaneRow(0, rows[0], width)
+	if !strings.Contains(row, cursorStyle().Render("g")) {
+		t.Fatalf("caret missed the cell tmux reported: %q", row)
+	}
+
+	// The caret at the end of the painted row still lands inside the frame.
+	m.pane.cursor = paneCursor{x: 28, y: 0, ok: true}
+	if end := m.renderPaneRow(0, rows[0], width); !strings.Contains(end, "\x1b[") ||
+		ansi.StringWidth(end) != width {
+		t.Fatalf("caret at the row's end paints %d cells: %q", ansi.StringWidth(end), end)
+	}
+
+	m.pane.cursor = paneCursor{}
+	press(m, m.pane.box.x+8, m.pane.box.y)
+	drag(m, m.pane.box.x+15, m.pane.box.y)
+	if text := m.selectionText(); text != "github." {
+		t.Fatalf("dragging over the painted columns copied %q", text)
+	}
+}

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -704,7 +704,7 @@ func focusTopRule(width int) string {
 // would put a margin around a terminal that has its own.
 func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 	var lines []contentLine
-	pane := paneExact(m.preview, height)
+	pane := paneExact(m.preview, height, width)
 	if len(pane) == 0 {
 		// No rows painted means nothing to hit-test: a box left over from
 		// the previous session would catch clicks on empty space.

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -355,11 +355,40 @@ func previewLine(line string, width int) string {
 	return pinPaneLineLTR(line)
 }
 
-// paneExact returns up to n lines of pane text as captured, preserving
-// blank rows so a full-screen agent TUI looks the same in the preview.
-// When the capture is taller than the panel (stale size), the bottom n
-// lines are kept — the visible end of the pane.
-func paneExact(pane string, n int) []string {
+// expandPaneTabs writes a captured row's tabs out as the spaces the pane
+// already painted. tmux serializes a tab as the single byte even though it
+// spans the cells up to the next eight-column stop, so a row that keeps one
+// measures narrower than it paints and overflows its column. The stops
+// count from the row's start, which is pane column zero; escape sequences
+// hold no column. A tab that would reach past the row's last cell stops on
+// it, which is where tmux leaves the cursor.
+func expandPaneTabs(line string, width int) string {
+	if !strings.ContainsRune(line, '\t') {
+		return line
+	}
+	const tabStop = 8
+	var out strings.Builder
+	column := 0
+	for i, segment := range strings.Split(line, "\t") {
+		if i > 0 {
+			pad := max(min(tabStop-column%tabStop, width-1-column), 0)
+			out.WriteString(strings.Repeat(" ", pad))
+			column += pad
+		}
+		out.WriteString(segment)
+		column += ansi.StringWidth(segment)
+	}
+	return out.String()
+}
+
+// paneExact returns up to n lines of pane text as the pane painted them,
+// preserving blank rows so a full-screen agent TUI looks the same in the
+// preview. When the capture is taller than the panel (stale size), the
+// bottom n lines are kept — the visible end of the pane. Rows arrive here
+// before anything measures them, so this is where a tab becomes the cells
+// it covers and the frame, the caret and the selection all count one set
+// of columns.
+func paneExact(pane string, n, width int) []string {
 	if n <= 0 || pane == "" {
 		return nil
 	}
@@ -368,6 +397,9 @@ func paneExact(pane string, n int) []string {
 	lines := strings.Split(pane, "\n")
 	if len(lines) > n {
 		lines = lines[len(lines)-n:]
+	}
+	for i, line := range lines {
+		lines[i] = expandPaneTabs(line, width)
 	}
 	return lines
 }

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -44,11 +44,11 @@ func TestScrollWindow(t *testing.T) {
 
 func TestPaneExactPreservesBlanks(t *testing.T) {
 	pane := "one\n\n\ntwo\n"
-	got := paneExact(pane, 10)
+	got := paneExact(pane, 10, 80)
 	if len(got) != 4 || got[1] != "" || got[2] != "" {
 		t.Fatalf("paneExact should keep blank rows: %q", got)
 	}
-	got = paneExact("a\nb\nc\nd", 2)
+	got = paneExact("a\nb\nc\nd", 2, 80)
 	if len(got) != 2 || got[0] != "c" || got[1] != "d" {
 		t.Fatalf("paneExact oversize should take bottom lines: %q", got)
 	}
@@ -144,6 +144,39 @@ func TestPreviewLine(t *testing.T) {
 	}
 	if body := strings.TrimRight(stripPreviewMarks(ansi.Strip(hebrew)), " "); body != "  העצמון 25 חולון" {
 		t.Fatalf("pure RTL row text changed: %q", body)
+	}
+}
+
+// A row `go test` wrote carries literal tabs, which the frame measures as
+// nothing and the host paints out to its own stops, pushing the preview,
+// footer and stat rows off their positions.
+func TestPaneExactExpandsTabs(t *testing.T) {
+	const width = 60
+	rows := paneExact("ok  \tgithub.com/YoanWai/agent-manager/internal/ui\t73.163s\n", 4, width)
+	if len(rows) != 1 || strings.ContainsRune(rows[0], '\t') {
+		t.Fatalf("tab reached the frame: %q", rows)
+	}
+	if !strings.HasPrefix(rows[0], "ok      github.com/") {
+		t.Fatalf("tab should reach the pane's next eight-column stop: %q", rows[0])
+	}
+	if w := ansi.StringWidth(previewLine(rows[0], width)); w != width {
+		t.Fatalf("tabbed row paints %d cells, want %d", w, width)
+	}
+
+	// A tab close to the right edge stops on the row's last cell, where
+	// tmux leaves it, so the cell painted after it stays in the preview.
+	// Measured on tmux 3.7b: in a 62-column pane, 58 columns then a tab
+	// leaves the cursor at column 61.
+	edge := paneExact(strings.Repeat("a", 58)+"\tX", 1, 62)
+	if want := strings.Repeat("a", 58) + "   X"; edge[0] != want {
+		t.Fatalf("tab at the edge expanded to %q, want %q", edge[0], want)
+	}
+
+	// A capture taken before a resize is wider than the box it lands in,
+	// and a tab past the right edge covers no cells at all.
+	stale := paneExact(strings.Repeat("a", 40)+"\tX", 1, 20)
+	if want := strings.Repeat("a", 40) + "X"; stale[0] != want {
+		t.Fatalf("tab past the edge expanded to %q, want %q", stale[0], want)
 	}
 }
 


### PR DESCRIPTION
## What changed

`paneExact` now turns each captured row into the cells the pane actually painted: a tab byte becomes the spaces it covers, out to the next eight-column stop, and a tab close to the right edge stops on the row's last cell, which is where tmux leaves the cursor. Rows reach every consumer already expanded, so the frame's measure and clip, the caret splice and the mouse selection all count one set of columns, the same ones tmux reports the cursor and the mouse in.

## Why

`go test` writes literal tabs between its result, package and duration fields. `ansi.StringWidth` gives a tab no columns, so a row that measured as fitting the preview came out wider once the host terminal expanded it: the frame overflowed and wrapped, and the preview, footer and computer-stat rows were painted at the wrong screen positions. Focus mode counted the same rows the same way, so on a tabbed row the caret and the selection highlight landed a tab's worth of padding away from the text they belonged to, and a drag copied the wrong characters.

Closes #288

## How it was verified

tmux's own behavior at the right edge, on the isolated socket (tmux 3.7b, 62-column pane):

```
env -u TMUX TMUX_TMPDIR=/tmp/am288 tmux -f /dev/null new-session -d -s p2 -x 62 -y 10 "printf '%s\tXY' '<58 a>'; sleep 60"
env -u TMUX TMUX_TMPDIR=/tmp/am288 tmux -f /dev/null display-message -p -t p2 '#{cursor_x},#{cursor_y}'
env -u TMUX TMUX_TMPDIR=/tmp/am288 tmux -f /dev/null capture-pane -p -t p2 | od -c
```

58 columns then a tab leaves the cursor at 61, X paints on column 61 and Y wraps to the next row, while `capture-pane` still serializes the row as 58 a's, `\t`, `X`. The expansion pads that tab by 3, which is what the pane shows.

End to end through the real render path: a temporary test created a session, sent the `go test` row into its pane, polled `capture-pane` until the row came back with its `0x09` intact, then rendered `m.View()` at 100x30. Every one of the 30 frame rows measured exactly 100 cells and the preview row read `ok      github.com/YoanWai/agent-manager/internal/ui    73.163s`. With the expansion removed the same check reports the tab surviving into the painted rows.

```
cd /Users/yoan/Desktop/projects/agent-manager-worktrees/issue-288-preview-tabs
gofmt -l .
go vet ./...
env -u TMUX TMUX_TMPDIR=/tmp/am288 go test ./...
env -u TMUX TMUX_TMPDIR=/tmp/am288 go test -race ./...
```

`gofmt -l .` printed nothing, `go vet ./...` was clean, and both test runs came back `ok` for every package (`internal/ui` 80.3s, 132.6s under `-race`).

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [ ] Ran it against real sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane rendering and text selection when content contains tab characters.
  * Ensured tabs align consistently to eight-column stops across previews, cursors, and mouse selections.
  * Preserved pane width and blank-space rendering at right edges and beyond narrow frames.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->