### PR TITLE
chore(review): stop linking the archived tool-profiles repo

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -187,8 +187,5 @@ knowledge_base:
   pull_requests:
     scope: local
   automatic_repository_linking: true
-  linked_repositories:
-    - repository: "YoanWai/agent-manager-tools"
-      instructions: "Community TOML profiles for CLI tools beyond the built-ins"
   code_guidelines:
     enabled: true


### PR DESCRIPTION
`YoanWai/agent-manager-tools` was archived today, so the review knowledge base was linked to a repository nobody maintains.

That repo held three profiles (`aider`, `crush`, `cursor-agent`), each carrying `command` plus `default_status = "idle"` and no status rules, so it offered nothing a review can use. Dropping the entry leaves `automatic_repository_linking` in place.