### PR TITLE
docs(feed): announce v0.30.0 and credit the release's contributors

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -1,1 +1,17 @@
-[]
+[
+  {
+    "id": "terminals-under-their-agent",
+    "banner": "new: terminals live under their agent",
+    "title": "Terminals nest under the session they were opened for",
+    "body": [
+      "T on a session opens a shell under it, named after it: terminal-review-done rather than terminal-0ab5.",
+      "Kill, archive, restore and delete take a session's terminals with it, and m moves one onto another agent.",
+      "Agents open and close their own terminals over MCP, so an SSH login you can watch is one tool call away.",
+      "Restore resumes the agent, archive kills the pane it froze, and a session stays working while its shells run.",
+      "The in-session editor key is F3 now, because ctrl+o belongs to the agent in the pane.",
+      "Thanks to @roshaans for the terminal names, @OkunaRei for the selection fix, @sunnor92 for two reports,",
+      "and @andrelago13 for the editor key that moved. #326 is where every binding becomes yours to set."
+    ],
+    "url": "https://github.com/YoanWai/agent-manager/releases/tag/v0.30.0"
+  }
+]


### PR DESCRIPTION
## What

One message-feed entry for v0.30.0: terminals nesting under the session they were opened for, the naming that came with them, the lifecycle keys that now follow the link, MCP `create_terminal` / `close_terminal`, and the editor key on `F3`. It names @roshaans, @OkunaRei, @sunnor92 and @andrelago13, and points at #326 for configurable bindings.

## Why

The feed is what running installs read between releases, and the release this announces is the one that changes where a terminal lives.

## Verified

- Ran the file through the real `sanitize` with a throwaway test: all 7 body lines survive byte for byte, nothing is dropped or truncated (banner 37/60, title 53/80, 7/8 lines, longest line 109/120).
- `https` URL pointing at the published tag, id matches `^[a-z0-9][a-z0-9-]{0,63}$`.