### PR TITLE
fix(review): key reviewed marks and round comments by scope

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -243,7 +243,7 @@ Tell your agent what you want to review in Agent Manager. Your agent can declare
 | `r` | Pick the repo when the session's directory holds several (type to filter) |
 | `b` | Switch review to another of the repo's worktrees, listed by branch |
 | `B` | Pick the target (merge-into branch) the "vs target" scope compares against |
-| `space` | Mark a file reviewed |
+| `space` | Mark a file reviewed in the current scope |
 | `f` | Show code files only, hiding images, compiled assets and lock files from the list; press again to show them |
 | `c` / `d` | Write or drop a draft; mark feedback from a sent round handled or open |
 | `C` | Send the current drafts to the agent as one review prompt (`enter` or `y` confirms, `esc` cancels) |
@@ -255,7 +255,7 @@ Each changeable value in the header wears its own key, so the scope, layout, rep
 
 ![review, side by side, with the changed lines tinted in full file context](screenshot-review.png)
 
-Comments and reviewed-file marks are saved as you work and return after Agent Manager restarts. `C` sends only the current drafts as one prompt and records them as the next numbered review round. Every sent comment stays inline as the session's review history, labelled with its review round and point number. Open comments keep the accent wash; handled comments settle into a subtle dark green wash, and `d` toggles the status locally.
+Comments and reviewed-file marks are saved as you work and return after Agent Manager restarts. A reviewed mark belongs to the scope it was taken in: it records that you reviewed the exact diff that scope showed, so each scope keeps its own marks and cycling scopes leaves them untouched. `C` sends only the current drafts as one prompt and records them as the next numbered review round. Every sent comment stays inline as the session's review history, labelled with its review round and point number. Open comments keep the accent wash; handled comments settle into a subtle dark green wash, and `d` toggles the status locally.
 
 Each point sent to the agent carries a stable comment id. After addressing it, an MCP-capable agent marks it handled with `review_comment`; an agent using shell commands runs `agent-manager review-comment <comment-id>`. Either can reopen it, with `handled: false` or `--reopen`. The status is stored immediately, so opening review shows the current state at once; a panel already open picks it up on its next refresh. The comment itself remains in place. The header names the latest review round and marks it changed when the scope or the code differs from what was sent. A comment whose original code can no longer be found is marked outdated instead of silently moving to an unrelated line.
 

