### PR TITLE
docs(agents): name the file the release-notes edit reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,8 @@ rather than sitting above it, so a file passed that way has to carry the
 list itself. Publishing first and then editing is the simpler order: take
 what goreleaser published with `gh release view <tag> --json body -q .body`,
 put the summary and thanks above its `## What's Changed`, and send it back
-with `gh release edit <tag> --notes-file`. The header and footer from
-`.goreleaser.yaml` come along either way.
+with `gh release edit <tag> --notes-file notes.md`. The header and footer
+from `.goreleaser.yaml` come along either way.
 
 ## Layout
 


### PR DESCRIPTION
The release-notes instructions end on `gh release edit <tag> --notes-file`,
and `gh` needs the file named there:

```
$ gh release edit v0.31.0 --notes-file
flag needs an argument: --notes-file
```

`gh release edit --help` gives the flag as `-F, --notes-file file`, so the
line now reads `--notes-file notes.md`, matching the `notes.md` the same
paragraph already uses.
