### PR TITLE
fix(ui): keep a just-spawned session on screen

### DIFF
--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -617,6 +617,7 @@ func (m *Model) applyConfirmedArchived(archived bool) error {
 		if err := m.store.SetArchived(sess.ID, archived); err != nil {
 			return err
 		}
+		m.forgetLaunch(sess.ID)
 	}
 	return nil
 }
@@ -846,6 +847,7 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 				delete(m.pickedRepos, sess.ID)
 				delete(m.awaitedRenames, sess.ID)
+				m.forgetLaunch(sess.ID)
 				if err := m.store.Delete(sess.ID); err != nil {
 					m.errBar.text = err.Error()
 					return m, nil

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -181,6 +181,9 @@ type Model struct {
 	// settle timers with an older gen are dropped so key-repeat cannot
 	// queue a second of tmux work after the user stops.
 	previewGen uint64
+	// launched is when this run recorded each session it spawned. A poll
+	// that listed the store before that has nothing to say about the row.
+	launched map[string]time.Time
 	// terminalKeyAt is when the last T finished being handled. Held down it
 	// autorepeats into a burst of keystrokes, and T is the only key that
 	// spawns on the keystroke itself rather than opening a form that would
@@ -406,7 +409,10 @@ type agentStats struct {
 }
 
 type refreshMsg struct {
-	sessions       []store.Session
+	sessions []store.Session
+	// listedAt is when the pass read that list, which is a whole pass of
+	// tmux and ps calls before the UI sees it.
+	listedAt       time.Time
 	groups         []string
 	groupPaths     map[string]string
 	groupWorktrees map[string]string
@@ -1072,7 +1078,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				focusExit = m.leaveFocus()
 			}
 		}
-		m.sessions = msg.sessions
+		m.sessions = m.keepPendingLaunches(msg.sessions, msg.listedAt)
 		m.groups = msg.groups
 		m.groupPaths = msg.groupPaths
 		m.groupWorktrees = msg.groupWorktrees

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1072,13 +1072,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.ageError()
 		// The focused session can die or vanish under us; fall back to the
 		// list rather than typing into nothing.
+		sessions := m.keepPendingLaunches(msg.sessions, msg.listedAt)
 		var focusExit tea.Cmd
 		if m.mode == modeFocus {
-			if sess, ok := m.selected(); !ok || sessionGone(msg.sessions, sess.ID) {
+			if sess, ok := m.selected(); !ok || sessionGone(sessions, sess.ID) {
 				focusExit = m.leaveFocus()
 			}
 		}
-		m.sessions = m.keepPendingLaunches(msg.sessions, msg.listedAt)
+		m.sessions = sessions
 		m.groups = msg.groups
 		m.groupPaths = msg.groupPaths
 		m.groupWorktrees = msg.groupWorktrees

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -223,6 +223,7 @@ func (p *poller) refreshOnce() tea.Msg {
 	}
 	p.tick++
 
+	listedAt := time.Now()
 	sessions, err := p.store.ListSessions(includeArchived)
 	if err != nil {
 		return errMsg{err}
@@ -404,6 +405,7 @@ func (p *poller) refreshOnce() tea.Msg {
 
 	msg := refreshMsg{
 		sessions:       sessions,
+		listedAt:       listedAt,
 		groups:         names,
 		groupPaths:     paths,
 		groupWorktrees: worktrees,

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -48,6 +48,13 @@ func (m *Model) launchNewSession(sess store.Session, tool config.Tool, baseComma
 	return labelErr
 }
 
+// forgetLaunch drops a row from the pending set, so a session the user has
+// since sent away is not carried back onto the tree by a poll that listed
+// the store before it was launched.
+func (m *Model) forgetLaunch(id string) {
+	delete(m.launched, id)
+}
+
 // keepPendingLaunches carries over the rows this run spawned that the poll
 // has not looked for yet. A poll lists its sessions and then spends the pass
 // in tmux and ps calls, so the list the UI finally receives can predate a

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -39,7 +39,36 @@ func (m *Model) launchNewSession(sess store.Session, tool config.Tool, baseComma
 		return err
 	}
 	labelErr := m.tmux.SetLabel(sess.ID, sessionLabel(sess.Group, sess.Name))
+	if m.launched == nil {
+		m.launched = map[string]time.Time{}
+	}
+	m.launched[sess.ID] = time.Now()
 	m.sessions = append(m.sessions, sess)
 	m.rebuildRows()
 	return labelErr
+}
+
+// keepPendingLaunches carries over the rows this run spawned that the poll
+// has not looked for yet. A poll lists its sessions and then spends the pass
+// in tmux and ps calls, so the list the UI finally receives can predate a
+// launch and would otherwise blink the new agent off screen. The first poll
+// to list the store after a launch is the authority on it, whether it
+// reports the row or its absence.
+func (m *Model) keepPendingLaunches(polled []store.Session, listedAt time.Time) []store.Session {
+	for id, at := range m.launched {
+		if listedAt.After(at) {
+			delete(m.launched, id)
+			continue
+		}
+		if !sessionGone(polled, id) {
+			continue
+		}
+		for _, sess := range m.sessions {
+			if sess.ID == id {
+				polled = append(polled, sess)
+				break
+			}
+		}
+	}
+	return polled
 }

--- a/internal/ui/sessionlaunch_test.go
+++ b/internal/ui/sessionlaunch_test.go
@@ -1,0 +1,49 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAStaleRefreshKeepsASessionLaunchedAfterItWasListed(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+
+	// What a poll hands the UI: the session list as it stood when the pass
+	// opened, delivered once the pass has finished its tmux and ps calls.
+	inFlight := m.poller.refreshOnce()
+
+	if err := m.spawnSession("claude", "late-arrival", t.TempDir(), "", "", false, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	launched := m.sessionRows()
+	if len(launched) != 1 {
+		t.Fatalf("rows after the spawn = %d, want the one just launched", len(launched))
+	}
+
+	updated, _ := m.Update(inFlight)
+	*m = *updated.(*Model)
+
+	if sessionGone(m.sessions, launched[0].ID) {
+		t.Fatalf("the stale poll took the launched session off screen, leaving %v", m.sessionRows())
+	}
+}
+
+func TestAStaleRefreshKeepsALaunchListedWhileTmuxWasStartingIt(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+
+	if err := m.spawnSession("claude", "slow-window", t.TempDir(), "", "", false, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	launched := m.sessionRows()[0]
+
+	// Building the tmux window takes tens of milliseconds, so a poll can
+	// list the store after the launch began and still be missing its row.
+	updated, _ := m.Update(refreshMsg{listedAt: launched.CreatedAt.Add(time.Millisecond)})
+	*m = *updated.(*Model)
+
+	if sessionGone(m.sessions, launched.ID) {
+		t.Fatalf("the stale poll took the launched session off screen, leaving %v", m.sessionRows())
+	}
+}

--- a/internal/ui/sessionlaunch_test.go
+++ b/internal/ui/sessionlaunch_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"testing"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestAStaleRefreshKeepsASessionLaunchedAfterItWasListed(t *testing.T) {
@@ -45,5 +47,75 @@ func TestAStaleRefreshKeepsALaunchListedWhileTmuxWasStartingIt(t *testing.T) {
 
 	if sessionGone(m.sessions, launched.ID) {
 		t.Fatalf("the stale poll took the launched session off screen, leaving %v", m.sessionRows())
+	}
+}
+
+// pressRune sends one key through Update the way the terminal would.
+func (m *Model) pressRune(t *testing.T, r rune) {
+	t.Helper()
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	*m = *updated.(*Model)
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			updated, _ = m.Update(msg)
+			*m = *updated.(*Model)
+		}
+	}
+}
+
+// staleRefreshAfter is the refresh a poll pass that opened before the launch
+// would deliver: it carries no sessions and a listing time from before them.
+func staleRefreshAfter(m *Model) refreshMsg {
+	earliest := time.Now()
+	for _, at := range m.launched {
+		if at.Before(earliest) {
+			earliest = at
+		}
+	}
+	return refreshMsg{listedAt: earliest.Add(-time.Millisecond)}
+}
+
+func TestAStaleRefreshDoesNotBringBackASessionJustDeleted(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	if err := m.spawnSession("claude", "doomed", t.TempDir(), "", "", false, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	sess := m.sessionRows()[0]
+
+	m.selectSessionRow(t, sess.Name)
+	m.pressRune(t, 'd')
+	m.pressRune(t, 'y')
+	if _, err := m.store.Get(sess.ID); err == nil {
+		t.Fatal("the delete did not reach the store")
+	}
+
+	updated, _ := m.Update(staleRefreshAfter(m))
+	*m = *updated.(*Model)
+
+	if !sessionGone(m.sessions, sess.ID) {
+		t.Fatalf("a deleted session came back on a stale poll: %v", m.sessionRows())
+	}
+}
+
+func TestAStaleRefreshDoesNotBringBackASessionJustArchived(t *testing.T) {
+	m := buildModel(t)
+	m.applyCmd(t, m.refreshCmd())
+	if err := m.spawnSession("claude", "shelved", t.TempDir(), "", "", false, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	sess := m.sessionRows()[0]
+
+	m.selectSessionRow(t, sess.Name)
+	m.pressRune(t, 'a')
+	m.pressRune(t, 'y')
+
+	updated, _ := m.Update(staleRefreshAfter(m))
+	*m = *updated.(*Model)
+
+	for _, row := range m.sessionRows() {
+		if row.ID == sess.ID {
+			t.Fatalf("an archived session came back on the live tree as %q", row.Status)
+		}
 	}
 }


### PR DESCRIPTION
A session spawned while a poll pass was in flight vanished from the tree until the next pass came round. On a busy machine with a large fleet that is a visible blink; recording the docs demos is where it turned up.

## What was happening

`refreshOnce` reads the session list at the top of its pass, then spends the rest of it in tmux and `ps` calls. The UI applied the result wholesale, so a list assembled before the spawn erased the row that had just been added optimistically.

## The fix

The UI carries over the rows this run launched that the poll had not looked for yet. The first poll to list the store after a launch is the authority on it, whether it reports the row or its absence.

Launch time is stamped by the model rather than read from `CreatedAt`: building the tmux window takes 40-90ms before the store write, so a pass listing inside that window misses a row whose own timestamp already predates it.

## Second commit

Review caught three ways the first one was wrong, each reproduced through the real key path:

- a session **deleted** inside the window came back, with no tmux window behind it
- a session **archived** inside the window came back onto the live tree wearing the dead status the kill had just given it
- **focus** tested the poll's own list rather than the merged one, so spawning into focus and catching a stale poll dropped out of the session it had just entered

Both lifecycle paths now forget the launch as they send the session away, and focus reads the list the UI actually adopts.

## Verification

Four tests, each written before its fix and watched fail. `gofmt` clean, `go vet` clean, full suite green on an isolated tmux socket.