### PR TITLE
fix(session): stop losing the first message sent into a launching agent

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -49,6 +49,10 @@ type Session struct {
 	PendingInputs       []string
 	PendingInputClaimed bool
 	ParentID            string
+	// LaunchPrompt is the prompt handed to the agent on its command line.
+	// Pending input waits for it to show in the pane, because an agent
+	// taking it clears the composer and anything pasted there.
+	LaunchPrompt string
 }
 
 // LaunchTime is when the agent now in the pane started: the last restart,
@@ -100,7 +104,8 @@ CREATE TABLE IF NOT EXISTS sessions (
 	last_status_at INTEGER NOT NULL,
 	agent_session_id TEXT NOT NULL DEFAULT '',
 	pending_inputs TEXT NOT NULL DEFAULT '[]',
-	pending_claimed INTEGER NOT NULL DEFAULT 0
+	pending_claimed INTEGER NOT NULL DEFAULT 0,
+	launch_prompt  TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS groups (
 	name       TEXT PRIMARY KEY,
@@ -146,6 +151,7 @@ CREATE TABLE IF NOT EXISTS settings (
 		`ALTER TABLE sessions ADD COLUMN pending_inputs TEXT NOT NULL DEFAULT '[]'`,
 		`ALTER TABLE sessions ADD COLUMN pending_claimed INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN parent_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN launch_prompt TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, migration := range migrations {
 		if _, err := s.db.Exec(migration); err != nil {
@@ -301,12 +307,13 @@ func (s *Store) createSession(sess Session, anchorID string) error {
 		sess.Group = parentGroup
 	}
 	_, err = tx.Exec(
-		`INSERT INTO sessions (id, name, tool, cwd, group_name, status, archived, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, pending_inputs, parent_id, sort_order)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+		`INSERT INTO sessions (id, name, tool, cwd, group_name, status, archived, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, pending_inputs, parent_id, launch_prompt, sort_order)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 		         (SELECT COALESCE(MAX(sort_order)+1, 0) FROM sessions WHERE group_name = ? AND parent_id = ?))`,
 		sess.ID, sess.Name, sess.Tool, sess.Cwd, sess.Group, sess.Status,
 		boolToInt(sess.Archived), encodeTime(sess.CreatedAt), encodeTime(sess.LastStatusAt), sess.AgentSessionID,
-		sess.WorktreeRepo, sess.WorktreeBranch, pendingInputs, sess.ParentID, sess.Group, sess.ParentID,
+		sess.WorktreeRepo, sess.WorktreeBranch, pendingInputs, sess.ParentID, sess.LaunchPrompt,
+		sess.Group, sess.ParentID,
 	)
 	if err != nil {
 		return err
@@ -370,7 +377,7 @@ func (s *Store) AddGroup(name, path, worktree string) error {
 }
 
 func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
-	query := `SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id, pending_inputs, pending_claimed, parent_id
+	query := `SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id, pending_inputs, pending_claimed, parent_id, launch_prompt
 	          FROM sessions`
 	if !includeArchived {
 		query += ` WHERE archived = 0`
@@ -391,7 +398,7 @@ func (s *Store) ListSessions(includeArchived bool) ([]Session, error) {
 		if err := rows.Scan(&sess.ID, &sess.Name, &sess.Tool, &sess.Cwd,
 			&sess.Group, &sess.Status, &archived, &acked, &created, &lastStatus,
 			&sess.AgentSessionID, &sess.WorktreeRepo, &sess.WorktreeBranch,
-			&agentLaunched, &sess.RetiredAgentSessionID, &pendingInputs, &pendingClaimed, &sess.ParentID); err != nil {
+			&agentLaunched, &sess.RetiredAgentSessionID, &pendingInputs, &pendingClaimed, &sess.ParentID, &sess.LaunchPrompt); err != nil {
 			return nil, err
 		}
 		if err := json.Unmarshal([]byte(pendingInputs), &sess.PendingInputs); err != nil {
@@ -414,11 +421,11 @@ func (s *Store) Get(id string) (Session, error) {
 	var created, lastStatus, agentLaunched int64
 	var pendingInputs string
 	err := s.db.QueryRow(
-		`SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id, pending_inputs, pending_claimed, parent_id
+		`SELECT id, name, tool, cwd, group_name, status, archived, acked, created_at, last_status_at, agent_session_id, worktree_repo, worktree_branch, agent_launched_at, retired_agent_session_id, pending_inputs, pending_claimed, parent_id, launch_prompt
 		 FROM sessions WHERE id = ?`, id,
 	).Scan(&sess.ID, &sess.Name, &sess.Tool, &sess.Cwd, &sess.Group,
 		&sess.Status, &archived, &acked, &created, &lastStatus, &sess.AgentSessionID,
-		&sess.WorktreeRepo, &sess.WorktreeBranch, &agentLaunched, &sess.RetiredAgentSessionID, &pendingInputs, &pendingClaimed, &sess.ParentID)
+		&sess.WorktreeRepo, &sess.WorktreeBranch, &agentLaunched, &sess.RetiredAgentSessionID, &pendingInputs, &pendingClaimed, &sess.ParentID, &sess.LaunchPrompt)
 	if err != nil {
 		return Session{}, err
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -772,6 +772,28 @@ func TestSessionWorktreeColumnsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestLaunchPromptRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	prompt := "/create-jira-issue plan the sprint"
+	if err := s.CreateSession(Session{ID: "lp1", Name: "claude-1ff0", Tool: "claude", Cwd: "/tmp", LaunchPrompt: prompt}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := s.Get("lp1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.LaunchPrompt != prompt {
+		t.Fatalf("launch prompt = %q, want %q", got.LaunchPrompt, prompt)
+	}
+	list, err := s.ListSessions(true)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if list[0].LaunchPrompt != prompt {
+		t.Fatalf("list dropped the launch prompt: %+v", list[0])
+	}
+}
+
 func TestMoveSessionWorktree(t *testing.T) {
 	s := newTestStore(t)
 	sess := Session{

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"errors"
 	"path/filepath"
 	"slices"
@@ -791,6 +792,58 @@ func TestLaunchPromptRoundTrip(t *testing.T) {
 	}
 	if list[0].LaunchPrompt != prompt {
 		t.Fatalf("list dropped the launch prompt: %+v", list[0])
+	}
+}
+
+// A database from before the column reaches it through the migration, where
+// its rows read back with the empty prompt that turns the wait off.
+func TestLaunchPromptMigratesAnExistingDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	legacy, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy: %v", err)
+	}
+	if _, err := legacy.Exec(`CREATE TABLE sessions (
+		id             TEXT PRIMARY KEY,
+		name           TEXT NOT NULL,
+		tool           TEXT NOT NULL,
+		cwd            TEXT NOT NULL,
+		group_name     TEXT NOT NULL,
+		status         TEXT NOT NULL,
+		archived       INTEGER NOT NULL DEFAULT 0,
+		created_at     INTEGER NOT NULL,
+		last_status_at INTEGER NOT NULL
+	);
+	INSERT INTO sessions (id, name, tool, cwd, group_name, status, created_at, last_status_at)
+	VALUES ('old', 'claude-1ff0', 'claude', '/tmp', '', 'idle', 0, 0)`); err != nil {
+		t.Fatalf("seed legacy schema: %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("close legacy: %v", err)
+	}
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("open migrated: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	old, err := s.Get("old")
+	if err != nil {
+		t.Fatalf("get migrated row: %v", err)
+	}
+	if old.LaunchPrompt != "" {
+		t.Fatalf("migrated row launch prompt = %q, want empty", old.LaunchPrompt)
+	}
+	if err := s.CreateSession(Session{ID: "new", Name: "n", Tool: "claude", Cwd: "/tmp", LaunchPrompt: "/compact"}); err != nil {
+		t.Fatalf("create after migration: %v", err)
+	}
+	got, err := s.Get("new")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.LaunchPrompt != "/compact" {
+		t.Fatalf("launch prompt = %q, want /compact", got.LaunchPrompt)
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -411,18 +411,23 @@ func (d *Driver) awaitPasteEcho(target, before, text string) {
 	}
 }
 
-// MessageOpening is the slice of a message to look for in a pane. It stays
-// short and stops at the first line break because a composer wraps a long
-// message across lines, splitting any longer match.
+// MessageOpening is the slice of a message to look for in a pane: its first
+// line with anything on it, cut short because a composer wraps a long line
+// and would split any longer match. A message that opens on a blank line
+// still has to be waited for, so the blank lines are skipped rather than
+// answered with nothing to match.
 func MessageOpening(text string) string {
-	line := text
-	if end := strings.IndexAny(line, "\r\n"); end >= 0 {
-		line = line[:end]
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if runes := []rune(line); len(runes) > 16 {
+			line = strings.TrimSpace(string(runes[:16]))
+		}
+		return line
 	}
-	if runes := []rune(line); len(runes) > 16 {
-		line = string(runes[:16])
-	}
-	return strings.TrimSpace(line)
+	return ""
 }
 
 // paste loads text into a tmux buffer and pastes it into the pane.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -376,11 +376,17 @@ const (
 // carriage return as part of the bracketed paste rather than as a submit,
 // stranding the message in the composer.
 func (d *Driver) pasteAndEnter(target, text string) error {
-	before, _ := d.capturePlain(target)
+	before, baseline := d.capturePlain(target)
 	if err := d.paste(target, text); err != nil {
 		return err
 	}
-	d.awaitPasteEcho(target, before, text)
+	if baseline != nil {
+		// Without a baseline, text already on screen reads as the new paste,
+		// so the pane gets the whole window to draw it rather than a match.
+		time.Sleep(echoWait)
+	} else {
+		d.awaitPasteEcho(target, before, text)
+	}
 	_, err := d.run("send-keys", "-t", target, "Enter")
 	return err
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 const prefix = "am_"
@@ -363,12 +364,59 @@ func (d *Driver) Paste(id, text string) error {
 
 var pasteSeq atomic.Uint64
 
+// Only a pane that never echoes what it reads waits out echoWait; an agent
+// redraws a paste in tens of milliseconds, even mid-launch.
+const (
+	echoWait = time.Second
+	echoPoll = 25 * time.Millisecond
+)
+
+// pasteAndEnter holds the Enter until the pane has drawn the paste. Both
+// writes reach one pty, and a pane too busy to read between them takes the
+// carriage return as part of the bracketed paste rather than as a submit,
+// stranding the message in the composer.
 func (d *Driver) pasteAndEnter(target, text string) error {
+	before, _ := d.capturePlain(target)
 	if err := d.paste(target, text); err != nil {
 		return err
 	}
+	d.awaitPasteEcho(target, before, text)
 	_, err := d.run("send-keys", "-t", target, "Enter")
 	return err
+}
+
+// A pane that draws the paste some other way, as a collapsed placeholder or
+// not at all, is released at the cap and submits the way it did before.
+func (d *Driver) awaitPasteEcho(target, before, text string) {
+	opening := MessageOpening(text)
+	if opening == "" {
+		return
+	}
+	was := strings.Count(before, opening)
+	deadline := time.Now().Add(echoWait)
+	for {
+		if pane, err := d.capturePlain(target); err == nil && strings.Count(pane, opening) > was {
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(echoPoll)
+	}
+}
+
+// MessageOpening is the slice of a message to look for in a pane. It stays
+// short and stops at the first line break because a composer wraps a long
+// message across lines, splitting any longer match.
+func MessageOpening(text string) string {
+	line := text
+	if end := strings.IndexAny(line, "\r\n"); end >= 0 {
+		line = line[:end]
+	}
+	if runes := []rune(line); len(runes) > 16 {
+		line = string(runes[:16])
+	}
+	return strings.TrimSpace(line)
 }
 
 // paste loads text into a tmux buffer and pastes it into the pane.
@@ -477,6 +525,12 @@ func (d *Driver) Exists(id string) bool {
 // (-e), so previews keep the session's real colors. Strip before regex use.
 func (d *Driver) CapturePane(id string) (string, error) {
 	return d.run("capture-pane", "-p", "-e", "-t", sessionName(id))
+}
+
+// capturePlain drops the escapes CapturePane keeps, which an application is
+// free to write partway through a line, breaking a match on the text.
+func (d *Driver) capturePlain(target string) (string, error) {
+	return d.run("capture-pane", "-p", "-t", target)
 }
 
 // Resize pins a detached session's window to the given dimensions so its

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -229,7 +229,8 @@ func TestSendTextSubmitsIntoAPaneThatReadsLate(t *testing.T) {
 	reads := "/tmp/am-late-" + id
 	t.Cleanup(func() { os.Remove(reads) })
 
-	text := "hello world"
+	// Opens on a blank line, which still has to be waited for.
+	text := "\nhello world"
 	// Stalls before its first read, then logs each read between pipes and
 	// echoes it back so the pane shows what it took.
 	command := "stty raw -echo; printf '\\033[?2004h'; sleep 0.4; " +

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -257,6 +257,40 @@ func TestSendTextSubmitsIntoAPaneThatReadsLate(t *testing.T) {
 	t.Fatalf("pane reads = %q, want the paste to end a read (%q) before the Enter", got, want)
 }
 
+// A capture that fails leaves no baseline to measure the paste against, and
+// text already on screen would pass for it, so the Enter waits the window out
+// rather than matching against nothing.
+func TestSendTextWaitsOutTheWindowWhenTheBaselineCaptureFails(t *testing.T) {
+	dir := t.TempDir()
+	callLog := dir + "/calls"
+	stub := dir + "/tmux"
+	// Fails the first capture, then answers every later one with a pane that
+	// already holds the message.
+	script := "#!/bin/sh\necho \"$@\" >> " + callLog + "\n" +
+		"case \"$*\" in *capture-pane*)\n" +
+		"  [ \"$(grep -c capture-pane " + callLog + ")\" = 1 ] && exit 1\n" +
+		"  echo 'hello world';;\nesac\nexit 0\n"
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil {
+		t.Fatalf("stub: %v", err)
+	}
+	driver := &Driver{bin: stub, socket: testSocket}
+
+	start := time.Now()
+	if err := driver.SendText("x1", "hello world"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < echoWait {
+		t.Fatalf("Enter went out after %v, want the pane to get its full %v", elapsed, echoWait)
+	}
+	logged, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read call log: %v", err)
+	}
+	if !strings.Contains(string(logged), "send-keys -t am_x1 Enter") {
+		t.Fatalf("Enter never sent, calls:\n%s", logged)
+	}
+}
+
 // A clipboard paste forwarded into a focused pane must arrive inside the
 // pane's bracketed-paste markers with no Enter after it, so agent composers
 // keep multi-line text instead of submitting on the first newline.

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -220,6 +220,43 @@ func TestSendTextKeepsEnterOutsideBracketedPaste(t *testing.T) {
 	t.Fatalf("pane input = %q, want bracketed paste followed by Enter %q", got, want)
 }
 
+// A pane too busy to read between the two writes takes the carriage return
+// as part of the bracketed paste, so the Enter has to reach it as a read of
+// its own, however late the pane gets around to reading.
+func TestSendTextSubmitsIntoAPaneThatReadsLate(t *testing.T) {
+	driver := requireTmux(t)
+	id := "late" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	reads := "/tmp/am-late-" + id
+	t.Cleanup(func() { os.Remove(reads) })
+
+	text := "hello world"
+	// Stalls before its first read, then logs each read between pipes and
+	// echoes it back so the pane shows what it took.
+	command := "stty raw -echo; printf '\\033[?2004h'; sleep 0.4; " +
+		"while :; do dd bs=4096 count=1 2>/dev/null | tee -a " + ShellQuote(reads) +
+		"; printf '|' >> " + ShellQuote(reads) + "; done"
+	if err := driver.Create(id, "/tmp", command, nil, 0, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+
+	time.Sleep(100 * time.Millisecond)
+	if err := driver.SendText(id, text); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+
+	want := "\x1b[201~|\r"
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if got, err := os.ReadFile(reads); err == nil && strings.Contains(string(got), want) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	got, _ := os.ReadFile(reads)
+	t.Fatalf("pane reads = %q, want the paste to end a read (%q) before the Enter", got, want)
+}
+
 // A clipboard paste forwarded into a focused pane must arrive inside the
 // pane's bracketed-paste markers with no Enter after it, so agent composers
 // keep multi-line text instead of submitting on the first newline.

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -611,6 +611,12 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 	if deferDirective {
 		pendingInputs = append(pendingInputs, deferredRenameDirective)
 	}
+	// A tool typed into receives its prompt as the first pending input, so
+	// there is nothing for later input to wait behind.
+	commandLinePrompt := prompt
+	if tool.PromptMode == "send" {
+		commandLinePrompt = ""
+	}
 	// Tools that accept a chosen session id launch with one, so a later
 	// revive resumes this exact conversation rather than the directory's
 	// most recent one. Tools without the flag mint their own id, captured
@@ -633,6 +639,7 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 		WorktreeRepo:   worktreeRepo,
 		WorktreeBranch: worktreeBranch,
 		PendingInputs:  pendingInputs,
+		LaunchPrompt:   commandLinePrompt,
 	}, tool, base, launchOptions{
 		rollbackWorktree: worktreeRepo != "",
 	}); err != nil {

--- a/internal/ui/form_test.go
+++ b/internal/ui/form_test.go
@@ -840,3 +840,38 @@ func TestGroupFormStoresWorktreeChoice(t *testing.T) {
 		t.Fatalf("group form should store the worktree choice, got %+v", groups)
 	}
 }
+
+// The poller waits for a prompt the agent has to pick up on its own, so only
+// a command-line prompt is stored; a tool typed into gets its prompt as the
+// first pending input instead. Read before the first poll, which delivers it.
+func TestSpawnStoresOnlyACommandLinePrompt(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+
+	if err := m.spawnSession("ready-tool", "ready-tool-abcd", dir, "", "/compact", true, false); err != nil {
+		t.Fatalf("command-line spawn: %v", err)
+	}
+	if err := m.spawnSession("send-tool", "send-tool-abcd", dir, "", "/compact", true, false); err != nil {
+		t.Fatalf("send spawn: %v", err)
+	}
+
+	sessions, err := m.store.ListSessions(true)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, sess := range sessions {
+		switch sess.Tool {
+		case "ready-tool":
+			if sess.LaunchPrompt != "/compact" {
+				t.Fatalf("command-line launch prompt = %q, want /compact", sess.LaunchPrompt)
+			}
+		case "send-tool":
+			if sess.LaunchPrompt != "" {
+				t.Fatalf("typed prompt stored as a launch prompt: %q", sess.LaunchPrompt)
+			}
+			if len(sess.PendingInputs) == 0 || sess.PendingInputs[0] != "/compact" {
+				t.Fatalf("typed prompt is not the first pending input: %q", sess.PendingInputs)
+			}
+		}
+	}
+}

--- a/internal/ui/helpers_test.go
+++ b/internal/ui/helpers_test.go
@@ -56,6 +56,13 @@ func buildModel(t *testing.T) *Model {
 				DefaultStatus:  status.Idle,
 				ActivityCutoff: "(?m)^❯",
 			},
+			// Draws its input line at once and takes the prompt it launched
+			// with half a second later, the way an agent finishes booting.
+			"slow-take-tool": {
+				Command:        `sh -c 'printf "❯ "; sleep 0.5; printf "\n❯ %s\n❯ " "$0"; cat'`,
+				DefaultStatus:  status.Idle,
+				ActivityCutoff: "(?m)^❯",
+			},
 			// Stands in for the agent CLIs, which turn on mouse tracking and
 			// scroll themselves instead of leaving history for tmux.
 			"mouse-tool": {

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -493,7 +493,11 @@ func (p *poller) maybeSendPendingInput(sess store.Session, pane string, agentAli
 	if !agentAlive {
 		return false, nil
 	}
-	if _, ready := p.engine.ActivityRegion(sess.Tool, ansi.Strip(pane)); !ready {
+	region, ready := p.engine.ActivityRegion(sess.Tool, ansi.Strip(pane))
+	if !ready {
+		return false, nil
+	}
+	if !launchPromptTaken(sess, region) {
 		return false, nil
 	}
 	claimed, err := p.store.ClaimPendingInput(sess.ID, input)
@@ -511,6 +515,22 @@ func (p *poller) maybeSendPendingInput(sess store.Session, pane string, agentAli
 		return false, fmt.Errorf("record pending input delivery for %s: %w", sess.Name, err)
 	}
 	return consumed, nil
+}
+
+// launchPromptGrace releases pending input for a session whose prompt
+// scrolled out of the pane, or whose agent never drew it there.
+const launchPromptGrace = 30 * time.Second
+
+// launchPromptTaken reports whether an agent has picked up the prompt it
+// launched with, which the prompt reaching finished output proves. Input
+// delivered before that is lost: taking the prompt clears the composer, and
+// anything pasted there goes with it.
+func launchPromptTaken(sess store.Session, region string) bool {
+	opening := tmux.MessageOpening(sess.LaunchPrompt)
+	if opening == "" || strings.Contains(region, opening) {
+		return true
+	}
+	return time.Since(sess.LaunchTime()) > launchPromptGrace
 }
 
 // applyPendingRename picks up a name the session's agent left via the

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -943,3 +943,19 @@ func TestPendingInputWaitsForTheLaunchPrompt(t *testing.T) {
 		t.Fatalf("pane should hold the directive, got:\n%s", pane)
 	}
 }
+
+// A prompt that never reaches the pane, because it scrolled out or the agent
+// never drew it, must not hold pending input past the grace.
+func TestLaunchPromptTakenGivesUpAfterTheGrace(t *testing.T) {
+	fresh := store.Session{LaunchPrompt: "/compact plan the sprint", CreatedAt: time.Now()}
+	if launchPromptTaken(fresh, "no prompt here") {
+		t.Fatal("pending input released before the prompt showed")
+	}
+	if !launchPromptTaken(fresh, "❯ /compact plan the sprint\nworking") {
+		t.Fatal("prompt in the region should release pending input")
+	}
+	stale := store.Session{LaunchPrompt: fresh.LaunchPrompt, CreatedAt: time.Now().Add(-launchPromptGrace - time.Second)}
+	if !launchPromptTaken(stale, "no prompt here") {
+		t.Fatal("pending input still held after the grace")
+	}
+}

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -901,5 +902,44 @@ func TestCaptureAgentSessionIDsDropsAnAnswerARestartOutran(t *testing.T) {
 	}
 	if got.AgentSessionID != "" {
 		t.Fatalf("restarted session bound to %q, want it left for the next pass", got.AgentSessionID)
+	}
+}
+
+// Taking the launch prompt clears the composer, so a directive delivered
+// before then is discarded and has to wait for the prompt to reach output.
+func TestPendingInputWaitsForTheLaunchPrompt(t *testing.T) {
+	m := buildModel(t)
+	if err := m.spawnSession("slow-take-tool", "slow-take-tool-abcd", t.TempDir(), "", "/compact", true, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	sess := m.sessionRows()[0]
+
+	// The input line is drawn from the first frame, so without the wait the
+	// directive would be gone by now.
+	for tries := 0; tries < 3; tries++ {
+		if !sessionHasPendingInput(t, m, sess.ID, deferredRenameDirective) {
+			pane, _ := m.tmux.CapturePane(sess.ID)
+			t.Fatalf("directive sent before the prompt was taken; pane:\n%s", pane)
+		}
+		time.Sleep(50 * time.Millisecond)
+		m.applyCmd(t, m.refreshCmd())
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for sessionHasPendingInput(t, m, sess.ID, deferredRenameDirective) {
+		if time.Now().After(deadline) {
+			pane, _ := m.tmux.CapturePane(sess.ID)
+			t.Fatalf("directive never sent after the prompt was taken; pane:\n%s", pane)
+		}
+		time.Sleep(100 * time.Millisecond)
+		m.applyCmd(t, m.refreshCmd())
+	}
+	pane, err := m.tmux.CapturePane(sess.ID)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if !strings.Contains(pane, "agent-manager rename") {
+		t.Fatalf("pane should hold the directive, got:\n%s", pane)
 	}
 }


### PR DESCRIPTION
## What

A message the manager delivers into a session that is still launching now arrives as a message.

Two things had to change for that. Pending input waits until the agent has picked up the prompt it launched with, which the prompt reaching the pane's finished output proves. And the Enter behind a paste goes out only once the pane has drawn that paste.

Sessions carry the prompt handed to their agent on its command line, in a new `launch_prompt` column, so the poller knows what to wait for. A tool that is typed into receives its prompt as its first pending input instead, and has nothing to wait behind.

## Why

An agent launched with a slash-command prompt keeps its generated name: the rename directive that follows the prompt never becomes a message, so the session stays `claude-1ff0` and the agent never runs `agent-manager rename`.

Two separate causes, each enough on its own:

- **The composer is cleared as the agent takes its launch prompt**, and anything pasted there in the meantime goes with it. A message delivered around two seconds in disappears entirely: no transcript entry, an empty composer.
- **tmux writes the paste and the Enter to one pty.** A pane too busy to read between them takes both in a single read, where a carriage return inside a bracketed paste counts as pasted text rather than a submit. The message sits in the composer, drawn but never sent.

Both windows sit inside the first seconds of a launch, which is exactly when the poller delivers a deferred directive.

## Verified

Real Claude Code, launched with a slash-command prompt, driven through the poller, judged by whether the directive became a message:

| | delivered |
|---|---|
| before | 0 of 4 |
| after | 4 of 4 |

Each cause measured on its own, with the message asking the agent to create a file so delivery is judged by that file existing:

| | lost |
|---|---|
| neither wait | 6 of 6 |
| paste echo only | 5 of 6 |
| launch prompt only | 3 of 6 |
| both | 0 of 6 |

At byte level, a pane that stalls before its first read takes the whole message in one chunk, `\x1b[200~...\x1b[201~\r`, while an idle one reads the paste and the carriage return separately.

Two tests cover it, each failing when its own wait is removed:

- `TestSendTextSubmitsIntoAPaneThatReadsLate` logs every read the pane makes and requires the paste to end one before the Enter arrives.
- `TestPendingInputWaitsForTheLaunchPrompt` spawns a tool that draws its input line at once and takes its prompt half a second later, and requires the directive to be held until then.

`gofmt -l .` prints nothing, `go vet ./...` is clean, and the full suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session launch prompts are now preserved when sessions are created, listed, or reopened.
  * Launch prompts are handled consistently across supported prompt delivery modes.

* **Bug Fixes**
  * Improved reliability when sending prompts to tools that respond slowly.
  * Pending input now waits for the launch prompt before being delivered.
  * Added a grace period for delayed or unavailable launch prompts.
  * Improved detection of prompt text and pane updates during session startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->