### PR TITLE
docs(feed): announce v0.31.0 and retire the entry it follows

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -1,5 +1,21 @@
 [
   {
+    "id": "sessions-coordinate-with-each-other",
+    "banner": "new: agents spawn and message each other",
+    "title": "Agent sessions spawn, message and coordinate with each other",
+    "body": [
+      "A session can spawn another agent on its own task, so independent work runs beside you instead of behind you.",
+      "Sessions list each other, read a pane, send a message that lands when that agent is at rest, and wait for one to stop.",
+      "Declare the files you are about to edit and another agent in the same checkout finds out before both of you change them.",
+      "Every verb is an MCP tool for the agent in the pane and an agent-manager subcommand for anything you script.",
+      "ctrl+v pastes a clipboard image into a new session's first task, and a missing agent CLI now names its own installer.",
+      "Thanks to @roshaans for the image paste and @creatorrr for the report behind the repaint of RTL rows.",
+      "@KyleBastien and @pandysp filed what is shaping the next one: #337, #349, #350 and #351."
+    ],
+    "url": "https://github.com/YoanWai/agent-manager/releases/tag/v0.31.0",
+    "max_version": "0.31.0"
+  },
+  {
     "id": "terminals-under-their-agent",
     "banner": "new: terminals live under their agent",
     "title": "Terminals nest under the session they were opened for",
@@ -12,6 +28,7 @@
       "Thanks to @roshaans for the terminal names, @OkunaRei for the selection fix, @sunnor92 for two reports,",
       "and @andrelago13 for the editor key that moved. #326 is where every binding becomes yours to set."
     ],
-    "url": "https://github.com/YoanWai/agent-manager/releases/tag/v0.30.0"
+    "url": "https://github.com/YoanWai/agent-manager/releases/tag/v0.30.0",
+    "max_version": "0.30.0"
   }
 ]

--- a/internal/feed/feed_test.go
+++ b/internal/feed/feed_test.go
@@ -1,6 +1,7 @@
 package feed
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -227,5 +228,41 @@ func TestFetchCapsCountAndSize(t *testing.T) {
 	}
 	if len(messages[0].Banner) > maxBannerLen || len(messages[0].Title) > maxTitleLen {
 		t.Fatalf("field lengths must be capped, got banner=%d title=%d", len(messages[0].Banner), len(messages[0].Title))
+	}
+}
+
+func TestShippedFeedFileIsRenderableAndRetires(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "docs", "messages.json"))
+	if err != nil {
+		t.Fatalf("read shipped feed: %v", err)
+	}
+	var entries []rawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		t.Fatalf("shipped feed must parse or every install falls back to a stale cache: %v", err)
+	}
+	for _, entry := range entries {
+		if !validFeedID.MatchString(entry.ID) {
+			t.Errorf("%q: invalid id", entry.ID)
+		}
+		if entry.URL != "" && !safeURL(entry.URL) {
+			t.Errorf("%s: unsafe url %q", entry.ID, entry.URL)
+		}
+		if got := cleanText(entry.Banner, maxBannerLen); got != entry.Banner {
+			t.Errorf("%s: banner is cut to %q", entry.ID, got)
+		}
+		if got := cleanText(entry.Title, maxTitleLen); got != entry.Title {
+			t.Errorf("%s: title is cut to %q", entry.ID, got)
+		}
+		if len(entry.Body) > maxBodyLines {
+			t.Errorf("%s: %d body lines, only the first %d render", entry.ID, len(entry.Body), maxBodyLines)
+		}
+		for i, line := range entry.Body {
+			if got := cleanText(line, maxBodyLine); got != line {
+				t.Errorf("%s: body line %d is cut to %q", entry.ID, i+1, got)
+			}
+		}
+		if entry.MaxVersion == "" && entry.ExpiresAt == "" {
+			t.Errorf("%s: needs max_version or expires_at, or it keeps showing after it stops being true", entry.ID)
+		}
 	}
 }

