### PR TITLE
feat(ui): open bug and feature GitHub forms from settings

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,11 +37,11 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `space` | Quick prompt: answer the selected session, or spawn an agent in the selected group |
 | `ctrl+r` | Review the selected session's changes: full-screen whole-file diffs, with `c` to comment a line and `C` to send the comments to the agent |
 | `F` | Fold / unfold every group |
-| `s` | Settings (quick-spawn tool, theme, theme follows OS, list density, review layout, after quick send, session keys, ←→ step in/out, worktree sessions, notifications, report a bug) |
+| `s` | Settings (quick-spawn tool, theme, theme follows OS, list density, review layout, after quick send, session keys, ←→ step in/out, worktree sessions, notifications, report a bug, suggest a change) |
 | `\|` | Resize the split: `←→` nudge the divider, `enter` commits, `esc` cancels |
 | `t` | Toggle archived view |
 | `w` | Filter to sessions that need attention (`waiting`, `finished`, `errored`); press again to show all |
-| `M` | Messages (updates, tips; `x` dismisses one for good). The welcome message points at Settings for bug reports. |
+| `M` | Messages (updates, tips; `x` dismisses one for good). The welcome message points at Settings for a bug or an idea. |
 | `e` | Hide / show empty groups |
 | `/` | Search |
 | `?` | The key map: every binding, grouped by what it acts on. It scrolls (`↑↓`/`jk`, `pgup`/`pgdn`, `g`/`G`) and `/` searches it down to one line. |

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -152,7 +152,7 @@ func helpSections() []helpSection {
 		{title: "settings (s)", rows: [][2]string{
 			{"↑↓", "pick a field"},
 			{"←→", "change the value"},
-			{"↵", "run the field's action (CLIs, bug report, update)"},
+			{"↵", "run the field's action (CLIs, report, suggest, update)"},
 			{"esc", "save and close"},
 		}},
 		{title: "dialogs (n, g, r, f, m)", rows: [][2]string{

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -325,20 +325,21 @@ func (m *Model) viewSettings() string {
 	actionRow := func(field int, name, action string) string {
 		return lead(field, name) + keyStyle.Render("↵") + mutedStyle.Render(" "+action)
 	}
-	// Bug report stays accent-colored even when unfocused so the action
-	// reads as a call-to-action among the picker rows above it.
-	bugLead := func() string {
+	// Report and suggest stay accent-colored even when unfocused so the
+	// actions read as a call-to-action among the picker rows above them.
+	ctaLead := func(field int, name string) string {
 		marker := "  "
 		labelStyle := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true)
-		if m.settings.field == settingsFieldBugReport {
+		if m.settings.field == field {
 			marker = lipgloss.NewStyle().Foreground(colorAccent).Render("❯ ")
 			labelStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 		}
-		return marker + padRight(labelStyle.Render("report a bug"), 18)
+		return marker + padRight(labelStyle.Render(name), 18)
 	}
-	bugRow := bugLead() + keyStyle.Render("↵") + " " +
-		lipgloss.NewStyle().Foreground(colorAccent2).Render("open a prefilled GitHub issue")
-	bugNote := subtleStyle.Render("  * found a bug? report it (prefilled)")
+	ctaRow := func(field int, name, action string) string {
+		return ctaLead(field, name) + keyStyle.Render("↵") + " " +
+			lipgloss.NewStyle().Foreground(colorAccent2).Render(action)
+	}
 	body := row(settingsFieldTool, "default tool", toolValue) + "\n" +
 		row(settingsFieldTheme, "theme", themes[m.settings.themeIndex].Name) + "  " +
 		themeSwatch(themes[m.settings.themeIndex]) + "\n" +
@@ -353,13 +354,13 @@ func (m *Model) viewSettings() string {
 		row(settingsFieldNotify, "notifications", notifications) + "\n" +
 		row(settingsFieldNotifyFinish, "notify on finish", notifyFinished) + "\n" +
 		actionRow(settingsFieldCLIs, "CLIs", "show or hide for new sessions") + "\n" +
-		bugRow + "\n" +
-		bugNote + "\n" +
+		ctaRow(settingsFieldBugReport, "report a bug", "open the bug report form") + "\n" +
+		ctaRow(settingsFieldFeatureRequest, "suggest a change", "open the feature request form") + "\n" +
 		m.settingsVersionRow(lead, actionRow)
 	hint := [][2]string{{"↑↓", "field"}, {"←→", "change"}, {"↵/esc", "save"}}
 	switch m.settings.field {
-	case settingsFieldBugReport:
-		hint = [][2]string{{"↑↓", "field"}, {"↵", "open issue"}, {"esc", "save"}}
+	case settingsFieldBugReport, settingsFieldFeatureRequest:
+		hint = [][2]string{{"↑↓", "field"}, {"↵", "open form"}, {"esc", "save"}}
 	case settingsFieldCLIs:
 		hint = [][2]string{{"↑↓", "field"}, {"↵", "manage CLIs"}, {"esc", "save"}}
 	case settingsFieldUpdate:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -406,6 +406,7 @@ const (
 	settingsFieldNotifyFinish
 	settingsFieldCLIs
 	settingsFieldBugReport
+	settingsFieldFeatureRequest
 	settingsFieldUpdate
 	settingsFieldCount
 )

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -151,7 +151,7 @@ func (m *Model) activeNotices() []notice {
 				"x / v  kill / revive         s      settings",
 				"",
 				"Press ? for every key: the map scrolls, and / searches it.",
-				"Found a bug? Settings (s) opens a prefilled report.",
+				"A bug or an idea? Settings (s) has a row for each.",
 				"Messages like this one live here; x dismisses one for good.",
 			},
 			url: repoURL + "#readme",
@@ -186,8 +186,16 @@ func (m *Model) activeNotices() []notice {
 }
 
 func bugReportURL(version string) string {
-	body := fmt.Sprintf("**Version:** %s\n**OS:** %s/%s\n\n**What happened:**\n", version, runtime.GOOS, runtime.GOARCH)
-	return repoURL + "/issues/new?body=" + url.QueryEscape(body)
+	q := url.Values{}
+	q.Set("template", "bug_report.yml")
+	if version != "" {
+		q.Set("version", version)
+	}
+	return repoURL + "/issues/new?" + q.Encode()
+}
+
+func featureRequestURL() string {
+	return repoURL + "/issues/new?template=feature_request.yml"
 }
 
 // arrowStepFeedbackURL prefills a report scoped to the beta ←→ pair, so

--- a/internal/ui/notices_test.go
+++ b/internal/ui/notices_test.go
@@ -62,9 +62,8 @@ func TestActiveNoticesPinnedByDefault(t *testing.T) {
 		}
 	}
 	joined := strings.Join(welcome.body, " ")
-	if !strings.Contains(joined, "Settings (s)") || !strings.Contains(joined, "Found a bug?") ||
-		!strings.Contains(joined, "prefilled report") {
-		t.Fatalf("welcome should point at Settings for bug reports: %q", joined)
+	if !strings.Contains(joined, "Settings (s)") || !strings.Contains(joined, "A bug or an idea?") {
+		t.Fatalf("welcome should point at Settings for a bug or an idea: %q", joined)
 	}
 	for _, n := range m.activeNotices() {
 		if n.id != noticeWelcome && n.url == bugReportURL(m.update.version) {
@@ -328,8 +327,21 @@ func TestBugReportURLPrefillsVersion(t *testing.T) {
 	if !strings.HasPrefix(got, "https://github.com/YoanWai/agent-manager/issues/new") {
 		t.Fatalf("bug report should open the new-issue page, got %q", got)
 	}
-	if !strings.Contains(got, "v0.2.0") {
+	if !strings.Contains(got, "template=bug_report.yml") {
+		t.Fatalf("bug report should use the bug form, got %q", got)
+	}
+	if !strings.Contains(got, "version=v0.2.0") {
 		t.Fatalf("issue URL should carry the version, got %q", got)
+	}
+}
+
+func TestFeatureRequestURLUsesFeatureTemplate(t *testing.T) {
+	got := featureRequestURL()
+	if !strings.Contains(got, "template=feature_request.yml") {
+		t.Fatalf("feature request should use the feature form, got %q", got)
+	}
+	if strings.Contains(got, "template=bug_report.yml") {
+		t.Fatalf("feature request opened the bug form: %q", got)
 	}
 }
 
@@ -478,7 +490,7 @@ func TestOpenNoticesFromList(t *testing.T) {
 func TestNoticesViewListsAndDetails(t *testing.T) {
 	m := modalModel(t)
 	frame := ansi.Strip(m.View())
-	for _, want := range []string{"messages", "Welcome to agent-manager", "Settings (s)", "Found a bug?", "dismiss"} {
+	for _, want := range []string{"messages", "Welcome to agent-manager", "Settings (s)", "A bug or an idea?", "dismiss"} {
 		if !strings.Contains(frame, want) {
 			t.Fatalf("modal missing %q:\n%s", want, frame)
 		}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -253,6 +253,8 @@ func (m *Model) handleSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch m.settings.field {
 		case settingsFieldBugReport:
 			return m, openLink(bugReportURL(m.update.version))
+		case settingsFieldFeatureRequest:
+			return m, openLink(featureRequestURL())
 		case settingsFieldCLIs:
 			m.openCLIPicker()
 			return m, nil

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -169,8 +169,11 @@ func TestSettingsBugReportRowOpensIssue(t *testing.T) {
 		t.Fatal("browser started during Update")
 	}
 	m.applyCmd(t, cmd)
-	if !strings.Contains(opened, "issues/new") {
-		t.Fatalf("enter should open the issue page, got %q", opened)
+	if !strings.Contains(opened, "template=bug_report.yml") {
+		t.Fatalf("enter should open the bug form, got %q", opened)
+	}
+	if !strings.Contains(opened, "version=") {
+		t.Fatalf("bug form should carry the version, got %q", opened)
 	}
 	if m.mode != modeSettings {
 		t.Fatal("the action row must not close settings")
@@ -182,24 +185,54 @@ func TestSettingsBugReportRowOpensIssue(t *testing.T) {
 	}
 }
 
+func TestSettingsFeatureRequestRowOpensForm(t *testing.T) {
+	m := footModel(t)
+	m.cfg = config.Config{Tools: map[string]config.Tool{"claude": {Command: "cat"}}}
+	m.openSettings()
+
+	var opened string
+	openBrowser = func(url string) error {
+		opened = url
+		return nil
+	}
+	t.Cleanup(func() { openBrowser = defaultOpenBrowser })
+
+	m.settings.field = settingsFieldFeatureRequest
+	_, cmd := m.handleSettingsKey(key("enter"))
+	m.applyCmd(t, cmd)
+	if !strings.Contains(opened, "template=feature_request.yml") {
+		t.Fatalf("enter should open the feature form, got %q", opened)
+	}
+	if strings.Contains(opened, "template=bug_report.yml") {
+		t.Fatalf("suggest a change opened the bug form: %q", opened)
+	}
+	if m.mode != modeSettings {
+		t.Fatal("the action row must not close settings")
+	}
+}
+
 func TestSettingsBugReportRowIsHighlighted(t *testing.T) {
 	m := footModel(t)
 	m.cfg = config.Config{Tools: map[string]config.Tool{"claude": {Command: "cat"}}}
 	m.openSettings()
-	// Keep focus off the bug row so the accent2 unfocused styling is what paints.
+	// Keep focus off the CTA rows so the accent2 unfocused styling is what paints.
 	m.settings.field = settingsFieldTool
 	card := ansi.Strip(m.viewSettings())
 	if !strings.Contains(card, "report a bug") {
 		t.Fatalf("settings should show the bug report row: %q", card)
 	}
-	if !strings.Contains(card, "found a bug? report it (prefilled)") {
-		t.Fatalf("settings should show the bug report notice: %q", card)
+	if !strings.Contains(card, "suggest a change") {
+		t.Fatalf("settings should show the feature request row: %q", card)
 	}
-	// Unfocused label uses accent2 + bold; prove that SGR lands on the label itself.
+	// Unfocused labels use accent2 + bold; prove that SGR lands on each label.
 	styled := m.viewSettings()
-	label := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true).Render("report a bug")
-	if !strings.Contains(styled, label) {
+	bugLabel := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true).Render("report a bug")
+	if !strings.Contains(styled, bugLabel) {
 		t.Fatalf("unfocused bug report label should use accent2 bold styling")
+	}
+	ideaLabel := lipgloss.NewStyle().Foreground(colorAccent2).Bold(true).Render("suggest a change")
+	if !strings.Contains(styled, ideaLabel) {
+		t.Fatalf("unfocused feature request label should use accent2 bold styling")
 	}
 }
 


### PR DESCRIPTION
## What changed

Settings now has two action rows: **report a bug** and **suggest a change**. Enter on each opens the matching GitHub issue form (`bug_report.yml` with the installed version filled in, `feature_request.yml`). The welcome message points at both rows.

## Why

Bugs and feature ideas already have different GitHub forms. Settings now has a row for each, so enter lands on the right form and the bug form still carries the installed version.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (`env -u TMUX TMUX_TMPDIR=/tmp/amtest`)
- [x] Ran it against real sessions (`agent-manager-dev`, settings `s`)
