### PR TITLE
docs(install): say which installs delegate the upgrade and which one does not

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -49,7 +49,9 @@ Run inside [WSL2](https://learn.microsoft.com/windows/wsl/install): agent-manage
 
 ## Updating
 
-The manager checks GitHub Releases every ten minutes and shows a `↑ vX.Y.Z available` badge in the header when a newer version is out. Press `u` on the update message (or `enter` on the version row in Settings) and the manager updates itself whatever the install source: a Homebrew, mise, or AUR install hands the terminal to that package manager's upgrade command, a direct install downloads the release and swaps the binary in place, and either way the manager restarts into the new build with every session intact. A pacman install needs an AUR helper (`yay` or `paru`) on PATH; without one the manager shows the command to run instead: `yay -S agent-manager-bin`.
+The manager checks GitHub Releases every ten minutes and shows a `↑ vX.Y.Z available` badge in the header when a newer version is out. Press `u` on the update message (or `enter` on the version row in Settings) and what happens next follows the install. A Homebrew, mise, or AUR install hands the terminal to that package manager's own upgrade command, so its progress and any password prompt behave as they would in a shell. An install-script, `go install`, or manual download is updated in place, by downloading the release and swapping the binary. Either way the manager restarts into the new build with every session still running.
+
+One case updates by hand: a pacman-owned install needs an AUR helper (`yay` or `paru`) on PATH, and without one the manager runs nothing and prints the command to use instead: `yay -S agent-manager-bin`.
 
 The same commands work from a shell:
 


### PR DESCRIPTION
The updating section opened with "the manager updates itself whatever the install source", which is imprecise in one direction and wrong in one case.

What the code actually does, from `internal/update/source.go:33-107` and `internal/ui/notices.go:541-575`:

- A Homebrew, mise or AUR install is **delegated**: `DetectManager` returns that manager's own upgrade command and `delegatedUpdateCmd` suspends the TUI to run it on the real terminal, so progress output and any password prompt behave as in a plain shell.
- An install-script, `go install` or manual download is the zero `Manager`, which downloads the release and swaps the binary in place.
- A pacman-owned install with no `yay` or `paru` on PATH is neither: `archManager` returns `Advice` only, and `notices.go:542-544` reports that string instead of upgrading anything. That case updates by hand.

The page now says which installs delegate, which are swapped in place, and calls out the by-hand case in its own note. The same rewrite went to agent-manager.dev/docs/install/.

Docs only, no code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified upgrade instructions for package-managed, install-script, Go, and manual-download installations.
  * Documented that upgrades preserve active sessions when restarting into the new build.
  * Added guidance for pacman-managed installations, including the required AUR helper command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->