### PR TITLE
fix(ui): sanitize terminal escape sequences in previewLine to prevent outer layout corruption

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -328,7 +328,11 @@ func (m *Model) groupStatusGlyphs(group string) string {
 // (S/T), insert/delete lines (L/M), set scroll region (r), and the 7-bit
 // index / reverse-index / next-line controls (D/M/E).
 var previewDangerSeqs = regexp.MustCompile(
-	`\x1b\[[0-9;]*[KJLMSTr]|\x1b[DEM]`,
+	`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)` + // OSC sequences
+	`|\x1b\[[?<=>]?[0-9;]*[A-LN-Za-ln-z]` + // CSI non-SGR sequences (excludes 'm')
+	`|\x1b[P^_X][^\x07\x1b]*(?:\x07|\x1b\\)` + // DCS / PM / APC / SOS
+	`|\x1b[()#%*+][0-9A-Za-z]` + // Charset and mode designations
+	`|\x1b[0-9<=>cDEM78HFNPXZ]`, // 2-byte escape commands (RIS, IND, NEL, RI, DECSC, DECRC, etc.)
 )
 
 func previewLine(line string, width int) string {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -112,6 +112,11 @@ func TestPreviewLine(t *testing.T) {
 		t.Fatalf("control chars should be dropped: %q", got)
 	}
 
+	escapes := "\x1b[?2026h\x1b[?1049h\x1b[12;34H\x1b]0;Title\x07\x1b]8;;http://x\x07\x1b[32mActive\x1b[0m\x1b]8;;\x07\x1b[?2026l"
+	if got := stripPreviewMarks(ansi.Strip(previewLine(escapes, 80))); strings.TrimRight(got, " ") != "Active" {
+		t.Fatalf("private modes, cursor moves and OSC should be stripped: %q", got)
+	}
+
 	wide := "\x1b[31m" + strings.Repeat("x", 100) + "\x1b[0m"
 	clipped := previewLine(wide, 20)
 	if w := lipglossWidth(clipped); w > 20 {


### PR DESCRIPTION
### Problem
When previewing or focusing CLI tools that emit rich ANSI streams (such as Antigravity CLI / `agy`), the outer Agent Manager TUI layout corrupts and shifts on screen.

### Root Cause
`previewDangerSeqs` previously only stripped a small subset of cursor clearing and line manipulation sequences (`\x1b\[[0-9;]*[KJLMSTr]|\x1b[DEM]`). Unhandled non-SGR sequences—such as cursor positioning (`\x1b[H`, `\x1b[12;34H`, `\x1b[A-G`), DEC private modes (`\x1b[?2026h` synchronized output, `\x1b[?1049h` alt screen), OSC commands, and 2-byte escape codes—passed through `previewLine()` directly into Bubble Tea's `View()` output. When emitted mid-frame, the host terminal executed these sequences directly, jumping the cursor to (0,0) or altering terminal modes and corrupting outer frame geometry (rail, border, headers, and footer).

### Solution
Expand `previewDangerSeqs` in `internal/ui/view.go` to neutralize all non-SGR CSI sequences, DEC private modes, OSC commands, DCS/APC/SOS controls, and 2-byte escape sequences while preserving full SGR color styling (TrueColor RGB and 256-color palettes).

### Testing
- Full unit test suite passes (`go test ./...`).
- Added test coverage in `internal/ui/view_test.go` verifying that DEC private modes, cursor moves, and OSC strings are stripped while SGR styling and layout column widths remain intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preview rendering by removing a broader range of terminal control sequences.
  - Previews now correctly hide cursor, title, hyperlink, color, and other non-visible formatting codes while preserving readable text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
