### PR TITLE
fix(ui): never shrink a pane, crop the preview instead

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -652,6 +652,36 @@ func noServer(out string) bool {
 		strings.Contains(out, "error connecting to")
 }
 
+// WindowSizes returns every managed session's window width×height in a
+// single tmux call, so sessions adopted from a previous run resize from
+// their real geometry rather than from nothing.
+func (d *Driver) WindowSizes() (map[string][2]int, error) {
+	out, err := exec.Command(d.bin, d.args("list-windows", "-a", "-F", "#{session_name} #{window_width} #{window_height}")...).CombinedOutput()
+	if err != nil {
+		if noServer(string(out)) {
+			return map[string][2]int{}, nil
+		}
+		return nil, fmt.Errorf("tmux list-windows: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	sizes := map[string][2]int{}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 3 || !strings.HasPrefix(fields[0], prefix) {
+			continue
+		}
+		id := strings.TrimPrefix(fields[0], prefix)
+		if _, taken := sizes[id]; taken {
+			continue
+		}
+		width, widthErr := strconv.Atoi(fields[1])
+		height, heightErr := strconv.Atoi(fields[2])
+		if widthErr == nil && heightErr == nil {
+			sizes[id] = [2]int{width, height}
+		}
+	}
+	return sizes, nil
+}
+
 // Panes returns every managed session's pane pid in a single tmux call,
 // which doubles as a liveness check: a session absent from the map is gone.
 func (d *Driver) Panes() (map[string]int, error) {

--- a/internal/ui/focusscroll.go
+++ b/internal/ui/focusscroll.go
@@ -261,21 +261,39 @@ func (m *Model) requestFocusRegion(sessID string) tea.Cmd {
 }
 
 // focusRegionCmd captures the pane region that sits offset lines above the
-// live bottom. tmux numbers the visible screen from 0 down, and history
-// above it with negative lines, so a scrolled window is just a shifted
-// start and end.
+// live bottom. The pane can be taller than the panel (resizeSessions
+// leaves it tall rather than costing Codex its scrollback), so the pane's
+// bottom, not tmux's visible row zero, anchors the window: the capture
+// takes the offset history lines plus the whole visible pane ("-E -"),
+// and the window is cut from its end, which needs no pane height at all.
 func (m *Model) focusRegionCmd(sessID string, offset int) tea.Cmd {
 	rows := m.previewPaneHeight()
-	command := fmt.Sprintf(`capture-pane -p -e -t %s -S %d -E %d`,
-		tmux.SessionName(sessID), -offset, rows-1-offset)
+	command := fmt.Sprintf(`capture-pane -p -e -t %s -S %d -E -`,
+		tmux.SessionName(sessID), -offset)
 	watch := m.focus
 	return func() tea.Msg {
 		if watch == nil {
 			return focusScrollMsg{sessID: sessID, offset: offset, rows: rows}
 		}
 		out, ok := watch.query(command)
-		return focusScrollMsg{sessID: sessID, offset: offset, rows: rows, preview: matchExecShape(out), ok: ok}
+		return focusScrollMsg{sessID: sessID, offset: offset, rows: rows,
+			preview: bottomWindow(matchExecShape(out), rows, offset), ok: ok}
 	}
+}
+
+// bottomWindow cuts the rows lines that end offset lines above the
+// capture's last row.
+func bottomWindow(capture string, rows, offset int) string {
+	lines := strings.Split(strings.TrimSuffix(capture, "\n"), "\n")
+	end := len(lines) - offset
+	if end < 0 {
+		end = 0
+	}
+	start := end - rows
+	if start < 0 {
+		start = 0
+	}
+	return strings.Join(lines[start:end], "\n") + "\n"
 }
 
 // scrolledBack reports whether the focused pane is showing history rather

--- a/internal/ui/focusscroll.go
+++ b/internal/ui/focusscroll.go
@@ -261,15 +261,18 @@ func (m *Model) requestFocusRegion(sessID string) tea.Cmd {
 }
 
 // focusRegionCmd captures the pane region that sits offset lines above the
-// live bottom. The pane can be taller than the panel (resizeSessions
-// leaves it tall rather than costing Codex its scrollback), so the pane's
-// bottom, not tmux's visible row zero, anchors the window: the capture
-// takes the offset history lines plus the whole visible pane ("-E -"),
-// and the window is cut from its end, which needs no pane height at all.
+// live bottom. The pane's height rarely matches the panel — resizeSessions
+// leaves a pane taller rather than costing Codex its scrollback, and the
+// session's status line makes the visible pane one row shorter than the
+// pinned window — so the pane's bottom, not tmux's visible row zero,
+// anchors the window: the capture reaches rows+offset lines into history
+// and runs to the visible end ("-E -"), and the window is cut from its
+// end, which needs no pane height at all. tmux clamps the start to the
+// history top, so a shallow history just yields a shorter frame.
 func (m *Model) focusRegionCmd(sessID string, offset int) tea.Cmd {
 	rows := m.previewPaneHeight()
 	command := fmt.Sprintf(`capture-pane -p -e -t %s -S %d -E -`,
-		tmux.SessionName(sessID), -offset)
+		tmux.SessionName(sessID), -(offset+rows))
 	watch := m.focus
 	return func() tea.Msg {
 		if watch == nil {

--- a/internal/ui/focusscroll.go
+++ b/internal/ui/focusscroll.go
@@ -272,7 +272,7 @@ func (m *Model) requestFocusRegion(sessID string) tea.Cmd {
 func (m *Model) focusRegionCmd(sessID string, offset int) tea.Cmd {
 	rows := m.previewPaneHeight()
 	command := fmt.Sprintf(`capture-pane -p -e -t %s -S %d -E -`,
-		tmux.SessionName(sessID), -(offset+rows))
+		tmux.SessionName(sessID), -(offset + rows))
 	watch := m.focus
 	return func() tea.Msg {
 		if watch == nil {

--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -195,7 +195,7 @@ func TestFocusScrollRecapturesAfterPreviewResize(t *testing.T) {
 	}
 	updated, _ = m.Update(recapture())
 	m = updated.(*Model)
-	if got, want := len(paneExact(m.preview, m.previewPaneHeight(), m.previewPaneWidth())), m.previewPaneHeight(); got != want {
+	if got, want := len(paneExact(m.preview, m.previewPaneHeight(), m.previewPaneWidth(), -1)), m.previewPaneHeight(); got != want {
 		t.Fatalf("scroll frame has %d rows, want %d", got, want)
 	}
 	if !strings.Contains(m.preview, "history-line-") {
@@ -238,7 +238,7 @@ func TestFocusScrollKeepsDeepHistoryFrame(t *testing.T) {
 	}
 	updated, _ := m.Update(msg)
 	m = updated.(*Model)
-	if got, want := len(paneExact(m.preview, m.previewPaneHeight(), m.previewPaneWidth())), m.previewPaneHeight(); got != want {
+	if got, want := len(paneExact(m.preview, m.previewPaneHeight(), m.previewPaneWidth(), -1)), m.previewPaneHeight(); got != want {
 		t.Fatalf("deep frame has %d rows, want %d", got, want)
 	}
 	if !strings.Contains(m.preview, "history-line-") {
@@ -306,32 +306,85 @@ func TestNoCaretWhileScrolled(t *testing.T) {
 }
 
 // The preview box changes height for reasons other than a terminal
-// resize; a pane left at the old height paints a dead band under its
-// output, so a refresh has to re-assert the geometry.
-func TestRefreshReassertsPaneHeight(t *testing.T) {
+// resize; a pane shorter than the box paints a dead band under its
+// output, so a refresh grows it. A box that lost rows to transient
+// chrome must not shrink the pane back: Codex answers any height shrink
+// by clearing the pane's entire scrollback (#369), so the render crops
+// the taller capture instead.
+func TestRefreshGrowsPaneHeightButNeverShrinksIt(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "sizer", t.TempDir(), "")
 	m.applyCmd(t, m.refreshCmd())
 	sess := m.rows[m.cursor].sess
 
-	if got, want := windowHeight(t, sess.ID), m.previewPaneHeight(); got != want {
-		t.Fatalf("initial pane height = %d, want %d", got, want)
+	pinned := m.previewPaneHeight()
+	if got := windowHeight(t, sess.ID); got != pinned {
+		t.Fatalf("initial pane height = %d, want %d", got, pinned)
 	}
 
 	// A shorter frame with no size message: the header or the status line
 	// taking a row moves the box the same way.
 	m.height -= 4
-	shrunk := m.previewPaneHeight()
+	if m.previewPaneHeight() >= pinned {
+		t.Fatal("test setup did not shrink the preview box")
+	}
 	m.applyCmd(t, m.refreshCmd())
-	if got := windowHeight(t, sess.ID); got != shrunk {
-		t.Fatalf("pane height after the box shrank = %d, want %d", got, shrunk)
+	if got := windowHeight(t, sess.ID); got != pinned {
+		t.Fatalf("pane height after the box shrank = %d, want it kept at %d", got, pinned)
 	}
 
-	m.height += 4
+	m.height += 8
 	grown := m.previewPaneHeight()
+	if grown <= pinned {
+		t.Fatal("test setup did not grow the preview box past the pane")
+	}
 	m.applyCmd(t, m.refreshCmd())
 	if got := windowHeight(t, sess.ID); got != grown {
 		t.Fatalf("pane height after the box grew = %d, want %d", got, grown)
+	}
+}
+
+// A shorter terminal is the issue's headline trigger: the height-only
+// shrink must not reach the pane either: the render crops it, and the
+// pane's scrollback survives. Growing the terminal back re-pins.
+func TestTerminalShrinkLeavesPaneTall(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "shrunk", t.TempDir(), "")
+	m.applyCmd(t, m.refreshCmd())
+	sess := m.rows[m.cursor].sess
+	pinned := windowHeight(t, sess.ID)
+
+	m.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height - 6})
+	if got := windowHeight(t, sess.ID); got != pinned {
+		t.Fatalf("pane height after a terminal shrink = %d, want it kept at %d", got, pinned)
+	}
+
+	m.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height + 12})
+	if got, want := windowHeight(t, sess.ID), m.previewPaneHeight(); got != want {
+		t.Fatalf("pane height after the terminal grew = %d, want %d", got, want)
+	}
+}
+
+// A session left over from a previous run can sit taller than today's
+// box. The first pass adopts its real geometry rather than shrinking it,
+// which would cost a Codex pane its scrollback before anything happened.
+func TestAdoptedTallerPaneIsNotShrunk(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "adopted", t.TempDir(), "")
+	m.applyCmd(t, m.refreshCmd())
+	sess := m.rows[m.cursor].sess
+
+	width := m.previewPaneWidth()
+	taller := m.previewPaneHeight() + 10
+	out, err := tmuxCmd("resize-window", "-t", "am_"+sess.ID,
+		"-x", strconv.Itoa(width), "-y", strconv.Itoa(taller)).CombinedOutput()
+	if err != nil {
+		t.Fatalf("resize-window: %v: %s", err, out)
+	}
+	m.pane.geom = nil
+	m.applyCmd(t, m.refreshCmd())
+	if got := windowHeight(t, sess.ID); got != taller {
+		t.Fatalf("adopted pane height = %d, want it kept at %d", got, taller)
 	}
 }
 

--- a/internal/ui/focussel.go
+++ b/internal/ui/focussel.go
@@ -55,18 +55,23 @@ func (m *Model) cursorCell(paneLines int) (row, col int, ok bool) {
 	return row, cursor.x, true
 }
 
-// paneRowOffset is how many captured rows the panel dropped off the top.
-// A capture taller than the box is painted from its bottom, so a painted
-// row and the pane's own row differ by exactly that many lines.
+// paneRowOffset is how many captured rows the panel dropped off the top,
+// which is exactly what separates a painted row from the pane's own row.
+// It reads the same crop window the renderer paints, so caret and mouse
+// coordinates can never drift from what the user sees.
 func (m *Model) paneRowOffset(paneLines int) int {
-	if paneLines <= 0 {
-		return 0
+	_, start := paneWindow(m.preview, paneLines, m.paneCaretRow())
+	return start
+}
+
+// paneCaretRow is the capture row the live caret sits on, or -1 when no
+// caret is in play. The crop keeps this row painted whatever the blank
+// rows around it look like: it is where typing lands.
+func (m *Model) paneCaretRow() int {
+	if m.mode == modeFocus && m.pane.cursor.ok && !m.scrolledBack() {
+		return m.pane.cursor.y
 	}
-	captured := len(strings.Split(strings.TrimSuffix(m.preview, "\n"), "\n"))
-	if captured <= paneLines {
-		return 0
-	}
-	return captured - paneLines
+	return -1
 }
 
 // focusSelection is a text selection drawn over the focused pane. anchor
@@ -108,7 +113,7 @@ func (m *Model) paneCell(x, y int) (row, col int, ok bool) {
 // same slice the renderer paints, so selection indices line up with what
 // is on screen.
 func (m *Model) paneTextLines() []string {
-	rows := paneExact(m.preview, m.pane.box.height, m.pane.box.width)
+	rows := paneExact(m.preview, m.pane.box.height, m.pane.box.width, m.paneCaretRow())
 	out := make([]string, len(rows))
 	for i, row := range rows {
 		out[i] = ansi.Strip(previewDangerSeqs.ReplaceAllString(row, ""))

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -23,6 +23,20 @@ func paneAt(t *testing.T, lines ...string) *Model {
 	return m
 }
 
+// A pane held taller than the panel crops at its content and never at the
+// caret, which can sit below the content on an empty prompt row; the caret
+// must land on the painted row the crop gave it.
+func TestCaretRowSurvivesTallPaneCrop(t *testing.T) {
+	rows := append([]string{"one", "two"}, make([]string, 38)...)
+	m := paneAt(t, rows...)
+	m.pane.box.height = 10
+	m.pane.cursor = paneCursor{x: 0, y: 25, ok: true}
+	row, col, ok := m.cursorCell(m.pane.box.height)
+	if !ok || row != 9 || col != 0 {
+		t.Fatalf("caret at pane row 25 = (%d,%d,%v), want painted row 9", row, col, ok)
+	}
+}
+
 func press(m *Model, x, y int) {
 	m.handleFocusMouse(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: x, Y: y})
 }
@@ -643,7 +657,7 @@ func TestTabbedRowSharesItsColumns(t *testing.T) {
 	const width = 30
 	m := paneAt(t, "ok  \tgithub.com/x/y\t1.5s")
 	m.pane.box.width = width
-	rows := paneExact(m.preview, m.pane.box.height, width)
+	rows := paneExact(m.preview, m.pane.box.height, width, -1)
 
 	// Column 8 is where the pane paints the package name's first letter.
 	m.pane.cursor = paneCursor{x: 8, y: 0, ok: true}

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -262,6 +262,7 @@ func (m *Model) relaunchSession(sess store.Session, tool config.Tool, baseComman
 	if err := m.tmux.Create(sess.ID, sess.Cwd, command, env, m.previewPaneWidth(), m.previewPaneHeight()); err != nil {
 		return err
 	}
+	m.markFreshPane(sess.ID)
 	if bindConversation != nil {
 		if err := bindConversation(); err != nil {
 			_ = m.tmux.Kill(sess.ID)

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -775,7 +775,7 @@ func ringLoader(width, height int, label string, phase int) []string {
 func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 	var lines []contentLine
 	loader := m.startupLoader(width, height)
-	pane := paneExact(m.preview, height, width)
+	pane := paneExact(m.preview, height, width, m.paneCaretRow())
 	if len(pane) == 0 {
 		// No rows painted means nothing to hit-test: a box left over from
 		// the previous session would catch clicks on empty space.

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -897,7 +897,7 @@ func TestPreviewShowsLoaderWhileSessionStarts(t *testing.T) {
 	if got := previewText(m); !strings.Contains(got, "starting up") {
 		t.Fatalf("preview should carry the launch loader, got %q", got)
 	}
-	if !m.pane.box.ok || m.pane.box.height != len(paneExact(blankCapture, 12, 80)) {
+	if !m.pane.box.ok || m.pane.box.height != len(paneExact(blankCapture, 12, 80, -1)) {
 		t.Fatalf("the loader must not cost the pane its geometry, box = %+v", m.pane.box)
 	}
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -977,9 +977,14 @@ func (m *Model) refreshCmd() tea.Cmd {
 }
 
 // resizeSessions syncs every live session's tmux window to the preview
-// panel's pixel box so a capture fills the preview 1:1. No-op when the
-// size already matches; otherwise resizes in parallel so a fleet of
-// sessions does not serialize N tmux round-trips on the UI path.
+// panel's pixel box so a capture fills the preview 1:1, resizing in
+// parallel so a fleet of sessions does not serialize N tmux round-trips
+// on the UI path. Width changes and height growth pin eagerly; a box that
+// lost rows, to transient chrome or a shorter terminal, leaves the pane
+// tall and lets paneWindow crop the view instead, because a height shrink
+// makes Codex clear the pane's entire scrollback (#369). The one crop this
+// leaves, a too-tall alt-screen TUI missing its top rows, heals on attach,
+// which sizes the window to the terminal and re-pins on detach.
 func (m *Model) resizeSessions() {
 	width, height := m.previewPaneWidth(), m.previewPaneHeight()
 	if width <= 0 || height <= 0 {
@@ -988,13 +993,16 @@ func (m *Model) resizeSessions() {
 	if m.pane.geom == nil {
 		m.pane.geom = map[string][2]int{}
 	}
+	m.seedPaneGeom()
 	var todo []string
 	for _, sess := range m.sessions {
 		if sess.Archived {
 			continue
 		}
-		if last, ok := m.pane.geom[sess.ID]; ok && last[0] == width && last[1] == height {
-			continue
+		if last, ok := m.pane.geom[sess.ID]; ok {
+			if last[0] == width && last[1] >= height {
+				continue
+			}
 		}
 		todo = append(todo, sess.ID)
 	}
@@ -1023,6 +1031,44 @@ func (m *Model) resizeSessions() {
 	})
 }
 
+// markFreshPane queues one exact size pin for a session whose window this
+// run just created. Its launch size came from pre-selection geometry, and
+// with nothing in its scrollback yet the one re-pin is free, unlike the
+// panes adopted from a previous run, which seedPaneGeom protects.
+func (m *Model) markFreshPane(id string) {
+	if m.pane.geom == nil {
+		m.pane.geom = map[string][2]int{}
+	}
+	m.pane.geom[id] = [2]int{0, 0}
+}
+
+// seedPaneGeom fills the geometry cache from tmux for sessions this run
+// has not sized yet, so a pane adopted from a previous run is not shrunk
+// (and its Codex scrollback cleared) just to match a box it already
+// exceeds. A failed listing leaves the entries missing and the next pass
+// pins those sessions to the box; the poll surfaces the tmux failure.
+func (m *Model) seedPaneGeom() {
+	needed := false
+	for _, sess := range m.sessions {
+		if _, sized := m.pane.geom[sess.ID]; !sized && !sess.Archived {
+			needed = true
+			break
+		}
+	}
+	if !needed {
+		return
+	}
+	sizes, err := m.tmux.WindowSizes()
+	if err != nil {
+		return
+	}
+	for id, size := range sizes {
+		if _, sized := m.pane.geom[id]; !sized {
+			m.pane.geom[id] = size
+		}
+	}
+}
+
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
@@ -1037,8 +1083,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Re-assert the terminal backdrop: a reattach or a fresh outer
 		// terminal delivers a size message and may carry stale colors.
 		SyncTerminalBackground()
-		// Geometry cache is stale for every session after a real resize.
-		m.pane.geom = nil
 		m.resizeSessions()
 		if m.mode == modeForm {
 			m.syncFormFieldWidths()
@@ -1104,17 +1148,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.snap = msg.snap
 			m.updateNetRates(msg.snap)
 		}
+		// Sessions left from a previous run carry that run's window size,
+		// which the cache knows nothing about; seedPaneGeom adopts their
+		// real geometry on the first pass, so nothing resets the cache here.
 		if !m.sessionsSized && m.width > 0 && len(m.sessions) > 0 {
 			m.sessionsSized = true
-			// Sessions left from a previous run carry that run's window
-			// size, which our cache knows nothing about, so the first pass
-			// re-asserts geometry for every one of them.
-			m.pane.geom = nil
 		}
 		// The preview box changes height for more reasons than a terminal
 		// resize: the quick bar opening, the status line appearing, a new
-		// badge in the header. A pane left at the old height paints a dead
-		// band under its output, so every pass re-asserts the geometry.
+		// badge in the header. A pane shorter than the box paints a dead
+		// band under its output, so every pass grows what falls short.
 		// The call is free when nothing moved: it diffs against paneGeom.
 		if m.sessionsSized && m.width > 0 {
 			m.resizeSessions()

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -185,19 +185,21 @@ func windowSize(t *testing.T, id string) (int, int) {
 }
 
 // Sessions left over from a previous manager run keep that run's window
-// size; the first refresh after startup must shrink them to the preview
-// panel so their captures fit without a terminal resize.
+// size; the first refresh after startup must bring a wrong-width window to
+// the preview panel so its captures fit without a terminal resize.
 func TestFirstRefreshResizesExistingSessions(t *testing.T) {
 	m := buildModel(t)
 	createSession(t, m, "leftover", t.TempDir(), "")
 	id := m.sessionRows()[0].ID
 
-	// Drift the window as if an older manager had sized it to the terminal.
+	// Drift the window as if an older manager had sized it to the terminal;
+	// a fresh manager also starts with no geometry cached for it.
 	if _, err := tmuxCmd("resize-window", "-t", "am_"+id, "-x", "191", "-y", "55").CombinedOutput(); err != nil {
 		t.Fatalf("resize-window: %v", err)
 	}
 
 	m.sessionsSized = false
+	m.pane.geom = nil
 	m.applyCmd(t, m.refreshCmd())
 	if w, _ := windowSize(t, id); w != m.previewPaneWidth() {
 		t.Fatalf("after first refresh, window width = %d, want %d", w, m.previewPaneWidth())

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -32,6 +32,7 @@ func (m *Model) launchNewSession(sess store.Session, tool config.Tool, baseComma
 		discardWorktree()
 		return err
 	}
+	m.markFreshPane(sess.ID)
 	if err := m.store.CreateSession(sess); err != nil {
 		_ = m.tmux.Kill(sess.ID)
 		_ = m.hooks.Remove(sess.ID)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -379,23 +379,52 @@ func expandPaneTabs(line string, width int) string {
 	return out.String()
 }
 
-// paneExact returns up to n lines of pane text as the pane painted them,
-// preserving blank rows so a full-screen agent TUI looks the same in the
-// preview. When the capture is taller than the panel (stale size), the
-// bottom n lines are kept — the visible end of the pane. Rows arrive here
-// before anything measures them, so this is where a tab becomes the cells
-// it covers and the frame, the caret and the selection all count one set
-// of columns.
-func paneExact(pane string, n, width int) []string {
+// paneWindow picks the half-open row range of a capture the panel shows.
+// A pane is left taller than the panel on purpose, since shrinking it
+// costs agents like Codex their whole scrollback (#369), so a plain crop
+// would show the blank tail such a pane leaves under short output and drop
+// the output itself. The window instead ends at the last painted row, but
+// never retreats past the panel's own row count (short output keeps its
+// top anchor, and a not-yet-painted pane keeps its blank rows hit-testable)
+// or past the caret's row, which is the cell someone is typing into.
+func paneWindow(pane string, n, caretRow int) (lines []string, start int) {
 	if n <= 0 || pane == "" {
-		return nil
+		return nil, 0
 	}
 	// capture-pane often ends with a trailing newline; drop only that.
-	pane = strings.TrimSuffix(pane, "\n")
-	lines := strings.Split(pane, "\n")
-	if len(lines) > n {
-		lines = lines[len(lines)-n:]
+	lines = strings.Split(strings.TrimSuffix(pane, "\n"), "\n")
+	end := len(lines)
+	for end > 0 && blankPaneRow(lines[end-1]) {
+		end--
 	}
+	if end < n {
+		end = n
+	}
+	if caretRow+1 > end {
+		end = caretRow + 1
+	}
+	if end > len(lines) {
+		end = len(lines)
+	}
+	start = end - n
+	if start < 0 {
+		start = 0
+	}
+	return lines[start:end], start
+}
+
+func blankPaneRow(line string) bool {
+	return strings.TrimSpace(ansi.Strip(line)) == ""
+}
+
+// paneExact returns up to n lines of pane text as the pane painted them,
+// preserving blank rows so a full-screen agent TUI looks the same in the
+// preview. caretRow is the capture row the live caret sits on, or -1 when
+// none is in play. Rows arrive here before anything measures them, so this
+// is where a tab becomes the cells it covers and the frame, the caret and
+// the selection all count one set of columns.
+func paneExact(pane string, n, width, caretRow int) []string {
+	lines, _ := paneWindow(pane, n, caretRow)
 	for i, line := range lines {
 		lines[i] = expandPaneTabs(line, width)
 	}

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -45,13 +45,47 @@ func TestScrollWindow(t *testing.T) {
 
 func TestPaneExactPreservesBlanks(t *testing.T) {
 	pane := "one\n\n\ntwo\n"
-	got := paneExact(pane, 10, 80)
+	got := paneExact(pane, 10, 80, -1)
 	if len(got) != 4 || got[1] != "" || got[2] != "" {
 		t.Fatalf("paneExact should keep blank rows: %q", got)
 	}
-	got = paneExact("a\nb\nc\nd", 2, 80)
+	got = paneExact("a\nb\nc\nd", 2, 80, -1)
 	if len(got) != 2 || got[0] != "c" || got[1] != "d" {
 		t.Fatalf("paneExact oversize should take bottom lines: %q", got)
+	}
+}
+
+// A pane held taller than the panel (kept tall on purpose, since a height
+// shrink costs Codex its scrollback, #369) carries a blank tail under
+// short output. The crop ends at the content so the output stays visible,
+// top-anchored the way a terminal shows it.
+func TestPaneWindowCropsBlankTailNotContent(t *testing.T) {
+	tall := "one\ntwo" + strings.Repeat("\n", 40)
+	lines, start := paneWindow(tall, 5, -1)
+	if start != 0 || len(lines) != 5 || lines[0] != "one" || lines[1] != "two" {
+		t.Fatalf("short output in a tall pane = start %d rows %q, want its top rows", start, lines)
+	}
+
+	full := strings.TrimSuffix(strings.Repeat("line\n", 40), "\n")
+	lines, start = paneWindow(full, 5, -1)
+	if start != 35 || len(lines) != 5 {
+		t.Fatalf("full pane = start %d, %d rows, want the bottom five", start, len(lines))
+	}
+
+	mid := "head" + strings.Repeat("\nbody", 30) + strings.Repeat("\n", 9)
+	lines, start = paneWindow(mid, 5, -1)
+	if start != 26 || lines[len(lines)-1] != "body" {
+		t.Fatalf("mid-ending content = start %d last %q, want the crop to end on it", start, lines[len(lines)-1])
+	}
+}
+
+// The caret can rest below the last painted row, on an empty prompt line,
+// and the crop must keep its row on screen.
+func TestPaneWindowKeepsCaretRow(t *testing.T) {
+	tall := "one" + strings.Repeat("\n", 40)
+	lines, start := paneWindow(tall, 5, 20)
+	if start != 16 || len(lines) != 5 {
+		t.Fatalf("caret at row 20 = start %d, %d rows, want rows 16..20", start, len(lines))
 	}
 }
 
@@ -136,7 +170,7 @@ func TestPreviewLine(t *testing.T) {
 // footer and stat rows off their positions.
 func TestPaneExactExpandsTabs(t *testing.T) {
 	const width = 60
-	rows := paneExact("ok  \tgithub.com/YoanWai/agent-manager/internal/ui\t73.163s\n", 4, width)
+	rows := paneExact("ok  \tgithub.com/YoanWai/agent-manager/internal/ui\t73.163s\n", 4, width, -1)
 	if len(rows) != 1 || strings.ContainsRune(rows[0], '\t') {
 		t.Fatalf("tab reached the frame: %q", rows)
 	}
@@ -151,14 +185,14 @@ func TestPaneExactExpandsTabs(t *testing.T) {
 	// tmux leaves it, so the cell painted after it stays in the preview.
 	// Measured on tmux 3.7b: in a 62-column pane, 58 columns then a tab
 	// leaves the cursor at column 61.
-	edge := paneExact(strings.Repeat("a", 58)+"\tX", 1, 62)
+	edge := paneExact(strings.Repeat("a", 58)+"\tX", 1, 62, -1)
 	if want := strings.Repeat("a", 58) + "   X"; edge[0] != want {
 		t.Fatalf("tab at the edge expanded to %q, want %q", edge[0], want)
 	}
 
 	// A capture taken before a resize is wider than the box it lands in,
 	// and a tab past the right edge covers no cells at all.
-	stale := paneExact(strings.Repeat("a", 40)+"\tX", 1, 20)
+	stale := paneExact(strings.Repeat("a", 40)+"\tX", 1, 20, -1)
 	if want := strings.Repeat("a", 40) + "X"; stale[0] != want {
 		t.Fatalf("tab past the edge expanded to %q, want %q", stale[0], want)
 	}


### PR DESCRIPTION
Fixes #369.

## The bug

Every height shrink the manager pushed through `resize-window` made a running Codex (`codex-cli` 0.147.0, inline mode) clear the pane's **entire scrollback** and replay its transcript. Output that predated Codex was destroyed for good. Shrinks fired from transient chrome relayouts, from a shorter terminal, and at startup for sessions adopted from a previous run.

Measured per tool with the same harness (400 seeded marker lines, one real turn, height-only `resize-window` 100x30→44→30): **codex wipes in both directions** (markers 400→0, history 583→175). claude and opencode run on the alt screen and are untouched; gemini keeps history across resizes (it clears pre-existing scrollback during its first turn on its own, which no manager behavior can affect).

## The fix

`resizeSessions` pins width changes and height growth only; a box that lost rows leaves the pane tall:

- `paneWindow` crops the render at the last painted row, so a taller pane shows its content with no dead band: short output stays top-anchored, a not-yet-painted pane keeps its blank rows hit-testable, and the caret's row always stays on screen.
- The crop start feeds `paneRowOffset`, so the caret cell and mouse forwarding map through the same window the renderer paints.
- Focus-mode scroll regions anchor to the pane's bottom through the capture itself (`-S -offset -E -`, cut in Go), so a taller pane scrolls its real history without knowing the pane height.
- Sessions adopted from a previous run seed their true geometry from one `list-windows` call and are never shrunk to fit a box they already exceed.
- A window created this run takes one exact pin (its launch size comes from pre-selection geometry, and its scrollback is still empty, so the pin is free).

Attach and detach still reflow: the width genuinely changes there, and a width reflow rebuilds the transcript in any terminal. The one cosmetic cost, an alt-screen TUI cropped at the top while its pane is taller than the box, heals on the next attach.

## Verified

- Full test suite green on an isolated tmux server, including new coverage: chrome shrink leaves the pane tall and grows it back past the pin, a height-only terminal shrink keeps the pane, adopted taller panes survive the first pass, `paneWindow` crop and caret math, and the bottom-anchored scroll window.
- End to end under the built manager driving a real replayed Codex transcript (`codex resume`, no tokens spent), against the shipped release as control:

| trigger | shipped v0.25 | this branch |
|---|---|---|
| terminal height resize | history 205→174, pre-Codex lines destroyed | history byte-identical |
| quick bar open/close | stable (already held by #342) | stable |
| selection flips | stable | stable |
| terminal shrink | pane re-pinned, replay | pane kept tall, render crops, history intact |