### PR TITLE
fix(ui): preserve Unicode and colors in pane selection

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -3,8 +3,10 @@
 package clipboard
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -14,6 +16,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"unicode/utf16"
 
 	"github.com/YoanWai/agent-manager/internal/termseq"
 	"github.com/charmbracelet/x/ansi"
@@ -354,7 +357,7 @@ func WriteText(text string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Stdin = strings.NewReader(text)
+	cmd.Stdin = bytes.NewReader(clipboardText(name, text))
 	if err := cmd.Run(); err != nil {
 		// A selected writer can still die at runtime: a stale SSH DISPLAY,
 		// a Wayland socket that is gone, a broken install. The terminal's
@@ -368,6 +371,18 @@ func WriteText(text string) error {
 		return fmt.Errorf("%s: %w", name, err)
 	}
 	return nil
+}
+
+func clipboardText(name, text string) []byte {
+	if goos != "linux" || !wslProbe() || !strings.EqualFold(filepath.Base(name), "clip.exe") {
+		return []byte(text)
+	}
+	units := utf16.Encode([]rune(text))
+	data := make([]byte, len(units)*2)
+	for i, unit := range units {
+		binary.LittleEndian.PutUint16(data[i*2:], unit)
+	}
+	return data
 }
 
 // copyCommand picks the platform's clipboard writer. The false return means

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,6 +1,7 @@
 package clipboard
 
 import (
+	"bytes"
 	"encoding/base64"
 	"errors"
 	"os"
@@ -456,6 +457,29 @@ func TestCopyCommandPlatformWriters(t *testing.T) {
 	wslProbe = func() bool { return true }
 	if name, _, ok := copyCommand(); !ok || name != "clip.exe" {
 		t.Fatalf("WSL writer = %q %v", name, ok)
+	}
+}
+
+func TestClipboardTextEncodesWSLClipAsUTF16LE(t *testing.T) {
+	defer restore()()
+	goos = "linux"
+	wslProbe = func() bool { return true }
+
+	got := clipboardText("clip.exe", "A─😀")
+	want := []byte{0x41, 0x00, 0x00, 0x25, 0x3d, 0xd8, 0x00, 0xde}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("WSL clipboard bytes = %x, want %x", got, want)
+	}
+}
+
+func TestClipboardTextLeavesOtherWritersUTF8(t *testing.T) {
+	defer restore()()
+	goos = "linux"
+	wslProbe = func() bool { return false }
+
+	text := "A─😀"
+	if got := clipboardText("xclip", text); !bytes.Equal(got, []byte(text)) {
+		t.Fatalf("Linux clipboard bytes = %x, want UTF-8 %x", got, []byte(text))
 	}
 }
 

--- a/internal/ui/focussel.go
+++ b/internal/ui/focussel.go
@@ -491,9 +491,10 @@ func (m *Model) renderPaneRow(row int, raw string, width int) string {
 		return m.withCursor(row, raw, []rune(line), width)
 	}
 	startByte, endByte := graphemeRangeAtColumns(line, start, end)
-	before := line[:startByte]
 	selected := line[startByte:endByte]
-	after := line[endByte:]
+	clean := previewDangerSeqs.ReplaceAllString(raw, "")
+	before := ansi.Truncate(clean, start, "")
+	after := ansi.TruncateLeft(clean, end, "")
 	painted := before + selectionStyle().Render(selected) + after
 	return previewLine(painted, width)
 }

