### PR TITLE
fix(deps): run apk through the same privilege handling as the rest

### DIFF
--- a/internal/deps/deps.go
+++ b/internal/deps/deps.go
@@ -26,7 +26,7 @@ var linuxManagers = []manager{
 	{"dnf", "sudo dnf install -y "},
 	{"pacman", "sudo pacman -S --needed "},
 	{"zypper", "sudo zypper install -y "},
-	{"apk", "apk add "},
+	{"apk", "sudo apk add "},
 	{"brew", "brew install "},
 }
 

--- a/internal/deps/deps_test.go
+++ b/internal/deps/deps_test.go
@@ -75,10 +75,27 @@ func TestInstallCommandSkipsAptWithoutSudo(t *testing.T) {
 	}
 }
 
-func TestInstallCommandApkHasNoSudo(t *testing.T) {
+func TestInstallCommandApkAsRootHasNoSudo(t *testing.T) {
+	stubUID(t, 0)
 	stubPath(t, "apk")
 	if got, want := installCommand("linux", "tmux"), "apk add tmux"; got != want {
 		t.Fatalf("installCommand = %q, want %q", got, want)
+	}
+}
+
+func TestInstallCommandApkAsNonRootTakesSudo(t *testing.T) {
+	stubUID(t, 1)
+	stubPath(t, "apk", "sudo")
+	if got, want := installCommand("linux", "tmux"), "sudo apk add tmux"; got != want {
+		t.Fatalf("installCommand = %q, want %q", got, want)
+	}
+}
+
+func TestInstallCommandSkipsApkWithoutSudo(t *testing.T) {
+	stubUID(t, 1)
+	stubPath(t, "apk")
+	if got := installCommand("linux", "tmux"); got != "" {
+		t.Fatalf("installCommand = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## What

`apk` was the only entry in `linuxManagers` carrying no `sudo `, so `privilegedInstall` passed it through untouched and every Alpine user got the same string regardless of who they were. It now reads `sudo apk add `, which routes it through the privilege handling the other five managers already use.

The behaviour per user, after the change:

| Who | Before | After |
| --- | --- | --- |
| root | `apk add tmux` | `apk add tmux` (`privilegedInstall` strips the prefix) |
| non-root, sudo present | `apk add tmux` | `sudo apk add tmux` |
| non-root, no sudo | `apk add tmux` | falls through to `install tmux with your package manager` |

## Why

A non-root Alpine user was handed a command that cannot install anything: `apk add` without privilege exits with `ERROR: Unable to lock database: Permission denied`. The hint exists to name the command that fixes a missing tmux or git, so naming one that fails defeats it.

The third row is the same treatment apt, dnf, pacman and zypper already give that user. Saying "install it with your package manager" is honest about what the machine can do; printing a command that will be rejected is not.

This revises a decision #344 pinned with `TestInstallCommandApkHasNoSudo`. Root, the common Alpine case, keeps its exact behaviour, so what changes is only the two cases that were broken. That test is replaced by three that fix the user identity explicitly, since the original left it to whoever ran the suite.

## Verified

- The two new cases fail on `main` before the change: `installCommand = "apk add tmux", want "sudo apk add tmux"` and `want empty`. Both pass after it, and the root case passes throughout.
- `gofmt -l .` silent, `go vet ./...` clean.
- `env -u TMUX TMUX_TMPDIR=/tmp/amapk go test ./...`: 25/25 packages ok.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alpine Linux package installation now uses `sudo` when required for non-root environments.
  * Installation continues to work without `sudo` when running as root.
  * Package installation is skipped safely when elevated access is unavailable.

* **Tests**
  * Added coverage for root, non-root, and unavailable-`sudo` installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->