--- a/internal/store/review.go
+++ b/internal/store/review.go
@@ -22,6 +22,7 @@ type ReviewComment struct {
 	Text        string `json:"text"`
 	ContentHash uint64 `json:"content_hash,omitempty"`
 	Round       int    `json:"round,omitempty"`
+	Scope       string `json:"scope,omitempty"`
 	Point       int    `json:"point,omitempty"`
 	Resolved    bool   `json:"resolved,omitempty"`
 	Outdated    bool   `json:"outdated,omitempty"`

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1527,6 +1527,17 @@ func (m *Model) reanchorAnnotationsFor(path string) bool {
 		if path != "" && note.file != path {
 			continue
 		}
+		// A comment's line and hash track the rendering of its own scope;
+		// another scope's rendering would move it onto lines it was never
+		// made against. Comments saved before they carried a scope fall
+		// back to the latest round's scope, the only one recorded then.
+		scope := note.scope
+		if scope == "" && note.round > 0 {
+			scope = m.diff.rounds[m.reviewKey()].Scope
+		}
+		if scope != "" && scope != m.diff.scope.String() {
+			continue
+		}
 		fd := m.fileDiffByPath(note.file)
 		if fd == nil {
 			continue
@@ -1630,6 +1641,7 @@ func (m *Model) saveAnnotation() tea.Cmd {
 		}
 		existing.text = text
 		existing.hash = contentHash(fd)
+		existing.scope = m.diff.scope.String()
 		return m.saveReviewStateCmd()
 	}
 	if text == "" {
@@ -1643,6 +1655,7 @@ func (m *Model) saveAnnotation() tea.Cmd {
 		excerpt: excerptOf(line.Text),
 		text:    text,
 		hash:    contentHash(fd),
+		scope:   m.diff.scope.String(),
 	})
 	return m.saveReviewStateCmd()
 }

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -753,10 +753,11 @@ func (m *Model) handleDiffLoaded(msg diffLoadedMsg) tea.Cmd {
 		previousPath = fd.File.Path
 	}
 	m.diff.set = msg.set
+	// Every accepted load re-judges the arriving scope's comments: a scope
+	// cycle is neither a refresh nor a restore, but the file list it brings
+	// in still decides which of its own comments read outdated.
 	stateChanged := clearStaleReviewedMarks(m)
-	if msg.refresh || restoredState {
-		stateChanged = m.markMissingRoundCommentsOutdated() || stateChanged
-	}
+	stateChanged = m.markMissingRoundCommentsOutdated() || stateChanged
 	// Re-anchor only on a silent same-scope refresh. A scope cycle or session
 	// switch loads a different file set, where matching a comment by excerpt
 	// would rewrite its line against content it was never made against.
@@ -1339,6 +1340,10 @@ func (m *Model) closeDiff() tea.Cmd {
 func (m *Model) toggleReviewed() tea.Cmd {
 	fd := m.currentFileDiff()
 	if fd == nil || !fd.Loaded() || m.diffFileHidden(fd) {
+		return nil
+	}
+	if m.store == nil {
+		m.errBar.text = "review state is unavailable"
 		return nil
 	}
 	marks := m.diff.reviewed[m.reviewKey()]

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -34,6 +34,7 @@ type annotation struct {
 	text     string
 	hash     uint64
 	round    int
+	scope    string
 	point    int
 	handled  bool
 	outdated bool
@@ -429,6 +430,13 @@ func (m *Model) reviewKey() string {
 	return m.diff.sessID + "\x00" + m.diff.repoSel
 }
 
+// reviewedMarkKey scopes a reviewed mark to the diff scope it was taken in:
+// the same file renders different lines - and so a different content hash -
+// under each scope, so only its own scope can read or judge the mark.
+func (m *Model) reviewedMarkKey(path string) string {
+	return m.diff.scope.String() + "\x00" + path
+}
+
 func readReviewState(stor *store.Store, sessID, repoRoot string) (store.ReviewState, error) {
 	state, err := stor.ReviewState(sessID, repoRoot)
 	if err != nil {
@@ -471,9 +479,12 @@ func (m *Model) restoreReviewState(state store.ReviewState) bool {
 		return false
 	}
 	marks := make(map[string]uint64, len(state.Reviewed))
-	for path, hash := range state.Reviewed {
-		if hash != 0 {
-			marks[path] = hash
+	for markKey, hash := range state.Reviewed {
+		// A mark saved before marks were scope-keyed carries a bare path; it
+		// can never match a scoped lookup, so dropping it here lets the next
+		// save clear it from the row.
+		if hash != 0 && strings.Contains(markKey, "\x00") {
+			marks[markKey] = hash
 		}
 	}
 	notes := make([]annotation, 0, len(state.Comments))
@@ -482,7 +493,7 @@ func (m *Model) restoreReviewState(state store.ReviewState) bool {
 		notes = append(notes, annotation{
 			id: note.ID, file: note.File, line: note.Line, deleted: note.Deleted,
 			excerpt: withoutControlBytes(note.Excerpt), text: withoutControlBytes(note.Text), hash: note.ContentHash,
-			round: note.Round, point: note.Point, handled: note.Resolved, outdated: note.Outdated,
+			round: note.Round, scope: note.Scope, point: note.Point, handled: note.Resolved, outdated: note.Outdated,
 		})
 	}
 	m.diff.reviewed[key] = marks
@@ -548,7 +559,7 @@ func (m *Model) reviewStateSnapshot(key string) store.ReviewState {
 		notes = append(notes, store.ReviewComment{
 			ID: note.id, File: note.file, Line: note.line, Deleted: note.deleted,
 			Excerpt: note.excerpt, Text: note.text, ContentHash: note.hash,
-			Round: note.round, Point: note.point, Resolved: note.handled, Outdated: note.outdated,
+			Round: note.round, Scope: note.scope, Point: note.point, Resolved: note.handled, Outdated: note.outdated,
 		})
 	}
 	return store.ReviewState{
@@ -771,8 +782,9 @@ func (m *Model) handleDiffLoaded(msg diffLoadedMsg) tea.Cmd {
 	var statefulLoads []tea.Cmd
 	if msg.refresh || restoredState {
 		stateful := map[string]bool{}
-		for path, hash := range m.diff.reviewed[m.reviewKey()] {
-			if hash != 0 {
+		for markKey, hash := range m.diff.reviewed[m.reviewKey()] {
+			scope, path, _ := strings.Cut(markKey, "\x00")
+			if hash != 0 && scope == m.diff.scope.String() {
 				stateful[path] = true
 			}
 		}
@@ -1334,18 +1346,19 @@ func (m *Model) toggleReviewed() tea.Cmd {
 		marks = map[string]uint64{}
 		m.diff.reviewed[m.reviewKey()] = marks
 	}
-	if marks[fd.File.Path] != 0 {
-		delete(marks, fd.File.Path)
+	markKey := m.reviewedMarkKey(fd.File.Path)
+	if marks[markKey] != 0 {
+		delete(marks, markKey)
 		return m.saveReviewStateCmd()
 	}
-	marks[fd.File.Path] = contentHash(fd)
+	marks[markKey] = contentHash(fd)
 	stateSave := m.saveReviewStateCmd()
 	// Advance to the next unreviewed file, review-queue style. The switch
 	// returns the highlight command for the newly shown file; dropping it
 	// would leave that file unhighlighted.
 	for step := 1; step < len(m.diff.set.Files); step++ {
 		next := (m.diff.fileIdx + step) % len(m.diff.set.Files)
-		if marks[m.diff.set.Files[next].File.Path] == 0 && !m.diffFileHidden(&m.diff.set.Files[next]) {
+		if marks[m.reviewedMarkKey(m.diff.set.Files[next].File.Path)] == 0 && !m.diffFileHidden(&m.diff.set.Files[next]) {
 			return tea.Batch(stateSave, m.switchDiffFile(next-m.diff.fileIdx))
 		}
 	}
@@ -1353,7 +1366,7 @@ func (m *Model) toggleReviewed() tea.Cmd {
 }
 
 func (m *Model) fileReviewed(path string) bool {
-	return m.diff.reviewed[m.reviewKey()][path] != 0
+	return m.diff.reviewed[m.reviewKey()][m.reviewedMarkKey(path)] != 0
 }
 
 func clearStaleReviewedMarks(m *Model) bool {
@@ -1362,15 +1375,20 @@ func clearStaleReviewedMarks(m *Model) bool {
 		return false
 	}
 	changed := false
-	for path, stored := range marks {
+	for markKey, stored := range marks {
 		if stored == 0 {
 			continue
 		}
-		// A scope that does not list the file says nothing about whether it
-		// changed since it was marked, and the mark outlives the scope.
+		// A mark hashes the rendering of the scope it was taken in, so only
+		// that scope can judge it stale. A scope that does not list the file
+		// says nothing about it either, and the mark outlives the scope.
+		scope, path, _ := strings.Cut(markKey, "\x00")
+		if scope != m.diff.scope.String() {
+			continue
+		}
 		fd := m.fileDiffByPath(path)
 		if fd != nil && fd.Loaded() && contentHash(fd) != stored {
-			delete(marks, path)
+			delete(marks, markKey)
 			changed = true
 		}
 	}
@@ -1379,13 +1397,14 @@ func clearStaleReviewedMarks(m *Model) bool {
 
 func clearStaleReviewedMark(m *Model, path string) bool {
 	marks := m.diff.reviewed[m.reviewKey()]
-	stored := marks[path]
+	markKey := m.reviewedMarkKey(path)
+	stored := marks[markKey]
 	if stored == 0 {
 		return false
 	}
 	fd := m.fileDiffByPath(path)
 	if fd != nil && fd.Loaded() && contentHash(fd) != stored {
-		delete(marks, path)
+		delete(marks, markKey)
 		return true
 	}
 	return false
@@ -1393,10 +1412,12 @@ func clearStaleReviewedMark(m *Model, path string) bool {
 
 // A round sent under another scope listed other files, so this scope's file
 // list says nothing about whether those comments still sit on their code.
+// Each comment is judged against the scope its own round was sent in.
 func (m *Model) markMissingRoundCommentsOutdated() bool {
-	if round := m.diff.rounds[m.reviewKey()]; round.Scope != "" && round.Scope != m.diff.scope.String() {
-		return false
-	}
+	current := m.diff.scope.String()
+	// Comments saved before they carried a scope fall back to the latest
+	// round's scope, the only one recorded then.
+	fallback := m.diff.rounds[m.reviewKey()].Scope
 	paths := make(map[string]bool, len(m.diff.set.Files))
 	for i := range m.diff.set.Files {
 		paths[m.diff.set.Files[i].File.Path] = true
@@ -1404,10 +1425,18 @@ func (m *Model) markMissingRoundCommentsOutdated() bool {
 	notes := m.diff.annotations[m.reviewKey()]
 	changed := false
 	for i := range notes {
-		if notes[i].round > 0 && !paths[notes[i].file] && !notes[i].outdated {
-			notes[i].outdated = true
-			changed = true
+		if notes[i].round == 0 || notes[i].outdated || paths[notes[i].file] {
+			continue
 		}
+		scope := notes[i].scope
+		if scope == "" {
+			scope = fallback
+		}
+		if scope != "" && scope != current {
+			continue
+		}
+		notes[i].outdated = true
+		changed = true
 	}
 	return changed
 }
@@ -1717,6 +1746,7 @@ func (m *Model) sendAnnotations() (tea.Model, tea.Cmd) {
 	m.diff.rounds[key] = round
 	for _, i := range draftIndexes {
 		notes[i].round = round.Number
+		notes[i].scope = round.Scope
 		notes[i].handled = false
 		notes[i].outdated = false
 	}

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -2771,7 +2771,7 @@ func TestReviewProgressAndDraftsRestoreFromStore(t *testing.T) {
 	m.applyCmd(t, m.saveAnnotation())
 	path := m.currentFileDiff().File.Path
 	m.drainCmds(t, m.toggleReviewed())
-	wantHash := m.diff.reviewed[m.reviewKey()][path]
+	wantHash := m.diff.reviewed[m.reviewKey()][m.reviewedMarkKey(path)]
 	if wantHash == 0 {
 		t.Fatal("reviewed hash was not recorded")
 	}
@@ -2788,7 +2788,7 @@ func TestReviewProgressAndDraftsRestoreFromStore(t *testing.T) {
 	if !m.restoreReviewState(state) {
 		t.Fatal("review state was not restored")
 	}
-	if got := m.diff.reviewed[key][path]; got != wantHash {
+	if got := m.diff.reviewed[key][m.reviewedMarkKey(path)]; got != wantHash {
 		t.Fatalf("restored reviewed hash = %d, want %d", got, wantHash)
 	}
 	notes := m.diff.annotations[key]
@@ -3154,6 +3154,60 @@ func TestAScopeMissingAFileKeepsItsReviewedMark(t *testing.T) {
 	}
 }
 
+// One trip around the scope cycle must not destroy a saved reviewed mark:
+// the same file renders different diff lines - so a different content hash -
+// under another scope, and only the scope a mark was taken in may judge it
+// stale.
+func TestScopeCycleKeepsReviewedMark(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	dir := gitTestRepo(t)
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	// Stage the current edit and add another on top, so the staged and
+	// uncommitted scopes both list main.go with different rendered diffs.
+	runGit("add", "main.go")
+	if err := os.WriteFile(filepath.Join(dir, "main.go"),
+		[]byte("package main\n\nfunc main() { println(2) }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	openReviewOn(t, m, "scopecycle", dir)
+	target := -1
+	for i, fd := range m.diff.set.Files {
+		if fd.File.Path == "main.go" {
+			target = i
+		}
+	}
+	if target < 0 {
+		t.Fatalf("main.go missing from the uncommitted scope: %+v", m.diff.set.Files)
+	}
+	m.drainCmds(t, m.switchDiffFile(target-m.diff.fileIdx))
+	m.drainCmds(t, m.toggleReviewed())
+	if !m.fileReviewed("main.go") {
+		t.Fatal("main.go was not marked reviewed")
+	}
+
+	for cycle := 0; cycle < 4; cycle++ {
+		m.drainCmds(t, m.cycleDiffScope())
+		if m.diff.scope != git.ScopeUncommitted && m.fileReviewed("main.go") {
+			t.Fatalf("a mark taken under uncommitted read as reviewed under %q", m.diff.scope)
+		}
+	}
+	if m.diff.scope != git.ScopeUncommitted {
+		t.Fatalf("four cycles should return to uncommitted, got %q", m.diff.scope)
+	}
+	if !m.fileReviewed("main.go") {
+		t.Fatal("cycling scopes destroyed the reviewed mark")
+	}
+}
+
 func TestNarrowReviewKeepsBothPanesMeasurable(t *testing.T) {
 	m := buildModel(t)
 	if m.gitDrv == nil {
@@ -3199,6 +3253,56 @@ func TestAnotherScopeDoesNotOutdateARoundsComments(t *testing.T) {
 	}
 	if m.diff.annotations[key][0].outdated {
 		t.Fatal("the comment was labelled outdated by a scope it was not sent in")
+	}
+}
+
+// Each round's comments are judged against the scope that round was sent in:
+// an older round from another scope stays untouched even when the latest
+// round was sent in the current scope.
+func TestOlderRoundFromAnotherScopeIsNotOutdated(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "roundscopes", gitRepoWithTwoChangedFiles(t))
+	key := m.reviewKey()
+	m.diff.annotations[key] = []annotation{
+		{id: "aaaaaaaaaaaaaaa1", file: "gone-from-this-scope.go", line: 1,
+			text: "older round", round: 1, point: 1, scope: m.diff.scope.Next().String()},
+		{id: "aaaaaaaaaaaaaaa2", file: "also-gone.go", line: 1,
+			text: "latest round", round: 2, point: 1, scope: m.diff.scope.String()},
+	}
+	m.diff.rounds[key] = store.ReviewRound{Number: 2, Scope: m.diff.scope.String()}
+
+	if !m.markMissingRoundCommentsOutdated() {
+		t.Fatal("the current scope's round comment on a missing file should read outdated")
+	}
+	notes := m.diff.annotations[key]
+	if notes[0].outdated {
+		t.Fatal("a round sent in another scope was outdated by this scope's file list")
+	}
+	if !notes[1].outdated {
+		t.Fatal("the current scope's round comment kept its standing")
+	}
+}
+
+// Marks persisted before marks were scope-keyed carry a bare path; they can
+// never match a scoped lookup, so restore drops them and the next save
+// clears them from the row.
+func TestRestoreDropsPreScopeReviewedMarks(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "baremarks", gitTestRepo(t))
+	key := m.reviewKey()
+	delete(m.diff.reviewed, key)
+	delete(m.diff.stateLoaded, key)
+	if !m.restoreReviewState(store.ReviewState{Reviewed: map[string]uint64{"main.go": 42}}) {
+		t.Fatal("review state was not restored")
+	}
+	if len(m.diff.reviewed[key]) != 0 {
+		t.Fatalf("a bare-path mark survived restore: %v", m.diff.reviewed[key])
 	}
 }
 

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -3286,6 +3286,29 @@ func TestOlderRoundFromAnotherScopeIsNotOutdated(t *testing.T) {
 	}
 }
 
+// A scope cycle re-judges the arriving scope's comments even without a
+// refresh: a comment whose file that scope no longer lists reads outdated.
+func TestScopeCycleOutdatesTheArrivingScopesComments(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "cycleoutdate", gitTestRepo(t))
+	key := m.reviewKey()
+	m.diff.annotations[key] = []annotation{{
+		id: "aaaaaaaaaaaaaaa1", file: "gone.go", line: 1,
+		text: "from staged", round: 1, point: 1, scope: git.ScopeStaged.String(),
+	}}
+	m.diff.rounds[key] = store.ReviewRound{Number: 1, Scope: git.ScopeStaged.String()}
+
+	for m.diff.scope != git.ScopeStaged {
+		m.drainCmds(t, m.cycleDiffScope())
+	}
+	if !m.diff.annotations[key][0].outdated {
+		t.Fatal("arriving at staged should outdate its round comment on a missing file")
+	}
+}
+
 // Marks persisted before marks were scope-keyed carry a bare path; they can
 // never match a scoped lookup, so restore drops them and the next save
 // clears them from the row.

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -3309,6 +3309,32 @@ func TestScopeCycleOutdatesTheArrivingScopesComments(t *testing.T) {
 	}
 }
 
+// A same-scope refresh re-anchors only that scope's comments: another
+// scope renders the same file differently, so its comment keeps the line
+// and hash it was made against.
+func TestRefreshDoesNotReanchorOtherScopesComments(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "scopereanchor", gitTestRepo(t))
+	key := m.reviewKey()
+	other := m.diff.scope.Next().String()
+	m.diff.annotations[key] = []annotation{{
+		id: "aaaaaaaaaaaaaaa1", file: "main.go", line: 999,
+		excerpt: "func main() { println(1) }", text: "from another scope",
+		round: 1, point: 1, scope: other, hash: 12345,
+	}}
+	m.diff.rounds[key] = store.ReviewRound{Number: 1, Scope: other}
+
+	if m.reanchorAnnotationsFor("main.go") {
+		t.Fatal("a refresh in this scope re-anchored another scope's comment")
+	}
+	if note := m.diff.annotations[key][0]; note.line != 999 || note.hash != 12345 {
+		t.Fatalf("the comment moved: line=%d hash=%d", note.line, note.hash)
+	}
+}
+
 // Marks persisted before marks were scope-keyed carry a bare path; they can
 // never match a scoped lookup, so restore drops them and the next save
 // clears them from the row.


### PR DESCRIPTION
## What

Reviewed-file marks are now keyed by diff scope, and each sent review comment records the scope its round was sent in.

- The in-memory and persisted mark key becomes `scope + NUL + path`, mirroring the per-scope scroll positions. `toggleReviewed`, `fileReviewed`, both stale-mark sweeps, and the eager-load walk in `handleDiffLoaded` read and write the scoped key, and staleness is judged only by the scope a mark was taken in.
- `store.ReviewComment` gains a `Scope` field, set at send time from the round's scope. `markMissingRoundCommentsOutdated` judges each comment against its own round's scope, falling back to the latest round's scope for comments saved before they carried one.
- `docs/usage.md` states the per-scope behavior where `space` and the saved marks are described.

## Why

A reviewed mark stores the hash of the rendered diff it was taken on, but lived under a bare file path shared by every scope. Pressing `s` into a scope that also lists the file rendered different lines, hashed differently, read the mark as stale, and persisted the deletion. Cycling back did not restore it: one keystroke destroyed saved state. Round comments had the same hole one layer up: outdated marking was guarded only by the latest round's scope, so an older round sent under another scope was judged against the wrong file list.

Marks become per-scope on purpose: a file reviewed under "uncommitted" reads unreviewed under "staged" and reviewed again when you switch back. The hash already meant "I reviewed this exact diff", and the key now says so.

The persisted JSON shape stays `map[string]uint64`, so existing `review_states` rows still unmarshal. Marks saved before this change carry a bare path, never match a scoped lookup, and are dropped on restore. The shape has not shipped in a release, so no migration is needed.

## Verified

- New `TestScopeCycleKeepsReviewedMark` drives the real key path (mark under uncommitted, four `s` cycles through every scope, back home) and failed against main with `a mark taken under uncommitted read as reviewed under "vs target"` before the fix.
- New `TestOlderRoundFromAnotherScopeIsNotOutdated` covers the per-round comment scope, and `TestRestoreDropsPreScopeReviewedMarks` covers the bare-path drop.
- Full suite green on an isolated tmux socket; `gofmt -l .` prints nothing; `go vet ./...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reviewed-file marks are now tied to the active review scope.
  * Marks persist across restarts and remain separate when switching between scopes.
  * Review comments retain their originating scope, improving comment status and outdated-comment handling.
  * Legacy reviewed marks without scope information are no longer restored.
  * Review actions now report an error when review-state storage is unavailable.

* **Documentation**
  * Updated usage guidance to explain scope-specific reviewed marks and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->