### PR TITLE
test(ui): redraw the fixture prompt so a long envelope cannot stall the gate

### DIFF
--- a/internal/ui/helpers_test.go
+++ b/internal/ui/helpers_test.go
@@ -45,9 +45,10 @@ func buildModel(t *testing.T) *Model {
 				DefaultStatus:  status.Idle,
 				ActivityCutoff: "(?m)^›",
 			},
-			// Redraws its prompt for every line it reads, the way the agent
-			// CLIs keep an input line drawn: a long inbox envelope must not
-			// scroll the prompt off the pane, or TypingHold holds forever.
+			// Draws a fresh prompt for every line it reads, so the prompt
+			// stays on the pane however long an inbox envelope is. Left to
+			// `cat`, a long envelope scrolls it off and TypingHold never
+			// clears.
 			"ready-tool": {
 				Command:        `sh -c 'printf "❯ "; while IFS= read -r line; do printf "\n❯ "; done'`,
 				DefaultStatus:  status.Idle,

--- a/internal/ui/helpers_test.go
+++ b/internal/ui/helpers_test.go
@@ -45,13 +45,16 @@ func buildModel(t *testing.T) *Model {
 				DefaultStatus:  status.Idle,
 				ActivityCutoff: "(?m)^›",
 			},
+			// Redraws its prompt for every line it reads, the way the agent
+			// CLIs keep an input line drawn: a long inbox envelope must not
+			// scroll the prompt off the pane, or TypingHold holds forever.
 			"ready-tool": {
-				Command:        `printf '❯ ' && cat`,
+				Command:        `sh -c 'printf "❯ "; while IFS= read -r line; do printf "\n❯ "; done'`,
 				DefaultStatus:  status.Idle,
 				ActivityCutoff: "(?m)^❯",
 			},
 			"send-tool": {
-				Command:        `printf '❯ ' && cat`,
+				Command:        `sh -c 'printf "❯ "; while IFS= read -r line; do printf "\n❯ "; done'`,
 				PromptMode:     "send",
 				DefaultStatus:  status.Idle,
 				ActivityCutoff: "(?m)^❯",

--- a/internal/ui/inbox_test.go
+++ b/internal/ui/inbox_test.go
@@ -512,8 +512,9 @@ func inboxStall(t *testing.T, m *Model, sessionID string) string {
 	return report.String()
 }
 
-// settledPane waits for the pane to hold every marker and stop changing,
-// since the tool echoes what was typed and then prints it back.
+// settledPane waits for the pane to hold every marker and stop changing.
+// The markers come from the tty echo of what was pasted; the fixture tools
+// consume their input and print only a fresh prompt.
 func settledPane(t *testing.T, m *Model, sessionID string, markers ...string) string {
 	t.Helper()
 	// Two waits, not one. A paste still landing resets the quiet run, so
@@ -593,6 +594,11 @@ func TestThePollLoopDeliversQueuedMessagesOldestFirst(t *testing.T) {
 	if head.ID != second {
 		t.Fatalf("the newer message was delivered first: head = %+v", head)
 	}
+	// Prove the oldest body rendered while it is still the only one on the
+	// pane. Once the second envelope lands it scrolls off, and the store's
+	// delivery stamp alone would not tell a delivered paste from one that
+	// never reached the composer.
+	settledPane(t, m, sess.ID, "rebase on main")
 
 	pollUntilQueued(t, m, sess.ID, 0)
 	for _, id := range []int64{first, second} {
@@ -604,9 +610,9 @@ func TestThePollLoopDeliversQueuedMessagesOldestFirst(t *testing.T) {
 			t.Fatalf("message %d never reached the pane: %+v", id, state)
 		}
 	}
-	// The tool keeps its input line drawn, so two envelopes overflow the
-	// pane and the first body scrolls off; its delivery is what the store
-	// recorded above.
+	// The fixture draws a fresh prompt per line it reads, so two envelopes
+	// overflow the pane and the first body has scrolled off by now; it was
+	// asserted above while it was still visible.
 	settledPane(t, m, sess.ID, "then push the branch")
 }
 

--- a/internal/ui/inbox_test.go
+++ b/internal/ui/inbox_test.go
@@ -604,7 +604,10 @@ func TestThePollLoopDeliversQueuedMessagesOldestFirst(t *testing.T) {
 			t.Fatalf("message %d never reached the pane: %+v", id, state)
 		}
 	}
-	settledPane(t, m, sess.ID, "rebase on main", "then push the branch")
+	// The tool keeps its input line drawn, so two envelopes overflow the
+	// pane and the first body scrolls off; its delivery is what the store
+	// recorded above.
+	settledPane(t, m, sess.ID, "then push the branch")
 }
 
 // A message typed a second time runs the same instruction twice, so the


### PR DESCRIPTION
## What changed

The `ready-tool` and `send-tool` test fixtures drew their prompt once and then read stdin, so the fixture behaved like no real agent CLI: it let a long inbox envelope scroll its only prompt line off the pane. They now redraw the prompt for every line they read, the way the agent CLIs keep an input line drawn at all times.

One assertion followed from that: with the prompt kept drawn, two envelopes overflow a default 24-row pane and the first body scrolls off once the second lands, so `TestThePollLoopDeliversQueuedMessagesOldestFirst` settles on the newest message and reads the first delivery from the store, which already recorded it.

## Why

Delivering a cross-session envelope long enough to push the `❯` activity marker off the pane left `TypingHold` with no activity region. It then reported `working`, the delivery gate stayed shut, and the queue never drained. CI hit this twice today: the main push of #360 ([run 32545235825](https://github.com/YoanWai/agent-manager/actions/runs/32545235825)) and PR #371's branch ([run 32563196518](https://github.com/YoanWai/agent-manager/actions/runs/32563196518)), both failing in `TestThePollLoopNeverRetypesADeliveredMessage` with `queue held 1 messages, want 0` and the stall report showing `typingHold="working"`.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] `go build ./...` passes
- [ ] Ran it against real sessions

Ran it against real sessions: not applicable, this change touches only test fixtures and one test assertion.

The stall report's pane capture is what identified the mechanism: after the first delivery the pane held the full envelope and not a single `❯`, so the activity cutoff could never match again.

## Visual evidence

**Not applicable because:** no product or UI behavior changes; the visible pane difference lives inside test runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixtures to more accurately simulate prompt redraws after input.
  * Updated inbox test coverage to account for pane scrolling and verify messages as they become visible.
  * Clarified test comments around prompt rendering and pane behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->