--- a/internal/feed/feed_test.go
+++ b/internal/feed/feed_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -85,7 +86,8 @@ func TestFetchStripsControlSequences(t *testing.T) {
 func TestFetchHonorsVersionBounds(t *testing.T) {
 	serve(t, `[
 		{"id":"old-only","banner":"x","title":"x","max_version":"v0.14.1"},
-		{"id":"new-only","banner":"x","title":"x","min_version":"v0.14.2"}
+		{"id":"new-only","banner":"x","title":"x","min_version":"v0.14.2"},
+		{"id":"wildcard-bound","banner":"x","title":"x","max_version":"0.14.x"}
 	]`)
 	messages := fetch(t, t.TempDir(), "v0.14.2")
 	if len(messages) != 1 || messages[0].ID != "feed-new-only" {
@@ -240,6 +242,7 @@ func TestShippedFeedFileIsRenderableAndRetires(t *testing.T) {
 	if err := json.Unmarshal(raw, &entries); err != nil {
 		t.Fatalf("shipped feed must parse or every install falls back to a stale cache: %v", err)
 	}
+	now := time.Now()
 	for _, entry := range entries {
 		if !validFeedID.MatchString(entry.ID) {
 			t.Errorf("%q: invalid id", entry.ID)
@@ -264,5 +267,40 @@ func TestShippedFeedFileIsRenderableAndRetires(t *testing.T) {
 		if entry.MaxVersion == "" && entry.ExpiresAt == "" {
 			t.Errorf("%s: needs max_version or expires_at, or it keeps showing after it stops being true", entry.ID)
 		}
+		if entry.MaxVersion != "" {
+			if !serves(sanitize(entries, entry.MaxVersion, now), entry.ID) {
+				t.Errorf("%s: max_version %q hides it from its own release; a bound that fails to parse hides it from everyone", entry.ID, entry.MaxVersion)
+			}
+			if above := majorAbove(t, entry.MaxVersion); serves(sanitize(entries, above, now), entry.ID) {
+				t.Errorf("%s: still served on %s", entry.ID, above)
+			}
+		}
+		if entry.ExpiresAt != "" {
+			if _, err := time.Parse(time.RFC3339, entry.ExpiresAt); err != nil {
+				t.Errorf("%s: expires_at %q does not parse, which drops the entry: %v", entry.ID, entry.ExpiresAt, err)
+			}
+		}
 	}
+}
+
+func serves(messages []Message, id string) bool {
+	for _, msg := range messages {
+		if msg.ID == "feed-"+id {
+			return true
+		}
+	}
+	return false
+}
+
+func majorAbove(t *testing.T, version string) string {
+	t.Helper()
+	fields := strings.Split(strings.TrimPrefix(version, "v"), ".")
+	if len(fields) != 3 {
+		t.Fatalf("version bound %q is not three fields", version)
+	}
+	major, err := strconv.Atoi(fields[0])
+	if err != nil {
+		t.Fatalf("version bound %q has a non-numeric major field", version)
+	}
+	return strconv.Itoa(major+1) + "." + fields[1] + "." + fields[2]
 }


### PR DESCRIPTION
## What

`docs/messages.json` gains the v0.31.0 entry, and both entries now name the release they describe in `max_version`.

A `TestShippedFeedFileIsRenderableAndRetires` in `internal/feed` reads the shipped file the way the TUI does and fails if the JSON stops parsing, if `cleanText` would cut a banner, title or body line in front of a reader, or if an entry carries neither `max_version` nor `expires_at`.

## Why

The v0.30.0 entry carried no bound. `sanitize` treats an empty bound as open (`update.VersionWithin` returns true when both are empty), so every install kept receiving it. A v0.31.0 user was shown "new: terminals live under their agent" as current news, directly beneath the generated notice telling them they had just updated past it.

`max_version` is inclusive on both ends, so naming the announced release retires the entry as soon as a newer one is running. The 0.30 line closed at 0.30.0, and the v0.31.0 entry is bounded the same way.

The test exists because the failure is silent in both directions: a malformed file leaves `fetchMessages` serving the stale cache, and an over-long line is truncated mid-word rather than rejected.

## Verified

Ran the real `sanitize` over the shipped file at each version:

| Running | Messages served |
| --- | --- |
| 0.29.1 | both, v0.31.0 first |
| 0.30.0 | both |
| 0.31.0 | v0.31.0 only |
| 0.32.0 | none |

The new test fails on the file as it stands on `main`:

```
feed_test.go:265: terminals-under-their-agent: needs max_version or expires_at, or it keeps showing after it stops being true
```

and passes on this branch.

`gofmt -l .` prints nothing, `go vet ./...` is clean, and `go test ./...` is green on an isolated tmux socket.

One note for whoever runs the suite next: `internal/ui` `TestPendingInputWaitsForTheLaunchPrompt` failed for me on the `/tmp/amtest` socket that AGENTS.md names, capturing pane text belonging to another agent session running against the same socket. It passes on a socket of its own. The shared path makes that test flaky whenever two sessions build at once, which is worth a separate look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added release notes for v0.31.0 covering agent sessions, messaging, coordination, file declarations, MCP/CLI access, and image pasting.

* **Bug Fixes**
  * Improved release feed metadata and validation for identifiers, links, formatting, length limits, version filtering, retirement details, and expiration timestamps.
  * Added maximum-version metadata to the v0.30.0 release entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->