### PR TITLE
chore(badges): list roshaans in the contributor strip

### DIFF
--- a/tools/badges/contributors.go
+++ b/tools/badges/contributors.go
@@ -40,6 +40,11 @@ var additionalContributors = []contributor{
 		AvatarURL: "https://avatars.githubusercontent.com/u/674667?v=4",
 		Type:      "User",
 	},
+	{
+		Login:     "roshaans",
+		AvatarURL: "https://avatars.githubusercontent.com/u/25015977?v=4",
+		Type:      "User",
+	},
 }
 
 func refreshContributors() error {


### PR DESCRIPTION
## What

Adds @roshaans to `additionalContributors`, the list that carries people GitHub's contributors endpoint leaves out.

## Why

He wrote the terminal naming in #328; #332 reimplemented it on top of the nesting from #323 with him as the commit author. The squash merge turned that authorship into a `Co-authored-by` trailer, and the endpoint the strip is built from counts commit authors only, so the README would have shown the feature without the person who designed it.

## Verified

- `gofmt -l .` silent, `go build ./...` clean, `go test ./tools/badges/` green.
- Avatar id read from `gh api users/roshaans` (`25015977`), matching the shape of the two entries already in the list.