### PR TITLE
feat(cli): print help without starting the TUI

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -60,6 +61,13 @@ func main() {
 	update.SetBuildSource(buildSource)
 
 	if len(os.Args) > 1 {
+		if os.Args[1] == "--help" || os.Args[1] == "-h" {
+			if err := printHelp(os.Stdout); err != nil {
+				fmt.Fprintln(os.Stderr, "agent-manager:", err)
+				os.Exit(1)
+			}
+			return
+		}
 		if os.Args[1] == "--version" || os.Args[1] == "-v" {
 			fmt.Println("agent-manager", version)
 			return
@@ -76,6 +84,24 @@ func main() {
 		fmt.Fprintln(os.Stderr, "agent-manager:", err)
 		os.Exit(1)
 	}
+}
+
+func printHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage: agent-manager [command]
+
+Run the interactive manager when no command is given.
+
+Commands:
+  mcp          Run the Model Context Protocol server for an agent session
+  rename       Rename the current agent session
+  review-repo  Record the repository for the current agent session
+  review-base  Record the base ref for the current agent session
+
+Options:
+  -h, --help     Show this help text
+  -v, --version  Print the installed version
+`)
+	return err
 }
 
 func subcommands() map[string]func(args []string) error {

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -13,6 +15,57 @@ import (
 
 	"github.com/YoanWai/agent-manager/internal/hooks"
 )
+
+func TestPrintHelpDoesNotRequireATerminal(t *testing.T) {
+	var out bytes.Buffer
+	if err := printHelp(&out); err != nil {
+		t.Fatalf("printHelp: %v", err)
+	}
+	for _, want := range []string{
+		"Usage: agent-manager [command]",
+		"Run the interactive manager when no command is given.",
+		"-h, --help",
+		"-v, --version",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("help text does not contain %q:\n%s", want, out.String())
+		}
+	}
+}
+
+type failingHelpWriter struct{}
+
+func (failingHelpWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestPrintHelpReturnsWriteError(t *testing.T) {
+	if err := printHelp(failingHelpWriter{}); err == nil {
+		t.Fatal("printHelp succeeded after the writer failed")
+	}
+}
+
+func TestMainPrintsHelpWithoutStartingTUI(t *testing.T) {
+	if os.Getenv("AGENT_MANAGER_HELP_TEST") == "1" {
+		flag := os.Args[len(os.Args)-1]
+		os.Args = []string{"agent-manager", flag}
+		main()
+		return
+	}
+	for _, flag := range []string{"--help", "-h"} {
+		t.Run(flag, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=TestMainPrintsHelpWithoutStartingTUI", "--", flag)
+			cmd.Env = append(os.Environ(), "AGENT_MANAGER_HELP_TEST=1")
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("agent-manager %s: %v\n%s", flag, err, out)
+			}
+			if !strings.Contains(string(out), "Usage: agent-manager [command]") {
+				t.Fatalf("agent-manager %s did not print help:\n%s", flag, out)
+			}
+		})
+	}
+}
 
 // Startup is the only place the alternate-scroll reset goes out, and it
 // cannot be exercised headlessly: run() takes over the terminal. Reading


### PR DESCRIPTION
## What changed

`--help` and `-h` print usage and return before the interactive manager starts. Write failures propagate. Both flags are covered through `main()` without a TTY.

Split out of #312 (masukiw).

## Why

`agent-manager --help` used to start Bubble Tea, so it failed in a non-interactive environment with `could not open a new TTY`.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test` on the main package (`env -u TMUX TMUX_TMPDIR=/tmp/amhelp`)
- [ ] Ran it against real sessions
- [ ] `go test -race ./...` (CI)