### PR TITLE
docs: require visual evidence in pull requests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -75,6 +75,17 @@ reviews:
           description has no Breaking Changes section that names each
           change. Pass when there is no breaking change, or each one is
           documented.
+      - name: "Visual evidence"
+        mode: warning
+        instructions: >-
+          Check the PR description's Visual evidence section. For a change
+          that can be shown visually, fail when before and after screenshots
+          are missing. Accept a short recording instead when it demonstrates
+          interaction or motion more clearly. If one state cannot be captured,
+          accept the available evidence with an explicit explanation. For a
+          change with no meaningful visual state, accept an explicit reason
+          that visual evidence is not applicable. Fail when the description
+          provides neither useful visual evidence nor an explanation.
       - name: "No speculative fallbacks"
         mode: warning
         instructions: >-

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -63,7 +63,13 @@ automatically. Do not duplicate feature and fix notes in the maintainer message
 feed; see [Release summaries and messages](../docs/notifications.md) for the two
 publishing paths.
 
-In the pull request description, say what changed and why, and how you verified it. Screenshots or a short recording make UI changes much easier to review.
+In the pull request description, say what changed and why, and how you verified
+it. Complete the Visual evidence section for every pull request. Include before
+and after screenshots whenever the change can be shown visually; use a short
+recording when interaction or motion is clearer that way. If useful visual
+evidence is not possible, say why. For example, a new UI may have no
+reproducible before state, while an internal refactor may have no meaningful
+visual state at all.
 
 ## Licensing
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@ Closes #
 - [ ] `gofmt -l .` prints nothing
 - [ ] `go vet ./...` passes
 - [ ] `go test -race ./...` passes
+- [ ] `go build ./...` passes
 - [ ] Ran it against real sessions
 
 ## Visual evidence

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,23 @@ Closes #
 
 ## How it was verified
 
-<!-- Commands you ran, sessions you drove, what you saw. Screenshots or a recording for UI changes. -->
+<!-- Commands you ran, sessions you drove, and what you saw. -->
 
 - [ ] `gofmt -l .` prints nothing
 - [ ] `go vet ./...` passes
 - [ ] `go test -race ./...` passes
 - [ ] Ran it against real sessions
+
+## Visual evidence
+
+<!--
+Add before and after screenshots whenever the change can be shown visually.
+A short recording can replace them when interaction or motion matters more.
+If useful visual evidence is not possible, explain why.
+-->
+
+**Before:**
+
+**After:**
+
+**Not applicable because:**


### PR DESCRIPTION
## What changed

- Added a dedicated Visual evidence section to the pull request template.
- Documented the expectation to provide before and after screenshots when possible.
- Added a CodeRabbit warning when a PR provides neither visual evidence nor an explanation.

## Why

Before and after evidence makes user-visible changes faster and safer to review, while an explicit not-applicable reason keeps the requirement practical for non-visual work.

## How it was verified

- `git diff --check`
- Parsed `.coderabbit.yaml` successfully with Ruby YAML
- `gofmt -l .` prints nothing
- `go vet ./...` passes

## Visual evidence

Not applicable because this changes repository guidance and review configuration, not the rendered application UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pull request guidance and templates with a required Visual evidence section.
  * Contributors should provide before-and-after screenshots or recordings for visually demonstrable changes.
  * When visual evidence is not applicable, contributors can include a brief explanation.

* **Chores**
  * Added an automated check to remind contributors when visual evidence or an explanation is missing from a pull request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->