### PR TITLE
feat(ui): animate session startup loaders

### DIFF
--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -449,13 +449,13 @@ func (m *Model) renderTreeRow(entry treeRow, selected bool, width, index int, bg
 // A shell takes a caret rather than an idle dot it would never leave, but
 // a pane that has gone still has to say so.
 func (m *Model) sessionGlyph(sess store.Session) string {
-	resting := sess.Status != status.Dead && sess.Status != status.Errored
-	if resting && m.isShell(sess.Tool) {
-		return subtleStyle.Render(shellGlyph)
-	}
 	if sess.Status == status.Starting {
 		return lipgloss.NewStyle().Foreground(statusColor(status.Starting)).
 			Render(startupFrames[m.startupPhase%len(startupFrames)])
+	}
+	resting := sess.Status != status.Dead && sess.Status != status.Errored
+	if resting && m.isShell(sess.Tool) {
+		return subtleStyle.Render(shellGlyph)
 	}
 	return lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
 }
@@ -718,7 +718,7 @@ func (m *Model) startupLoader(width, height int) []string {
 		centerLine(valueStyle.Bold(true).Render("starting up"), width),
 	}
 	if height <= len(block) {
-		return block[:max(height, 0)]
+		return block[:height]
 	}
 	lines := make([]string, height)
 	copy(lines[(height-len(block))/2:], block)

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -453,6 +453,10 @@ func (m *Model) sessionGlyph(sess store.Session) string {
 	if resting && m.isShell(sess.Tool) {
 		return subtleStyle.Render(shellGlyph)
 	}
+	if sess.Status == status.Starting {
+		return lipgloss.NewStyle().Foreground(statusColor(status.Starting)).
+			Render(startupFrames[m.startupPhase%len(startupFrames)])
+	}
 	return lipgloss.NewStyle().Foreground(statusColor(sess.Status)).Render(statusGlyph(sess.Status))
 }
 
@@ -681,28 +685,44 @@ func focusTopRule(width int) string {
 	return rule
 }
 
-// startupFrames turn a quarter arc around the circle the status marks are
-// drawn from, so a booting session animates in their geometric family while
-// standing clear of every mark that names a state: a frame caught mid-turn
-// cannot be read as one of them.
-var startupFrames = []string{"◜", "◝", "◞", "◟"}
+var startupFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
-// startupLoader is the preview's line for a selected session that is coming
-// up, and "" for every other session. A launching agent leaves its pane
-// blank for as long as it takes to draw, and an empty preview under a live
-// row reads as a broken session rather than one on its way up. paneBooted
-// is the poller's own test for a pane nothing has drawn to, so the loader
-// clears on the first captured frame rather than waiting for the poll that
-// moves the row off the launch state. A focused pane keeps its own first
-// row: that is the screen the user is typing on, and its caret lives there.
-func (m *Model) startupLoader() string {
+const startupRingPoints = 12
+
+func (m *Model) startupLoader(width, height int) []string {
 	sess, ok := m.selected()
 	if !ok || m.mode == modeFocus || sess.Status != status.Starting || paneBooted(m.preview) {
-		return ""
+		return nil
 	}
-	frame := startupFrames[m.startupPhase%len(startupFrames)]
-	return lipgloss.NewStyle().Foreground(statusColor(status.Starting)).
-		Render(frame + " " + statusLabel(status.Starting))
+
+	accent := lipgloss.NewStyle().Foreground(statusColor(status.Starting)).Bold(true)
+	glow := lipgloss.NewStyle().Foreground(statusColor(status.Starting))
+	phase := m.startupPhase % startupRingPoints
+	dot := func(position int) string {
+		switch position {
+		case phase:
+			return accent.Render("●")
+		case (phase + startupRingPoints - 1) % startupRingPoints:
+			return glow.Render("•")
+		default:
+			return subtleStyle.Render("·")
+		}
+	}
+
+	block := []string{
+		centerLine(dot(11)+"   "+dot(0)+"   "+dot(1), width),
+		centerLine(dot(10)+"       "+dot(2), width),
+		centerLine(dot(9)+"       "+dot(3), width),
+		centerLine(dot(8)+"       "+dot(4), width),
+		centerLine(dot(7)+"   "+dot(6)+"   "+dot(5), width),
+		centerLine(valueStyle.Bold(true).Render("starting up"), width),
+	}
+	if height <= len(block) {
+		return block[:max(height, 0)]
+	}
+	lines := make([]string, height)
+	copy(lines[(height-len(block))/2:], block)
+	return lines
 }
 
 // previewLines is the captured pane, filling every row under the detail
@@ -712,17 +732,19 @@ func (m *Model) startupLoader() string {
 // would put a margin around a terminal that has its own.
 func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 	var lines []contentLine
-	loader := m.startupLoader()
+	loader := m.startupLoader(width, height)
 	pane := paneExact(m.preview, height, width)
 	if len(pane) == 0 {
 		// No rows painted means nothing to hit-test: a box left over from
 		// the previous session would catch clicks on empty space.
 		m.pane.box = paneBox{}
-		notice := loader
-		if notice == "" {
-			notice = mutedStyle.Render("(no output yet)")
+		if loader != nil {
+			for _, line := range loader {
+				lines = append(lines, contentLine{text: previewLine(line, width), raw: true})
+			}
+			return lines
 		}
-		return append(lines, contentLine{text: gutter + notice})
+		return append(lines, contentLine{text: gutter + mutedStyle.Render("(no output yet)")})
 	}
 	// Record where these rows land so mouse hit-testing reads the same
 	// geometry the paint used.
@@ -734,11 +756,8 @@ func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 		ok:     true,
 	}
 	for i, line := range pane {
-		// The loader takes the pane's own first row rather than replacing the
-		// block, so the geometry recorded above is the geometry painted: a
-		// session whose pane stays blank keeps every click it would have had.
-		if i == 0 && loader != "" {
-			lines = append(lines, contentLine{text: previewLine(loader, width), raw: true})
+		if i < len(loader) && loader[i] != "" {
+			lines = append(lines, contentLine{text: previewLine(loader[i], width), raw: true})
 			continue
 		}
 		lines = append(lines, contentLine{text: m.renderPaneRow(i, line, width), raw: true})

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -864,28 +864,43 @@ func TestPreviewSkipsLoaderForSettledSessions(t *testing.T) {
 	}
 }
 
-// The loader animates on the preview tick the starting session already
-// earns, and cycles rather than running off the end of its frames.
-func TestPreviewLoaderTurnsOnThePreviewTick(t *testing.T) {
+func TestPreviewLoaderIsCenteredAndMovesOnThePreviewTick(t *testing.T) {
 	m := previewModel(status.Starting, blankCapture)
-	glyph := func() string {
-		line := strings.TrimSpace(previewText(m))
-		if line == "" {
-			t.Fatalf("preview painted nothing")
+	first := previewText(m)
+	lines := strings.Split(first, "\n")
+	painted := make([]int, 0, 6)
+	for i, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			painted = append(painted, i)
 		}
-		return string([]rune(line)[0])
 	}
-	seen := map[string]bool{}
-	first := glyph()
-	for i := 0; i < len(startupFrames); i++ {
-		seen[glyph()] = true
-		m.Update(previewTickMsg{})
+	if len(painted) != 6 || painted[0] != 3 || painted[5] != 8 {
+		t.Fatalf("loader rows = %v, want the middle of a 12-row preview", painted)
 	}
-	if len(seen) != len(startupFrames) {
-		t.Fatalf("loader showed %d of %d frames over a full turn: %v", len(seen), len(startupFrames), seen)
+	if strings.Count(first, "●") != 1 || strings.Count(first, "•") != 1 {
+		t.Fatalf("loader should show one head and one trailing dot, got %q", first)
 	}
-	if got := glyph(); got != first {
-		t.Fatalf("after a full turn the loader shows %q, want %q", got, first)
+	for _, row := range painted {
+		left := len(lines[row]) - len(strings.TrimLeft(lines[row], " "))
+		content := strings.TrimSpace(lines[row])
+		right := 80 - left - ansi.StringWidth(content)
+		if diff := left - right; diff < -1 || diff > 1 {
+			t.Fatalf("loader row %q is not centered: left=%d right=%d", lines[row], left, right)
+		}
+	}
+	m.Update(previewTickMsg{})
+	if next := previewText(m); next == first {
+		t.Fatal("preview loader did not move on the preview tick")
+	}
+}
+
+func TestStartingSessionGlyphMovesOnThePreviewTick(t *testing.T) {
+	m := previewModel(status.Starting, blankCapture)
+	first := ansi.Strip(m.sessionGlyph(m.rows[0].sess))
+	m.Update(previewTickMsg{})
+	second := ansi.Strip(m.sessionGlyph(m.rows[0].sess))
+	if first == second {
+		t.Fatalf("starting session glyph stayed on %q", first)
 	}
 }
 

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/sysstat"
@@ -888,19 +889,26 @@ func TestPreviewLoaderIsCenteredAndMovesOnThePreviewTick(t *testing.T) {
 			t.Fatalf("loader row %q is not centered: left=%d right=%d", lines[row], left, right)
 		}
 	}
-	m.Update(previewTickMsg{})
+	m.Update(startupTickMsg{})
 	if next := previewText(m); next == first {
-		t.Fatal("preview loader did not move on the preview tick")
+		t.Fatal("preview loader did not move on the startup tick")
 	}
 }
 
-func TestStartingSessionGlyphMovesOnThePreviewTick(t *testing.T) {
-	m := previewModel(status.Starting, blankCapture)
-	first := ansi.Strip(m.sessionGlyph(m.rows[0].sess))
-	m.Update(previewTickMsg{})
-	second := ansi.Strip(m.sessionGlyph(m.rows[0].sess))
-	if first == second {
-		t.Fatalf("starting session glyph stayed on %q", first)
+func TestStartingSessionGlyphMovesOnTheStartupTick(t *testing.T) {
+	for _, tool := range []string{"agent", "shell"} {
+		m := previewModel(status.Starting, blankCapture)
+		m.rows[0].sess.Tool = tool
+		m.cfg.Tools = map[string]config.Tool{"shell": {Shell: true}}
+		first := ansi.Strip(m.sessionGlyph(m.rows[0].sess))
+		m.Update(startupTickMsg{})
+		second := ansi.Strip(m.sessionGlyph(m.rows[0].sess))
+		if first == second {
+			t.Fatalf("starting %s glyph stayed on %q", tool, first)
+		}
+		if second == shellGlyph {
+			t.Fatal("starting shell used the resting shell glyph")
+		}
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -187,7 +187,8 @@ type Model struct {
 	bannerPhase int
 
 	// startupPhase advances the launch animation in the rail and preview.
-	startupPhase int
+	startupPhase     int
+	startupAnimating bool
 
 	update updateInfo
 
@@ -486,6 +487,8 @@ func (m *Model) cursorBlink() tea.Cmd {
 // previewTickMsg drives that timer.
 type previewTickMsg struct{}
 
+type startupTickMsg struct{}
+
 func (m *Model) hasStartingRow() bool {
 	for _, row := range m.rows {
 		if !row.isGroup && row.sess.Status == status.Starting {
@@ -495,16 +498,31 @@ func (m *Model) hasStartingRow() bool {
 	return false
 }
 
+func (m *Model) previewInterval() time.Duration {
+	if sess, ok := m.selected(); ok {
+		switch sess.Status {
+		case status.Working, status.Starting:
+			return previewIntervalLive
+		}
+	}
+	return previewIntervalCalm
+}
+
 // previewTick re-arms the preview timer at the cadence the selection earns.
 func (m *Model) previewTick() tea.Cmd {
-	interval := previewIntervalCalm
-	if sess, ok := m.selected(); ok && sess.Status == status.Working {
-		interval = previewIntervalLive
+	return tea.Tick(m.previewInterval(), func(time.Time) tea.Msg { return previewTickMsg{} })
+}
+
+func (m *Model) startStartupTick() tea.Cmd {
+	if m.startupAnimating || !m.hasStartingRow() {
+		return nil
 	}
-	if m.hasStartingRow() {
-		interval = startupInterval
-	}
-	return tea.Tick(interval, func(time.Time) tea.Msg { return previewTickMsg{} })
+	m.startupAnimating = true
+	return m.startupTick()
+}
+
+func (m *Model) startupTick() tea.Cmd {
+	return tea.Tick(startupInterval, func(time.Time) tea.Msg { return startupTickMsg{} })
 }
 
 type errMsg struct{ err error }
@@ -693,7 +711,7 @@ func (m *Model) requestRefresh() {
 
 func (m *Model) Init() tea.Cmd {
 	m.syncPollInput()
-	return tea.Batch(m.syncPaneTheme(), m.refreshExistingSessionUX, m.checkForUpdate, m.checkFeed, m.updateTick(), m.bannerTick(), m.previewTick(), m.sweepPastes, m.pasteSweepTick())
+	return tea.Batch(m.syncPaneTheme(), m.refreshExistingSessionUX, m.checkForUpdate, m.checkFeed, m.updateTick(), m.bannerTick(), m.previewTick(), m.startStartupTick(), m.sweepPastes, m.pasteSweepTick())
 }
 
 // updateMsg carries the result of a GitHub release check. A failed check may
@@ -1037,24 +1055,21 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.handleBrowserOpen(msg)
 		return m, nil
 
-	case previewTickMsg:
+	case startupTickMsg:
+		if !m.hasStartingRow() {
+			m.startupAnimating = false
+			return m, nil
+		}
 		m.startupPhase++
+		return m, m.startupTick()
+
+	case previewTickMsg:
 		// Only the list keeps a live pane on screen; review and the modal
 		// screens have no preview to feed, so they skip the capture and
 		// just keep the timer alive.
 		sess, ok := m.selected()
 		if !ok || (m.mode != modeList && m.mode != modeRename && m.mode != modeFocus) {
 			return m, m.previewTick()
-		}
-		if m.hasStartingRow() {
-			captureInterval := previewIntervalCalm
-			if sess.Status == status.Working || sess.Status == status.Starting {
-				captureInterval = previewIntervalLive
-			}
-			captureEvery := int((captureInterval + startupInterval - 1) / startupInterval)
-			if m.startupPhase%captureEvery != 0 {
-				return m, m.previewTick()
-			}
 		}
 		// A session with a control client already pushes every frame; a
 		// tick capture on top of that is work whose result is discarded.
@@ -1104,7 +1119,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if sess, ok := m.selected(); ok && sess.ID != msg.procFor {
 			m.syncPollInput()
 			m.previewGen++
-			return m, tea.Batch(focusExit, m.previewCmd(sess, m.previewGen), m.diffRefreshCmd())
+			return m, tea.Batch(focusExit, m.previewCmd(sess, m.previewGen), m.diffRefreshCmd(), m.startStartupTick())
 		}
 		m.proc = msg.proc
 		m.procFor = msg.procFor
@@ -1115,7 +1130,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.watchSelection()
 		}
 		m.watchedGen = m.previewGen
-		return m, tea.Batch(focusExit, m.diffRefreshCmd())
+		return m, tea.Batch(focusExit, m.diffRefreshCmd(), m.startStartupTick())
 
 	case updateMsg:
 		if msg.manual {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -186,9 +186,7 @@ type Model struct {
 	// the frame is not repainted forever.
 	bannerPhase int
 
-	// startupPhase advances the preview's launch loader. It rides the
-	// preview tick, which already runs at its fast cadence while a session
-	// is starting, rather than adding a timer of its own.
+	// startupPhase advances the launch animation in the rail and preview.
 	startupPhase int
 
 	update updateInfo
@@ -466,6 +464,7 @@ const previewSettle = 50 * time.Millisecond
 // agent that is producing output earns a fast cadence, one that is waiting
 // on a human does not.
 const (
+	startupInterval     = 80 * time.Millisecond
 	previewIntervalLive = 300 * time.Millisecond
 	previewIntervalCalm = 1200 * time.Millisecond
 	updateTickInterval  = 10 * time.Minute
@@ -487,14 +486,23 @@ func (m *Model) cursorBlink() tea.Cmd {
 // previewTickMsg drives that timer.
 type previewTickMsg struct{}
 
+func (m *Model) hasStartingRow() bool {
+	for _, row := range m.rows {
+		if !row.isGroup && row.sess.Status == status.Starting {
+			return true
+		}
+	}
+	return false
+}
+
 // previewTick re-arms the preview timer at the cadence the selection earns.
 func (m *Model) previewTick() tea.Cmd {
 	interval := previewIntervalCalm
-	if sess, ok := m.selected(); ok {
-		switch sess.Status {
-		case status.Working, status.Starting:
-			interval = previewIntervalLive
-		}
+	if sess, ok := m.selected(); ok && sess.Status == status.Working {
+		interval = previewIntervalLive
+	}
+	if m.hasStartingRow() {
+		interval = startupInterval
 	}
 	return tea.Tick(interval, func(time.Time) tea.Msg { return previewTickMsg{} })
 }
@@ -1037,6 +1045,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		sess, ok := m.selected()
 		if !ok || (m.mode != modeList && m.mode != modeRename && m.mode != modeFocus) {
 			return m, m.previewTick()
+		}
+		if m.hasStartingRow() {
+			captureInterval := previewIntervalCalm
+			if sess.Status == status.Working || sess.Status == status.Starting {
+				captureInterval = previewIntervalLive
+			}
+			captureEvery := int((captureInterval + startupInterval - 1) / startupInterval)
+			if m.startupPhase%captureEvery != 0 {
+				return m, m.previewTick()
+			}
 		}
 		// A session with a control client already pushes every frame; a
 		// tick capture on top of that is work whose result is discarded.

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -186,7 +186,6 @@ type Model struct {
 	// the frame is not repainted forever.
 	bannerPhase int
 
-	// startupPhase advances the launch animation in the rail and preview.
 	startupPhase     int
 	startupAnimating bool
 
@@ -508,7 +507,6 @@ func (m *Model) previewInterval() time.Duration {
 	return previewIntervalCalm
 }
 
-// previewTick re-arms the preview timer at the cadence the selection earns.
 func (m *Model) previewTick() tea.Cmd {
 	return tea.Tick(m.previewInterval(), func(time.Time) tea.Msg { return previewTickMsg{} })
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -25,6 +25,45 @@ func TestPreviewSettleDropsStaleGen(t *testing.T) {
 	}
 }
 
+func TestPreviewCadenceIsIndependentFromStartupAnimation(t *testing.T) {
+	tests := []struct {
+		name string
+		rows []treeRow
+		want time.Duration
+	}{
+		{"selected starting", []treeRow{{sess: store.Session{Status: status.Starting}}}, previewIntervalLive},
+		{"selected working", []treeRow{{sess: store.Session{Status: status.Working}}, {sess: store.Session{Status: status.Starting}}}, previewIntervalLive},
+		{"selected idle", []treeRow{{sess: store.Session{Status: status.Idle}}, {sess: store.Session{Status: status.Starting}}}, previewIntervalCalm},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{rows: tt.rows}
+			if got := m.previewInterval(); got != tt.want {
+				t.Fatalf("preview interval = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartupTickRunsOnlyWhileAStartingRowIsVisible(t *testing.T) {
+	m := &Model{}
+	if cmd := m.startStartupTick(); cmd != nil {
+		t.Fatal("startup tick began without a starting row")
+	}
+	m.rows = []treeRow{{sess: store.Session{Status: status.Starting}}}
+	if cmd := m.startStartupTick(); cmd == nil || !m.startupAnimating {
+		t.Fatal("starting row did not begin the startup tick")
+	}
+	if cmd := m.startStartupTick(); cmd != nil {
+		t.Fatal("an active startup tick was scheduled twice")
+	}
+	m.rows[0].sess.Status = status.Idle
+	_, cmd := m.Update(startupTickMsg{})
+	if cmd != nil || m.startupAnimating {
+		t.Fatal("startup tick kept running after the starting row settled")
+	}
+}
+
 func TestMoveCursorDebouncesPreview(t *testing.T) {
 	m := &Model{
 		mode:   modeList,

--- a/internal/ui/terminals_section_test.go
+++ b/internal/ui/terminals_section_test.go
@@ -41,7 +41,12 @@ func groupWithShell(t *testing.T, m *Model, group string) {
 func TestRestingShellUsesCaretGlyph(t *testing.T) {
 	m := buildModel(t)
 	m.applyCmd(t, m.refreshCmd())
-	spawnTerminal(t, m)
+	shell := spawnTerminal(t, m)
+	for i := range m.rows {
+		if m.rows[i].sess.ID == shell.ID {
+			m.rows[i].sess.Status = status.Idle
+		}
+	}
 
 	if rail := m.rail(); !strings.Contains(rail, shellGlyph) {
 		t.Fatalf("a resting shell should carry the caret:\n%s", rail)
@@ -52,6 +57,7 @@ func TestDeadInlineShellKeepsItsStatusGlyph(t *testing.T) {
 	m := buildModel(t)
 	m.applyCmd(t, m.refreshCmd())
 	shell := spawnTerminal(t, m)
+	shell.Status = status.Idle
 
 	if glyph := ansi.Strip(m.sessionGlyph(shell)); glyph != shellGlyph {
 		t.Fatalf("a resting shell wears the caret, got %q", glyph)


### PR DESCRIPTION
## What changed

- animate every starting session row with a smooth ten-frame spinner
- center a large twelve-position launch ring in an empty session preview
- advance loader frames at 80 ms while keeping pane capture near its existing cadence

## Why

The existing startup indicator was a small four-frame arc fixed to the preview's first row, while the session row itself stayed static. A launch could therefore look stalled or broken even though the agent was still starting.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] `go build ./...` passes
- [x] Ran it against real sessions

The loader was iterated and visually checked in the locally installed `dev` build. The animation stays smooth while tmux pane captures remain throttled.

## Visual evidence

Text-mode snapshots preserve the terminal geometry; the motion was verified live in the `dev` build.

**Before:**

```text
◜ starting up
```

**After:**

```text
·   ·   •
·       ●
·       ·
·       ·
·   ·   ·
starting up
```

**Not applicable because:** Screenshots cannot show the animation cadence; the static terminal geometry is reproduced above and motion was checked live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added animated startup indicators to session status icons.
  - Updated preview loading screens with a centered circular animation and “starting up” label.
  - Preview loaders can now overlay available pane output while preserving existing fallback behavior.
  - Startup animations advance smoothly while sessions are launching, with responsive preview updates.
  - Startup indicators adapt to the selected session type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->