### PR TITLE
feat(review): toggle non-code files out of the review file list

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -189,6 +189,7 @@ Press `ctrl+r` on a session to open a full-screen review of its repo: changed fi
 | `b` | Pick the branch from the repo's worktrees |
 | `B` | Pick the target (merge-into branch) the "vs target" scope compares against |
 | `space` | Mark a file reviewed |
+| `f` | Show code files only, hiding images, compiled assets and lock files from the list; press again to show them |
 | `c` / `d` | Write / drop a line comment |
 | `C` | Send every comment to the agent as one review prompt (`enter` or `y` confirms) |
 | `esc` / `q` | Close the review |

--- a/internal/ui/diffrender.go
+++ b/internal/ui/diffrender.go
@@ -384,8 +384,17 @@ func (m *Model) diffEmptyText() string {
 	return ""
 }
 
+// diffAllHiddenNote is what both review panes fall back to when the code-only
+// filter leaves nothing to show. It has to fit the narrow file rail.
+func diffAllHiddenNote() string {
+	return mutedStyle.Render("(no code files)") + "\n" +
+		subtleStyle.Render("f shows the rest")
+}
+
 func (m *Model) diffBodyNote(fd *diff.FileDiff) string {
 	switch {
+	case m.diffFileHidden(fd):
+		return diffAllHiddenNote()
 	case !fd.Loaded():
 		return mutedStyle.Render("(loading file…)")
 	case fd.Err != nil:
@@ -576,6 +585,9 @@ func (m *Model) viewDiffHeader(sessName string) string {
 	left := "  " + lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("review · "+sessName) + "  " +
 		keyPill("s", m.diff.scope.String(), colorAccent2) + "  " +
 		keyPill("u", layout, colorAccent)
+	if m.diff.codeOnly {
+		left += "  " + keyPill("f", "code only", colorAccent)
+	}
 	if root := m.diff.set.Repo.Root; root != "" {
 		name := filepath.Base(m.diff.repoSel)
 		if name == "" || name == "." {
@@ -599,8 +611,14 @@ func (m *Model) viewDiffHeader(sessName string) string {
 	}
 
 	adds, dels := 0, 0
+	shown := 0
 	uncounted := false
-	for _, fd := range m.diff.set.Files {
+	for i := range m.diff.set.Files {
+		fd := &m.diff.set.Files[i]
+		if m.diffFileHidden(fd) {
+			continue
+		}
+		shown++
 		if !fd.StatKnown() {
 			uncounted = true
 			continue
@@ -608,7 +626,7 @@ func (m *Model) viewDiffHeader(sessName string) string {
 		adds += fd.Stat.Adds
 		dels += fd.Stat.Dels
 	}
-	right := mutedStyle.Render(fmt.Sprintf("%d files", len(m.diff.set.Files))) + subtleStyle.Render(" · ") +
+	right := mutedStyle.Render(fmt.Sprintf("%d files", shown)) + subtleStyle.Render(" · ") +
 		lipgloss.NewStyle().Foreground(colorFinished).Render(fmt.Sprintf("+%d", adds)) + " " +
 		lipgloss.NewStyle().Foreground(colorErrored).Render(fmt.Sprintf("−%d", dels))
 	if uncounted {
@@ -628,7 +646,7 @@ func (m *Model) viewDiffHeader(sessName string) string {
 
 func (m *Model) diffCodeTitle() string {
 	fd := m.currentFileDiff()
-	if fd == nil {
+	if fd == nil || m.diffFileHidden(fd) {
 		return "Diff"
 	}
 	return fd.File.Path
@@ -639,7 +657,23 @@ func (m *Model) viewDiffFileList(width, height int) string {
 		return empty
 	}
 	files := m.diff.set.Files
-	start, end := scrollWindow(len(files), m.diff.fileIdx, height)
+	shown := make([]int, 0, len(files))
+	for i := range files {
+		if !m.diffFileHidden(&files[i]) {
+			shown = append(shown, i)
+		}
+	}
+	if len(shown) == 0 {
+		return diffAllHiddenNote()
+	}
+	cursor := 0
+	for pos, i := range shown {
+		if i == m.diff.fileIdx {
+			cursor = pos
+			break
+		}
+	}
+	start, end := scrollWindow(len(shown), cursor, height)
 	var b strings.Builder
 	if start > 0 {
 		b.WriteString(subtleStyle.Render(fmt.Sprintf("  ↑ %d more", start)) + "\n")
@@ -648,7 +682,8 @@ func (m *Model) viewDiffFileList(width, height int) string {
 	for _, note := range m.diff.annotations[m.reviewKey()] {
 		notes[note.file]++
 	}
-	for i := start; i < end; i++ {
+	for pos := start; pos < end; pos++ {
+		i := shown[pos]
 		fd := files[i]
 		glyph := subtleStyle.Render("○")
 		if m.fileReviewed(fd.File.Path) {
@@ -681,8 +716,8 @@ func (m *Model) viewDiffFileList(width, height int) string {
 		}
 		b.WriteString(row + "\n")
 	}
-	if end < len(files) {
-		b.WriteString(subtleStyle.Render(fmt.Sprintf("  ↓ %d more", len(files)-end)))
+	if end < len(shown) {
+		b.WriteString(subtleStyle.Render(fmt.Sprintf("  ↓ %d more", len(shown)-end)))
 	}
 	return strings.TrimRight(b.String(), "\n")
 }
@@ -924,6 +959,10 @@ func (m *Model) viewDiffFooter() string {
 	if count := len(m.diff.annotations[m.reviewKey()]); count > 0 {
 		send = fmt.Sprintf("send %d", count)
 	}
+	filter := "code only"
+	if m.diff.codeOnly {
+		filter = "all files"
+	}
 	return legendBar([]legendSection{
 		{title: "Review", pairs: [][2]string{
 			{"c", "comment"}, {"d", "remove"}, {"C", send}, {"space", "reviewed"},
@@ -931,7 +970,7 @@ func (m *Model) viewDiffFooter() string {
 		}},
 		{title: "Move", quiet: true, pairs: [][2]string{
 			{"↑↓/jk", "scroll line"}, {"ctrl+d/ctrl+u", "half page"}, {"g/G", "top/bottom"},
-			{"tab/J K/shift+tab", "file"}, {"n/N", "change"}, {"u", "layout"},
+			{"tab/J K/shift+tab", "file"}, {"n/N", "change"}, {"u", "layout"}, {"f", filter},
 			{"esc/q", "close"}, {"ctrl+c", "quit"},
 		}},
 	}, m.width)

--- a/internal/ui/diffrender_test.go
+++ b/internal/ui/diffrender_test.go
@@ -220,17 +220,22 @@ func TestReviewHeaderTargetLabelCleanAndKeyed(t *testing.T) {
 }
 
 // The header carries the filter state the way it carries the scope and the
-// layout, and its file count follows what the list actually shows.
+// layout, and its readings follow what the list actually shows. A lock file
+// is the case the totals turn on: git hands back real add and delete counts
+// for it, so a header that kept counting it would disagree with its own list.
 func TestReviewHeaderShowsCodeOnlyFilter(t *testing.T) {
 	m := buildModel(t)
 	if m.gitDrv == nil {
 		t.Skip("git not installed")
 	}
-	openReviewOn(t, m, "hdr", gitRepoWithBinaryBetweenTextFiles(t))
+	openReviewOn(t, m, "hdr", gitRepoWithLockFileBetweenTextFiles(t))
 
 	header := ansi.Strip(m.viewDiffHeader("hdr"))
-	if !strings.Contains(header, "3 files") {
+	if !strings.Contains(header, "4 files") {
 		t.Fatalf("header should count every changed file, got %q", header)
+	}
+	if !strings.Contains(header, "+5") || !strings.Contains(header, "−5") {
+		t.Fatalf("header should total every changed file, got %q", header)
 	}
 	if strings.Contains(header, "code only") {
 		t.Fatalf("header should not claim a filter that is off, got %q", header)
@@ -243,5 +248,8 @@ func TestReviewHeaderShowsCodeOnlyFilter(t *testing.T) {
 	}
 	if !strings.Contains(header, "2 files") {
 		t.Fatalf("header should count only the files on show, got %q", header)
+	}
+	if !strings.Contains(header, "+2") || !strings.Contains(header, "−2") {
+		t.Fatalf("header should drop the lock file's totals, got %q", header)
 	}
 }

--- a/internal/ui/diffrender_test.go
+++ b/internal/ui/diffrender_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -215,5 +216,32 @@ func TestReviewHeaderTargetLabelCleanAndKeyed(t *testing.T) {
 	}
 	if !strings.Contains(header, "feature → feature") {
 		t.Fatalf("header should show the cleaned target → branch, got %q", header)
+	}
+}
+
+// The header carries the filter state the way it carries the scope and the
+// layout, and its file count follows what the list actually shows.
+func TestReviewHeaderShowsCodeOnlyFilter(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "hdr", gitRepoWithBinaryBetweenTextFiles(t))
+
+	header := ansi.Strip(m.viewDiffHeader("hdr"))
+	if !strings.Contains(header, "3 files") {
+		t.Fatalf("header should count every changed file, got %q", header)
+	}
+	if strings.Contains(header, "code only") {
+		t.Fatalf("header should not claim a filter that is off, got %q", header)
+	}
+
+	m.drainCmds(t, m.toggleCodeOnly())
+	header = ansi.Strip(m.viewDiffHeader("hdr"))
+	if !regexp.MustCompile(`f\s+code only`).MatchString(header) {
+		t.Fatalf("header should show the filter and its key, got %q", header)
+	}
+	if !strings.Contains(header, "2 files") {
+		t.Fatalf("header should count only the files on show, got %q", header)
 	}
 }

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -601,6 +601,7 @@ var nonCodeExts = map[string]bool{
 	".zip": true, ".tar": true, ".gz": true, ".bz2": true, ".xz": true,
 	".7z": true, ".mp3": true, ".mp4": true, ".wav": true, ".ogg": true,
 	".avi": true, ".mov": true, ".pdf": true, ".lock": true,
+	".class": true, ".pyc": true,
 }
 
 var nonCodeNames = map[string]bool{

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -39,6 +39,7 @@ type diffState struct {
 	scroll     int
 	cursorLine int
 	sideBySide bool
+	codeOnly   bool
 
 	scrollByFile map[string]int
 	reviewed     map[string]map[string]uint64
@@ -416,6 +417,7 @@ func (m *Model) handleDiffLoaded(msg diffLoadedMsg) tea.Cmd {
 			break
 		}
 	}
+	m.diff.fileIdx = m.nextShownFile(m.diff.fileIdx, 1)
 	m.clampDiffCursor()
 	currentLoad := m.loadCurrentDiffFile()
 	var statefulLoads []tea.Cmd
@@ -492,6 +494,11 @@ func (m *Model) handleDiffFileLoaded(msg diffFileLoadedMsg) tea.Cmd {
 	}
 	if msg.index != m.diff.fileIdx {
 		return nil
+	}
+	// A NUL sniff is the only thing that outs a blob whose name gives nothing
+	// away, so the file under the cursor can turn into one the filter hides.
+	if target := m.nextShownFile(m.diff.fileIdx, 1); target != m.diff.fileIdx {
+		return m.switchDiffFile(target - m.diff.fileIdx)
 	}
 	m.clampDiffCursor()
 	return m.ensureHighlight()
@@ -583,15 +590,82 @@ func (m *Model) scrollKey(path string) string {
 	return m.reviewKey() + "\x00" + m.diff.scope.String() + "\x00" + path
 }
 
+// nonCodeExts and nonCodeNames name the files a review takes in whole rather
+// than line by line: images, fonts, archives, compiled artifacts, and the lock
+// files a package manager rewrites wholesale.
+var nonCodeExts = map[string]bool{
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".webp": true,
+	".ico": true, ".svg": true, ".woff": true, ".woff2": true, ".ttf": true,
+	".otf": true, ".eot": true, ".wasm": true, ".bin": true, ".exe": true,
+	".dll": true, ".so": true, ".dylib": true, ".o": true, ".a": true,
+	".zip": true, ".tar": true, ".gz": true, ".bz2": true, ".xz": true,
+	".7z": true, ".mp3": true, ".mp4": true, ".wav": true, ".ogg": true,
+	".avi": true, ".mov": true, ".pdf": true, ".lock": true,
+}
+
+var nonCodeNames = map[string]bool{
+	"package-lock.json": true, "pnpm-lock.yaml": true, "go.sum": true,
+}
+
+func nonCodePath(repoPath string) bool {
+	name := filepath.Base(repoPath)
+	return nonCodeNames[name] || nonCodeExts[strings.ToLower(filepath.Ext(name))]
+}
+
+// diffFileHidden reports whether the code-only filter drops a file from the
+// review's file list. The name is what settles the verdict before the toggle
+// is ever pressed: git's numstat never classifies an untracked path, and the
+// loader sniffs for NUL only once the cursor reaches a file. Git's own binary
+// verdict and that sniff then catch a blob whose name gives nothing away.
+func (m *Model) diffFileHidden(fd *diff.FileDiff) bool {
+	return m.diff.codeOnly && (fd.Binary || fd.Stat.Binary || nonCodePath(fd.File.Path))
+}
+
+// nextShownFile walks from index in the direction dir to the first file the
+// code-only filter leaves in the list, and returns index untouched when the
+// filter hides every file.
+func (m *Model) nextShownFile(index, dir int) int {
+	count := len(m.diff.set.Files)
+	if count == 0 {
+		return index
+	}
+	for step := 0; step < count; step++ {
+		candidate := ((index+dir*step)%count + count) % count
+		if !m.diffFileHidden(&m.diff.set.Files[candidate]) {
+			return candidate
+		}
+	}
+	return index
+}
+
+// toggleCodeOnly hides or shows the non-code files, carrying the selection to
+// a file the list still shows.
+func (m *Model) toggleCodeOnly() tea.Cmd {
+	m.diff.codeOnly = !m.diff.codeOnly
+	target := m.nextShownFile(m.diff.fileIdx, 1)
+	if target == m.diff.fileIdx {
+		return nil
+	}
+	return m.switchDiffFile(target - m.diff.fileIdx)
+}
+
 func (m *Model) switchDiffFile(delta int) tea.Cmd {
 	count := len(m.diff.set.Files)
 	if count == 0 {
 		return nil
 	}
+	dir := 1
+	if delta < 0 {
+		dir = -1
+	}
+	target := m.nextShownFile((m.diff.fileIdx+delta+count)%count, dir)
+	if m.diffFileHidden(&m.diff.set.Files[target]) {
+		return nil
+	}
 	if fd := m.currentFileDiff(); fd != nil {
 		m.diff.scrollByFile[m.scrollKey(fd.File.Path)] = m.diff.scroll
 	}
-	m.diff.fileIdx = (m.diff.fileIdx + delta + count) % count
+	m.diff.fileIdx = target
 	fd := m.currentFileDiff()
 	m.diff.scroll = m.diff.scrollByFile[m.scrollKey(fd.File.Path)]
 	m.diff.cursorLine = m.diff.scroll
@@ -800,6 +874,8 @@ func (m *Model) handleDiffKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		lineIdx := m.cursorDiffLine()
 		m.diff.sideBySide = !m.diff.sideBySide
 		m.setCursorDiffLine(lineIdx)
+	case "f":
+		return m, m.toggleCodeOnly()
 	case " ", "space":
 		return m, m.toggleReviewed()
 	case "c":
@@ -871,7 +947,7 @@ func (m *Model) toggleReviewed() tea.Cmd {
 	// would leave that file unhighlighted.
 	for step := 1; step < len(m.diff.set.Files); step++ {
 		next := (m.diff.fileIdx + step) % len(m.diff.set.Files)
-		if marks[m.diff.set.Files[next].File.Path] == 0 {
+		if marks[m.diff.set.Files[next].File.Path] == 0 && !m.diffFileHidden(&m.diff.set.Files[next]) {
 			return m.switchDiffFile(next - m.diff.fileIdx)
 		}
 	}

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -918,6 +918,13 @@ func (m *Model) pressDiffKey(t *testing.T, key rune) {
 	m.drainCmds(t, cmd)
 }
 
+func (m *Model) pressFilterKey(t *testing.T) {
+	t.Helper()
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	*m = *updated.(*Model)
+	m.drainCmds(t, cmd)
+}
+
 // pickRepo drives the repo picker the way a human would: r, type the repo
 // name, enter.
 func (m *Model) pickRepo(t *testing.T, name string) {
@@ -1404,6 +1411,307 @@ func TestTrackedBinaryPastEagerCapShowsBinary(t *testing.T) {
 	}
 	if strings.Contains(row, "+0") || strings.Contains(row, "−0") {
 		t.Errorf("zz.bin row still shows zero counts: %q", row)
+	}
+}
+
+// writeGitRepo commits a first version of every file, then lays down the
+// second one, leaving a working tree whose changes a review can open.
+func writeGitRepo(t *testing.T, committed, working map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+	run("git", "init", "-b", "main")
+	for name, content := range committed {
+		writeRepoFile(t, dir, name, content)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "init")
+	for name, content := range working {
+		writeRepoFile(t, dir, name, content)
+	}
+	return dir
+}
+
+func writeRepoFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// gitRepoWithBinaryBetweenTextFiles changes a tracked binary file sitting
+// between two text files. Its name says nothing, so git's numstat verdict is
+// the only thing that can call it binary.
+func gitRepoWithBinaryBetweenTextFiles(t *testing.T) string {
+	t.Helper()
+	return writeGitRepo(t,
+		map[string]string{
+			"a.go":  "package a\n\nfunc A() int { return 1 }\n",
+			"b.dat": "\x00\x01\x02one",
+			"c.go":  "package a\n\nfunc C() int { return 3 }\n",
+		},
+		map[string]string{
+			"a.go":  "package a\n\nfunc A() int { return 10 }\n",
+			"b.dat": "\x00\x01\x02two",
+			"c.go":  "package a\n\nfunc C() int { return 30 }\n",
+		})
+}
+
+// f drops the files git calls binary out of the review, and neither the
+// selection nor a file switch is left on one of them.
+func TestReviewCodeOnlyHidesBinaryFiles(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "filter", gitRepoWithBinaryBetweenTextFiles(t))
+
+	binary := -1
+	for i := range m.diff.set.Files {
+		if m.diff.set.Files[i].File.Path == "b.dat" {
+			binary = i
+		}
+	}
+	if binary < 0 {
+		t.Fatalf("b.dat missing from the diff set: %+v", m.diff.set.Files)
+	}
+	if !m.diff.set.Files[binary].Stat.Binary {
+		t.Fatal("numstat should mark b.dat binary before its content is read")
+	}
+	m.diff.fileIdx = binary
+
+	m.pressFilterKey(t)
+	if !m.diff.codeOnly {
+		t.Fatal("f should turn the code-only filter on")
+	}
+	if m.diff.fileIdx == binary {
+		t.Fatal("the selection should leave a file the filter hides")
+	}
+	list := ansi.Strip(m.viewDiffFileList(60, 20))
+	if strings.Contains(list, "b.dat") {
+		t.Fatalf("b.dat should be filtered out of the file list:\n%s", list)
+	}
+	if !strings.Contains(list, "a.go") || !strings.Contains(list, "c.go") {
+		t.Fatalf("the code files should stay listed:\n%s", list)
+	}
+
+	for i := range m.diff.set.Files {
+		if m.diff.set.Files[i].File.Path == "a.go" {
+			m.diff.fileIdx = i
+		}
+	}
+	m.drainCmds(t, m.switchDiffFile(1))
+	if got := m.diff.set.Files[m.diff.fileIdx].File.Path; got != "c.go" {
+		t.Fatalf("the file after a.go = %q, want c.go", got)
+	}
+	m.drainCmds(t, m.switchDiffFile(-1))
+	if got := m.diff.set.Files[m.diff.fileIdx].File.Path; got != "a.go" {
+		t.Fatalf("the file before c.go = %q, want a.go", got)
+	}
+
+	m.pressFilterKey(t)
+	if m.diff.codeOnly {
+		t.Fatal("f again should show the binary files")
+	}
+	if list := ansi.Strip(m.viewDiffFileList(60, 20)); !strings.Contains(list, "b.dat") {
+		t.Fatalf("b.dat should be back in the file list:\n%s", list)
+	}
+}
+
+// A newly written image and a regenerated lock file are the common case, and
+// neither has a git verdict to go on: the filter has to settle them by name so
+// they go the moment the key is pressed and stay gone across a silent reload.
+func TestReviewCodeOnlyHidesUntrackedAndLockFiles(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	dir := writeGitRepo(t,
+		map[string]string{
+			"a.go":   "package a\n\nfunc A() int { return 1 }\n",
+			"go.sum": "mod v1.0.0 h1:aaa=\n",
+			"src.go": "package a\n\nfunc S() int { return 2 }\n",
+		},
+		map[string]string{
+			"a.go":   "package a\n\nfunc A() int { return 10 }\n",
+			"go.sum": "mod v1.0.1 h1:bbb=\n",
+			"src.go": "package a\n\nfunc S() int { return 20 }\n",
+			"z.png":  "\x89PNG\r\n\x1a\n\x00\x00\x00\x00new",
+		})
+	openReviewOn(t, m, "blobs", dir)
+
+	untracked := m.fileDiffByPath("z.png")
+	if untracked == nil {
+		t.Fatalf("z.png missing from the diff set: %+v", m.diff.set.Files)
+	}
+	if untracked.Loaded() || untracked.Stat.Binary {
+		t.Fatal("an untracked file the cursor never reached should carry no binary verdict")
+	}
+
+	m.pressFilterKey(t)
+	list := ansi.Strip(m.viewDiffFileList(60, 20))
+	if strings.Contains(list, "z.png") || strings.Contains(list, "go.sum") {
+		t.Fatalf("the image and the lock file should be off the list:\n%s", list)
+	}
+	if !strings.Contains(list, "a.go") || !strings.Contains(list, "src.go") {
+		t.Fatalf("the code files should stay listed:\n%s", list)
+	}
+
+	// Reverting the file under the cursor drops it from the reloaded set, so the
+	// selection falls on go.sum unless the reload settles it on the spot. The
+	// load it schedules is drained afterwards: the list is rendered between the
+	// two, and a cursor parked on a hidden row draws no cursor at all.
+	writeRepoFile(t, dir, "a.go", "package a\n\nfunc A() int { return 1 }\n")
+	sess, ok := m.diffSession()
+	if !ok {
+		t.Fatal("no diff session")
+	}
+	m.diff.gen++
+	updated, cmd := m.Update(m.diffLoadCmd(sess, m.diff.scope, m.diff.gen, m.diff.repoSel, true)())
+	*m = *updated.(*Model)
+	if got := m.diff.set.Files[m.diff.fileIdx].File.Path; got != "src.go" {
+		t.Fatalf("the reload should settle the selection itself, landed on %q", got)
+	}
+	m.drainCmds(t, cmd)
+	if list := ansi.Strip(m.viewDiffFileList(60, 20)); strings.Contains(list, "z.png") {
+		t.Fatalf("the filter should survive a silent reload:\n%s", list)
+	}
+}
+
+// A blob whose name gives nothing away is only outed when its load sniffs a
+// NUL, so the cursor has to be carried off it the way every other file switch
+// moves: with the file it lands on scrolled back where the user left it.
+func TestReviewCodeOnlyCarriesCursorOffASniffedBlob(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	var long, edited strings.Builder
+	for i := 1; i <= 200; i++ {
+		fmt.Fprintf(&long, "line %d\n", i)
+		fmt.Fprintf(&edited, "line %d\n", i)
+	}
+	edited.WriteString("tail\n")
+	dir := writeGitRepo(t,
+		map[string]string{
+			"a.txt": long.String(),
+			"c.go":  "package a\n\nfunc C() int { return 3 }\n",
+		},
+		map[string]string{
+			"a.txt":    edited.String(),
+			"c.go":     "package a\n\nfunc C() int { return 30 }\n",
+			"blob.dat": "\x00\x01\x02new",
+		})
+	openReviewOn(t, m, "sniff", dir)
+	if got := m.diff.set.Files[m.diff.fileIdx].File.Path; got != "a.txt" {
+		t.Fatalf("review should open on a.txt, got %q", got)
+	}
+
+	m.pressFilterKey(t)
+	m.diff.scroll = 150
+	m.diff.cursorLine = 150
+	m.drainCmds(t, m.switchDiffFile(1))
+	if got := m.diff.set.Files[m.diff.fileIdx].File.Path; got != "c.go" {
+		t.Fatalf("the file after a.txt = %q, want c.go", got)
+	}
+
+	m.pressDiffKey(t, 'J')
+	if got := m.diff.set.Files[m.diff.fileIdx].File.Path; got != "a.txt" {
+		t.Fatalf("the load should carry the cursor off blob.dat, landed on %q", got)
+	}
+	if m.diff.scroll != 150 {
+		t.Fatalf("a.txt scroll = %d, want the 150 it was left at", m.diff.scroll)
+	}
+}
+
+// space walks to the next file still to review, and a file the filter hides is
+// not one the user can review.
+func TestReviewCodeOnlySpaceSkipsHiddenFile(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "queue", writeGitRepo(t,
+		map[string]string{
+			"a.go":  "package a\n\nfunc A() int { return 1 }\n",
+			"b.png": "\x89PNG\r\n\x1a\n\x00\x00\x00\x00one",
+			"c.go":  "package a\n\nfunc C() int { return 3 }\n",
+			"d.go":  "package a\n\nfunc D() int { return 4 }\n",
+		},
+		map[string]string{
+			"a.go":  "package a\n\nfunc A() int { return 10 }\n",
+			"b.png": "\x89PNG\r\n\x1a\n\x00\x00\x00\x00two",
+			"c.go":  "package a\n\nfunc C() int { return 30 }\n",
+			"d.go":  "package a\n\nfunc D() int { return 40 }\n",
+		}))
+	paths := make([]string, len(m.diff.set.Files))
+	for i := range m.diff.set.Files {
+		paths[i] = m.diff.set.Files[i].File.Path
+	}
+	want := []string{"a.go", "b.png", "c.go", "d.go"}
+	if strings.Join(paths, ",") != strings.Join(want, ",") {
+		t.Fatalf("file order = %v, want %v", paths, want)
+	}
+
+	m.pressFilterKey(t)
+	m.drainCmds(t, m.switchDiffFile(2))
+	m.pressDiffKey(t, ' ')
+	if !m.fileReviewed("c.go") {
+		t.Fatal("space should mark c.go reviewed")
+	}
+	m.drainCmds(t, m.switchDiffFile(-3))
+	if got := m.diff.set.Files[m.diff.fileIdx].File.Path; got != "a.go" {
+		t.Fatalf("the cursor should be back on a.go, got %q", got)
+	}
+
+	m.pressDiffKey(t, ' ')
+	if got := m.diff.set.Files[m.diff.fileIdx].File.Path; got != "d.go" {
+		t.Fatalf("space should walk past the hidden b.png and the reviewed c.go to d.go, landed on %q", got)
+	}
+}
+
+// Filtering a review whose every change is a blob leaves both panes with
+// nothing to show, which has to read as a state rather than as a broken pane,
+// and leaves tab with nowhere to go.
+func TestReviewCodeOnlyWithNoCodeFiles(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "onlybin", writeGitRepo(t,
+		map[string]string{
+			"b.dat":    "\x00\x01\x02one",
+			"logo.png": "\x89PNG\r\n\x1a\n\x00\x00\x00\x00one",
+		},
+		map[string]string{
+			"b.dat":    "\x00\x01\x02two",
+			"logo.png": "\x89PNG\r\n\x1a\n\x00\x00\x00\x00two",
+		}))
+
+	m.pressFilterKey(t)
+	if list := ansi.Strip(m.viewDiffFileList(30, 20)); !strings.Contains(list, "no code files") {
+		t.Fatalf("the file list should say why it is empty:\n%s", list)
+	}
+	code := ansi.Strip(m.viewDiffCode(60, 20))
+	if strings.Contains(code, "b.dat") {
+		t.Fatalf("the code pane should not render a hidden file:\n%s", code)
+	}
+	if !strings.Contains(code, "no code files") {
+		t.Fatalf("the code pane should say why it is empty:\n%s", code)
+	}
+
+	m.pressDiffKey(t, 'J')
+	if m.diff.fileIdx != 0 {
+		t.Fatalf("tab should not walk the selection through hidden files, fileIdx = %d", m.diff.fileIdx)
 	}
 }
 

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -1466,6 +1466,50 @@ func gitRepoWithBinaryBetweenTextFiles(t *testing.T) string {
 		})
 }
 
+// gitRepoWithLockFileBetweenTextFiles carries a lock file git counts in full,
+// so a header reading that follows the list can be told apart from one that
+// followed every changed file.
+func gitRepoWithLockFileBetweenTextFiles(t *testing.T) string {
+	t.Helper()
+	lock := func(version string) string {
+		return "one " + version + "\ntwo " + version + "\nthree " + version + "\n"
+	}
+	return writeGitRepo(t,
+		map[string]string{
+			"a.go":   "package a\n\nfunc A() int { return 1 }\n",
+			"b.dat":  "\x00\x01\x02one",
+			"c.go":   "package a\n\nfunc C() int { return 3 }\n",
+			"go.sum": lock("v1"),
+		},
+		map[string]string{
+			"a.go":   "package a\n\nfunc A() int { return 10 }\n",
+			"b.dat":  "\x00\x01\x02two",
+			"c.go":   "package a\n\nfunc C() int { return 30 }\n",
+			"go.sum": lock("v2"),
+		})
+}
+
+// A compiled artifact is dropped on its name alone, which is what a file git
+// has not classified yet needs: an untracked one carries no numstat verdict,
+// and nothing sniffs its bytes until the cursor reaches it.
+func TestNonCodePathNamesCompiledArtifacts(t *testing.T) {
+	hidden := []string{
+		"build/Main.class", "app/__pycache__/mod.pyc", "assets/logo.PNG",
+		"go.sum", "Cargo.lock", "web/package-lock.json", "vendor/lib.so",
+	}
+	for _, path := range hidden {
+		if !nonCodePath(path) {
+			t.Errorf("%q should be filtered out of a code-only review", path)
+		}
+	}
+	shown := []string{"main.go", "Main.java", "mod.py", "readme.md", "classy.go"}
+	for _, path := range shown {
+		if nonCodePath(path) {
+			t.Errorf("%q is source and should stay in the review", path)
+		}
+	}
+}
+
 // f drops the files git calls binary out of the review, and neither the
 // selection nor a file switch is left on one of them.
 func TestReviewCodeOnlyHidesBinaryFiles(t *testing.T) {

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -128,6 +128,7 @@ func helpSections() []helpSection {
 			{"d", "remove the comment"},
 			{"C", "send every comment to the agent"},
 			{"space", "mark the file reviewed"},
+			{"f", "code files only (hides images, assets, lock files)"},
 			{"s", "cycle the scope (uncommitted / branch / last commit / staged)"},
 			{"r", "pick the repo when the session dir holds several"},
 			{"b", "pick the branch from the repo's worktrees"},


### PR DESCRIPTION
## What changed

`f` in review mode narrows the file list to the files worth reading line by line. Images, fonts, archives, compiled artifacts and the lock files a package manager rewrites wholesale leave the list, the header's file count and its add/delete totals, and the header carries an `f code only` pill while the filter is on. Press it again and everything comes back. `f` is a plain letter so the key reaches the app when agent-manager itself runs inside a user's tmux, whose prefix owns the control keys.

The verdict is settled by name, so a file an agent has just written is filtered the moment the key is pressed and stays filtered across every silent reload the fingerprint poller triggers. Git's own numstat verdict and the loader's NUL sniff cover a blob whose name gives nothing away; whenever one of those lands under the cursor, the selection is carried to a file the list still shows, with that file scrolled back where it was left. `space` walks the review queue past the hidden rows, and a review whose every change is a blob says `(no code files)` in both panes.

## Why

An agent working in a repo writes images, build output and regenerated lock files alongside its source changes. Every one of them takes a row in the review list, a slot in the `tab` cycle, and a share of the header totals, for a file nobody reads a diff of. `f` puts the list back to the changes a reviewer is actually there to read.

Closes #75

## How it was verified

`gofmt -l .` printed nothing and `go vet ./...` printed nothing:

```
cd /Users/yoan/Desktop/projects/agent-manager-worktrees/issue-75-binary-filter
gofmt -l .
go vet ./...
```

Full suite, then again under the race detector, both from the worktree:

```
env -u TMUX TMUX_TMPDIR=/tmp/am75 go test ./...
env -u TMUX TMUX_TMPDIR=/tmp/am75 go test -race ./...
```

Both runs ended `ok` for all 22 packages, `internal/ui` in 70.4s and 94.7s.

Mutation testing over the eight state-settling guards this change relies on, running only the filter tests (`TestReviewCodeOnly*`, `TestReviewHeaderShowsCodeOnlyFilter`): deleting the name check from `diffFileHidden`, the selection settle from `handleDiffLoaded`, the cursor carry from `handleDiffFileLoaded` (both dropped and downgraded to a direct assignment), the hidden guard from `toggleReviewed`, the all-hidden guard from `switchDiffFile`, the hidden case from `diffBodyNote`, and the hidden skip from the header count. All eight fail the suite; the clean tree passes.

Driven in the real TUI, on an isolated tmux socket and config dir (`TMUX_TMPDIR=/tmp/am75`, `HOME=/tmp/am75home`) so the live sessions were never touched. A session on a repo with `a.go`, `src.go` and `go.sum` modified and `z.png` untracked:

```
review · rev75  s uncommitted  u split  r am75repo  main        4 files · +3 −3 +?
▎○ a.go     +1 −1
 ○ go.sum   +1 −1
 ○ src.go   +1 −1
 ○ z.png        ?
```

After `f`:

```
review · rev75  s uncommitted  u split  f code only  r am75repo  main   2 files · +2 −2
▎○ a.go     +1 −1
 ○ src.go   +1 −1
```

Then, with the filter still on, writing `chart.png` and `blob.dat` into the repo and waiting for the poller: `chart.png` never appeared, `blob.dat` was listed until `tab` reached it, at which point its load sniffed the NUL, it left the list and the cursor landed on `a.go` with its diff on screen. `f` again restored all six rows and the `+?` marker.

The key started this branch as `ctrl+b`; the transcripts above are from the live run made under that binding, and only the key string changed after it. `gofmt -l .`, `go vet ./...` and the full suite were re-run green on the rebind.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] Ran it against real sessions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a code-only review filter, toggled with `f`, that hides images, compiled assets, binaries, and lock files.
  * Updated file counts, navigation, selection, scrolling, and review progression to reflect only visible files.
  * Added an explanatory empty state when no code files remain visible.
  * Documented the new shortcut in the review help and usage guide.
* **Bug Fixes**
  * Preserved selection and scroll position when files are filtered or loaded asynchronously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->