### PR TITLE
fix(ui): hold the preview box still while a transient tier is up

### DIFF
--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -376,6 +376,10 @@ func TestFocusKeepsPaneHeight(t *testing.T) {
 		if got := m.previewPaneHeight(); got != listed {
 			t.Fatalf("width %d: focused box with mouse = %d rows, want %d", width, got, listed)
 		}
+		m.applyCmd(t, m.refreshCmd())
+		if got := windowHeight(t, sess.ID); got != listed {
+			t.Fatalf("width %d: focused pane with mouse = %d rows, want %d", width, got, listed)
+		}
 		m.pane.mouse = false
 		m.applyCmd(t, m.leaveFocus())
 	}

--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // sgrMouseReportRe matches one SGR mouse report as cat echoes it back to the
@@ -318,25 +319,72 @@ func TestRefreshReassertsPaneHeight(t *testing.T) {
 		t.Fatalf("initial pane height = %d, want %d", got, want)
 	}
 
-	full := m.previewPaneHeight()
-	// Opening the quick bar shrinks the box without any terminal resize.
-	m.openQuickMode()
+	// A shorter frame with no size message: the header or the status line
+	// taking a row moves the box the same way.
+	m.height -= 4
 	shrunk := m.previewPaneHeight()
-	if shrunk >= full {
-		t.Fatal("quick bar did not shrink the box height")
-	}
 	m.applyCmd(t, m.refreshCmd())
 	if got := windowHeight(t, sess.ID); got != shrunk {
-		t.Fatalf("pane height after opening the quick bar = %d, want %d", got, shrunk)
+		t.Fatalf("pane height after the box shrank = %d, want %d", got, shrunk)
 	}
 
-	// Closing it grows the box back; the pane has to follow.
-	m.quick.active = false
+	m.height += 4
 	grown := m.previewPaneHeight()
 	m.applyCmd(t, m.refreshCmd())
 	if got := windowHeight(t, sess.ID); got != grown {
-		t.Fatalf("pane height after closing the quick bar = %d, want %d", got, grown)
+		t.Fatalf("pane height after the box grew = %d, want %d", got, grown)
 	}
+}
+
+// The quick bar takes its rows from the painted preview alone: resizing the
+// pane for it would make an agent drawing on the normal screen redraw its
+// whole transcript, so the pane stays pinned and the view crops instead.
+func TestQuickBarKeepsPaneHeight(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "sizer", t.TempDir(), "")
+	m.applyCmd(t, m.refreshCmd())
+	sess := m.rows[m.cursor].sess
+	pinned := m.previewPaneHeight()
+
+	rows := make([]string, pinned+10)
+	for i := range rows {
+		rows[i] = fmt.Sprintf("line%03d", i+1)
+	}
+	m.preview = strings.Join(rows, "\n") + "\n"
+	listed := paintedPreview(m)
+
+	m.openQuickMode()
+	if got := m.previewPaneHeight(); got != pinned {
+		t.Fatalf("box height with the quick bar open = %d, want %d", got, pinned)
+	}
+	painted := paintedPreview(m)
+	// The bar's rows come off the top of the view; the pane's live end stays.
+	if oldest := rows[len(rows)-pinned]; !strings.Contains(listed, oldest) || strings.Contains(painted, oldest) {
+		t.Fatalf("the quick bar should have cropped %s off the top:\n%s", oldest, painted)
+	}
+	if newest := rows[len(rows)-1]; !strings.Contains(painted, newest) {
+		t.Fatalf("the quick bar hid the pane's live end (%s):\n%s", newest, painted)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	if got := windowHeight(t, sess.ID); got != pinned {
+		t.Fatalf("pane height with the quick bar open = %d, want %d", got, pinned)
+	}
+
+	m.quick.active = false
+	m.applyCmd(t, m.refreshCmd())
+	if got := windowHeight(t, sess.ID); got != pinned {
+		t.Fatalf("pane height after closing the quick bar = %d, want %d", got, pinned)
+	}
+}
+
+// paintedPreview is the right column as the list paints it, escapes stripped.
+func paintedPreview(m *Model) string {
+	_, rightWidth := m.splitWidths()
+	var painted strings.Builder
+	for _, row := range m.contentLines(rightWidth, m.listBodyHeight()) {
+		painted.WriteString(ansi.Strip(row.text) + "\n")
+	}
+	return painted.String()
 }
 
 // windowHeight is the tmux window height a session is currently pinned to.
