### PR TITLE
fix(ui): drop the highlight when the next click lands elsewhere

### DIFF
--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -124,8 +124,7 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 		m.focus.retryNow()
 	}
 	m.watchSelection()
-	m.sel = focusSelection{}
-	m.copied = 0
+	m.clearSelection()
 	m.cursorOn = true
 	m.focusScroll = 0
 	// Pane state from a previously watched session must not route this
@@ -224,10 +223,9 @@ func textBeforeCaret(engine *status.Engine, tool, row string, caretX int) bool {
 // view, so the list swallows the wheel instead.
 func (m *Model) leaveFocus() tea.Cmd {
 	m.mode = modeList
-	m.sel = focusSelection{}
+	m.clearSelection()
 	m.pending = pendingClick{}
 	m.clearForwardingMouse()
-	m.copied = 0
 	return nil
 }
 
@@ -252,8 +250,7 @@ func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Ctrl+R opens the review, matching the binding a real attach gets;
 	// closing it focuses the session again rather than landing in the list.
 	if msg.String() == "ctrl+r" {
-		m.sel = focusSelection{}
-		m.copied = 0
+		m.clearSelection()
 		cmd := m.openDiff()
 		if m.mode == modeDiff {
 			m.diff.refocus = true

--- a/internal/ui/focussel.go
+++ b/internal/ui/focussel.go
@@ -241,6 +241,7 @@ func (m *Model) deferClick(button, row, col int) {
 func (m *Model) clearSelection() {
 	m.sel = focusSelection{}
 	m.copied = 0
+	m.copyGen++
 }
 
 // clickRunContinues reports whether a press at this cell extends the click
@@ -289,6 +290,7 @@ func (m *Model) startSelection(row, col int) {
 // motion turned into a drag anchors here without widening the run.
 func (m *Model) beginSelection(row, col int) {
 	m.copied = 0
+	m.copyGen++
 	m.sel.active = true
 	m.sel.dragging = true
 	m.sel.anchorRow, m.sel.anchorCol = row, col
@@ -480,17 +482,21 @@ func (m *Model) copySelectionCmd() tea.Cmd {
 	if strings.TrimSpace(text) == "" {
 		return nil
 	}
+	gen := m.copyGen
 	return func() tea.Msg {
 		if err := clipboard.WriteText(text); err != nil {
 			return errMsg{err}
 		}
-		return focusCopiedMsg{chars: len([]rune(text))}
+		return focusCopiedMsg{chars: len([]rune(text)), gen: gen}
 	}
 }
 
 // focusCopiedMsg reports a finished clipboard write so the status line can
 // confirm it.
-type focusCopiedMsg struct{ chars int }
+type focusCopiedMsg struct {
+	chars int
+	gen   int
+}
 
 // renderPaneRow draws one captured pane row, overlaying the selection when
 // it covers part of it. The agent's own styling survives on both sides of

--- a/internal/ui/focussel.go
+++ b/internal/ui/focussel.go
@@ -146,7 +146,7 @@ func (m *Model) handleFocusMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 	if msg.Action == tea.MouseActionPress && msg.Alt && m.pane.mouse {
 		if row, col, inside := m.paneCell(msg.X, msg.Y); inside {
-			m.sel = focusSelection{}
+			m.clearSelection()
 			m.pending = pendingClick{}
 			m.forwardingMouse = true
 			m.forwardingButton = mouseButton(msg.Button)
@@ -167,7 +167,7 @@ func (m *Model) handleFocusMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		}
 		row, col, ok := m.paneCell(msg.X, msg.Y)
 		if !ok {
-			m.sel = focusSelection{}
+			m.clearSelection()
 			return m, nil
 		}
 		// A repeated press at the same cell is the user asking for a word or
@@ -226,11 +226,21 @@ func (m *Model) handleFocusMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 }
 
 // deferClick parks a press until motion or release resolves the gesture,
-// recording it as the start of a possible double or triple click run.
+// recording it as the start of a possible double or triple click run. The
+// press drops the earlier selection whichever way it resolves: a highlight
+// left standing under a click elsewhere reads as still selected.
 func (m *Model) deferClick(button, row, col int) {
+	m.clearSelection()
 	m.pending = pendingClick{active: true, button: button, row: row, col: col}
 	m.sel.lastClick, m.sel.lastRow, m.sel.lastCol = time.Now(), row, col
 	m.sel.clickCount = 1
+}
+
+// clearSelection drops the highlight along with the copy confirmation that
+// belongs to it.
+func (m *Model) clearSelection() {
+	m.sel = focusSelection{}
+	m.copied = 0
 }
 
 // clickRunContinues reports whether a press at this cell extends the click

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -710,3 +710,31 @@ func TestClickElsewhereClearsSelection(t *testing.T) {
 		}
 	}
 }
+
+// The clipboard writer runs off the update loop, so its confirmation can
+// land after a click elsewhere has already dropped the highlight it counted.
+// Re-arming the banner there would put "copied N chars" under no selection,
+// which is the state this file exists to prevent.
+func TestLateCopyConfirmationIsDroppedAfterTheSelectionGoes(t *testing.T) {
+	m := paneAt(t, "alpha beta", "gamma delta")
+	press(m, 10, 5)
+	drag(m, 14, 5)
+	m.handleFocusMouse(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 14, Y: 5})
+	inFlight := focusCopiedMsg{chars: 4, gen: m.copyGen}
+
+	press(m, 12, 6)
+	m.Update(inFlight)
+	if m.copied != 0 {
+		t.Fatalf("a write that landed after the click re-armed the count: %d", m.copied)
+	}
+
+	// The same confirmation still counts while its own selection stands.
+	m2 := paneAt(t, "alpha beta", "gamma delta")
+	press(m2, 10, 5)
+	drag(m2, 14, 5)
+	m2.handleFocusMouse(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 14, Y: 5})
+	m2.Update(focusCopiedMsg{chars: 4, gen: m2.copyGen})
+	if m2.copied != 4 {
+		t.Fatalf("the write for the standing selection was dropped: %d", m2.copied)
+	}
+}

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -680,3 +680,33 @@ func TestTabbedRowSharesItsColumns(t *testing.T) {
 		t.Fatalf("dragging over the painted columns copied %q", text)
 	}
 }
+
+// A click somewhere else ends the previous selection, in a pane that tracks
+// the mouse and forwards the press as much as in one that selects on it: a
+// highlight left standing reads as text still selected, and the copy
+// confirmation belongs to the highlight it counted.
+func TestClickElsewhereClearsSelection(t *testing.T) {
+	for _, tracksMouse := range []bool{false, true} {
+		m := paneAt(t, "alpha beta", "gamma delta")
+		m.pane.mouse = tracksMouse
+		press(m, 10, 5)
+		drag(m, 14, 5)
+		m.handleFocusMouse(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 14, Y: 5})
+		if got := m.selectionText(); got != "alph" {
+			t.Fatalf("mouse=%v: drag selected %q", tracksMouse, got)
+		}
+		m.copied = 4
+
+		press(m, 12, 6)
+		if got := m.selectionText(); got != "" {
+			t.Fatalf("mouse=%v: click elsewhere still selects %q", tracksMouse, got)
+		}
+		if m.copied != 0 {
+			t.Fatalf("mouse=%v: click elsewhere kept the copy confirmation: %d", tracksMouse, m.copied)
+		}
+		m.handleFocusMouse(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 12, Y: 6})
+		if got := m.selectionText(); got != "" {
+			t.Fatalf("mouse=%v: releasing the click restored the selection %q", tracksMouse, got)
+		}
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -97,9 +97,12 @@ type Model struct {
 	// sel is the focused-pane selection, written during paint so clicks
 	// resolve against the current frame. copied is the size of the last
 	// clipboard write, shown once in the status line and cleared on the
-	// next selection.
-	copied int
-	sel    focusSelection
+	// next selection. copyGen rises whenever the selection behind a write
+	// stops being the one on screen, so a write that lands late is dropped
+	// instead of re-arming the count under nothing.
+	copied  int
+	copyGen int
+	sel     focusSelection
 	// forwardingMouse holds an Alt-initiated in-pane click lifecycle until
 	// its release. The button and last in-pane cell keep an X10 release
 	// paired with its press when it reports MouseButtonNone outside the pane.
@@ -1280,6 +1283,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.cursorBlink()
 
 	case focusCopiedMsg:
+		// The clipboard writer runs off the update loop and can take
+		// hundreds of milliseconds, long enough for a click elsewhere to
+		// drop the highlight this count belongs to.
+		if msg.gen != m.copyGen {
+			return m, nil
+		}
 		m.errBar.text = ""
 		m.copied = msg.chars
 		return m, nil


### PR DESCRIPTION
## What changed

A press in the focused pane now drops the previous selection, along with the `copied N chars to clipboard` count that belonged to it.

In a pane whose application tracks the mouse, a press is parked as a *pending click* (`deferClick`) instead of starting a selection: release on the same cell forwards it to the agent, motion turns it into a drag. That path never touched `m.sel`, so the earlier highlight stayed painted while the click went through to the agent. `clearSelection` is the shared reset, and the three hand-rolled `m.sel = focusSelection{}` plus `m.copied = 0` pairs in `focuskeys.go` call it too, so the pair cannot drift.

## The same banner, arriving by the other door

`copySelectionCmd` writes to the clipboard off the update loop with a three second cap, and on WSL `clip.exe` or a loaded `wl-copy` that takes hundreds of milliseconds. A click elsewhere inside that window cleared the highlight and the count, then `focusCopiedMsg` landed and set `m.copied` unconditionally: `copied N chars to clipboard` back under no selection at all. Starting a new selection had the same shape, with the previous write's count landing on top of it.

`copyGen` rises whenever the selection behind a pending write stops being the one on screen, so a confirmation is dropped unless its own selection still stands.

## Why

After copying a line, clicking anywhere else, including inside the agent's own TUI, left the copied text highlighted. The pane reads as if that text is still selected, and the status line keeps counting a copy that is over.

## How it was verified

Unit: `TestClickElsewhereClearsSelection` drives `handleFocusMouse` with real `tea.MouseMsg` values over both values of `m.pane.mouse`: drag-select, release, then a press elsewhere. Asserts the selection text is empty and `m.copied` is back to zero, before and after the release resolves. `TestLateCopyConfirmationIsDroppedAfterTheSelectionGoes` covers the race from both sides: a confirmation stamped before the click is dropped, and one whose selection still stands still counts. It was run against the unguarded handler first and fails there.

Live: two builds, `main` and this branch, each driven through the same scripted run in an isolated tmux server and a throwaway `HOME`. Spawn a session, replace its pane with a script that prints three known lines and enables SGR mouse tracking (`\e[?1000h\e[?1006h`), focus it, drag-select `alpha`, then click on the `iota kappa lambda mu` row three rows down. Screen read back with `capture-pane -e`:

| | `main` | this branch |
|---|---|---|
| after the drag | `\e[48;2;109;170;186malpha` + `copied 5 chars to clipboard` | same |
| after clicking elsewhere | highlight still painted, banner still up | highlight gone, banner gone |

The escape sequence in the first row is the selection highlight: on `main` it is still in the captured row after the click, on this branch the row comes back unstyled and the status line is empty.

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] `go build ./...` passes
- [x] Ran it against real sessions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Visual evidence

Both frames were rendered from real runs, one build apart, driven through the identical scripted sequence described above: drag-select `alpha`, then click three rows down on `iota kappa lambda mu`.

**Before,** `main`: `alpha` on the first pane row still carries the selection background, and `copied 5 chars to clipboard` is still up in the top right, three rows away from where the click landed.

**After,** this branch: the identical frame has `alpha` in the pane's own styling with no highlight, and the top right is back to the session's normal `started 15s ago · cpu 0.0% · ram 0.0%` row. Nothing else on the frame differs.

They are described rather than inlined on purpose. Hosting the PNGs needed a throwaway `assets/` branch on the public repo, and a body that outlives that branch would show two broken images instead. The `capture-pane -e` table under **How it was verified** is the readback of exactly those two states, down to the highlight's escape sequence, so the permanent record carries its own evidence.

## Summary by CodeRabbit

* **Bug Fixes**
  * Selections are now cleared consistently when clicking elsewhere, changing focus, forwarding input, or opening a review.
  * Delayed clipboard confirmations no longer restore copy indicators for an outdated selection.
  * Copy status is reset whenever the active selection is cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
