### PR TITLE
fix(ui): show the startup loader after restore and revive

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -35,8 +35,8 @@ type Session struct {
 	// Revive resumes this exact conversation instead of the cwd's most recent one.
 	AgentSessionID string
 	// AgentLaunchedAt is when the agent process now in the pane started, which
-	// restart moves forward while CreatedAt keeps marking the row's birth.
-	// Zero for sessions that never restarted, whose launch is CreatedAt.
+	// restart and revive move forward while CreatedAt keeps marking the row's birth.
+	// Zero for sessions that never relaunched, whose launch is CreatedAt.
 	AgentLaunchedAt time.Time
 	// RetiredAgentSessionID is the conversation a restart left behind, kept so
 	// id capture never binds the fresh run back to the context it dropped.
@@ -55,8 +55,8 @@ type Session struct {
 	LaunchPrompt string
 }
 
-// LaunchTime is when the agent now in the pane started: the last restart,
-// or the row's creation for a session that never restarted.
+// LaunchTime is when the agent now in the pane started: the last restart
+// or revive, or the row's creation for a session that never relaunched.
 func (sess Session) LaunchTime() time.Time {
 	if sess.AgentLaunchedAt.IsZero() {
 		return sess.CreatedAt
@@ -665,6 +665,18 @@ func (s *Store) RestartAgent(id, agentSessionID string, launchedAt time.Time) er
 			agent_session_id = ?,
 			agent_launched_at = ?
 		 WHERE id = ?`, agentSessionID, encodeTime(launchedAt), id)
+	if err != nil {
+		return err
+	}
+	return requireRow(res, id)
+}
+
+// SetAgentLaunchedAt records when the agent now in the pane started, without
+// touching the conversation it is resuming.
+func (s *Store) SetAgentLaunchedAt(id string, launchedAt time.Time) error {
+	res, err := s.db.Exec(
+		`UPDATE sessions SET agent_launched_at = ? WHERE id = ?`,
+		encodeTime(launchedAt), id)
 	if err != nil {
 		return err
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1001,7 +1001,7 @@ func TestSetAgentLaunchedAtMovesLaunchTimeWithoutRetiringConversation(t *testing
 		t.Fatal(err)
 	}
 
-	launchedAt := created.CreatedAt.Add(5 * 24 * time.Hour)
+	launchedAt := created.CreatedAt.Add(5 * 24 * time.Hour).In(time.FixedZone("east", 9*3600))
 	if err := st.SetAgentLaunchedAt("a", launchedAt); err != nil {
 		t.Fatalf("launch: %v", err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -432,14 +432,15 @@ func TestWritesToADeletedSessionReportGone(t *testing.T) {
 	}
 
 	writes := map[string]error{
-		"UpdateStatus":      st.UpdateStatus("a", "idle"),
-		"SetAcked":          st.SetAcked("a", true),
-		"SetAgentSessionID": st.SetAgentSessionID("a", "conv"),
-		"SetSnapshot":       st.SetSnapshot("a", "pane"),
-		"SetArchived":       st.SetArchived("a", true),
-		"RenameSession":     st.RenameSession("a", "renamed"),
-		"UpdateTool":        st.UpdateTool("a", "grok"),
-		"Delete":            st.Delete("a"),
+		"UpdateStatus":       st.UpdateStatus("a", "idle"),
+		"SetAcked":           st.SetAcked("a", true),
+		"SetAgentSessionID":  st.SetAgentSessionID("a", "conv"),
+		"SetAgentLaunchedAt": st.SetAgentLaunchedAt("a", time.Now()),
+		"SetSnapshot":        st.SetSnapshot("a", "pane"),
+		"SetArchived":        st.SetArchived("a", true),
+		"RenameSession":      st.RenameSession("a", "renamed"),
+		"UpdateTool":         st.UpdateTool("a", "grok"),
+		"Delete":             st.Delete("a"),
 	}
 	for name, err := range writes {
 		if !errors.Is(err, ErrSessionGone) {
@@ -455,13 +456,14 @@ func TestNoOpWriteDoesNotLookLikeADeletedSession(t *testing.T) {
 	// Rewriting a column with the value it already holds still counts as a
 	// row affected, so ErrSessionGone only ever means the row is absent.
 	writes := map[string]error{
-		"UpdateStatus":      st.UpdateStatus("a", "idle"),
-		"SetAcked":          st.SetAcked("a", false),
-		"SetAgentSessionID": st.SetAgentSessionID("a", ""),
-		"SetSnapshot":       st.SetSnapshot("a", ""),
-		"SetArchived":       st.SetArchived("a", false),
-		"RenameSession":     st.RenameSession("a", "n-a"),
-		"UpdateTool":        st.UpdateTool("a", "claude"),
+		"UpdateStatus":       st.UpdateStatus("a", "idle"),
+		"SetAcked":           st.SetAcked("a", false),
+		"SetAgentSessionID":  st.SetAgentSessionID("a", ""),
+		"SetAgentLaunchedAt": st.SetAgentLaunchedAt("a", time.Time{}),
+		"SetSnapshot":        st.SetSnapshot("a", ""),
+		"SetArchived":        st.SetArchived("a", false),
+		"RenameSession":      st.RenameSession("a", "n-a"),
+		"UpdateTool":         st.UpdateTool("a", "claude"),
 	}
 	for name, err := range writes {
 		if err != nil {
@@ -984,6 +986,34 @@ func TestAddGroupStoresSettingsWithoutReplacingExistingGroup(t *testing.T) {
 	}
 	if len(groups) != 1 || groups[0].Path != "/first" || groups[0].Worktree != "off" {
 		t.Fatalf("duplicate add changed group: %+v", groups)
+	}
+}
+
+func TestSetAgentLaunchedAtMovesLaunchTimeWithoutRetiringConversation(t *testing.T) {
+	st := newTestStore(t)
+	sess := sample("a", "g1")
+	sess.AgentSessionID = "kept"
+	if err := st.CreateSession(sess); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	created, err := st.Get("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	launchedAt := created.CreatedAt.Add(5 * 24 * time.Hour)
+	if err := st.SetAgentLaunchedAt("a", launchedAt); err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	got, err := st.Get("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentSessionID != "kept" || got.RetiredAgentSessionID != "" {
+		t.Fatalf("conversation = %q retired = %q, want kept and empty", got.AgentSessionID, got.RetiredAgentSessionID)
+	}
+	if !got.LaunchTime().Equal(launchedAt) {
+		t.Fatalf("launch time = %v, want %v", got.LaunchTime(), launchedAt)
 	}
 }
 

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -148,7 +148,6 @@ func (m *Model) reviveSelected() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.errBar.text = m.degradedResumeNotice(entry.sess)
-	m.rebuildRows()
 	m.requestRefresh()
 	return m, nil
 }
@@ -190,7 +189,6 @@ func (m *Model) reviveMany(sessions []store.Session, emptyNotice string) (tea.Mo
 	default:
 		m.errBar.text = ""
 	}
-	m.rebuildRows()
 	m.requestRefresh()
 	return m, nil
 }
@@ -243,7 +241,11 @@ func (m *Model) reviveSession(sess store.Session) error {
 		m.bindReviveLocally(sess.ID, launchedAt)
 		return nil
 	}
-	return m.relaunchSession(sess, tool, launch.ReviveCommand(tool, sess.AgentSessionID), status.Starting, bind)
+	if err := m.relaunchSession(sess, tool, launch.ReviveCommand(tool, sess.AgentSessionID), status.Starting, bind); err != nil {
+		return err
+	}
+	m.rebuildRows()
+	return nil
 }
 
 // relaunchSession puts a dead session's row back on a running tmux window
@@ -787,7 +789,6 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 			}
 			m.errBar.text = ""
-			m.rebuildRows()
 		case actionKill:
 			for _, sess := range m.confirm.sessions {
 				if err := m.killSession(sess); err != nil {
@@ -817,7 +818,6 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 			}
 			m.errBar.text = ""
-			m.rebuildRows()
 		case actionDelete:
 			for _, sess := range childrenFirst(m.confirm.sessions) {
 				if err := m.tmux.Kill(sess.ID); err != nil {

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -148,6 +148,7 @@ func (m *Model) reviveSelected() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.errBar.text = m.degradedResumeNotice(entry.sess)
+	m.rebuildRows()
 	m.requestRefresh()
 	return m, nil
 }
@@ -189,6 +190,7 @@ func (m *Model) reviveMany(sessions []store.Session, emptyNotice string) (tea.Mo
 	default:
 		m.errBar.text = ""
 	}
+	m.rebuildRows()
 	m.requestRefresh()
 	return m, nil
 }
@@ -233,7 +235,15 @@ func (m *Model) reviveSession(sess store.Session) error {
 	if !isDir(sess.Cwd) {
 		return fmt.Errorf("working directory no longer exists: %s", sess.Cwd)
 	}
-	return m.relaunchSession(sess, tool, launch.ReviveCommand(tool, sess.AgentSessionID), tool.DefaultStatus, nil)
+	bind := func() error {
+		launchedAt := time.Now()
+		if err := m.store.SetAgentLaunchedAt(sess.ID, launchedAt); err != nil {
+			return err
+		}
+		m.bindReviveLocally(sess.ID, launchedAt)
+		return nil
+	}
+	return m.relaunchSession(sess, tool, launch.ReviveCommand(tool, sess.AgentSessionID), status.Starting, bind)
 }
 
 // relaunchSession puts a dead session's row back on a running tmux window
@@ -351,6 +361,24 @@ func (m *Model) bindRestartLocally(id, agentSessionID string, launchedAt time.Ti
 		m.sessions[i].AgentLaunchedAt = launchedAt
 		m.sessions[i].Status = status.Starting
 		m.sessions[i].Acked = false
+	}
+}
+
+// bindReviveLocally mirrors the store write in the loaded rows, so the
+// startup loader can paint before the next poll re-reads them.
+func (m *Model) bindReviveLocally(id string, launchedAt time.Time) {
+	for i := range m.sessions {
+		if m.sessions[i].ID != id {
+			continue
+		}
+		m.sessions[i].AgentLaunchedAt = launchedAt
+		m.sessions[i].Status = status.Starting
+		m.sessions[i].Acked = false
+	}
+	if sel, ok := m.selected(); ok && sel.ID == id {
+		// A killed or archived row still holds its last pane; that would
+		// count as painted and hide the loader.
+		m.preview = ""
 	}
 }
 
@@ -759,6 +787,7 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 			}
 			m.errBar.text = ""
+			m.rebuildRows()
 		case actionKill:
 			for _, sess := range m.confirm.sessions {
 				if err := m.killSession(sess); err != nil {
@@ -788,6 +817,7 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 			}
 			m.errBar.text = ""
+			m.rebuildRows()
 		case actionDelete:
 			for _, sess := range childrenFirst(m.confirm.sessions) {
 				if err := m.tmux.Kill(sess.ID); err != nil {

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -450,6 +450,18 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	if err := m.store.SetAgentSessionID(sess.ID, "kept-conversation"); err != nil {
 		t.Fatal(err)
 	}
+	m.applyCmd(t, m.refreshCmd())
+	m.selectSessionRow(t, "phoenix")
+	sess = m.sessionRows()[0]
+	if sess.AgentSessionID != "kept-conversation" {
+		t.Fatalf("loaded session id = %q, want kept-conversation", sess.AgentSessionID)
+	}
+
+	argsFile := filepath.Join(t.TempDir(), "launch-args")
+	tool := m.cfg.Tools[sess.Tool]
+	tool.ResumeByIDCommand = argCaptureCommand(argsFile) + " --resume {id}"
+	m.cfg.Tools[sess.Tool] = tool
+
 	if err := m.tmux.Kill(sess.ID); err != nil {
 		t.Fatalf("kill: %v", err)
 	}
@@ -495,6 +507,10 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	}
 	if strings.Contains(gotPreview, "old pane from last life") {
 		t.Fatalf("stale pane should not survive revive, got %q", gotPreview)
+	}
+	args := readWhenWritten(t, argsFile)
+	if !strings.Contains(args, "--resume") || !strings.Contains(args, "kept-conversation") {
+		t.Fatalf("revive launch arguments = %q, want --resume kept-conversation", args)
 	}
 }
 

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -518,6 +518,27 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	}
 }
 
+func TestReviveKillsNewPaneWhenLaunchTimeCannotPersist(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "phoenix", t.TempDir(), "")
+
+	sess := m.sessionRows()[0]
+	if err := m.tmux.Kill(sess.ID); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	if err := m.store.Delete(sess.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	err := m.reviveSession(sess)
+	if !errors.Is(err, store.ErrSessionGone) {
+		t.Fatalf("revive error = %v, want ErrSessionGone", err)
+	}
+	if m.tmux.Exists(sess.ID) {
+		t.Fatal("failed revive must kill the newly created tmux session")
+	}
+}
+
 func TestRevivedLaunchTimeSitsInsideStartingGrace(t *testing.T) {
 	created := time.Now().Add(-5 * 24 * time.Hour)
 	revived := store.Session{CreatedAt: created, AgentLaunchedAt: time.Now()}

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -461,6 +461,7 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	if err := m.store.SetAcked(sess.ID, true); err != nil {
 		t.Fatalf("set acked: %v", err)
 	}
+	m.preview = "old pane from last life\n"
 
 	if _, _ = m.reviveSelected(); m.errBar.text != "" {
 		t.Fatalf("revive: %q", m.errBar.text)
@@ -488,9 +489,12 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	if row.Status != status.Starting {
 		t.Fatalf("row status = %q want %q", row.Status, status.Starting)
 	}
-	m.preview = blankCapture
-	if got := previewText(m); !strings.Contains(got, "starting up") {
-		t.Fatalf("revived preview should carry the launch loader, got %q", got)
+	gotPreview := previewText(m)
+	if !strings.Contains(gotPreview, "starting up") {
+		t.Fatalf("revived preview should carry the launch loader, got %q", gotPreview)
+	}
+	if strings.Contains(gotPreview, "old pane from last life") {
+		t.Fatalf("stale pane should not survive revive, got %q", gotPreview)
 	}
 }
 
@@ -907,6 +911,9 @@ func TestArchiveGroupMovesWholeSubtree(t *testing.T) {
 		}
 		if stored.Status != status.Starting {
 			t.Fatalf("after restore, %s status = %q want %q", sess.Name, stored.Status, status.Starting)
+		}
+		if stored.LaunchTime().Equal(stored.CreatedAt) {
+			t.Fatalf("after restore, %s launch time was not refreshed", sess.Name)
 		}
 	}
 	m.applyCmd(t, cmd)

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -456,6 +456,7 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	if sess.AgentSessionID != "kept-conversation" {
 		t.Fatalf("loaded session id = %q, want kept-conversation", sess.AgentSessionID)
 	}
+	previousLaunchTime := sess.LaunchTime()
 
 	argsFile := filepath.Join(t.TempDir(), "launch-args")
 	tool := m.cfg.Tools[sess.Tool]
@@ -496,6 +497,9 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	}
 	if got.AgentLaunchedAt.IsZero() || !got.LaunchTime().Equal(got.AgentLaunchedAt) {
 		t.Fatalf("launch time = %v, created = %v", got.LaunchTime(), got.CreatedAt)
+	}
+	if !got.AgentLaunchedAt.After(previousLaunchTime) {
+		t.Fatalf("launch time = %v, want after %v", got.AgentLaunchedAt, previousLaunchTime)
 	}
 	row := m.sessionRows()[0]
 	if row.Status != status.Starting {

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -53,6 +53,16 @@ func TestCreateArchiveRestoreDelete(t *testing.T) {
 	m.selectSessionRow(t, "alpha")
 	m.restoreSelected()
 	_, cmd = m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	got, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != status.Starting {
+		t.Fatalf("after restore, status = %q want %q", got.Status, status.Starting)
+	}
+	if got.LaunchTime().Equal(got.CreatedAt) {
+		t.Fatal("restore should stamp a new launch time")
+	}
 	m.applyCmd(t, cmd)
 	m.showArchived = false
 	m.applyCmd(t, m.refreshCmd())
@@ -437,6 +447,9 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	createSession(t, m, "phoenix", t.TempDir(), "")
 
 	sess := m.sessionRows()[0]
+	if err := m.store.SetAgentSessionID(sess.ID, "kept-conversation"); err != nil {
+		t.Fatal(err)
+	}
 	if err := m.tmux.Kill(sess.ID); err != nil {
 		t.Fatalf("kill: %v", err)
 	}
@@ -459,11 +472,37 @@ func TestReviveRecreatesDeadSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	if got.Status != status.Idle {
-		t.Fatalf("after revive, status = %q want %q", got.Status, status.Idle)
+	if got.Status != status.Starting {
+		t.Fatalf("after revive, status = %q want %q", got.Status, status.Starting)
 	}
 	if got.Acked {
 		t.Fatal("revive should clear a leftover ack")
+	}
+	if got.AgentSessionID != "kept-conversation" || got.RetiredAgentSessionID != "" {
+		t.Fatalf("conversation = %q retired = %q, want kept-conversation", got.AgentSessionID, got.RetiredAgentSessionID)
+	}
+	if got.AgentLaunchedAt.IsZero() || !got.LaunchTime().Equal(got.AgentLaunchedAt) {
+		t.Fatalf("launch time = %v, created = %v", got.LaunchTime(), got.CreatedAt)
+	}
+	row := m.sessionRows()[0]
+	if row.Status != status.Starting {
+		t.Fatalf("row status = %q want %q", row.Status, status.Starting)
+	}
+	m.preview = blankCapture
+	if got := previewText(m); !strings.Contains(got, "starting up") {
+		t.Fatalf("revived preview should carry the launch loader, got %q", got)
+	}
+}
+
+func TestRevivedLaunchTimeSitsInsideStartingGrace(t *testing.T) {
+	created := time.Now().Add(-5 * 24 * time.Hour)
+	revived := store.Session{CreatedAt: created, AgentLaunchedAt: time.Now()}
+	if time.Since(revived.LaunchTime()) >= startingGrace {
+		t.Fatal("a revive that stamps launch time must still be inside the grace")
+	}
+	stale := store.Session{CreatedAt: created}
+	if time.Since(stale.LaunchTime()) < startingGrace {
+		t.Fatal("a 5-day-old row with no relaunch is outside the grace")
 	}
 }
 
@@ -858,8 +897,18 @@ func TestArchiveGroupMovesWholeSubtree(t *testing.T) {
 	}
 
 	m.selectGroupRow(t, "proj")
+	archived := m.sessionRows()
 	m.restoreSelected()
 	_, cmd = m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	for _, sess := range archived {
+		stored, err := m.store.Get(sess.ID)
+		if err != nil {
+			t.Fatalf("get %s: %v", sess.Name, err)
+		}
+		if stored.Status != status.Starting {
+			t.Fatalf("after restore, %s status = %q want %q", sess.Name, stored.Status, status.Starting)
+		}
+	}
 	m.applyCmd(t, cmd)
 	m.showArchived = false
 	m.applyCmd(t, m.refreshCmd())


### PR DESCRIPTION
## What changed

Restore (`u`) and revive (`v`) now enter `starting` and stamp the pane's launch time, the same way a restart already does. The existing startup loader can therefore paint until the agent draws its first frame, including for a session whose row is days old.

## Why

Restoring a group relaunches every agent in it. Those rows came back `idle` with an empty pane while the tool was still booting, so a live session read as a blank, settled one. The loader only runs in the launch state, and the launch grace is measured from `LaunchTime`, which stayed the row's original creation time.

## How it was verified

```
$ gofmt -l .
$ go vet ./...
$ go build ./...
$ env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...
$ env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./internal/store ./internal/ui
```

All printed nothing / passed. `TestReviveRecreatesDeadSession` now asserts the launch loader, the kept conversation id, and a fresh launch time. Restore of a session and of a group subtree both land on `starting` before the next poll.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (`./internal/store` and `./internal/ui`; full `./...` without `-race`)
- [x] `go build ./...` passes
- [ ] Ran it against real sessions

## Visual evidence

Text-mode snapshots of the preview the loader already draws. Restore now reaches that state; a focused pane still shows the live tmux capture, same as a new spawn.

**Before:**

```text
○  phoenix   idle · claude

(empty pane)
```

**After:**

```text
◌  phoenix   starting up · claude

        ·   ·   •
        ·       ●
        ·       ·
        ·       ·
        ·   ·   ·
         starting up
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restored and revived sessions now display a startup state while relaunching.
  * Startup progress appears immediately, replacing stale previews.
  * Launch times refresh when sessions are restored or revived.
  * Reviving a session preserves its existing conversation history.
  * Batch restoration consistently refreshes session state and the session list.

* **Bug Fixes**
  * Fixed stale acknowledgements after restoring or reviving sessions.
  * Improved handling of failed revival operations.
  * Ensured refreshed sessions retain the correct conversation information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->