@@ -351,6 +399,38 @@ func windowHeight(t *testing.T, id string) int {
 		t.Fatalf("parse height %q: %v", out, err)
 	}
 	return height
+}
+
+// Focusing must leave the preview box where it was: a pane resized on the
+// way in makes an agent drawing on the normal screen redraw its whole
+// transcript, which throws the view up its history and back.
+func TestFocusKeepsPaneHeight(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "focused", t.TempDir(), "")
+	m.applyCmd(t, m.refreshCmd())
+	sess := m.rows[m.cursor].sess
+
+	for _, width := range []int{100, 240} {
+		m.width = width
+		m.applyCmd(t, m.refreshCmd())
+		listed := m.previewPaneHeight()
+
+		m.focusSelected()
+		if got := m.previewPaneHeight(); got != listed {
+			t.Fatalf("width %d: focused box = %d rows, want %d", width, got, listed)
+		}
+		m.applyCmd(t, m.refreshCmd())
+		if got := windowHeight(t, sess.ID); got != listed {
+			t.Fatalf("width %d: focused pane = %d rows, want %d", width, got, listed)
+		}
+		// An agent claiming the mouse adds a key to the focused tier.
+		m.pane.mouse = true
+		if got := m.previewPaneHeight(); got != listed {
+			t.Fatalf("width %d: focused box with mouse = %d rows, want %d", width, got, listed)
+		}
+		m.pane.mouse = false
+		m.applyCmd(t, m.leaveFocus())
+	}
 }
 
 // focusedMouseApp focuses a session whose tool claims the mouse, with the

--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/x/ansi"
 )
 
 // sgrMouseReportRe matches one SGR mouse report as cat echoes it back to the
@@ -334,57 +333,6 @@ func TestRefreshReassertsPaneHeight(t *testing.T) {
 	if got := windowHeight(t, sess.ID); got != grown {
 		t.Fatalf("pane height after the box grew = %d, want %d", got, grown)
 	}
-}
-
-// The quick bar takes its rows from the painted preview alone: resizing the
-// pane for it would make an agent drawing on the normal screen redraw its
-// whole transcript, so the pane stays pinned and the view crops instead.
-func TestQuickBarKeepsPaneHeight(t *testing.T) {
-	m := buildModel(t)
-	createSession(t, m, "sizer", t.TempDir(), "")
-	m.applyCmd(t, m.refreshCmd())
-	sess := m.rows[m.cursor].sess
-	pinned := m.previewPaneHeight()
-
-	rows := make([]string, pinned+10)
-	for i := range rows {
-		rows[i] = fmt.Sprintf("line%03d", i+1)
-	}
-	m.preview = strings.Join(rows, "\n") + "\n"
-	listed := paintedPreview(m)
-
-	m.openQuickMode()
-	if got := m.previewPaneHeight(); got != pinned {
-		t.Fatalf("box height with the quick bar open = %d, want %d", got, pinned)
-	}
-	painted := paintedPreview(m)
-	// The bar's rows come off the top of the view; the pane's live end stays.
-	if oldest := rows[len(rows)-pinned]; !strings.Contains(listed, oldest) || strings.Contains(painted, oldest) {
-		t.Fatalf("the quick bar should have cropped %s off the top:\n%s", oldest, painted)
-	}
-	if newest := rows[len(rows)-1]; !strings.Contains(painted, newest) {
-		t.Fatalf("the quick bar hid the pane's live end (%s):\n%s", newest, painted)
-	}
-	m.applyCmd(t, m.refreshCmd())
-	if got := windowHeight(t, sess.ID); got != pinned {
-		t.Fatalf("pane height with the quick bar open = %d, want %d", got, pinned)
-	}
-
-	m.quick.active = false
-	m.applyCmd(t, m.refreshCmd())
-	if got := windowHeight(t, sess.ID); got != pinned {
-		t.Fatalf("pane height after closing the quick bar = %d, want %d", got, pinned)
-	}
-}
-
-// paintedPreview is the right column as the list paints it, escapes stripped.
-func paintedPreview(m *Model) string {
-	_, rightWidth := m.splitWidths()
-	var painted strings.Builder
-	for _, row := range m.contentLines(rightWidth, m.listBodyHeight()) {
-		painted.WriteString(ansi.Strip(row.text) + "\n")
-	}
-	return painted.String()
 }
 
 // windowHeight is the tmux window height a session is currently pinned to.

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -96,8 +96,9 @@ func (m *Model) previewPaneWidth() int {
 }
 
 // previewPaneHeight is the rows of session pane content the Preview
