### PR TITLE
fix(review): show a reviewed file's control bytes instead of obeying them

### DIFF
--- a/internal/ui/controlbytes.go
+++ b/internal/ui/controlbytes.go
@@ -10,25 +10,46 @@ import (
 
 func isControlByte(c byte) bool { return c < 0x20 || c == 0x7f }
 
+// isEscapedRune reports the C1 controls, which reach a pane as well-formed
+// UTF-8 and would otherwise pass through whole. U+009B is CSI and U+009D is
+// OSC; beyond what a terminal that reads them does with them, a C1 rune paints
+// a cell that ansi.StringWidth does not count, so a row carrying one runs past
+// the seam it was measured for.
+func isEscapedRune(r rune) bool { return r >= 0x80 && r <= 0x9f }
+
 // needsEscaping also reports malformed UTF-8, because a byte that decodes to
 // nothing is where a raw 8-bit CSI or OSC would hide.
 func needsEscaping(text string) bool {
-	for i := 0; i < len(text); i++ {
-		if isControlByte(text[i]) {
+	for i := 0; i < len(text); {
+		if c := text[i]; c < utf8.RuneSelf {
+			if isControlByte(c) && c != '\n' {
+				return true
+			}
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if (r == utf8.RuneError && size == 1) || isEscapedRune(r) {
 			return true
 		}
+		i += size
 	}
-	return !utf8.ValidString(text)
+	return false
 }
 
 // escapeControls rewrites control bytes as caret notation, so an ESC reads as
-// "^[", and a byte that is not part of well-formed UTF-8 as hex. Review shows
-// code and paths the user did not write, and either kind left intact is obeyed
-// by the terminal rather than shown: it can repaint the screen the live agent
-// panes share, or set the window title. A lone 0x9b or 0x9d is the 8-bit CSI
-// and OSC, and is malformed UTF-8, so it escapes as hex; the same code points
-// encoded properly are ordinary text and stay whole, which is what keeps a
-// Hebrew line (its continuation bytes land in that range) readable.
+// "^[", a byte that is not part of well-formed UTF-8 as hex, and a C1 control
+// as its code point. Review shows code and paths the user did not write, and
+// any of those left intact is obeyed by the terminal rather than shown: it can
+// repaint the screen the live agent panes share, or set the window title. A
+// lone 0x9b or 0x9d is the 8-bit CSI and OSC and is malformed UTF-8, so it
+// escapes as hex, while the same code points encoded properly escape as their
+// code point. Hebrew survives either way: its continuation bytes land in that
+// range, but the runes they build decode to U+05D0 and up.
+//
+// Newlines are kept. A multi-line git error is the shape this renders most
+// often, and folding it into one row leaves paint to truncate everything past
+// the first line; a surface that owns a single row calls escapeControlsInline.
 func escapeControls(text string) string {
 	if !needsEscaping(text) {
 		return text
@@ -37,7 +58,7 @@ func escapeControls(text string) string {
 	b.Grow(len(text) + 16)
 	for i := 0; i < len(text); {
 		if c := text[i]; c < utf8.RuneSelf {
-			if isControlByte(c) {
+			if isControlByte(c) && c != '\n' {
 				b.WriteByte('^')
 				b.WriteByte(c ^ 0x40)
 			} else {
@@ -47,19 +68,30 @@ func escapeControls(text string) string {
 			continue
 		}
 		r, size := utf8.DecodeRuneInString(text[i:])
-		if r == utf8.RuneError && size == 1 {
+		switch {
+		case r == utf8.RuneError && size == 1:
 			fmt.Fprintf(&b, `\x%02X`, text[i])
 			i++
-			continue
+		case isEscapedRune(r):
+			fmt.Fprintf(&b, `\u%04X`, r)
+			i += size
+		default:
+			b.WriteString(text[i : i+size])
+			i += size
 		}
-		b.WriteString(text[i : i+size])
-		i += size
 	}
 	return b.String()
 }
 
+// escapeControlsInline is escapeControls for a surface that owns exactly one
+// row: a header pill, a file name, a status line. It flattens the newlines
+// escapeControls keeps, since a second line there pushes the layout around it.
+func escapeControlsInline(text string) string {
+	return strings.ReplaceAll(escapeControls(text), "\n", " ")
+}
+
 // escapeSpans moves word-diff byte offsets onto the escaped rendering, where a
-// control byte now takes two bytes and a malformed one takes four.
+// control byte now takes two bytes, a malformed one four, and a C1 rune six.
 func escapeSpans(text string, spans []diff.Span) []diff.Span {
 	if len(spans) == 0 || !needsEscaping(text) {
 		return spans
@@ -75,15 +107,18 @@ func escapedOffset(text string, offset int) int {
 	shift := 0
 	for i := 0; i < offset && i < len(text); {
 		if c := text[i]; c < utf8.RuneSelf {
-			if isControlByte(c) {
+			if isControlByte(c) && c != '\n' {
 				shift++
 			}
 			i++
 			continue
 		}
 		r, size := utf8.DecodeRuneInString(text[i:])
-		if r == utf8.RuneError && size == 1 {
+		switch {
+		case r == utf8.RuneError && size == 1:
 			shift += 3
+		case isEscapedRune(r):
+			shift += 6 - size
 		}
 		i += size
 	}

--- a/internal/ui/controlbytes.go
+++ b/internal/ui/controlbytes.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/YoanWai/agent-manager/internal/diff"
+)
+
+func isControlByte(c byte) bool { return c < 0x20 || c == 0x7f }
+
+func hasControlBytes(text string) bool {
+	for i := 0; i < len(text); i++ {
+		if isControlByte(text[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// escapeControls rewrites control bytes as caret notation, so an ESC reads as
+// "^[". Review shows code and paths the user did not write, and a control byte
+// left intact there is obeyed by the terminal rather than shown: it can repaint
+// the screen the live agent panes share, or set the window title. Bytes above
+// ASCII pass through, which leaves multi-byte UTF-8 whole.
+func escapeControls(text string) string {
+	if !hasControlBytes(text) {
+		return text
+	}
+	var b strings.Builder
+	b.Grow(len(text) + 16)
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		if isControlByte(c) {
+			b.WriteByte('^')
+			b.WriteByte(c ^ 0x40)
+			continue
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+// escapeSpans moves word-diff byte offsets onto the escaped rendering, where
+// every control byte now takes two bytes instead of one.
+func escapeSpans(text string, spans []diff.Span) []diff.Span {
+	if len(spans) == 0 || !hasControlBytes(text) {
+		return spans
+	}
+	moved := make([]diff.Span, len(spans))
+	for i, span := range spans {
+		moved[i] = diff.Span{Start: escapedOffset(text, span.Start), End: escapedOffset(text, span.End)}
+	}
+	return moved
+}
+
+func escapedOffset(text string, offset int) int {
+	shift := 0
+	for i := 0; i < offset && i < len(text); i++ {
+		if isControlByte(text[i]) {
+			shift++
+		}
+	}
+	return offset + shift
+}

--- a/internal/ui/controlbytes.go
+++ b/internal/ui/controlbytes.go
@@ -1,49 +1,67 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/YoanWai/agent-manager/internal/diff"
 )
 
 func isControlByte(c byte) bool { return c < 0x20 || c == 0x7f }
 
-func hasControlBytes(text string) bool {
+// needsEscaping also reports malformed UTF-8, because a byte that decodes to
+// nothing is where a raw 8-bit CSI or OSC would hide.
+func needsEscaping(text string) bool {
 	for i := 0; i < len(text); i++ {
 		if isControlByte(text[i]) {
 			return true
 		}
 	}
-	return false
+	return !utf8.ValidString(text)
 }
 
 // escapeControls rewrites control bytes as caret notation, so an ESC reads as
-// "^[". Review shows code and paths the user did not write, and a control byte
-// left intact there is obeyed by the terminal rather than shown: it can repaint
-// the screen the live agent panes share, or set the window title. Bytes above
-// ASCII pass through, which leaves multi-byte UTF-8 whole.
+// "^[", and a byte that is not part of well-formed UTF-8 as hex. Review shows
+// code and paths the user did not write, and either kind left intact is obeyed
+// by the terminal rather than shown: it can repaint the screen the live agent
+// panes share, or set the window title. A lone 0x9b or 0x9d is the 8-bit CSI
+// and OSC, and is malformed UTF-8, so it escapes as hex; the same code points
+// encoded properly are ordinary text and stay whole, which is what keeps a
+// Hebrew line (its continuation bytes land in that range) readable.
 func escapeControls(text string) string {
-	if !hasControlBytes(text) {
+	if !needsEscaping(text) {
 		return text
 	}
 	var b strings.Builder
 	b.Grow(len(text) + 16)
-	for i := 0; i < len(text); i++ {
-		c := text[i]
-		if isControlByte(c) {
-			b.WriteByte('^')
-			b.WriteByte(c ^ 0x40)
+	for i := 0; i < len(text); {
+		if c := text[i]; c < utf8.RuneSelf {
+			if isControlByte(c) {
+				b.WriteByte('^')
+				b.WriteByte(c ^ 0x40)
+			} else {
+				b.WriteByte(c)
+			}
+			i++
 			continue
 		}
-		b.WriteByte(c)
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if r == utf8.RuneError && size == 1 {
+			fmt.Fprintf(&b, `\x%02X`, text[i])
+			i++
+			continue
+		}
+		b.WriteString(text[i : i+size])
+		i += size
 	}
 	return b.String()
 }
 
-// escapeSpans moves word-diff byte offsets onto the escaped rendering, where
-// every control byte now takes two bytes instead of one.
+// escapeSpans moves word-diff byte offsets onto the escaped rendering, where a
+// control byte now takes two bytes and a malformed one takes four.
 func escapeSpans(text string, spans []diff.Span) []diff.Span {
-	if len(spans) == 0 || !hasControlBytes(text) {
+	if len(spans) == 0 || !needsEscaping(text) {
 		return spans
 	}
 	moved := make([]diff.Span, len(spans))
@@ -55,10 +73,19 @@ func escapeSpans(text string, spans []diff.Span) []diff.Span {
 
 func escapedOffset(text string, offset int) int {
 	shift := 0
-	for i := 0; i < offset && i < len(text); i++ {
-		if isControlByte(text[i]) {
-			shift++
+	for i := 0; i < offset && i < len(text); {
+		if c := text[i]; c < utf8.RuneSelf {
+			if isControlByte(c) {
+				shift++
+			}
+			i++
+			continue
 		}
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if r == utf8.RuneError && size == 1 {
+			shift += 3
+		}
+		i += size
 	}
 	return offset + shift
 }

--- a/internal/ui/controlbytes_test.go
+++ b/internal/ui/controlbytes_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/YoanWai/agent-manager/internal/diff"
 )
@@ -14,6 +15,9 @@ import (
 // nothing but SGR colour sequences, so any other control byte in a painted
 // frame is the repo driving the terminal.
 func strayControl(frame string) string {
+	if !utf8.ValidString(frame) {
+		return "malformed UTF-8, where a raw 8-bit CSI or OSC would hide"
+	}
 	for i := 0; i < len(frame); i++ {
 		c := frame[i]
 		if c == '\n' || !isControlByte(c) {
@@ -55,10 +59,25 @@ func TestEscapeControlsShowsBytesAndKeepsUTF8(t *testing.T) {
 		"nul\x00":          "nul^@",
 		"שלום ok":          "שלום ok",
 		"plain":            "plain",
+		// A lone 0x9b/0x9d is the 8-bit CSI/OSC and is malformed UTF-8.
+		"x\x9b31mred":  `x\x9B31mred`,
+		"x\x9d0;P\x9c": `x\x9D0;P\x9C`,
+		// The same code points encoded properly are ordinary text.
+		"x31m": "x31m",
 	}
 	for in, want := range cases {
 		if got := escapeControls(in); got != want {
 			t.Errorf("escapeControls(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// Hebrew encodes continuation bytes in the 0x80-0x9f range, so a byte-range
+// check for C1 would mangle it. Escaping keys off malformed UTF-8 instead.
+func TestEscapeControlsKeepsTextWhoseBytesLookLikeC1(t *testing.T) {
+	for _, text := range []string{"שלום", "מה קורה", "日本語", "café"} {
+		if got := escapeControls(text); got != text {
+			t.Errorf("escapeControls(%q) = %q, want it untouched", text, got)
 		}
 	}
 }

--- a/internal/ui/controlbytes_test.go
+++ b/internal/ui/controlbytes_test.go
@@ -1,0 +1,183 @@
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/diff"
+)
+
+// The reviewed repo is code the user did not write. Our own rendering emits
+// nothing but SGR colour sequences, so any other control byte in a painted
+// frame is the repo driving the terminal.
+func strayControl(frame string) string {
+	for i := 0; i < len(frame); i++ {
+		c := frame[i]
+		if c == '\n' || !isControlByte(c) {
+			continue
+		}
+		if n := sgrLen(frame[i:]); n > 0 {
+			i += n - 1
+			continue
+		}
+		start := max(0, i-20)
+		return frame[start:min(len(frame), i+20)]
+	}
+	return ""
+}
+
+// sgrLen returns the length of the SGR colour sequence at the head of s, or 0
+// when s does not start with one.
+func sgrLen(s string) int {
+	if len(s) < 3 || s[0] != 0x1b || s[1] != '[' {
+		return 0
+	}
+	for i := 2; i < len(s); i++ {
+		if s[i] == 'm' {
+			return i + 1
+		}
+		if (s[i] < '0' || s[i] > '9') && s[i] != ';' && s[i] != ':' {
+			return 0
+		}
+	}
+	return 0
+}
+
+func TestEscapeControlsShowsBytesAndKeepsUTF8(t *testing.T) {
+	cases := map[string]string{
+		"\x1b]0;PWNED\x07": "^[]0;PWNED^G",
+		"a\x1b[2Jb":        "a^[[2Jb",
+		"over\rwrite":      "over^Mwrite",
+		"del\x7f":          "del^?",
+		"nul\x00":          "nul^@",
+		"שלום ok":          "שלום ok",
+		"plain":            "plain",
+	}
+	for in, want := range cases {
+		if got := escapeControls(in); got != want {
+			t.Errorf("escapeControls(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEscapeSpansFollowTheEscapedText(t *testing.T) {
+	// "a\x1bbc": the span over "bc" starts at byte 2 raw, byte 3 escaped,
+	// because the ESC now occupies "^[".
+	spans := escapeSpans("a\x1bbc", []diff.Span{{Start: 2, End: 4}})
+	if len(spans) != 1 || spans[0] != (diff.Span{Start: 3, End: 5}) {
+		t.Fatalf("spans = %+v, want [{3 5}]", spans)
+	}
+	clean := []diff.Span{{Start: 1, End: 2}}
+	if got := escapeSpans("abc", clean); &got[0] != &clean[0] {
+		t.Fatal("a line with no control bytes should keep its spans untouched")
+	}
+}
+
+// The whole point: a file under review must not be able to drive the terminal
+// the review is painted into. Both layouts, because they render through
+// different cells.
+func TestReviewedFileCannotDriveTheTerminal(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	// An OSC window-title set and a clear-screen, sequences our renderer
+	// never emits, so finding them in the frame is unambiguous.
+	payload := "const banner = \"\x1b]0;PWNED\x07\x1b[2J\x1b[31mgotcha\"\n"
+	dir := gitRepoWithPayload(t, "payload.go", payload)
+	openReviewOn(t, m, "escape", dir)
+	m.width, m.height = 120, 40
+
+	for _, layout := range []string{"unified", "split"} {
+		frame := m.viewDiffFull()
+		if !strings.Contains(frame, "PWNED") {
+			t.Fatalf("%s: the payload line should be on screen to be a real test", layout)
+		}
+		if stray := strayControl(frame); stray != "" {
+			t.Errorf("%s layout leaks a control byte to the terminal near %q", layout, stray)
+		}
+		m.diff.sideBySide = !m.diff.sideBySide
+	}
+}
+
+// A clean repo proves the assertion above is not vacuous: the frame really
+// does carry nothing but SGR, so a stray control byte means something leaked.
+func TestCleanReviewFrameCarriesOnlySGR(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "clean", gitRepoWithTwoChangedFiles(t))
+	m.width, m.height = 120, 40
+	if stray := strayControl(m.viewDiffFull()); stray != "" {
+		t.Fatalf("a clean review frame should be SGR only, found %q", stray)
+	}
+}
+
+// Git is driven with -z, so a path is handed to us as raw bytes and reaches
+// the file rail, the code title and the comment bar unquoted.
+func TestReviewedPathCannotDriveTheTerminal(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	dir := committedRepo(t)
+	name := "w\x1b]0;P\x07.go"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("package a\n"), 0o644); err != nil {
+		t.Skipf("filesystem rejects control bytes in a name: %v", err)
+	}
+	openReviewOn(t, m, "path", dir)
+	m.width, m.height = 120, 40
+
+	frame := m.viewDiffFull()
+	if !strings.Contains(frame, "w^[]0;P^G.go") {
+		t.Fatalf("the path should read as caret notation on screen, got %q", frame)
+	}
+	if stray := strayControl(frame); stray != "" {
+		t.Errorf("a reviewed path leaks a control byte near %q", stray)
+	}
+}
+
+// gitRepoWithPayload commits a plain first version of name, then writes the
+// payload over it, so review has a real change to render.
+func gitRepoWithPayload(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := committedRepo(t)
+	writeFile(t, dir, name, "package a\n")
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-m", "add")
+	writeFile(t, dir, name, content)
+	return dir
+}
+
+func committedRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	writeFile(t, dir, "seed.go", "package a\n")
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-m", "init")
+	return dir
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+}

--- a/internal/ui/controlbytes_test.go
+++ b/internal/ui/controlbytes_test.go
@@ -62,13 +62,36 @@ func TestEscapeControlsShowsBytesAndKeepsUTF8(t *testing.T) {
 		// A lone 0x9b/0x9d is the 8-bit CSI/OSC and is malformed UTF-8.
 		"x\x9b31mred":  `x\x9B31mred`,
 		"x\x9d0;P\x9c": `x\x9D0;P\x9C`,
-		// The same code points encoded properly are ordinary text.
-		"x\u009b31m": "x\u009b31m",
+		// The same code points encoded properly are C1 controls all the
+		// same: a terminal that reads them obeys them, and ansi.StringWidth
+		// counts them as nothing while they take a cell.
+		"x\u009b31m": `x\u009B31m`,
+		"x\u009d0;P": `x\u009D0;P`,
 	}
 	for in, want := range cases {
 		if got := escapeControls(in); got != want {
 			t.Errorf("escapeControls(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// A git error arrives from CombinedOutput with its lines intact, and the hint
+// under the first line is the half that says what to do. Only a surface owning
+// exactly one row folds them together.
+func TestEscapeControlsKeepsNewlinesAndInlineDropsThem(t *testing.T) {
+	const gitErr = "fatal: ambiguous argument 'x'\nUse '--' to separate paths from revisions"
+	if got := escapeControls(gitErr); got != gitErr {
+		t.Errorf("escapeControls(%q) = %q, want it untouched", gitErr, got)
+	}
+	if got := escapeControls("a\n\x1bb"); got != "a\n^[b" {
+		t.Errorf(`escapeControls("a\n\x1bb") = %q, want "a\n^[b"`, got)
+	}
+	want := "fatal: ambiguous argument 'x' Use '--' to separate paths from revisions"
+	if got := escapeControlsInline(gitErr); got != want {
+		t.Errorf("escapeControlsInline(%q) = %q, want %q", gitErr, got, want)
+	}
+	if got := escapeControlsInline("a\n\x1bb"); got != "a ^[b" {
+		t.Errorf(`escapeControlsInline("a\n\x1bb") = %q, want "a ^[b"`, got)
 	}
 }
 
@@ -96,9 +119,65 @@ func TestEscapeSpansFollowTheEscapedText(t *testing.T) {
 		t.Fatalf("malformed-byte spans = %+v, want [{5 7}]", spans)
 	}
 
+	// "a\u009bbc": the C1 rune is two bytes raw and six escaped, so the span
+	// over "bc" moves from byte 3 to byte 7.
+	spans = escapeSpans("a\u009bbc", []diff.Span{{Start: 3, End: 5}})
+	if len(spans) != 1 || spans[0] != (diff.Span{Start: 7, End: 9}) {
+		t.Fatalf("C1 spans = %+v, want [{7 9}]", spans)
+	}
+
 	clean := []diff.Span{{Start: 1, End: 2}}
 	if got := escapeSpans("abc", clean); &got[0] != &clean[0] {
 		t.Fatal("a line with no control bytes should keep its spans untouched")
+	}
+}
+
+// The agent in the pane runs `agent-manager rename` itself, so the session
+// name is content the review header paints, not something the user typed.
+func TestSessionNameCannotDriveTheTerminal(t *testing.T) {
+	m := buildModel(t)
+	if m.gitDrv == nil {
+		t.Skip("git not installed")
+	}
+	openReviewOn(t, m, "named", gitRepoWithTwoChangedFiles(t))
+	m.width, m.height = 120, 40
+	for i := range m.sessions {
+		if m.sessions[i].ID == m.diff.sessID {
+			m.sessions[i].Name = "rev\x1b]0;PWNED\x07iew"
+		}
+	}
+
+	frame := m.viewDiffFull()
+	if !strings.Contains(frame, "rev^[]0;PWNED^Giew") {
+		t.Fatal("the session name should read as caret notation in the header")
+	}
+	if stray := strayControl(frame); stray != "" {
+		t.Errorf("a session name leaks a control byte near %q", stray)
+	}
+
+	m.diff.notice = "sent review round 1 to rev\x1b]0;PWNED\x07iew"
+	if stray := strayControl(m.viewDiffFooter()); stray != "" {
+		t.Errorf("the review notice leaks a control byte near %q", stray)
+	}
+	m.diff.notice = ""
+	m.errBar.text = "rename failed for rev\x1b]0;PWNED\x07iew"
+	if stray := strayControl(m.statusMessage("✕", "●")); stray != "" {
+		t.Errorf("the status bar leaks a control byte near %q", stray)
+	}
+}
+
+// git.Driver.run embeds CombinedOutput, and the second line of an ambiguous
+// -argument error is the one that says what to do about it. The review's empty
+// state owns the rows to show it; paint would truncate a folded single row.
+func TestMultiLineGitErrorKeepsItsLines(t *testing.T) {
+	m := buildModel(t)
+	m.diff.errText = "fatal: ambiguous argument 'x'\nUse '--' to separate paths from revisions"
+	rows := strings.Split(m.diffEmptyText(), "\n")
+	if len(rows) != 2 {
+		t.Fatalf("a two-line git error rendered %d rows: %q", len(rows), rows)
+	}
+	if !strings.Contains(rows[1], "separate paths from revisions") {
+		t.Fatalf("the hint line was lost, rows = %q", rows)
 	}
 }
 

--- a/internal/ui/controlbytes_test.go
+++ b/internal/ui/controlbytes_test.go
@@ -63,7 +63,7 @@ func TestEscapeControlsShowsBytesAndKeepsUTF8(t *testing.T) {
 		"x\x9b31mred":  `x\x9B31mred`,
 		"x\x9d0;P\x9c": `x\x9D0;P\x9C`,
 		// The same code points encoded properly are ordinary text.
-		"x31m": "x31m",
+		"x\u009b31m": "x\u009b31m",
 	}
 	for in, want := range cases {
 		if got := escapeControls(in); got != want {
@@ -89,6 +89,13 @@ func TestEscapeSpansFollowTheEscapedText(t *testing.T) {
 	if len(spans) != 1 || spans[0] != (diff.Span{Start: 3, End: 5}) {
 		t.Fatalf("spans = %+v, want [{3 5}]", spans)
 	}
+	// "a\x9bbc": the malformed byte renders as four bytes of hex, so the span
+	// over "bc" moves from byte 2 to byte 5.
+	spans = escapeSpans("a\x9bbc", []diff.Span{{Start: 2, End: 4}})
+	if len(spans) != 1 || spans[0] != (diff.Span{Start: 5, End: 7}) {
+		t.Fatalf("malformed-byte spans = %+v, want [{5 7}]", spans)
+	}
+
 	clean := []diff.Span{{Start: 1, End: 2}}
 	if got := escapeSpans("abc", clean); &got[0] != &clean[0] {
 		t.Fatal("a line with no control bytes should keep its spans untouched")

--- a/internal/ui/diffrender.go
+++ b/internal/ui/diffrender.go
@@ -114,12 +114,13 @@ func highlightFile(fd *diff.FileDiff) *fileHL {
 func sideTexts(fd *diff.FileDiff) (oldText, newText string) {
 	var oldBuilder, newBuilder strings.Builder
 	for _, line := range fd.Lines {
+		text := escapeControls(line.Text)
 		if line.Kind != diff.Add {
-			oldBuilder.WriteString(line.Text)
+			oldBuilder.WriteString(text)
 			oldBuilder.WriteByte('\n')
 		}
 		if line.Kind != diff.Del {
-			newBuilder.WriteString(line.Text)
+			newBuilder.WriteString(text)
 			newBuilder.WriteByte('\n')
 		}
 	}
@@ -159,7 +160,7 @@ func (hl *fileHL) hlLine(line diff.Line) string {
 			return hl.newLines[line.NewNum-1]
 		}
 	}
-	return line.Text
+	return escapeControls(line.Text)
 }
 
 // wrapTinted overlays a diff background onto a chroma-highlighted line
@@ -394,7 +395,7 @@ func (m *Model) reviewSpinnerLine(label string) string {
 
 func (m *Model) diffEmptyText() string {
 	if m.diff.errText != "" {
-		return errStyle.Render("✖ " + m.diff.errText)
+		return errStyle.Render("✖ " + escapeControls(m.diff.errText))
 	}
 	if m.diff.sessID == "" {
 		return mutedStyle.Render("(select a session to diff)")
@@ -418,7 +419,7 @@ func (m *Model) diffBodyNote(fd *diff.FileDiff) string {
 	case m.diffFileHidden(fd):
 		return diffAllHiddenNote()
 	case fd.Err != nil:
-		return errStyle.Render("✖ " + fd.Err.Error())
+		return errStyle.Render("✖ " + escapeControls(fd.Err.Error()))
 	case fd.Binary:
 		return mutedStyle.Render("(binary file)")
 	case fd.Truncated && len(fd.Lines) == 0:
@@ -450,7 +451,7 @@ func (m *Model) renderDiffRow(fd *diff.FileDiff, hl *fileHL, index, width int, c
 	if textWidth < 4 {
 		textWidth = 4
 	}
-	textRows := wrapTinted(hl.hlLine(line), line.Spans, baseBg, spanBg, textWidth)
+	textRows := wrapTinted(hl.hlLine(line), escapeSpans(line.Text, line.Spans), baseBg, spanBg, textWidth)
 
 	marker := " "
 	if len(m.annotationsAt(fd.File.Path, line)) > 0 {
@@ -552,7 +553,7 @@ func (m *Model) viewDiffFull() string {
 	// application rather than a second one.
 	fileLines := append([]string{"", strings.Repeat(" ", railInset) + subtleStyle.Render("files")},
 		indentLines(splitLines(m.viewDiffFileList(fileWidth-2*railGutter, bodyHeight-2)), railInset)...)
-	codeLines := append([]string{"", "  " + subtleStyle.Render(ansi.Strip(m.diffCodeTitle()))},
+	codeLines := append([]string{"", "  " + subtleStyle.Render(escapeControls(m.diffCodeTitle()))},
 		indentLines(splitLines(m.viewDiffCode(codeWidth-2*contentGutter, bodyHeight-2)), contentGutter)...)
 
 	// The column seam tees into the rules that open and close the body,
@@ -609,13 +610,14 @@ func (m *Model) viewDiffHeader(sessName string) string {
 		if name == "" || name == "." {
 			name = filepath.Base(root)
 		}
+		name = escapeControls(name)
 		if len(m.diff.repoRoots) > 1 {
 			name = fmt.Sprintf("%s · %d repos", name, len(m.diff.repoRoots))
 		}
 		left += "  " + keyPill("r", name, colorAccent)
-		branch := m.diff.set.Repo.Branch
+		branch := escapeControls(m.diff.set.Repo.Branch)
 		if m.diff.scope == git.ScopeBranch && m.diff.set.BaseDesc != "" && branch != "" {
-			target := stripBaseHash(m.diff.set.BaseDesc)
+			target := escapeControls(stripBaseHash(m.diff.set.BaseDesc))
 			summary := target + " → " + branch
 			if m.diff.set.BaseOverride == "" {
 				summary += " " + subtleStyle.Render("(auto)")
@@ -741,7 +743,7 @@ func (m *Model) viewDiffFileList(width, height int) string {
 		if nameBudget < 4 {
 			nameBudget = 4
 		}
-		name := truncatePath(fd.File.Path, nameBudget)
+		name := truncatePath(escapeControls(fd.File.Path), nameBudget)
 		left := bar + glyph + " " + valueStyle.Render(name)
 		gap := width - ansi.StringWidth(left) - ansi.StringWidth(counts)
 		if gap < 1 {
@@ -780,7 +782,7 @@ func (m *Model) viewDiffCode(width, height int) string {
 		num, _ := annotationLine(fdLine)
 		m.diff.annInput.SetWidth(width)
 		m.diff.annInput.SetHeight(m.annotationInputHeight(width))
-		bar = divider(fmt.Sprintf("Comment · %s:%d", fd.File.Path, num), width) + "\n" + m.diff.annInput.View()
+		bar = divider(fmt.Sprintf("Comment · %s:%d", escapeControls(fd.File.Path), num), width) + "\n" + m.diff.annInput.View()
 		height -= lipgloss.Height(bar) + 1
 		if height < 3 {
 			height = 3
@@ -960,7 +962,7 @@ func (m *Model) renderSideCell(fd *diff.FileDiff, hl *fileHL, index, width int, 
 	if textWidth < 4 {
 		textWidth = 4
 	}
-	textRows := wrapTinted(hl.hlLine(line), line.Spans, baseBg, spanBg, textWidth)
+	textRows := wrapTinted(hl.hlLine(line), escapeSpans(line.Text, line.Spans), baseBg, spanBg, textWidth)
 	blankGutter := strings.Repeat(" ", gutterWidth)
 	out := make([]string, len(textRows))
 	for i, text := range textRows {
@@ -996,7 +998,7 @@ func (m *Model) viewDiffFooter() string {
 	}
 	repo := "repo"
 	if len(m.diff.repoRoots) > 0 {
-		repo = "repo: " + filepath.Base(m.diff.repoSel)
+		repo = "repo: " + escapeControls(filepath.Base(m.diff.repoSel))
 	}
 	send := "send"
 	if count := m.draftAnnotationCount(); count > 0 {

--- a/internal/ui/diffrender.go
+++ b/internal/ui/diffrender.go
@@ -553,7 +553,7 @@ func (m *Model) viewDiffFull() string {
 	// application rather than a second one.
 	fileLines := append([]string{"", strings.Repeat(" ", railInset) + subtleStyle.Render("files")},
 		indentLines(splitLines(m.viewDiffFileList(fileWidth-2*railGutter, bodyHeight-2)), railInset)...)
-	codeLines := append([]string{"", "  " + subtleStyle.Render(escapeControls(m.diffCodeTitle()))},
+	codeLines := append([]string{"", "  " + subtleStyle.Render(escapeControlsInline(m.diffCodeTitle()))},
 		indentLines(splitLines(m.viewDiffCode(codeWidth-2*contentGutter, bodyHeight-2)), contentGutter)...)
 
 	// The column seam tees into the rules that open and close the body,
@@ -599,7 +599,7 @@ func (m *Model) viewDiffHeader(sessName string) string {
 	if m.diff.sideBySide {
 		layout = "split"
 	}
-	left := "  " + lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("review · "+sessName) + "  " +
+	left := "  " + lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("review · "+escapeControlsInline(sessName)) + "  " +
 		keyPill("s", m.diff.scope.String(), colorAccent2) + "  " +
 		keyPill("u", layout, colorAccent)
 	if m.diff.codeOnly {
@@ -610,14 +610,14 @@ func (m *Model) viewDiffHeader(sessName string) string {
 		if name == "" || name == "." {
 			name = filepath.Base(root)
 		}
-		name = escapeControls(name)
+		name = escapeControlsInline(name)
 		if len(m.diff.repoRoots) > 1 {
 			name = fmt.Sprintf("%s · %d repos", name, len(m.diff.repoRoots))
 		}
 		left += "  " + keyPill("r", name, colorAccent)
-		branch := escapeControls(m.diff.set.Repo.Branch)
+		branch := escapeControlsInline(m.diff.set.Repo.Branch)
 		if m.diff.scope == git.ScopeBranch && m.diff.set.BaseDesc != "" && branch != "" {
-			target := escapeControls(stripBaseHash(m.diff.set.BaseDesc))
+			target := escapeControlsInline(stripBaseHash(m.diff.set.BaseDesc))
 			summary := target + " → " + branch
 			if m.diff.set.BaseOverride == "" {
 				summary += " " + subtleStyle.Render("(auto)")
@@ -743,7 +743,7 @@ func (m *Model) viewDiffFileList(width, height int) string {
 		if nameBudget < 4 {
 			nameBudget = 4
 		}
-		name := truncatePath(escapeControls(fd.File.Path), nameBudget)
+		name := truncatePath(escapeControlsInline(fd.File.Path), nameBudget)
 		left := bar + glyph + " " + valueStyle.Render(name)
 		gap := width - ansi.StringWidth(left) - ansi.StringWidth(counts)
 		if gap < 1 {
@@ -782,7 +782,7 @@ func (m *Model) viewDiffCode(width, height int) string {
 		num, _ := annotationLine(fdLine)
 		m.diff.annInput.SetWidth(width)
 		m.diff.annInput.SetHeight(m.annotationInputHeight(width))
-		bar = divider(fmt.Sprintf("Comment · %s:%d", escapeControls(fd.File.Path), num), width) + "\n" + m.diff.annInput.View()
+		bar = divider(fmt.Sprintf("Comment · %s:%d", escapeControlsInline(fd.File.Path), num), width) + "\n" + m.diff.annInput.View()
 		height -= lipgloss.Height(bar) + 1
 		if height < 3 {
 			height = 3
@@ -980,7 +980,7 @@ func (m *Model) viewDiffStatus() string {
 		return padRight(m.statusMessage(" ✖", " ✔"), m.width)
 	}
 	if m.diff.notice != "" {
-		return padRight(doneStyle.Render(" ✔ "+m.diff.notice), m.width)
+		return padRight(doneStyle.Render(" ✔ "+escapeControlsInline(m.diff.notice)), m.width)
 	}
 	if m.diff.sendConfirm {
 		count := m.draftAnnotationCount()
@@ -998,7 +998,7 @@ func (m *Model) viewDiffFooter() string {
 	}
 	repo := "repo"
 	if len(m.diff.repoRoots) > 0 {
-		repo = "repo: " + escapeControls(filepath.Base(m.diff.repoSel))
+		repo = "repo: " + escapeControlsInline(filepath.Base(m.diff.repoSel))
 	}
 	send := "send"
 	if count := m.draftAnnotationCount(); count > 0 {

--- a/internal/ui/repopicker.go
+++ b/internal/ui/repopicker.go
@@ -268,11 +268,11 @@ func (m *Model) repoPickRow(row pickRow, selected bool) string {
 		nameStyle = nameStyle.Foreground(colorAccent).Bold(true)
 	}
 	inner := m.cardWidth() - 2*cardPaddingX
-	name := truncateTail(row.label, inner-lipgloss.Width(marker))
+	name := truncateTail(escapeControls(row.label), inner-lipgloss.Width(marker))
 	budget := inner - lipgloss.Width(marker) - lipgloss.Width(name) - 2
 	dir := ""
 	if budget > 1 {
-		dir = subtleStyle.Render("  " + truncateTail(filepath.Dir(row.root), budget))
+		dir = subtleStyle.Render("  " + truncateTail(escapeControls(filepath.Dir(row.root)), budget))
 	}
 	return marker + nameStyle.Render(name) + dir
 }

--- a/internal/ui/repopicker.go
+++ b/internal/ui/repopicker.go
@@ -268,11 +268,11 @@ func (m *Model) repoPickRow(row pickRow, selected bool) string {
 		nameStyle = nameStyle.Foreground(colorAccent).Bold(true)
 	}
 	inner := m.cardWidth() - 2*cardPaddingX
-	name := truncateTail(escapeControls(row.label), inner-lipgloss.Width(marker))
+	name := truncateTail(escapeControlsInline(row.label), inner-lipgloss.Width(marker))
 	budget := inner - lipgloss.Width(marker) - lipgloss.Width(name) - 2
 	dir := ""
 	if budget > 1 {
-		dir = subtleStyle.Render("  " + truncateTail(escapeControls(filepath.Dir(row.root)), budget))
+		dir = subtleStyle.Render("  " + truncateTail(escapeControlsInline(filepath.Dir(row.root)), budget))
 	}
 	return marker + nameStyle.Render(name) + dir
 }

--- a/internal/ui/repopicker_test.go
+++ b/internal/ui/repopicker_test.go
@@ -1,0 +1,27 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// A picker row names a repo directory or a git ref, and both reach us as raw
+// bytes, so the row has to show a control byte rather than hand it to the
+// terminal.
+func TestRepoPickRowEscapesControlBytes(t *testing.T) {
+	m := &Model{width: 120}
+	row := pickRow{label: "br\x1b]0;P\x07anch", root: "/tmp/re\x1b[2Jpo/leaf"}
+
+	for _, selected := range []bool{false, true} {
+		out := m.repoPickRow(row, selected)
+		if !strings.Contains(out, "br^[]0;P^Ganch") {
+			t.Errorf("selected=%v: label should read as caret notation, got %q", selected, out)
+		}
+		if !strings.Contains(out, "/tmp/re^[[2Jpo") {
+			t.Errorf("selected=%v: root should read as caret notation, got %q", selected, out)
+		}
+		if stray := strayControl(out); stray != "" {
+			t.Errorf("selected=%v: picker row leaks a control byte near %q", selected, stray)
+		}
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -157,10 +157,11 @@ func (m *Model) statusLine() string {
 // through reads as an outcome, everything else as a failure, in the glyphs
 // the calling surface marks the two with.
 func (m *Model) statusMessage(fail, done string) string {
+	text := escapeControls(m.errBar.text)
 	if m.errBar.worked() {
-		return doneStyle.Render(done + " " + m.errBar.text)
+		return doneStyle.Render(done + " " + text)
 	}
-	return errStyle.Render(fail + " " + m.errBar.text)
+	return errStyle.Render(fail + " " + text)
 }
 
 // inGroupSubtree reports whether a session's group sits at or below the

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -147,7 +147,7 @@ func (m *Model) statusLine() string {
 	case m.errBar.text != "":
 		return m.statusMessage("✕", "●")
 	case m.diff.notice != "":
-		return doneStyle.Render("● " + m.diff.notice)
+		return doneStyle.Render("● " + escapeControlsInline(m.diff.notice))
 	default:
 		return ""
 	}
@@ -157,7 +157,7 @@ func (m *Model) statusLine() string {
 // through reads as an outcome, everything else as a failure, in the glyphs
 // the calling surface marks the two with.
 func (m *Model) statusMessage(fail, done string) string {
-	text := escapeControls(m.errBar.text)
+	text := escapeControlsInline(m.errBar.text)
 	if m.errBar.worked() {
 		return doneStyle.Render(done + " " + text)
 	}

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -628,3 +628,31 @@ func TestFooterTogglesNameTheNextAction(t *testing.T) {
 		t.Fatalf("the archived view should offer the way back:\n%s", ansi.Strip(footer))
 	}
 }
+
+// The status bar carries git and filesystem errors, whose text quotes a path
+// or a ref that can hold control bytes, on both the failure and the outcome
+// branch.
+func TestStatusMessageEscapesControlBytes(t *testing.T) {
+	payload := "boom \x1b]0;P\x07\x1b[2J"
+	const want = "boom ^[]0;P^G^[[2J"
+
+	var m Model
+	m.errBar.text = payload
+	if got := ansi.Strip(m.statusMessage("✖", "✔")); !strings.Contains(got, want) {
+		t.Errorf("failure branch should read as caret notation, got %q", got)
+	}
+	if stray := strayControl(m.statusMessage("✖", "✔")); stray != "" {
+		t.Errorf("failure branch leaks a control byte near %q", stray)
+	}
+
+	m.errBar.done = payload
+	if !m.errBar.worked() {
+		t.Fatal("matching text and done should read as an outcome")
+	}
+	if got := ansi.Strip(m.statusMessage("✖", "✔")); !strings.Contains(got, want) {
+		t.Errorf("outcome branch should read as caret notation, got %q", got)
+	}
+	if stray := strayControl(m.statusMessage("✖", "✔")); stray != "" {
+		t.Errorf("outcome branch leaks a control byte near %q", stray)
+	}
+}


### PR DESCRIPTION
## What

A terminal reads the bytes it is sent as a mix of text to display and commands to run. Review printed a reviewed file's bytes with only carriage returns and tabs taken out, so an escape sequence inside the file was handed over as a command rather than shown.

Opening review on a file containing `\x1b]0;PWNED\x07\x1b[2J` set the terminal window title to `PWNED` and cleared the screen. In this app that surface is shared with the live agent panes, so a file can repaint what an agent appears to be doing. Opening review on code you did not write, a contributor's branch or a vendored dependency, is the case this matters for.

## How

Control bytes are escaped into caret notation as they are drawn, so an ESC reads as `^[`. Showing the byte is what a review tool owes its reader: a hidden escape sequence in someone else's branch is exactly the thing worth spotting.

The rewrite happens at draw time, so stored line text still matches the file on disk and the content fingerprint behind saved reviewed-file marks stays put. Word-diff spans are remapped onto the escaped text, whose control bytes now take two columns.

Git is driven with `-z` and hands back raw paths, so coverage runs past the diff body: the file rail, code title, header repo and branch pills, comment bar, footer, picker rows and error text.

## Three gaps the first pass left

**The session name.** It reached the review header and the round notice raw. `agent-manager rename` is run by the agent in the pane, so the name is content this frame paints rather than something the user typed, and `sessioncmd.Rename` only trims while `store.RenameSession` only rejects empty. The header, the notice and the status bar escape it now, and the assertion uses a name that carries control bytes rather than a plain one.

**C1 encoded as UTF-8.** `U+009B` is CSI and `U+009D` is OSC, and they were passing through whole. Beyond what a terminal that reads them does with them, `ansi.StringWidth` counts a C1 rune as nothing while it takes a cell, so a row carrying one runs past the seam it was measured for. They escape as their code point, six bytes, which `escapedOffset` follows. Hebrew is untouched: its continuation bytes land in that range, but the runes they build decode to `U+05D0` and up.

**Multi-line errors.** Escaping `\n` as `^J` folded a git error into one row that `paint` then truncated, losing the "Use `--` to separate paths from revisions" half; `git.Driver.run` embeds `CombinedOutput`, so that shape is common. Newlines survive now, as they already did in the sibling `withoutControlBytes`, and the surfaces owning exactly one row call `escapeControlsInline` to flatten them: the header pills, the file name, the code title, the comment bar, the repo picker rows, the review notice and the status bar.

## Verified

Observed rather than reasoned about: a real git repo with a real payload file, the rendered frame piped into a real tmux pane, the window title read back.

| | title | screen | line reads |
|---|---|---|---|
| before | `PWNED` | cleared | invisible |
| after | untouched | intact | `^[]0;PWNED^G^[[2J^[[31mgotcha` |

Nine tests, four of them end to end through `viewDiffFull()`, two in both unified and split layouts. One reviews a clean repo and asserts the frame carries nothing but SGR, which is what keeps the leak assertions from passing for the wrong reason. The session-name and multi-line-error tests were each run against the unfixed rendering first and fail there, so they carry their own proof. Full suite green, 25/25 packages, plus `gofmt`, `go build` and `go vet`.

## Follow-ups

Trojan Source (bidi overrides and zero-width characters) is a different mechanism and a separate change. iTerm2's raw C1 handling was not exercised directly, which is the one unverified value behind the escaping scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal safety by escaping control characters and terminal escape sequences in displayed content.
  * Protected file contents, paths, branch names, repository labels, error messages, and review metadata from affecting terminal rendering.
  * Preserved readable non-ASCII text, line breaks, and accurate diff highlighting after escaping.
  * Added coverage for safe rendering across review layouts, repository selection, and status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->