### PR TITLE
fix(ui): drop a focused mouse report the pane no longer expects

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -471,6 +471,17 @@ func (d *Driver) SendRaw(command string) error {
 	return err
 }
 
+// SendCommand runs one tmux command from already-separated arguments,
+// for a command such as if-shell whose branch is itself a command and so
+// cannot survive the whitespace split SendRaw does.
+func (d *Driver) SendCommand(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("tmux command is empty")
+	}
+	_, err := d.run(args...)
+	return err
+}
+
 // SetLabel puts the session's name and group path in the status bar's
 // left side, replacing the hidden window list.
 func (d *Driver) SetLabel(id, label string) error {

--- a/internal/ui/focusscroll.go
+++ b/internal/ui/focusscroll.go
@@ -116,6 +116,19 @@ func (m *Model) mouseReport(button int, release bool, col, row int) (string, boo
 // plain pane, so the wheel walks tmux's own scrollback instead. Agent CLIs
 // are the first case: they run on the alternate screen, where tmux keeps
 // no history at all, and do their own scrolling.
+// guardedMouseCommand has tmux drop the report unless the pane still tracks
+// the mouse when it arrives. The cached flag trails a pane that left mouse
+// mode by a debounce, and a report the application no longer expects is
+// printed on its input line instead. mouse_any_flag covers every mode, so
+// the per-mode flags would only repeat it.
+func guardedMouseCommand(sessID, report string) (string, []string) {
+	target := tmux.SessionName(sessID)
+	const condition = "#{mouse_any_flag}"
+	send := "send-keys -t " + target + " -H " + hexBytes(report)
+	command := "if-shell -F -t " + target + " '" + condition + "' '" + send + "'"
+	return command, []string{"if-shell", "-F", "-t", target, condition, send}
+}
+
 func (m *Model) wheelFocus(up bool, x, y int) tea.Cmd {
 	sess, ok := m.selected()
 	if !ok || m.mode != modeFocus || m.focus == nil {
@@ -130,9 +143,9 @@ func (m *Model) wheelFocus(up bool, x, y int) tea.Cmd {
 		if !ok {
 			return nil
 		}
-		command := "send-keys -t " + tmux.SessionName(sess.ID) + " -H " + hexBytes(report)
+		command, args := guardedMouseCommand(sess.ID, report)
 		if !m.focus.attempt(command) {
-			if err := m.tmux.SendRaw(command); err != nil {
+			if err := m.tmux.SendCommand(args...); err != nil {
 				m.errBar.text = err.Error()
 			}
 		}
@@ -173,9 +186,9 @@ func (m *Model) sendFocusReport(report string) {
 	if !ok || m.focus == nil {
 		return
 	}
-	command := "send-keys -t " + tmux.SessionName(sess.ID) + " -H " + hexBytes(report)
+	command, args := guardedMouseCommand(sess.ID, report)
 	if !m.focus.attempt(command) {
-		if err := m.tmux.SendRaw(command); err != nil {
+		if err := m.tmux.SendCommand(args...); err != nil {
 			m.errBar.text = err.Error()
 		}
 	}

--- a/internal/ui/mouseguard_test.go
+++ b/internal/ui/mouseguard_test.go
@@ -1,0 +1,95 @@
+package ui
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/tmux"
+)
+
+func TestGuardedMouseCommandWrapsTheSend(t *testing.T) {
+	command, args := guardedMouseCommand("abc", "\x1b[<64;3;2M")
+	if !strings.HasPrefix(command, "if-shell -F -t "+tmux.SessionName("abc")+" '#{mouse_any_flag}' 'send-keys") {
+		t.Fatalf("control-pipe command = %q", command)
+	}
+	if len(args) != 6 || args[0] != "if-shell" || args[4] != "#{mouse_any_flag}" {
+		t.Fatalf("fallback args = %q", args)
+	}
+	// The nested send has to stay one argument, which is why it cannot ride
+	// the whitespace-splitting SendRaw.
+	if !strings.HasPrefix(args[5], "send-keys -t ") || !strings.Contains(args[5], " -H ") {
+		t.Fatalf("nested command = %q", args[5])
+	}
+}
+
+// The guard has to be transparent while the application really is tracking
+// the mouse, and silent once it has stopped.
+func TestGuardedMouseCommandFollowsTheLiveFlag(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	driver, err := tmux.NewWithSocket("amguard")
+	if err != nil {
+		t.Fatalf("driver: %v", err)
+	}
+	sessID := "guard-probe"
+	if err := driver.Create(sessID, t.TempDir(),
+		`printf '\033[?1003h\033[?1006h'; cat`, map[string]string{}, 80, 24); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { _ = driver.Kill(sessID) })
+	waitForMouseFlag(t, driver, sessID, "1")
+
+	_, args := guardedMouseCommand(sessID, "\x1b[<64;7;3M")
+	if err := driver.SendCommand(args...); err != nil {
+		t.Fatalf("guarded send while tracking: %v", err)
+	}
+	if !paneGains(t, driver, sessID, "64;7;3M") {
+		t.Fatal("a report was dropped while the application was tracking the mouse")
+	}
+
+	// cat holds the line until a newline arrives, and only what it echoes
+	// reaches the pane's terminal to turn mouse reporting off.
+	if err := driver.SendRaw("send-keys -t " + tmux.SessionName(sessID) +
+		" -H 1b 5b 3f 31 30 30 33 6c 1b 5b 3f 31 30 30 36 6c 0a"); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	waitForMouseFlag(t, driver, sessID, "0")
+
+	_, args = guardedMouseCommand(sessID, "\x1b[<64;9;4M")
+	if err := driver.SendCommand(args...); err != nil {
+		t.Fatalf("guarded send after tracking stopped: %v", err)
+	}
+	if paneGains(t, driver, sessID, "64;9;4M") {
+		pane, _ := driver.CapturePane(sessID)
+		t.Fatalf("a report reached the pane after the application left mouse mode:\n%s", strings.TrimSpace(pane))
+	}
+}
+
+func waitForMouseFlag(t *testing.T, driver *tmux.Driver, sessID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		out, err := exec.Command("tmux", "-L", driver.SocketName(),
+			"display-message", "-p", "-t", tmux.SessionName(sessID), "#{mouse_any_flag}").Output()
+		if err == nil && strings.TrimSpace(string(out)) == want {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("mouse_any_flag never reached %q", want)
+}
+
+func paneGains(t *testing.T, driver *tmux.Driver, sessID, want string) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if pane, err := driver.CapturePane(sessID); err == nil && strings.Contains(pane, want) {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
+}


### PR DESCRIPTION
Closes #370.

## What changed

- Ask tmux to re-read the pane's live mouse flag as it delivers a focused mouse report, so a report is dropped when the application has stopped tracking.
- Send the guarded command from already-separated arguments on the fallback path, since its nested branch contains spaces.

## Why

The wheel and forwarded clicks read a flag cached from the watcher's last capture (`internal/ui/focusscroll.go:124`, filled at `internal/ui/model.go:1265`). An application that leaves mouse mode is ahead of that flag by `focusDebounce` plus one trip through the update loop, and by far more whenever the control client is between retries, since `focusRetryBackoff` is 15 seconds and the polled preview path carries no mouse flags. A report sent in that window reaches the pane, which prints its printable tail on the input line where the next Return would run it.

`mouse_any_flag` is set for every mouse mode, so the per-mode flags add nothing. `SendRaw` splits on whitespace by design, which the nested `send-keys` branch cannot survive, hence the argument-wise fallback.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./... -count=1` passes
- [x] `go build ./...` passes
- [x] Ran it against real sessions

`TestGuardedMouseCommandFollowsTheLiveFlag` drives a real pane through both sides: it enables mouse reporting, sends a guarded report and requires it to arrive, then has the application disable reporting and requires the next one not to. The first half is the important one, since a guard that dropped everything would also pass a test that only checked for suppression.

## Known limitation

While the cached flag still claims the application is tracking, a notch is now dropped rather than leaked, so the wheel does nothing for that window instead of scrolling. Gating the local decision on the watcher serving the session would recover the scroll, but it also stops legitimate forwarding during a control-client outage and changes click deferral, so it is left out here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse input handling in tmux sessions.
  * Mouse wheel and focused mouse events are now forwarded only when mouse mode is enabled, preventing unintended input from reaching applications.

* **Tests**
  * Added coverage verifying mouse event forwarding and suppression as tmux mouse mode changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->