-// section can show. Mirrors viewSidebar + viewPreview so tmux is pinned
-// to the same box the UI paints into.
+// section can show with nothing transient over it, which is what tmux is
+// pinned to: the painted view crops a taller pane, where resizing it for
+// a passing overlay would cost an agent a full transcript redraw.
 func (m *Model) previewPaneHeight() int {
 	// Our own blocks wrap inside the column's gutters, so their heights
 	// are measured at that width rather than at the preview's full span.
@@ -111,9 +112,6 @@ func (m *Model) previewPaneHeight() int {
 	avail := m.listBodyHeight()
 	if avail < 1 {
 		return 1
-	}
-	if m.quick.active {
-		avail -= lipgloss.Height(m.viewQuickBar(inner)) + 1
 	}
 	// Mirrors contentLines: the detail head, the seam, then the pane
 	// filling everything below.
@@ -424,15 +422,15 @@ func (m *Model) viewFooter() string {
 		case m.quickWorktreeOn():
 			worktreeHint = "on"
 		}
-		return legendBar([]legendSection{{title: "Prompt", pairs: [][2]string{
+		return m.transientFooter(legendSection{title: "Prompt", pairs: [][2]string{
 			{"↵", "send"}, {"↑↓", "switch target"}, {"tab", "tool: " + m.quickTool()},
 			{"shift+tab", "worktree: " + worktreeHint}, {"esc", "close"},
-		}}}, m.width)
+		}})
 	}
 	if m.split.resizeMode {
-		return legendBar([]legendSection{{title: "Resize", pairs: [][2]string{
+		return m.transientFooter(legendSection{title: "Resize", pairs: [][2]string{
 			{"←→", "nudge"}, {"drag", "divider"}, {"| / release", "commit"}, {"esc", "cancel"},
-		}}}, m.width)
+		}})
 	}
 	if m.mode == modeRename {
 		pairs := [][2]string{{"↵", "save"}, {"esc", "cancel"}}
@@ -441,7 +439,7 @@ func (m *Model) viewFooter() string {
 		} else if tool := m.renameTool(); tool != "" {
 			pairs = [][2]string{{"tab", "tool: " + tool}, {"↵", "save"}, {"esc", "cancel"}}
 		}
-		return legendBar([]legendSection{{title: "Rename", pairs: pairs}}, m.width)
+		return m.transientFooter(legendSection{title: "Rename", pairs: pairs})
 	}
 	// Focused, the keyboard belongs to the agent: the tier says so in its
 	// title, carries the few keys the manager keeps, and drops the app-wide
@@ -459,9 +457,20 @@ func (m *Model) viewFooter() string {
 		if m.pane.mouse {
 			pairs = append(pairs, [2]string{"click / alt+drag", "agent UI"})
 		}
-		return legendBar([]legendSection{{title: "Focused", pairs: pairs}}, m.width)
+		return m.transientFooter(legendSection{title: "Focused", pairs: pairs})
 	}
+	return m.listFooter()
+}
+
+func (m *Model) listFooter() string {
 	return legendBar([]legendSection{m.rowLegend(), m.viewLegend()}, m.width)
+}
+
+// transientFooter renders one tier at the list footer's height: the footer
+// sets the preview box, and a box that moves resizes every session's pane,
+// which costs an agent drawing on the normal screen a full transcript redraw.
+func (m *Model) transientFooter(section legendSection) string {
+	return padToHeight(legendBar([]legendSection{section}, m.width), lipgloss.Height(m.listFooter()))
 }
 
 // rowLegend is the tier for the entry under the cursor: what this session or

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -441,8 +441,10 @@ func TestFooterInFocusMode(t *testing.T) {
 	if strings.Contains(footer, "navigate") || strings.Contains(footer, "View") {
 		t.Fatalf("app-wide keys go to the agent while focused, so the tier must go:\n%s", footer)
 	}
-	if lines := strings.Split(footer, "\n"); len(lines) != 1 {
-		t.Fatalf("focus footer should be one row, got %d:\n%s", len(lines), footer)
+	// Blank rows below hold the list footer's height so focusing never
+	// resizes the pane.
+	if lines := strings.Split(strings.TrimRight(footer, "\n"), "\n"); len(lines) != 1 {
+		t.Fatalf("focus footer should be one row of keys, got %d:\n%s", len(lines), footer)
 	}
 	if strings.Contains(footer, "agent UI") {
 		t.Fatalf("a plain focused pane should not offer mouse pass-through:\n%s", footer)
@@ -451,6 +453,32 @@ func TestFooterInFocusMode(t *testing.T) {
 	m.pane.mouse = true
 	if footer := ansi.Strip(m.viewFooter()); !strings.Contains(footer, "click / alt+drag") || !strings.Contains(footer, "agent UI") {
 		t.Fatalf("a mouse-tracking pane should advertise pass-through:\n%s", footer)
+	}
+}
+
+// Every transient tier holds the list footer's height: the footer sets the
+// preview box, and a box that moves resizes every session's pane, which
+// costs an agent drawing on the normal screen a full transcript redraw.
+func TestTransientFootersKeepListHeight(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "sizer", t.TempDir(), "")
+	m.applyCmd(t, m.refreshCmd())
+	listed := lipgloss.Height(m.viewFooter())
+
+	for _, tier := range []struct {
+		name string
+		open func()
+	}{
+		{"prompt", func() { m.openQuickMode() }},
+		{"resize", func() { m.split.resizeMode = true }},
+		{"rename", func() { m.mode = modeRename }},
+		{"focus", func() { m.mode = modeFocus }},
+	} {
+		tier.open()
+		if got := lipgloss.Height(m.viewFooter()); got != listed {
+			t.Errorf("%s footer = %d rows, want %d", tier.name, got, listed)
+		}
+		m.quick.active, m.split.resizeMode, m.mode = false, false, modeList
 	}
 }
 

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -454,6 +455,56 @@ func TestFooterInFocusMode(t *testing.T) {
 	if footer := ansi.Strip(m.viewFooter()); !strings.Contains(footer, "click / alt+drag") || !strings.Contains(footer, "agent UI") {
 		t.Fatalf("a mouse-tracking pane should advertise pass-through:\n%s", footer)
 	}
+}
+
+// The quick bar takes its rows from the painted preview alone: resizing the
+// pane for it would make an agent drawing on the normal screen redraw its
+// whole transcript, so the pane stays pinned and the view crops instead.
+func TestQuickBarKeepsPaneHeight(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "sizer", t.TempDir(), "")
+	m.applyCmd(t, m.refreshCmd())
+	sess := m.rows[m.cursor].sess
+	pinned := m.previewPaneHeight()
+
+	rows := make([]string, pinned+10)
+	for i := range rows {
+		rows[i] = fmt.Sprintf("line%03d", i+1)
+	}
+	m.preview = strings.Join(rows, "\n") + "\n"
+	listed := paintedPreview(m)
+
+	m.openQuickMode()
+	if got := m.previewPaneHeight(); got != pinned {
+		t.Fatalf("box height with the quick bar open = %d, want %d", got, pinned)
+	}
+	painted := paintedPreview(m)
+	// The bar's rows come off the top of the view; the pane's live end stays.
+	if oldest := rows[len(rows)-pinned]; !strings.Contains(listed, oldest) || strings.Contains(painted, oldest) {
+		t.Fatalf("the quick bar should have cropped %s off the top:\n%s", oldest, painted)
+	}
+	if newest := rows[len(rows)-1]; !strings.Contains(painted, newest) {
+		t.Fatalf("the quick bar hid the pane's live end (%s):\n%s", newest, painted)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	if got := windowHeight(t, sess.ID); got != pinned {
+		t.Fatalf("pane height with the quick bar open = %d, want %d", got, pinned)
+	}
+
+	m.quick.active = false
+	m.applyCmd(t, m.refreshCmd())
+	if got := windowHeight(t, sess.ID); got != pinned {
+		t.Fatalf("pane height after closing the quick bar = %d, want %d", got, pinned)
+	}
+}
+
+func paintedPreview(m *Model) string {
+	_, rightWidth := m.splitWidths()
+	var painted strings.Builder
+	for _, row := range m.contentLines(rightWidth, m.listBodyHeight()) {
+		painted.WriteString(ansi.Strip(row.text) + "\n")
+	}
+	return painted.String()
 }
 
 // Every transient tier holds the list footer's height: the footer sets the


### PR DESCRIPTION
## What changed

Every transient footer tier (Prompt, Resize, Rename, Focused) now renders at the list footer's height, and the quick bar takes its rows from the painted view alone. The pinned pane stays where it is and the view crops to what is on screen.

## Why

The footer's height sets the preview box, and the box sets the tmux window we pin each session to. Swapping the two-tier list footer for a one-tier transient footer grew the box by a row or two, so focusing a session, opening the quick prompt, renaming, or arming the split resized every session's window.

Codex draws on the normal screen rather than the alternate one, so that resize reached it as a SIGWINCH and it re-emitted its whole transcript: the view scrolled up through the history and then back down to the prompt. The taller the conversation, the longer the jump.

## How it was verified

Live A/B on one codex session, driving the manager with the shipped key bindings and watching the agent's own window from outside:

| Action | pane rows | `history_size` | bytes codex wrote |
| --- | --- | --- | --- |
| focus, before this change | 41 to 42 | 75 to 106 | 2160 |
| focus, after | 41 to 41 | unchanged | 0 |
| quick prompt, after | 41 to 41 | unchanged | 0 |

Tracing the redraw itself: with the pane piped out, a resize made codex emit `ESC[2J` and `ESC[3J`, then a run of `ESC M` reverse indexes that walk the view back up its history, then a repaint at the bottom. Claude sits on the alternate screen, which is why it stayed still through the same resize.

New tests: `TestFocusKeepsPaneHeight` (both footer wrap widths, plus the mouse key the focused tier gains mid session), `TestQuickBarKeepsPaneHeight` (pane pinned, view crops from the top, live end still painted), `TestTransientFootersKeepListHeight` (all four tiers). `TestRefreshReassertsPaneHeight` now drives the box with a frame height change, since the quick bar no longer moves it.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] `go build ./...` passes
- [x] Ran it against real sessions

## Visual evidence

The change is the absence of motion, so a still frame of the manager looks the same before and after. What is visible is the geometry: the focused view keeps the list view's panel rows, with the legend on the last content row and the reserved row below it.

**After (focused, bottom of the frame):**

```
█ net  ↓ 46.1KB/s  ↑ 865.0KB/s       │ │                   │ │
█                                    │ ╰─M open ───────────╯ ▐
▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄╰──────────
   Focused   typing goes to the agent  ctrl+q / ctrl+\ back to manager  …
```

The panel borders land on the same rows as in the list view, so nothing shifts on the way in or out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved preview pane height when opening or closing the quick bar.
  * Prevented prompts, resize notices, rename fields, and focus mode from shifting the layout.
  * Improved preview cropping so content remains positioned consistently during layout changes.

* **Tests**
  * Added coverage for stable pane heights across resizing, preview changes, quick-bar interactions, focus mode, and mouse tracking.
  * Verified that transient footers maintain a consistent height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->