### PR TITLE
fix(ui): resolve the missing-git hint before the update loop

### DIFF
--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/YoanWai/agent-manager/internal/deps"
 	"github.com/YoanWai/agent-manager/internal/diff"
 	"github.com/YoanWai/agent-manager/internal/git"
 	"github.com/YoanWai/agent-manager/internal/store"
@@ -1251,7 +1250,7 @@ const diffGutterSign = 2
 // content scrolls freely instead of sharing the narrow sidebar.
 func (m *Model) openDiff() tea.Cmd {
 	if m.gitDrv == nil {
-		m.errBar.text = "git not found in PATH, " + deps.Hint("git")
+		m.errBar.text = m.gitMissingText
 		return nil
 	}
 	sess, ok := m.selected()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/config"
+	"github.com/YoanWai/agent-manager/internal/deps"
 	"github.com/YoanWai/agent-manager/internal/feed"
 	"github.com/YoanWai/agent-manager/internal/git"
 	"github.com/YoanWai/agent-manager/internal/hooks"
@@ -61,7 +62,9 @@ type Model struct {
 	tmux   *tmux.Driver
 	hooks  *hooks.Manager
 	gitDrv *git.Driver
-	engine *status.Engine
+	// Resolving the install command walks PATH, which Update must not do.
+	gitMissingText string
+	engine         *status.Engine
 
 	// setSnapshot writes a session's pane capture before archive or kill
 	// takes the window; a seam so snapshot failures can be exercised
@@ -519,6 +522,10 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 	// A missing git binary only disables the diff view; everything else
 	// works without it, so the error surfaces on first use instead.
 	gitDriver, _ := git.New()
+	gitMissingText := ""
+	if gitDriver == nil {
+		gitMissingText = "git not found in PATH, " + deps.Hint("git")
+	}
 	applyTheme(themes[themeIndex(resolveStartupTheme(st))])
 	model := &Model{
 		cfg:                 cfg,
@@ -526,6 +533,7 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 		tmux:                driver,
 		hooks:               hookManager,
 		gitDrv:              gitDriver,
+		gitMissingText:      gitMissingText,
 		engine:              engine,
 		setSnapshot:         st.SetSnapshot,
 		poller:              newPoller(st, driver, engine, hookManager, gitDriver, statusSources, sessionStores, cfg.PollInterval.Duration),


### PR DESCRIPTION
## What

The install script now resolves dependencies instead of only naming them. After the binary lands it checks for tmux and git, detects the machine's package manager (Homebrew, apt, dnf, pacman, zypper, apk), and offers to install whatever is missing. Declining prints the exact command for that machine. `AGENT_MANAGER_INSTALL_DEPS=1` answers the prompt up front, `=0` skips it.

The routes no script can reach get the same help from the binary. Starting without tmux now ends with `install it with: brew install tmux` rather than a bare exec error, and the diff view says the same about git. A new `internal/deps` maps GOOS plus PATH to the right command, and tmux, git, and the diff view all read from it.

`docs/install.md` gains a dependency table covering tmux, git, and the Linux extras that image paste and desktop notifications use.

## Why

tmux is fatal without it and git drives diff review and worktree sessions. The Homebrew cask pulled tmux in and the AUR package pulled both, so those two routes were covered. The install script only printed a warning, and mise, `go install`, and the prebuilt binaries said nothing at all, which left the reader to discover a hard dependency from a failed launch.

The cask stays as it is: `brew install yoanwai/tap/agent-manager` clones a git tap, so git is a precondition of Homebrew running at all.

## Verified

- Built with a stubbed PATH holding no tmux: the binary exits with `tmux not found on PATH ... install tmux with your package manager`, and with only `brew` present, `install it with: brew install tmux`.
- Drove `install_deps` against stub package managers across every branch: apt with sudo, dnf without, pacman, no package manager at all, no tty, `AGENT_MANAGER_INSTALL_DEPS=1`, and `=0`. Each printed or ran the right command, and the script survived `set -e` through the tty probe.
- The package manager runs with stdin on `/dev/tty` or `/dev/null`, so the `curl | sh` pipe carrying the rest of the script stays out of its reach.
- `sh -n install.sh`, `gofmt -l .` silent, `go vet ./...` clean.
- `env -u TMUX TMUX_TMPDIR=/tmp/amdeps go test ./...`: 23/23 packages ok.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the message shown when Git is unavailable.
  * Added clearer guidance for resolving Git installation or PATH configuration issues.
  * Ensured the same helpful message is displayed consistently when opening differences without Git.
  * Preserved normal difference viewing behavior when Git is installed and available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->