--- a/internal/ui/focussel.go
+++ b/internal/ui/focussel.go
@@ -478,11 +478,13 @@ func (m *Model) copySelectionCmd() tea.Cmd {
 type focusCopiedMsg struct{ chars int }
 
 // renderPaneRow draws one captured pane row, overlaying the selection when
-// it covers part of it. A selected row is painted from its plain text: the
-// agent's own colors would fight the highlight, and the selection is
-// transient.
+// it covers part of it. The agent's own styling survives on both sides of
+// the highlight; only the selected span is repainted. The splice points are
+// the selection's grapheme-snapped columns, so a wide grapheme under an
+// edge stays on exactly one side.
 func (m *Model) renderPaneRow(row int, raw string, width int) string {
-	line := ansi.Strip(previewDangerSeqs.ReplaceAllString(raw, ""))
+	clean := previewDangerSeqs.ReplaceAllString(raw, "")
+	line := ansi.Strip(clean)
 	if !m.sel.active {
 		return m.withCursor(row, raw, []rune(line), width)
 	}
@@ -492,9 +494,8 @@ func (m *Model) renderPaneRow(row int, raw string, width int) string {
 	}
 	startByte, endByte := graphemeRangeAtColumns(line, start, end)
 	selected := line[startByte:endByte]
-	clean := previewDangerSeqs.ReplaceAllString(raw, "")
-	before := ansi.Truncate(clean, start, "")
-	after := ansi.TruncateLeft(clean, end, "")
+	before := ansi.Truncate(clean, ansi.StringWidth(line[:startByte]), "")
+	after := ansi.TruncateLeft(clean, ansi.StringWidth(line[:endByte]), "")
 	painted := before + selectionStyle().Render(selected) + after
 	return previewLine(painted, width)
 }

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -327,9 +327,35 @@ func TestSelectionOverlayPreservesSurroundingANSI(t *testing.T) {
 		headRow:   0,
 		headCol:   4,
 	}
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
 	row := m.renderPaneRow(0, m.preview, 20)
-	if !strings.Contains(row, "\x1b[31m") || !strings.Contains(row, "\x1b[34m") {
-		t.Fatalf("selection dropped surrounding ANSI colors: %q", row)
+	overlay := selectionStyle().Render(" ")
+	redStart := strings.Index(row, "\x1b[31mred")
+	overlayStart := strings.Index(row, overlay)
+	blueStart := strings.Index(row, "\x1b[34mblue")
+	if redStart < 0 || overlayStart < 0 || blueStart < 0 ||
+		redStart >= overlayStart || overlayStart >= blueStart {
+		t.Fatalf("selection overlay missing or misplaced: %q", row)
+	}
+}
+
+// A selection edge landing on one cell of a wide grapheme snaps outward to
+// the whole grapheme; the styled splice must keep the row's text intact
+// rather than repeating the grapheme on both sides of the edge.
+func TestSelectionOverlayKeepsWideGraphemesWhole(t *testing.T) {
+	m := paneAt(t, "a\U0001f600b")
+	m.sel = focusSelection{
+		active:    true,
+		anchorRow: 0,
+		anchorCol: 0,
+		headRow:   0,
+		headCol:   2,
+	}
+	row := m.renderPaneRow(0, m.preview, 10)
+	if plain := strings.TrimRight(ansi.Strip(row), " "); plain != "a\U0001f600b" {
+		t.Fatalf("selection overlay changed row text: %q", plain)
 	}
 }
 

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -318,6 +318,21 @@ func TestSelectionIgnoresANSI(t *testing.T) {
 	}
 }
 
+func TestSelectionOverlayPreservesSurroundingANSI(t *testing.T) {
+	m := paneAt(t, "\x1b[31mred\x1b[0m \x1b[34mblue\x1b[0m")
+	m.sel = focusSelection{
+		active:    true,
+		anchorRow: 0,
+		anchorCol: 3,
+		headRow:   0,
+		headCol:   4,
+	}
+	row := m.renderPaneRow(0, m.preview, 20)
+	if !strings.Contains(row, "\x1b[31m") || !strings.Contains(row, "\x1b[34m") {
+		t.Fatalf("selection dropped surrounding ANSI colors: %q", row)
+	}
+}
+
 func TestSelectionSurvivesShortLines(t *testing.T) {
 	m := paneAt(t, "ab", "")
 	press(m, 10, 5)


### PR DESCRIPTION
## What

- encode focused-pane selections as UTF-16LE before sending them to Windows `clip.exe` under WSL
- preserve the pane's ANSI styling before and after agent-manager's selection overlay
- cover both paths with focused regression tests, including non-BMP Unicode and non-WSL clipboard writers

## Why

Agent-manager owns click-drag selection while a child pane is focused. On WSL, v0.30 sent that UTF-8 text directly to `clip.exe`, which interpreted the bytes through the Windows OEM code page. Box-drawing characters such as `─` consequently pasted as `ΓöÇ`.

The selection renderer also rebuilt every selected row from plain text. Selecting even one span therefore removed the agent's colors from the rest of that row.

## Visual evidence

This is a CLI-only submission, so I cannot attach the local screenshots directly. The deterministic text reproduction is:

```text
before copy: ────────────────────
before paste: ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ

after copy:  ────────────────────
after paste: ────────────────────
```

For selection rendering, a row containing red `red`, a selected separator, and blue `blue` previously lost both surrounding ANSI colors. The regression test now asserts that both color sequences survive the overlay.

## Verified

- `gofmt -l .`
- `go vet ./...`
- `env -u TMUX TMUX_TMPDIR=/tmp/amup go test -race ./...`
- `go build ./...` from a fresh local clone of this branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard text handling on WSL for correct Unicode support, including emoji and other surrogate-pair characters.
  * Preserved existing text encoding behavior on other platforms.
  * Fixed selection highlighting so surrounding terminal colors and styling remain intact.
  * Preserved wide characters and graphemes when rendering selected text.

* **Tests**
  * Added coverage for WSL Unicode clipboard output and styled selection rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->