### PR TITLE
docs(feed): carry the release entry through v0.32.1

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -11,10 +11,10 @@
       "A session waiting on its rename wears the prompt it was given, and the preview leaves a Codex pane's scrollback alone.",
       "Thanks to @dolutech, who asked for a self-update command in #355 and then wrote it (#361), and to @creatorrr for the",
       "WSL clipboard fix that keeps box-drawing characters whole in a pane selection (#341).",
-      "@pandysp's #349 is why left and right step in and out of a session; pi's bare prompt joins that pair now."
+      "@pandysp's #349 is why left and right step in and out of a session; pi and opencode join that pair now."
     ],
     "url": "https://github.com/YoanWai/agent-manager/releases/tag/v0.32.0",
-    "max_version": "0.32.0"
+    "max_version": "0.32.1"
   },
   {
     "id": "sessions-coordinate-with-each-other",

--- a/docs/messages.json
+++ b/docs/messages.json
@@ -9,8 +9,8 @@
       "Agents mark a comment handled or reopen it over MCP and the CLI, closing the loop without erasing what was said.",
       "A reviewed file shows its control bytes now instead of obeying them: a hidden escape sequence cannot repaint the screen.",
       "A session waiting on its rename wears the prompt it was given, and the preview leaves a Codex pane's scrollback alone.",
-      "Thanks to @dolutech, who asked for a self-update command in #355 and then wrote it (#361), and to @creatorrr for the",
-      "WSL clipboard fix that keeps box-drawing characters whole in a pane selection (#341).",
+      "Thanks to @dolutech, who asked for a self-update command in #355 and then wrote it (#361).",
+      "@creatorrr fixed WSL pane selection, so box-drawing characters copy whole instead of as mojibake (#341).",
       "@pandysp's #349 is why left and right step in and out of a session; pi and opencode join that pair now."
     ],
     "url": "https://github.com/YoanWai/agent-manager/releases/tag/v0.32.0",


### PR DESCRIPTION
v0.32.1 ships the opencode half of the arrow-step fix (#381). `max_version` is inclusive, so without the bump the release entry would retire for the very install the patch targets. The credits line names both tools now.

Also fixes how the entry reads in the messages box: the @dolutech/@creatorrr thanks was one sentence split across two body rows to duck the 120-char cap, and the box paints each row as its own line, so it rendered as a broken wrap mid-sentence. Every body line is a whole sentence now, longest 120 chars.

`internal/feed` tests pass, including `TestShippedFeedFileIsRenderableAndRetires` against the edited file.