### PR TITLE
feat(ui): name a waiting row by the prompt it was given

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -58,6 +58,13 @@ func pastesDir() string {
 	return filepath.Join(os.TempDir(), "agent-manager-pastes")
 }
 
+// IsPastePath reports whether a word is one of the image paths a pasted
+// picture becomes on its way to an agent, so a reader showing the prompt
+// back can leave the pictures out of it.
+func IsPastePath(word string) bool {
+	return filepath.Dir(word) == pastesDir()
+}
+
 // StaleAfter is how long a pasted image stays on disk before a sweep can
 // take it: long enough for an agent to reopen an image from an earlier
 // session, short enough that screenshots do not pile up in temp.

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -607,9 +607,9 @@ func (m *Model) spawnSession(toolName, name, dir, group, prompt string, autoName
 	// the agent picks instead of showing the one generated for it.
 	if autoNamed {
 		if m.awaitedRenames == nil {
-			m.awaitedRenames = map[string]string{}
+			m.awaitedRenames = map[string]awaitedRename{}
 		}
-		m.awaitedRenames[id] = name
+		m.awaitedRenames[id] = awaitedRename{generated: name, prompt: prompt}
 	}
 	return nil
 }

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -465,19 +465,33 @@ func (m *Model) sessionGlyph(sess store.Session) string {
 // instead of flashing a throwaway one first.
 const namePlaceholder = "…"
 
+// placeholderPromptWidth caps the prompt a waiting row borrows. It is what
+// the narrowest rail affords beside a starting row's state, tool and age, so
+// the row keeps the shape every other row has instead of pushing a column
+// off its own end.
+const placeholderPromptWidth = 12
+
 // renameGrace caps the wait for that answer. It spans the whole way there,
 // the boot, the directive reaching the agent, and the command it runs, so it
 // is generous; past it the session keeps the name it was given.
 const renameGrace = time.Minute
 
+// awaitedRename is what a spawn launched with: the name generated for it,
+// which it falls back to, and the prompt it was given, which says which task
+// the row is while it has no name of its own.
+type awaitedRename struct {
+	generated string
+	prompt    string
+}
+
 // awaitingRename drops the record it reads as soon as the wait is over, so
 // a session settling on its name needs nothing to sweep the map after it.
 func (m *Model) awaitingRename(sess store.Session) bool {
-	generated, awaited := m.awaitedRenames[sess.ID]
-	if !awaited {
+	awaited, ok := m.awaitedRenames[sess.ID]
+	if !ok {
 		return false
 	}
-	if sess.Name == generated && sess.Status != status.Dead &&
+	if sess.Name == awaited.generated && sess.Status != status.Dead &&
 		time.Since(sess.CreatedAt) < renameGrace {
 		return true
 	}
@@ -488,10 +502,21 @@ func (m *Model) awaitingRename(sess store.Session) bool {
 // displayName is what every reading of a session prints, so the rail row and
 // the columns beside it never disagree about who an agent is.
 func (m *Model) displayName(sess store.Session) string {
-	if m.awaitingRename(sess) {
-		return namePlaceholder
+	if !m.awaitingRename(sess) {
+		return sess.Name
 	}
-	return sess.Name
+	// The stored LaunchPrompt is the decorated one, carrying the rename
+	// directive the agent was sent; what the row wants is what was typed.
+	if preview := promptPreview(m.awaitedRenames[sess.ID].prompt); preview != "" {
+		return preview
+	}
+	return namePlaceholder
+}
+
+// promptPreview flattens a prompt into the one short line a row can wear as
+// a name, so five agents spawned in a burst say which is which right away.
+func promptPreview(prompt string) string {
+	return ansi.Truncate(strings.Join(strings.Fields(prompt), " "), placeholderPromptWidth, "…")
 }
 
 func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad, guides, trail, bg string) string {

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/sysstat"
@@ -515,8 +516,18 @@ func (m *Model) displayName(sess store.Session) string {
 
 // promptPreview flattens a prompt into the one short line a row can wear as
 // a name, so five agents spawned in a burst say which is which right away.
+// A pasted image reaches the agent as the path it was written to, which
+// would name every image-first spawn the same thing, so the pictures drop
+// out of the preview and the words stay.
 func promptPreview(prompt string) string {
-	return ansi.Truncate(strings.Join(strings.Fields(prompt), " "), placeholderPromptWidth, "…")
+	words := make([]string, 0, len(strings.Fields(prompt)))
+	for _, word := range strings.Fields(prompt) {
+		if clipboard.IsPastePath(word) {
+			continue
+		}
+		words = append(words, word)
+	}
+	return ansi.Truncate(strings.Join(words, " "), placeholderPromptWidth, "…")
 }
 
 func (m *Model) renderSessionEntry(entry treeRow, selected bool, width int, pad, guides, trail, bg string) string {

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -657,7 +657,7 @@ func TestSessionRowStandsInForAnAwaitedName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			m := &Model{}
 			if tc.awaited {
-				m.awaitedRenames = map[string]string{tc.sess.ID: generated}
+				m.awaitedRenames = map[string]awaitedRename{tc.sess.ID: {generated: generated}}
 			}
 			row := ansi.Strip(m.renderTreeRow(treeRow{sess: tc.sess}, false, 80, 0, panelHex()))
 			if !strings.Contains(row, tc.want) {
@@ -702,11 +702,14 @@ func TestEveryReadingOfASessionStandsInForAnAwaitedName(t *testing.T) {
 	m.openQuickMode()
 	readings = append(readings, reading{"quick bar", ansi.Strip(m.viewQuickBar(112))})
 
+	// The prompt the spawn was given is what every reading wears until the
+	// agent answers with a name of its own.
+	const standIn = "do things"
 	for _, shown := range readings {
 		if strings.Contains(shown.text, generated) {
 			t.Errorf("%s shows the generated name:\n%s", shown.where, shown.text)
 		}
-		if !strings.Contains(shown.text, namePlaceholder) {
+		if !strings.Contains(shown.text, standIn) {
 			t.Errorf("%s does not stand in for the awaited name:\n%s", shown.where, shown.text)
 		}
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -163,12 +163,11 @@ type Model struct {
 	// declaration for as long as this manager runs.
 	pickedRepos map[string]string
 
-	// awaitedRenames holds the generated name a spawned session launched
-	// under, for as long as the agent it carries the rename directive to is
-	// still expected to answer. A rename that has not landed by the time
-	// this manager run ends is one that is never arriving, so the set is
-	// deliberately not persisted.
-	awaitedRenames map[string]string
+	// awaitedRenames holds what a spawned session launched with, for as long
+	// as the agent it carries the rename directive to is still expected to
+	// answer. A rename that has not landed by the time this manager run ends
+	// is one that is never arriving, so the set is deliberately not persisted.
+	awaitedRenames map[string]awaitedRename
 
 	width  int
 	height int

--- a/internal/ui/nameplaceholder_test.go
+++ b/internal/ui/nameplaceholder_test.go
@@ -1,0 +1,85 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// spawnUnnamed launches through the New Session form with the name left
+// blank, which is what makes a spawn auto-named and sends the agent the
+// directive to name itself.
+func spawnUnnamed(t *testing.T, m *Model, prompt string) store.Session {
+	t.Helper()
+	m.openForm()
+	m.form.name.SetValue("")
+	m.form.dir.SetValue(t.TempDir())
+	m.form.prompt.input.SetValue(prompt)
+	m.form.toolIndex = 0
+	if _, _ = m.submitForm(); m.mode != modeList {
+		t.Fatalf("submit left mode=%v err=%q", m.mode, m.errBar.text)
+	}
+	rows := m.sessionRows()
+	if len(rows) != 1 {
+		t.Fatalf("session rows = %d, want the one just spawned", len(rows))
+	}
+	return rows[0]
+}
+
+func TestAWaitingRowIsNamedByThePromptItWasGiven(t *testing.T) {
+	m := buildModel(t)
+	sess := spawnUnnamed(t, m, "add cursor pagination to the sessions list endpoint")
+
+	got := ansi.Strip(m.displayName(sess))
+	if !strings.HasPrefix(got, "add cursor") {
+		t.Fatalf("displayName = %q, want it to open with the prompt", got)
+	}
+}
+
+func TestAWaitingRowNeverShowsTheRenameDirective(t *testing.T) {
+	m := buildModel(t)
+	sess := spawnUnnamed(t, m, "rate limit the public search route")
+
+	got := ansi.Strip(m.displayName(sess))
+	for _, leaked := range []string{"Run this exact", "agent-manager rename", "Other agent sessions"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("displayName = %q, leaked the launch directive %q", got, leaked)
+		}
+	}
+}
+
+func TestAWaitingRowSpawnedWithNoPromptKeepsThePlaceholder(t *testing.T) {
+	m := buildModel(t)
+	sess := spawnUnnamed(t, m, "")
+
+	if got := ansi.Strip(m.displayName(sess)); got != namePlaceholder {
+		t.Fatalf("displayName = %q, want the bare placeholder %q", got, namePlaceholder)
+	}
+}
+
+func TestAWaitingRowKeepsThePromptToOneShortLine(t *testing.T) {
+	m := buildModel(t)
+	sess := spawnUnnamed(t, m, "split the staging workspace\nout of the prod state file\nand re-run the plan")
+
+	got := ansi.Strip(m.displayName(sess))
+	if strings.ContainsAny(got, "\n\t") {
+		t.Fatalf("displayName = %q, want one line", got)
+	}
+	if width := ansi.StringWidth(got); width > placeholderPromptWidth {
+		t.Fatalf("displayName = %q is %d wide, want at most %d", got, width, placeholderPromptWidth)
+	}
+}
+
+func TestAPromptNamedRowFallsBackToItsGeneratedNamePastTheGrace(t *testing.T) {
+	m := buildModel(t)
+	sess := spawnUnnamed(t, m, "cache the session lookup for 30 seconds")
+
+	sess.CreatedAt = time.Now().Add(-renameGrace - time.Second)
+	got := ansi.Strip(m.displayName(sess))
+	if got != sess.Name || !strings.HasPrefix(got, "claude-") {
+		t.Fatalf("displayName past the grace = %q, want the generated name %q", got, sess.Name)
+	}
+}

--- a/internal/ui/nameplaceholder_test.go
+++ b/internal/ui/nameplaceholder_test.go
@@ -1,9 +1,12 @@
 package ui
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/YoanWai/agent-manager/internal/clipboard"
 
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/charmbracelet/x/ansi"
@@ -81,5 +84,26 @@ func TestAPromptNamedRowFallsBackToItsGeneratedNamePastTheGrace(t *testing.T) {
 	got := ansi.Strip(m.displayName(sess))
 	if got != sess.Name || !strings.HasPrefix(got, "claude-") {
 		t.Fatalf("displayName past the grace = %q, want the generated name %q", got, sess.Name)
+	}
+}
+
+func TestAWaitingRowIsNamedByTheWordsNotThePastedImage(t *testing.T) {
+	// A chip reaches the agent as the path the picture was written to, so an
+	// image-first prompt would otherwise name every such row the same thing.
+	pasted, err := clipboard.SaveToTemp([]byte("not really a png"), "png")
+	if err != nil {
+		t.Fatalf("save paste: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pasted) })
+
+	m := buildModel(t)
+	sess := spawnUnnamed(t, m, pasted+" fix the flaky auth middleware test")
+
+	got := ansi.Strip(m.displayName(sess))
+	if strings.Contains(got, "/") || strings.Contains(got, "paste-") {
+		t.Fatalf("displayName = %q, want the words rather than the pasted path", got)
+	}
+	if !strings.HasPrefix(got, "fix the") {
+		t.Fatalf("displayName = %q, want it to open with what was typed", got)
 	}
 }


### PR DESCRIPTION
A session spawned without a name holds a placeholder until the agent answers the rename directive, which takes as long as a boot plus a turn. Five agents launched in a burst all wore the same `…` for that whole minute, so the tree could not say which row was which task.

## What the row wears now

The prompt it was given, capped at what the narrowest rail affords beside a starting row's state, tool and age:

```
add cursor …   starting up · claude · 0s ago
backfill th…   starting up · codex  · 0s ago
rate limit …   starting up · grok   · 0s ago
```

It is correct whether the rename lands in two seconds, in sixty, or never, so the name arriving is the only thing that changes. Past the one-minute grace the row still falls back to its generated `claude-ab12`, exactly as before.

## Why the prompt is carried rather than read back

`store.Session.LaunchPrompt` is the **decorated** prompt: it carries the rename directive and the coordination note that were sent to the agent with it. Painting that would put "Run this exact shell command once, replacing `<name>`…" in the row. The raw prompt rides beside the generated name in the record that already tracks the wait, which is run-scoped and needs no schema change.

## Second commit

Review caught a real defect. A pasted image reaches the agent as the path it was written to, so a prompt opening with a screenshot named the row after a temp directory — and every image-first spawn produced the same string, which is worse than the placeholder it replaced. The pictures now drop out of the preview and the words stay.

## Cap

12 columns. Measured against the rail: at 20 the row lost its tool and its age, and at 16 and 14 the age rendered half-truncated. 12 is the width where the row keeps the shape every other row has.

## Verification

Six tests, the primary one watched fail first. The naive implementation was written deliberately to confirm the guard tests catch a leaked directive and an unflattened prompt — they do. `gofmt` clean, `go vet` clean, full suite green on an isolated tmux socket.