### PR TITLE
fix(tmux): keep every session command on the agent's own pane

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -627,19 +627,11 @@ func (d *Driver) fitAgentPane(id string, width, height int) error {
 	if err != nil {
 		return err
 	}
-	fields := strings.Fields(out)
-	if len(fields) != 5 {
-		return fmt.Errorf("tmux reported no geometry for session %s: %q", id, out)
+	var panes, windowWidth, windowHeight, paneWidth, paneHeight int
+	if _, err := fmt.Sscanf(strings.TrimSpace(out), "%d %d %d %d %d",
+		&panes, &windowWidth, &windowHeight, &paneWidth, &paneHeight); err != nil {
+		return fmt.Errorf("tmux geometry %q for session %s: %w", strings.TrimSpace(out), id, err)
 	}
-	geometry := make([]int, len(fields))
-	for i, field := range fields {
-		value, err := strconv.Atoi(field)
-		if err != nil {
-			return fmt.Errorf("tmux geometry %q for session %s: %w", field, id, err)
-		}
-		geometry[i] = value
-	}
-	panes, windowWidth, windowHeight, paneWidth, paneHeight := geometry[0], geometry[1], geometry[2], geometry[3], geometry[4]
 	if panes < 2 {
 		return nil
 	}
@@ -736,63 +728,33 @@ func noServer(out string) bool {
 		strings.Contains(out, "error connecting to")
 }
 
-// PaneGeom is a session's agent pane size and how many panes share its
-// window. The size is what the preview draws, and a count above one means
-// the agent split the window itself, leaving its own pane a fraction of
-// the geometry the manager pinned.
-type PaneGeom struct {
+// Pane is a managed session's agent pane: the process running in it, the
+// size the preview draws it at, and how many panes share its window. A
+// count above one means the agent split the window itself, leaving its own
+// pane a fraction of the geometry the manager pinned.
+type Pane struct {
+	PID    int
 	Width  int
 	Height int
 	Panes  int
 }
 
-// PaneGeoms returns every managed session's agent pane geometry in a single
-// tmux call, so a session adopted from a previous run resizes from its real
-// size rather than from nothing, and a window an agent has split is known
-// as split without a call per session.
-func (d *Driver) PaneGeoms() (map[string]PaneGeom, error) {
-	out, err := exec.Command(d.bin, d.args("list-panes", "-a", "-f", "#{==:#{pane_index},0}", "-F", "#{session_name} #{pane_width} #{pane_height} #{window_panes}")...).CombinedOutput()
-	if err != nil {
-		if noServer(string(out)) {
-			return map[string]PaneGeom{}, nil
-		}
-		return nil, fmt.Errorf("tmux list-panes: %w: %s", err, strings.TrimSpace(string(out)))
-	}
-	geoms := map[string]PaneGeom{}
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) != 4 || !strings.HasPrefix(fields[0], prefix) {
-			continue
-		}
-		id := strings.TrimPrefix(fields[0], prefix)
-		if _, taken := geoms[id]; taken {
-			continue
-		}
-		width, widthErr := strconv.Atoi(fields[1])
-		height, heightErr := strconv.Atoi(fields[2])
-		panes, panesErr := strconv.Atoi(fields[3])
-		if widthErr == nil && heightErr == nil && panesErr == nil {
-			geoms[id] = PaneGeom{Width: width, Height: height, Panes: panes}
-		}
-	}
-	return geoms, nil
-}
-
-// Panes returns every managed session's pane pid in a single tmux call,
+// Panes returns every managed session's agent pane in a single tmux call,
 // which doubles as a liveness check: a session absent from the map is gone.
-// The filter keeps the agent's own pane, the one PaneTarget addresses, so
-// a session whose agent split the window still reports the agent's pid.
-func (d *Driver) Panes() (map[string]int, error) {
-	out, err := exec.Command(d.bin, d.args("list-panes", "-a", "-f", "#{==:#{pane_index},0}", "-F", "#{session_name} #{pane_pid}")...).CombinedOutput()
+// The filter keeps the agent's own pane, the one PaneTarget addresses, so a
+// session whose agent split the window reports the agent's own process and
+// the size the preview draws, never a teammate's.
+func (d *Driver) Panes() (map[string]Pane, error) {
+	out, err := exec.Command(d.bin, d.args("list-panes", "-a", "-f", "#{==:#{pane_index},0}", "-F", "#{session_name} #{pane_pid} #{pane_width} #{pane_height} #{window_panes}")...).CombinedOutput()
 	if err != nil {
 		if noServer(string(out)) {
-			return map[string]int{}, nil
+			return map[string]Pane{}, nil
 		}
 		return nil, fmt.Errorf("tmux list-panes: %w: %s", err, strings.TrimSpace(string(out)))
 	}
-	panes := map[string]int{}
+	panes := map[string]Pane{}
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		name, pidText, ok := strings.Cut(line, " ")
+		name, geometry, ok := strings.Cut(line, " ")
 		if !ok || !strings.HasPrefix(name, prefix) {
 			continue
 		}
@@ -800,8 +762,9 @@ func (d *Driver) Panes() (map[string]int, error) {
 		if _, taken := panes[id]; taken {
 			continue
 		}
-		if pid, err := strconv.Atoi(pidText); err == nil {
-			panes[id] = pid
+		var pane Pane
+		if _, err := fmt.Sscanf(geometry, "%d %d %d %d", &pane.PID, &pane.Width, &pane.Height, &pane.Panes); err == nil {
+			panes[id] = pane
 		}
 	}
 	return panes, nil

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -122,8 +122,16 @@ func sessionName(id string) string {
 	return prefix + id
 }
 
-func SessionName(id string) string {
-	return sessionName(id)
+// PaneTarget addresses the pane the agent itself runs in. A bare session
+// name does not: tmux resolves that to whichever pane is active, and an
+// agent is free to split the window and hand focus to the new pane, as
+// Claude Code's agent teams do when they run a teammate beside their
+// leader. Reading or typing through a session-wide target then lands on
+// the teammate. ":^" pins the session's first window for the same reason,
+// and EnsureBindings pins pane-base-index so ".0" is the agent's pane on
+// any user's tmux config.
+func PaneTarget(id string) string {
+	return sessionName(id) + ":^.0"
 }
 
 // tmux requires -L <socket> before the command word.
@@ -341,12 +349,19 @@ func attachStatusRight(primary, secondary string) string {
 	return " agent-manager · Ctrl+r = review · F3 = editor · " + strings.Join(exits, " / ") + " = back "
 }
 
+// EnsureBindings installs the server-wide setup every managed session
+// relies on: the in-session key bindings, and the pane numbering
+// PaneTarget addresses. A tmux config that starts panes at 1 is the
+// dangerous case for the numbering, because tmux answers a target whose
+// index does not exist with the active pane rather than an error, so
+// every capture and keystroke would silently follow the focused pane.
 func (d *Driver) EnsureBindings() error {
 	inSession := "#{m:" + prefix + "*,#{session_name}}"
 	request := func(name string) string {
 		return "set-option -g " + requestOption + " " + name + " ; detach-client"
 	}
-	binds := [][]string{
+	commands := [][]string{
+		{"set-window-option", "-g", "pane-base-index", "0"},
 		{"bind-key", "-n", "C-q", "if-shell", "-F", inSession, "detach-client", "send-keys C-q"},
 		{"bind-key", "-n", `C-\`, "if-shell", "-F", inSession, "detach-client", `send-keys C-\\`},
 		{"bind-key", "-n", "C-r", "if-shell", "-F", inSession, request(RequestReview), "send-keys C-r"},
@@ -358,7 +373,7 @@ func (d *Driver) EnsureBindings() error {
 		// Restore the standard fallback when the prefix shadows a direct binding.
 		{"bind-key", "-T", "prefix", "d", "detach-client"},
 	}
-	_, err := d.run(commandList(binds...)...)
+	_, err := d.run(commandList(commands...)...)
 	return err
 }
 
@@ -372,13 +387,13 @@ func (d *Driver) RefreshChrome(id string) error {
 // SendText delivers text into the session's pane and presses Enter, so the
 // agent inside receives it as a user message.
 func (d *Driver) SendText(id, text string) error {
-	return d.pasteAndEnter(sessionName(id), text)
+	return d.pasteAndEnter(PaneTarget(id), text)
 }
 
 // SendKeys delivers exact tmux key names to a session. Keeping each key as
 // its own argv entry avoids routing agent-supplied input through a shell.
 func (d *Driver) SendKeys(id string, keys ...string) error {
-	args := []string{"send-keys", "-t", sessionName(id), "--"}
+	args := []string{"send-keys", "-t", PaneTarget(id), "--"}
 	_, err := d.run(append(args, keys...)...)
 	return err
 }
@@ -388,7 +403,7 @@ func (d *Driver) SendKeys(id string, keys ...string) error {
 // keystrokes would turn every newline into an Enter press and submit the
 // agent's prompt mid-paste.
 func (d *Driver) Paste(id, text string) error {
-	return d.paste(sessionName(id), text)
+	return d.paste(PaneTarget(id), text)
 }
 
 var pasteSeq atomic.Uint64
@@ -575,7 +590,7 @@ func (d *Driver) Exists(id string) bool {
 // CapturePane returns the visible pane content with ANSI escapes intact
 // (-e), so previews keep the session's real colors. Strip before regex use.
 func (d *Driver) CapturePane(id string) (string, error) {
-	return d.run("capture-pane", "-p", "-e", "-t", sessionName(id))
+	return d.run("capture-pane", "-p", "-e", "-t", PaneTarget(id))
 }
 
 // capturePlain drops the escapes CapturePane keeps, which an application is
@@ -593,7 +608,50 @@ func (d *Driver) Resize(id string, width, height int) error {
 	if width <= 0 || height <= 0 {
 		return nil
 	}
-	_, err := d.run("resize-window", "-t", sessionName(id), "-x", strconv.Itoa(width), "-y", strconv.Itoa(height))
+	if _, err := d.run("resize-window", "-t", sessionName(id), "-x", strconv.Itoa(width), "-y", strconv.Itoa(height)); err != nil {
+		return err
+	}
+	return d.fitAgentPane(id, width, height)
+}
+
+// fitAgentPane grows a split window until the agent's own pane is the size
+// the preview asked for. Teammate panes an agent opened beside itself take
+// their columns out of the window, so pinning the window alone leaves the
+// pane the preview draws at a fraction of the panel, with the rest of the
+// panel blank. The shortfall is added to the window rather than taken from
+// the teammates, so fitting the agent pane never shrinks one, which is what
+// keeps a Codex teammate's scrollback (#369).
+func (d *Driver) fitAgentPane(id string, width, height int) error {
+	out, err := d.run("display-message", "-p", "-t", PaneTarget(id),
+		"#{window_panes} #{window_width} #{window_height} #{pane_width} #{pane_height}")
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	if len(fields) != 5 {
+		return fmt.Errorf("tmux reported no geometry for session %s: %q", id, out)
+	}
+	geometry := make([]int, len(fields))
+	for i, field := range fields {
+		value, err := strconv.Atoi(field)
+		if err != nil {
+			return fmt.Errorf("tmux geometry %q for session %s: %w", field, id, err)
+		}
+		geometry[i] = value
+	}
+	panes, windowWidth, windowHeight, paneWidth, paneHeight := geometry[0], geometry[1], geometry[2], geometry[3], geometry[4]
+	if panes < 2 {
+		return nil
+	}
+	growWidth, growHeight := max(0, width-paneWidth), max(0, height-paneHeight)
+	if growWidth == 0 && growHeight == 0 {
+		return nil
+	}
+	if _, err := d.run("resize-window", "-t", sessionName(id),
+		"-x", strconv.Itoa(windowWidth+growWidth), "-y", strconv.Itoa(windowHeight+growHeight)); err != nil {
+		return err
+	}
+	_, err = d.run("resize-pane", "-t", PaneTarget(id), "-x", strconv.Itoa(width), "-y", strconv.Itoa(height))
 	return err
 }
 
@@ -622,7 +680,7 @@ func (d *Driver) PrepareAttach(id string) error {
 // cells from the top left. A capture carries no cursor, so a caller that
 // has to tell an empty prompt from a half-written line asks tmux for it.
 func (d *Driver) Cursor(id string) (int, int, error) {
-	out, err := d.run("display-message", "-p", "-t", sessionName(id), "#{cursor_x},#{cursor_y}")
+	out, err := d.run("display-message", "-p", "-t", PaneTarget(id), "#{cursor_x},#{cursor_y}")
 	if err != nil {
 		return 0, 0, err
 	}
@@ -642,7 +700,7 @@ func (d *Driver) Cursor(id string) (int, int, error) {
 }
 
 func (d *Driver) PanePID(id string) (int, error) {
-	out, err := d.run("list-panes", "-t", sessionName(id), "-F", "#{pane_pid}")
+	out, err := d.run("display-message", "-p", "-t", PaneTarget(id), "#{pane_pid}")
 	if err != nil {
 		return 0, err
 	}
@@ -650,7 +708,6 @@ func (d *Driver) PanePID(id string) (int, error) {
 	if line == "" {
 		return 0, fmt.Errorf("no pane for session %s", id)
 	}
-	line = strings.SplitN(line, "\n", 2)[0]
 	return strconv.Atoi(line)
 }
 
@@ -658,7 +715,7 @@ func (d *Driver) PanePID(id string) (int, error) {
 // cd the shell or the agent made since launch, unlike the directory the
 // session was created in.
 func (d *Driver) PaneCurrentPath(id string) (string, error) {
-	out, err := d.run("list-panes", "-t", sessionName(id), "-F", "#{pane_current_path}")
+	out, err := d.run("display-message", "-p", "-t", PaneTarget(id), "#{pane_current_path}")
 	if err != nil {
 		return "", err
 	}
@@ -679,40 +736,54 @@ func noServer(out string) bool {
 		strings.Contains(out, "error connecting to")
 }
 
-// WindowSizes returns every managed session's window width×height in a
-// single tmux call, so sessions adopted from a previous run resize from
-// their real geometry rather than from nothing.
-func (d *Driver) WindowSizes() (map[string][2]int, error) {
-	out, err := exec.Command(d.bin, d.args("list-windows", "-a", "-F", "#{session_name} #{window_width} #{window_height}")...).CombinedOutput()
+// PaneGeom is a session's agent pane size and how many panes share its
+// window. The size is what the preview draws, and a count above one means
+// the agent split the window itself, leaving its own pane a fraction of
+// the geometry the manager pinned.
+type PaneGeom struct {
+	Width  int
+	Height int
+	Panes  int
+}
+
+// PaneGeoms returns every managed session's agent pane geometry in a single
+// tmux call, so a session adopted from a previous run resizes from its real
+// size rather than from nothing, and a window an agent has split is known
+// as split without a call per session.
+func (d *Driver) PaneGeoms() (map[string]PaneGeom, error) {
+	out, err := exec.Command(d.bin, d.args("list-panes", "-a", "-f", "#{==:#{pane_index},0}", "-F", "#{session_name} #{pane_width} #{pane_height} #{window_panes}")...).CombinedOutput()
 	if err != nil {
 		if noServer(string(out)) {
-			return map[string][2]int{}, nil
+			return map[string]PaneGeom{}, nil
 		}
-		return nil, fmt.Errorf("tmux list-windows: %w: %s", err, strings.TrimSpace(string(out)))
+		return nil, fmt.Errorf("tmux list-panes: %w: %s", err, strings.TrimSpace(string(out)))
 	}
-	sizes := map[string][2]int{}
+	geoms := map[string]PaneGeom{}
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		fields := strings.Fields(line)
-		if len(fields) != 3 || !strings.HasPrefix(fields[0], prefix) {
+		if len(fields) != 4 || !strings.HasPrefix(fields[0], prefix) {
 			continue
 		}
 		id := strings.TrimPrefix(fields[0], prefix)
-		if _, taken := sizes[id]; taken {
+		if _, taken := geoms[id]; taken {
 			continue
 		}
 		width, widthErr := strconv.Atoi(fields[1])
 		height, heightErr := strconv.Atoi(fields[2])
-		if widthErr == nil && heightErr == nil {
-			sizes[id] = [2]int{width, height}
+		panes, panesErr := strconv.Atoi(fields[3])
+		if widthErr == nil && heightErr == nil && panesErr == nil {
+			geoms[id] = PaneGeom{Width: width, Height: height, Panes: panes}
 		}
 	}
-	return sizes, nil
+	return geoms, nil
 }
 
 // Panes returns every managed session's pane pid in a single tmux call,
 // which doubles as a liveness check: a session absent from the map is gone.
+// The filter keeps the agent's own pane, the one PaneTarget addresses, so
+// a session whose agent split the window still reports the agent's pid.
 func (d *Driver) Panes() (map[string]int, error) {
-	out, err := exec.Command(d.bin, d.args("list-panes", "-a", "-F", "#{session_name} #{pane_pid}")...).CombinedOutput()
+	out, err := exec.Command(d.bin, d.args("list-panes", "-a", "-f", "#{==:#{pane_index},0}", "-F", "#{session_name} #{pane_pid}")...).CombinedOutput()
 	if err != nil {
 		if noServer(string(out)) {
 			return map[string]int{}, nil

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -615,43 +615,51 @@ func (d *Driver) Resize(id string, width, height int) error {
 	if width <= 0 || height <= 0 {
 		return nil
 	}
-	if _, err := d.run("resize-window", "-t", windowTarget(id), "-x", strconv.Itoa(width), "-y", strconv.Itoa(height)); err != nil {
-		return err
-	}
-	return d.fitAgentPane(id, width, height)
-}
-
-// fitAgentPane grows a split window until the agent's own pane is the size
-// the preview asked for. Teammate panes an agent opened beside itself take
-// their columns out of the window, so pinning the window alone leaves the
-// pane the preview draws at a fraction of the panel, with the rest of the
-// panel blank. The shortfall is added to the window rather than taken from
-// the teammates, so fitting the agent pane never shrinks one, which is what
-// keeps a Codex teammate's scrollback (#369).
-func (d *Driver) fitAgentPane(id string, width, height int) error {
-	out, err := d.run("display-message", "-p", "-t", PaneTarget(id),
-		"#{window_panes} #{window_width} #{window_height} #{pane_width} #{pane_height}")
+	panes, windowWidth, windowHeight, paneWidth, paneHeight, err := d.geometry(id)
 	if err != nil {
 		return err
 	}
-	var panes, windowWidth, windowHeight, paneWidth, paneHeight int
-	if _, err := fmt.Sscanf(strings.TrimSpace(out), "%d %d %d %d %d",
-		&panes, &windowWidth, &windowHeight, &paneWidth, &paneHeight); err != nil {
-		return fmt.Errorf("tmux geometry %q for session %s: %w", strings.TrimSpace(out), id, err)
+	// A window the agent split shares its geometry with the teammate panes,
+	// so pinning it to the box leaves the pane the preview draws at a
+	// fraction of the panel, with the rest of the panel blank. Sizing the
+	// window to the box plus what the teammates already hold, then pinning
+	// the agent's pane to the box, gives the preview its pane at full size
+	// and hands the teammates back their share of the axis the split
+	// divides, whether the box grew or shrank -- which is what keeps a Codex
+	// teammate's scrollback (#369). The other axis belongs to the window, so
+	// every pane follows the box there.
+	if panes > 1 {
+		windowWidth = width + (windowWidth - paneWidth)
+		windowHeight = height + (windowHeight - paneHeight)
+	} else {
+		windowWidth, windowHeight = width, height
+	}
+	if _, err := d.run("resize-window", "-t", windowTarget(id),
+		"-x", strconv.Itoa(windowWidth), "-y", strconv.Itoa(windowHeight)); err != nil {
+		return err
 	}
 	if panes < 2 {
 		return nil
 	}
-	growWidth, growHeight := max(0, width-paneWidth), max(0, height-paneHeight)
-	if growWidth == 0 && growHeight == 0 {
-		return nil
-	}
-	if _, err := d.run("resize-window", "-t", windowTarget(id),
-		"-x", strconv.Itoa(windowWidth+growWidth), "-y", strconv.Itoa(windowHeight+growHeight)); err != nil {
-		return err
-	}
 	_, err = d.run("resize-pane", "-t", PaneTarget(id), "-x", strconv.Itoa(width), "-y", strconv.Itoa(height))
 	return err
+}
+
+// geometry reports how many panes share the agent's window, the window's
+// size and the agent pane's own, which is what a resize needs to tell the
+// teammates' share of the window from the pane the preview draws.
+func (d *Driver) geometry(id string) (panes, windowWidth, windowHeight, paneWidth, paneHeight int, err error) {
+	out, err := d.run("display-message", "-p", "-t", PaneTarget(id),
+		"#{window_panes} #{window_width} #{window_height} #{pane_width} #{pane_height}")
+	if err != nil {
+		return 0, 0, 0, 0, 0, err
+	}
+	line := strings.TrimSpace(out)
+	if _, err := fmt.Sscanf(line, "%d %d %d %d %d",
+		&panes, &windowWidth, &windowHeight, &paneWidth, &paneHeight); err != nil {
+		return 0, 0, 0, 0, 0, fmt.Errorf("tmux geometry %q for session %s: %w", line, id, err)
+	}
+	return panes, windowWidth, windowHeight, paneWidth, paneHeight, nil
 }
 
 // PrepareAttach restores automatic window sizing so the session fills the

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -122,6 +122,13 @@ func sessionName(id string) string {
 	return prefix + id
 }
 
+// windowTarget addresses the window the agent's pane lives in, the
+// session's first, which is not the session's current window once anyone
+// opens a second one inside it.
+func windowTarget(id string) string {
+	return sessionName(id) + ":^"
+}
+
 // PaneTarget addresses the pane the agent itself runs in. A bare session
 // name does not: tmux resolves that to whichever pane is active, and an
 // agent is free to split the window and hand focus to the new pane, as
@@ -131,7 +138,7 @@ func sessionName(id string) string {
 // and EnsureBindings pins pane-base-index so ".0" is the agent's pane on
 // any user's tmux config.
 func PaneTarget(id string) string {
-	return sessionName(id) + ":^.0"
+	return windowTarget(id) + ".0"
 }
 
 // tmux requires -L <socket> before the command word.
@@ -608,7 +615,7 @@ func (d *Driver) Resize(id string, width, height int) error {
 	if width <= 0 || height <= 0 {
 		return nil
 	}
-	if _, err := d.run("resize-window", "-t", sessionName(id), "-x", strconv.Itoa(width), "-y", strconv.Itoa(height)); err != nil {
+	if _, err := d.run("resize-window", "-t", windowTarget(id), "-x", strconv.Itoa(width), "-y", strconv.Itoa(height)); err != nil {
 		return err
 	}
 	return d.fitAgentPane(id, width, height)
@@ -639,7 +646,7 @@ func (d *Driver) fitAgentPane(id string, width, height int) error {
 	if growWidth == 0 && growHeight == 0 {
 		return nil
 	}
-	if _, err := d.run("resize-window", "-t", sessionName(id),
+	if _, err := d.run("resize-window", "-t", windowTarget(id),
 		"-x", strconv.Itoa(windowWidth+growWidth), "-y", strconv.Itoa(windowHeight+growHeight)); err != nil {
 		return err
 	}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -287,7 +287,7 @@ func TestSendTextWaitsOutTheWindowWhenTheBaselineCaptureFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read call log: %v", err)
 	}
-	if !strings.Contains(string(logged), "send-keys -t am_x1 Enter") {
+	if !strings.Contains(string(logged), "send-keys -t "+PaneTarget("x1")+" Enter") {
 		t.Fatalf("Enter never sent, calls:\n%s", logged)
 	}
 }
@@ -961,4 +961,143 @@ func TestExportEnvPrefixesTheCommand(t *testing.T) {
 	if got := ExportEnv(env, "claude --resume 7"); got != want {
 		t.Fatalf("ExportEnv = %q, want %q", got, want)
 	}
+}
+
+// An agent is free to split its own window and leave the new pane focused,
+// which Claude Code's agent teams do when they run a teammate beside their
+// leader. Everything the manager reads and types has to stay on the agent's
+// own pane through that.
+func TestManagerStaysOnTheAgentPaneAfterASplit(t *testing.T) {
+	driver := requireTmux(t)
+	id := "split" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "cat", nil, 0, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+	agentPID, err := driver.PanePID(id)
+	if err != nil {
+		t.Fatalf("PanePID: %v", err)
+	}
+
+	// No -d: the split leaves the teammate pane active, which is what a
+	// session-wide target would follow.
+	if out, err := tmuxCmd("split-window", "-t", "am_"+id, "--",
+		"sh", "-c", "printf teammate-pane; sleep 30").CombinedOutput(); err != nil {
+		t.Fatalf("split-window: %v: %s", err, out)
+	}
+
+	if pid, err := driver.PanePID(id); err != nil || pid != agentPID {
+		t.Fatalf("PanePID after split = %d, %v, want the agent pane %d", pid, err, agentPID)
+	}
+	if err := driver.SendText(id, "hello world"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	var pane string
+	for time.Now().Before(deadline) {
+		pane, err = driver.CapturePane(id)
+		if err != nil {
+			t.Fatalf("CapturePane: %v", err)
+		}
+		if strings.Contains(pane, "hello world") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !strings.Contains(pane, "hello world") {
+		t.Fatalf("message should reach the agent pane, pane: %q", pane)
+	}
+	if strings.Contains(pane, "teammate-pane") {
+		t.Fatalf("capture should read the agent pane, not the teammate: %q", pane)
+	}
+}
+
+// tmux answers a pane target whose index does not exist with the active
+// pane rather than an error, so a user config that numbers panes from 1
+// would point every capture and keystroke at whatever pane has focus.
+func TestEnsureBindingsPinsPaneNumbering(t *testing.T) {
+	driver := requireTmux(t)
+	if out, err := tmuxCmd("set-window-option", "-g", "pane-base-index", "1").CombinedOutput(); err != nil {
+		t.Fatalf("set pane-base-index: %v: %s", err, out)
+	}
+	t.Cleanup(func() { tmuxCmd("set-window-option", "-g", "pane-base-index", "0").Run() })
+
+	if err := driver.EnsureBindings(); err != nil {
+		t.Fatalf("EnsureBindings: %v", err)
+	}
+
+	out, err := tmuxCmd("show-window-options", "-gv", "pane-base-index").CombinedOutput()
+	if err != nil {
+		t.Fatalf("show-window-options: %v: %s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "0" {
+		t.Fatalf("pane-base-index = %q, want 0", got)
+	}
+}
+
+// A window an agent split shares its columns with the teammate panes, so
+// pinning the window alone leaves the agent's own pane -- the one the
+// preview draws -- at a fraction of the panel it is drawn in.
+func TestResizeFitsTheAgentPaneInASplitWindow(t *testing.T) {
+	driver := requireTmux(t)
+	id := "fit" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "cat", nil, 80, 24); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+	if out, err := tmuxCmd("split-window", "-h", "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
+		t.Fatalf("split-window: %v: %s", err, out)
+	}
+
+	if err := driver.Resize(id, 100, 30); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	geoms, err := driver.PaneGeoms()
+	if err != nil {
+		t.Fatalf("PaneGeoms: %v", err)
+	}
+	if got := geoms[id]; got.Width != 100 || got.Height != 30 {
+		t.Fatalf("agent pane = %dx%d, want the preview box 100x30", got.Width, got.Height)
+	}
+}
+
+// Fitting the agent pane never costs a teammate the room it had: a pane
+// that loses height clears a Codex scrollback (#369), and one that loses
+// width reflows every line it holds.
+func TestResizeNeverShrinksATeammatePane(t *testing.T) {
+	driver := requireTmux(t)
+	id := "keep" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "cat", nil, 80, 24); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+	if out, err := tmuxCmd("split-window", "-h", "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
+		t.Fatalf("split-window: %v: %s", err, out)
+	}
+	before := teammateSize(t, id)
+
+	if err := driver.Resize(id, 100, 24); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	if after := teammateSize(t, id); after[0] < before[0] || after[1] < before[1] {
+		t.Fatalf("teammate pane = %v, want no less than the %v it had", after, before)
+	}
+}
+
+// teammateSize reports the second pane of a session's window.
+func teammateSize(t *testing.T, id string) [2]int {
+	t.Helper()
+	out, err := tmuxCmd("list-panes", "-t", "am_"+id, "-f", "#{==:#{pane_index},1}", "-F", "#{pane_width} #{pane_height}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("list-panes: %v: %s", err, out)
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) != 2 {
+		t.Fatalf("teammate pane geometry = %q", out)
+	}
+	width, _ := strconv.Atoi(fields[0])
+	height, _ := strconv.Atoi(fields[1])
+	return [2]int{width, height}
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -812,7 +812,7 @@ func TestLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Panes: %v", err)
 	}
-	if panes[id] <= 0 {
+	if panes[id].PID <= 0 {
 		t.Fatalf("Panes should map %q to a pane pid, got %v", id, panes)
 	}
 
@@ -980,14 +980,26 @@ func TestManagerStaysOnTheAgentPaneAfterASplit(t *testing.T) {
 	}
 
 	// No -d: the split leaves the teammate pane active, which is what a
-	// session-wide target would follow.
-	if out, err := tmuxCmd("split-window", "-t", "am_"+id, "--",
+	// session-wide target would follow. Its own directory is what tells the
+	// two panes apart in what the manager reads back.
+	teammateDir := t.TempDir()
+	if out, err := tmuxCmd("split-window", "-t", "am_"+id, "-c", teammateDir, "--",
 		"sh", "-c", "printf teammate-pane; sleep 30").CombinedOutput(); err != nil {
 		t.Fatalf("split-window: %v: %s", err, out)
 	}
 
 	if pid, err := driver.PanePID(id); err != nil || pid != agentPID {
 		t.Fatalf("PanePID after split = %d, %v, want the agent pane %d", pid, err, agentPID)
+	}
+	panes, err := driver.Panes()
+	if err != nil {
+		t.Fatalf("Panes: %v", err)
+	}
+	if panes[id].PID != agentPID {
+		t.Fatalf("Panes reports pid %d, want the agent pane %d", panes[id].PID, agentPID)
+	}
+	if path, err := driver.PaneCurrentPath(id); err != nil || path == teammateDir {
+		t.Fatalf("PaneCurrentPath = %q, %v, want the agent pane's own directory", path, err)
 	}
 	if err := driver.SendText(id, "hello world"); err != nil {
 		t.Fatalf("SendText: %v", err)
@@ -1035,54 +1047,62 @@ func TestEnsureBindingsPinsPaneNumbering(t *testing.T) {
 	}
 }
 
-// A window an agent split shares its columns with the teammate panes, so
+// A window an agent split shares its geometry with the teammate panes, so
 // pinning the window alone leaves the agent's own pane -- the one the
-// preview draws -- at a fraction of the panel it is drawn in.
+// preview draws -- at a fraction of the panel it is drawn in. Either split
+// axis takes that room, and the teammate must keep what it had: a pane that
+// loses height clears a Codex scrollback (#369), and one that loses width
+// reflows every line it holds.
 func TestResizeFitsTheAgentPaneInASplitWindow(t *testing.T) {
-	driver := requireTmux(t)
-	id := "fit" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
-	if err := driver.Create(id, "/tmp", "cat", nil, 80, 24); err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	t.Cleanup(func() { driver.Kill(id) })
-	if out, err := tmuxCmd("split-window", "-h", "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
-		t.Fatalf("split-window: %v: %s", err, out)
-	}
+	for _, split := range []struct {
+		axis string
+		flag string
+	}{{"horizontal", "-h"}, {"vertical", "-v"}} {
+		t.Run(split.axis, func(t *testing.T) {
+			driver := requireTmux(t)
+			id := "fit" + split.axis[:1] + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+			if err := driver.Create(id, "/tmp", "cat", nil, 80, 24); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			t.Cleanup(func() { driver.Kill(id) })
+			if out, err := tmuxCmd("split-window", split.flag, "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
+				t.Fatalf("split-window: %v: %s", err, out)
+			}
+			teammate := teammateSize(t, id)
 
-	if err := driver.Resize(id, 100, 30); err != nil {
-		t.Fatalf("Resize: %v", err)
-	}
+			if err := driver.Resize(id, 100, 30); err != nil {
+				t.Fatalf("Resize: %v", err)
+			}
 
-	geoms, err := driver.PaneGeoms()
-	if err != nil {
-		t.Fatalf("PaneGeoms: %v", err)
-	}
-	if got := geoms[id]; got.Width != 100 || got.Height != 30 {
-		t.Fatalf("agent pane = %dx%d, want the preview box 100x30", got.Width, got.Height)
+			panes, err := driver.Panes()
+			if err != nil {
+				t.Fatalf("Panes: %v", err)
+			}
+			if got := panes[id]; got.Width != 100 || got.Height != 30 {
+				t.Fatalf("agent pane = %dx%d, want the preview box 100x30", got.Width, got.Height)
+			}
+			if after := teammateSize(t, id); after[0] < teammate[0] || after[1] < teammate[1] {
+				t.Fatalf("teammate pane = %v, want no less than the %v it had", after, teammate)
+			}
+		})
 	}
 }
 
-// Fitting the agent pane never costs a teammate the room it had: a pane
-// that loses height clears a Codex scrollback (#369), and one that loses
-// width reflows every line it holds.
-func TestResizeNeverShrinksATeammatePane(t *testing.T) {
-	driver := requireTmux(t)
-	id := "keep" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
-	if err := driver.Create(id, "/tmp", "cat", nil, 80, 24); err != nil {
-		t.Fatalf("Create: %v", err)
+// A geometry line tmux did not answer in numbers leaves the agent pane at
+// whatever the split gave it, so the resize reports rather than returns.
+func TestResizeReportsUnreadableGeometry(t *testing.T) {
+	dir := t.TempDir()
+	stub := dir + "/tmux"
+	script := "#!/bin/sh\ncase \"$*\" in *display-message*) echo 'no geometry here';; esac\nexit 0\n"
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil {
+		t.Fatalf("stub: %v", err)
 	}
-	t.Cleanup(func() { driver.Kill(id) })
-	if out, err := tmuxCmd("split-window", "-h", "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
-		t.Fatalf("split-window: %v: %s", err, out)
-	}
-	before := teammateSize(t, id)
+	driver := &Driver{bin: stub, socket: testSocket}
 
-	if err := driver.Resize(id, 100, 24); err != nil {
-		t.Fatalf("Resize: %v", err)
-	}
+	err := driver.Resize("x1", 100, 30)
 
-	if after := teammateSize(t, id); after[0] < before[0] || after[1] < before[1] {
-		t.Fatalf("teammate pane = %v, want no less than the %v it had", after, before)
+	if err == nil || !strings.Contains(err.Error(), "geometry") {
+		t.Fatalf("Resize error = %v, want the unreadable geometry reported", err)
 	}
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1050,41 +1050,51 @@ func TestEnsureBindingsPinsPaneNumbering(t *testing.T) {
 // A window an agent split shares its geometry with the teammate panes, so
 // pinning the window alone leaves the agent's own pane -- the one the
 // preview draws -- at a fraction of the panel it is drawn in. Either split
-// axis takes that room, and the teammate must keep what it had: a pane that
-// loses height clears a Codex scrollback (#369), and one that loses width
-// reflows every line it holds.
+// axis takes that room, and a preview box that grew or shrank has to leave
+// the teammate its share of the axis the split divides, since that is the
+// room the fit could otherwise take: a pane that loses width reflows every
+// line it holds, and one that loses height clears a Codex scrollback
+// (#369). The other axis is the window's own and every pane follows it.
 func TestResizeFitsTheAgentPaneInASplitWindow(t *testing.T) {
 	for _, split := range []struct {
 		axis string
 		flag string
-	}{{"horizontal", "-h"}, {"vertical", "-v"}} {
-		t.Run(split.axis, func(t *testing.T) {
-			driver := requireTmux(t)
-			id := "fit" + split.axis[:1] + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
-			if err := driver.Create(id, "/tmp", "cat", nil, 80, 24); err != nil {
-				t.Fatalf("Create: %v", err)
-			}
-			t.Cleanup(func() { driver.Kill(id) })
-			if out, err := tmuxCmd("split-window", split.flag, "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
-				t.Fatalf("split-window: %v: %s", err, out)
-			}
-			teammate := teammateSize(t, id)
+		// divided indexes the dimension the split cuts, the one the panes
+		// share out between them rather than take whole from the window.
+		divided int
+	}{{"horizontal", "-h", 0}, {"vertical", "-v", 1}} {
+		for _, box := range []struct {
+			name          string
+			width, height int
+		}{{"grown", 100, 30}, {"shrunk", 60, 20}} {
+			t.Run(split.axis+"/"+box.name, func(t *testing.T) {
+				driver := requireTmux(t)
+				id := "fit" + split.axis[:1] + box.name[:1] + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+				if err := driver.Create(id, "/tmp", "cat", nil, 80, 24); err != nil {
+					t.Fatalf("Create: %v", err)
+				}
+				t.Cleanup(func() { driver.Kill(id) })
+				if out, err := tmuxCmd("split-window", split.flag, "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
+					t.Fatalf("split-window: %v: %s", err, out)
+				}
+				teammate := teammateSize(t, id)
 
-			if err := driver.Resize(id, 100, 30); err != nil {
-				t.Fatalf("Resize: %v", err)
-			}
+				if err := driver.Resize(id, box.width, box.height); err != nil {
+					t.Fatalf("Resize: %v", err)
+				}
 
-			panes, err := driver.Panes()
-			if err != nil {
-				t.Fatalf("Panes: %v", err)
-			}
-			if got := panes[id]; got.Width != 100 || got.Height != 30 {
-				t.Fatalf("agent pane = %dx%d, want the preview box 100x30", got.Width, got.Height)
-			}
-			if after := teammateSize(t, id); after[0] < teammate[0] || after[1] < teammate[1] {
-				t.Fatalf("teammate pane = %v, want no less than the %v it had", after, teammate)
-			}
-		})
+				panes, err := driver.Panes()
+				if err != nil {
+					t.Fatalf("Panes: %v", err)
+				}
+				if got := panes[id]; got.Width != box.width || got.Height != box.height {
+					t.Fatalf("agent pane = %dx%d, want the preview box %dx%d", got.Width, got.Height, box.width, box.height)
+				}
+				if after := teammateSize(t, id); after[split.divided] < teammate[split.divided] {
+					t.Fatalf("teammate pane = %v, want no less than the %v it had across the split", after, teammate)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1106,7 +1106,6 @@ func TestResizeReportsUnreadableGeometry(t *testing.T) {
 	}
 }
 
-// teammateSize reports the second pane of a session's window.
 func teammateSize(t *testing.T, id string) [2]int {
 	t.Helper()
 	out, err := tmuxCmd("list-panes", "-t", "am_"+id, "-f", "#{==:#{pane_index},1}", "-F", "#{pane_width} #{pane_height}").CombinedOutput()
@@ -1120,4 +1119,33 @@ func teammateSize(t *testing.T, id string) [2]int {
 	width, _ := strconv.Atoi(fields[0])
 	height, _ := strconv.Atoi(fields[1])
 	return [2]int{width, height}
+}
+
+// A window someone opened inside a session becomes that session's current
+// window, which is not the one the agent runs in. Everything the preview
+// pins has to stay on the agent's window through that.
+func TestResizePinsTheAgentWindowNotTheCurrentOne(t *testing.T) {
+	driver := requireTmux(t)
+	id := "window" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "cat", nil, 80, 24); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+	// No -d: the new window is left current, which is what a session-wide
+	// target would resize.
+	if out, err := tmuxCmd("new-window", "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
+		t.Fatalf("new-window: %v: %s", err, out)
+	}
+
+	if err := driver.Resize(id, 100, 30); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	panes, err := driver.Panes()
+	if err != nil {
+		t.Fatalf("Panes: %v", err)
+	}
+	if got := panes[id]; got.Width != 100 || got.Height != 30 {
+		t.Fatalf("agent pane = %dx%d, want the preview box 100x30", got.Width, got.Height)
+	}
 }

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -275,7 +275,7 @@ func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, resume
 	}
-	command, ok := focusKeyCommand(tmux.SessionName(sess.ID), msg)
+	command, ok := focusKeyCommand(tmux.PaneTarget(sess.ID), msg)
 	if !ok {
 		return m, resume
 	}

--- a/internal/ui/focusscroll.go
+++ b/internal/ui/focusscroll.go
@@ -122,7 +122,7 @@ func (m *Model) mouseReport(button int, release bool, col, row int) (string, boo
 // printed on its input line instead. mouse_any_flag covers every mode, so
 // the per-mode flags would only repeat it.
 func guardedMouseCommand(sessID, report string) (string, []string) {
-	target := tmux.SessionName(sessID)
+	target := tmux.PaneTarget(sessID)
 	const condition = "#{mouse_any_flag}"
 	send := "send-keys -t " + target + " -H " + hexBytes(report)
 	command := "if-shell -F -t " + target + " '" + condition + "' '" + send + "'"
@@ -272,7 +272,7 @@ func (m *Model) requestFocusRegion(sessID string) tea.Cmd {
 func (m *Model) focusRegionCmd(sessID string, offset int) tea.Cmd {
 	rows := m.previewPaneHeight()
 	command := fmt.Sprintf(`capture-pane -p -e -t %s -S %d -E -`,
-		tmux.SessionName(sessID), -(offset + rows))
+		tmux.PaneTarget(sessID), -(offset + rows))
 	watch := m.focus
 	return func() tea.Msg {
 		if watch == nil {

--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -85,7 +85,7 @@ func focusedWithHistory(t *testing.T, name string) (*Model, string) {
 // pipe, standing in for the pushed capture that normally caches it.
 func paneHistorySize(t *testing.T, m *Model, sessID string) int {
 	t.Helper()
-	out, ok := m.focus.query(`display-message -p -t ` + tmux.SessionName(sessID) + ` "#{history_size}"`)
+	out, ok := m.focus.query(`display-message -p -t ` + tmux.PaneTarget(sessID) + ` "#{history_size}"`)
 	if !ok {
 		t.Fatal("history query failed over the control pipe")
 	}

--- a/internal/ui/focuswatch.go
+++ b/internal/ui/focuswatch.go
@@ -209,7 +209,7 @@ func (w *focusWatch) watch(id string, stop chan struct{}) {
 		}
 		w.mu.Unlock()
 	}()
-	target := tmux.SessionName(id)
+	target := tmux.PaneTarget(id)
 	capture := func() bool {
 		pane, err := control.Command("capture-pane -p -e -t " + target)
 		if err != nil {

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -578,7 +578,7 @@ func (m *Model) liveSessions(sessions []store.Session) ([]store.Session, error) 
 	}
 	var live []store.Session
 	for _, sess := range sessions {
-		if panes[sess.ID] > 0 {
+		if panes[sess.ID].PID > 0 {
 			live = append(live, sess)
 		}
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -89,6 +89,9 @@ type Model struct {
 	// queuedMessages is replaced whole on every refresh rather than merged,
 	// so a delivered message's badge clears itself.
 	queuedMessages map[string]int
+	// panes is the last pass's agent pane geometry, which the poller reads
+	// off the UI loop alongside its liveness listing.
+	panes map[string]tmux.Pane
 
 	net netStats
 
@@ -426,6 +429,9 @@ type refreshMsg struct {
 	preview        string
 	agents         agentStats
 	queuedMessages map[string]int
+	// panes is the pass's agent pane geometry, read off the UI loop with
+	// the liveness listing the poller already makes.
+	panes map[string]tmux.Pane
 }
 
 type previewMsg struct {
@@ -993,9 +999,6 @@ func (m *Model) resizeSessions() {
 	if width <= 0 || height <= 0 {
 		return
 	}
-	if len(m.sessions) == 0 {
-		return
-	}
 	if m.pane.geom == nil {
 		m.pane.geom = map[string][2]int{}
 	}
@@ -1048,21 +1051,16 @@ func (m *Model) markFreshPane(id string) {
 	m.pane.geom[id] = [2]int{0, 0}
 }
 
-// seedPaneGeom fills the geometry cache from tmux for sessions this run
-// has not sized yet, so a pane adopted from a previous run is not shrunk
-// (and its Codex scrollback cleared) just to match a box it already
-// exceeds. A split window is re-read every pass instead: the agent opened
-// those panes out of its own window, taking columns from the pane the
+// seedPaneGeom fills the geometry cache from the pass's pane listing for
+// sessions this run has not sized yet, so a pane adopted from a previous
+// run is not shrunk (and its Codex scrollback cleared) just to match a box
+// it already exceeds. A split window is taken every pass instead: the agent
+// opened those panes out of its own window, taking room from the pane the
 // preview draws, and no manager action precedes that for the cache to
 // follow. Drift the manager did not cause otherwise stays, so a window
-// someone resized from another client is left where they put it. A failed
-// listing leaves the cache as it was; the poll surfaces the tmux failure.
+// someone resized from another client is left where they put it.
 func (m *Model) seedPaneGeom() {
-	geoms, err := m.tmux.PaneGeoms()
-	if err != nil {
-		return
-	}
-	for id, geom := range geoms {
+	for id, geom := range m.panes {
 		last, sized := m.pane.geom[id]
 		// markFreshPane's pin is still owed: a session created this run
 		// carries its pre-selection launch size, not the box.
@@ -1145,6 +1143,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		m.sessions = sessions
+		m.panes = msg.panes
 		m.groups = msg.groups
 		m.groupPaths = msg.groupPaths
 		m.groupWorktrees = msg.groupWorktrees

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -993,6 +993,9 @@ func (m *Model) resizeSessions() {
 	if width <= 0 || height <= 0 {
 		return
 	}
+	if len(m.sessions) == 0 {
+		return
+	}
 	if m.pane.geom == nil {
 		m.pane.geom = map[string][2]int{}
 	}
@@ -1048,27 +1051,28 @@ func (m *Model) markFreshPane(id string) {
 // seedPaneGeom fills the geometry cache from tmux for sessions this run
 // has not sized yet, so a pane adopted from a previous run is not shrunk
 // (and its Codex scrollback cleared) just to match a box it already
-// exceeds. A failed listing leaves the entries missing and the next pass
-// pins those sessions to the box; the poll surfaces the tmux failure.
+// exceeds. A split window is re-read every pass instead: the agent opened
+// those panes out of its own window, taking columns from the pane the
+// preview draws, and no manager action precedes that for the cache to
+// follow. Drift the manager did not cause otherwise stays, so a window
+// someone resized from another client is left where they put it. A failed
+// listing leaves the cache as it was; the poll surfaces the tmux failure.
 func (m *Model) seedPaneGeom() {
-	needed := false
-	for _, sess := range m.sessions {
-		if _, sized := m.pane.geom[sess.ID]; !sized && !sess.Archived {
-			needed = true
-			break
-		}
-	}
-	if !needed {
-		return
-	}
-	sizes, err := m.tmux.WindowSizes()
+	geoms, err := m.tmux.PaneGeoms()
 	if err != nil {
 		return
 	}
-	for id, size := range sizes {
-		if _, sized := m.pane.geom[id]; !sized {
-			m.pane.geom[id] = size
+	for id, geom := range geoms {
+		last, sized := m.pane.geom[id]
+		// markFreshPane's pin is still owed: a session created this run
+		// carries its pre-selection launch size, not the box.
+		if sized && last == [2]int{0, 0} {
+			continue
 		}
+		if sized && geom.Panes < 2 {
+			continue
+		}
+		m.pane.geom[id] = [2]int{geom.Width, geom.Height}
 	}
 }
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -511,39 +511,54 @@ func TestSearchMatchingArchivedChildDoesNotHoistLiveParent(t *testing.T) {
 	}
 }
 
-// An agent that splits its own window takes columns from the pane the
-// preview draws, and no manager action precedes it for the geometry cache
-// to follow. A later refresh has to notice and pin that pane back.
+// An agent that splits its own window takes room from the pane the preview
+// draws, on whichever axis it split, and no manager action precedes it for
+// the geometry cache to follow. A later refresh has to notice and pin that
+// pane back to the box.
 func TestRefreshRepinsAnAgentSplitPane(t *testing.T) {
-	m := buildModel(t)
-	createSession(t, m, "split", t.TempDir(), "")
-	id := m.sessionRows()[0].ID
-	m.applyCmd(t, m.refreshCmd())
+	for _, split := range []struct {
+		axis string
+		flag string
+	}{{"horizontal", "-h"}, {"vertical", "-v"}} {
+		t.Run(split.axis, func(t *testing.T) {
+			m := buildModel(t)
+			createSession(t, m, "split", t.TempDir(), "")
+			id := m.sessionRows()[0].ID
+			m.applyCmd(t, m.refreshCmd())
 
-	if out, err := tmuxCmd("split-window", "-h", "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
-		t.Fatalf("split-window: %v: %s", err, out)
-	}
-	if width := agentPaneWidth(t, id); width == m.previewPaneWidth() {
-		t.Fatalf("the split should have taken columns from the agent pane, width = %d", width)
-	}
+			if out, err := tmuxCmd("split-window", split.flag, "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
+				t.Fatalf("split-window: %v: %s", err, out)
+			}
+			if width, height := agentPaneSize(t, id); width == m.previewPaneWidth() && height == m.previewPaneHeight() {
+				t.Fatalf("the split should have taken room from the agent pane, pane = %dx%d", width, height)
+			}
 
-	m.applyCmd(t, m.refreshCmd())
+			m.applyCmd(t, m.refreshCmd())
 
-	if width := agentPaneWidth(t, id); width != m.previewPaneWidth() {
-		t.Fatalf("after refresh, agent pane width = %d, want the preview box %d", width, m.previewPaneWidth())
+			width, height := agentPaneSize(t, id)
+			if width != m.previewPaneWidth() || height != m.previewPaneHeight() {
+				t.Fatalf("after refresh, agent pane = %dx%d, want the preview box %dx%d",
+					width, height, m.previewPaneWidth(), m.previewPaneHeight())
+			}
+		})
 	}
 }
 
-// agentPaneWidth reports the columns a session's agent pane holds.
-func agentPaneWidth(t *testing.T, id string) int {
+// agentPaneSize reports the cells a session's agent pane holds.
+func agentPaneSize(t *testing.T, id string) (int, int) {
 	t.Helper()
-	out, err := tmuxCmd("list-panes", "-t", "am_"+id, "-f", "#{==:#{pane_index},0}", "-F", "#{pane_width}").CombinedOutput()
+	out, err := tmuxCmd("list-panes", "-t", "am_"+id, "-f", "#{==:#{pane_index},0}", "-F", "#{pane_width} #{pane_height}").CombinedOutput()
 	if err != nil {
 		t.Fatalf("list-panes: %v: %s", err, out)
 	}
-	width, err := strconv.Atoi(strings.TrimSpace(string(out)))
-	if err != nil {
-		t.Fatalf("pane width %q: %v", out, err)
+	fields := strings.Fields(string(out))
+	if len(fields) != 2 {
+		t.Fatalf("pane size %q", out)
 	}
-	return width
+	width, widthErr := strconv.Atoi(fields[0])
+	height, heightErr := strconv.Atoi(fields[1])
+	if widthErr != nil || heightErr != nil {
+		t.Fatalf("pane size %q: %v %v", out, widthErr, heightErr)
+	}
+	return width, height
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -510,3 +510,40 @@ func TestSearchMatchingArchivedChildDoesNotHoistLiveParent(t *testing.T) {
 		t.Fatalf("search hoisted live parent into archive view: %v", names)
 	}
 }
+
+// An agent that splits its own window takes columns from the pane the
+// preview draws, and no manager action precedes it for the geometry cache
+// to follow. A later refresh has to notice and pin that pane back.
+func TestRefreshRepinsAnAgentSplitPane(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "split", t.TempDir(), "")
+	id := m.sessionRows()[0].ID
+	m.applyCmd(t, m.refreshCmd())
+
+	if out, err := tmuxCmd("split-window", "-h", "-t", "am_"+id, "--", "sh", "-c", "sleep 30").CombinedOutput(); err != nil {
+		t.Fatalf("split-window: %v: %s", err, out)
+	}
+	if width := agentPaneWidth(t, id); width == m.previewPaneWidth() {
+		t.Fatalf("the split should have taken columns from the agent pane, width = %d", width)
+	}
+
+	m.applyCmd(t, m.refreshCmd())
+
+	if width := agentPaneWidth(t, id); width != m.previewPaneWidth() {
+		t.Fatalf("after refresh, agent pane width = %d, want the preview box %d", width, m.previewPaneWidth())
+	}
+}
+
+// agentPaneWidth reports the columns a session's agent pane holds.
+func agentPaneWidth(t *testing.T, id string) int {
+	t.Helper()
+	out, err := tmuxCmd("list-panes", "-t", "am_"+id, "-f", "#{==:#{pane_index},0}", "-F", "#{pane_width}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("list-panes: %v: %s", err, out)
+	}
+	width, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("pane width %q: %v", out, err)
+	}
+	return width
+}

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -544,7 +544,6 @@ func TestRefreshRepinsAnAgentSplitPane(t *testing.T) {
 	}
 }
 
-// agentPaneSize reports the cells a session's agent pane holds.
 func agentPaneSize(t *testing.T, id string) (int, int) {
 	t.Helper()
 	out, err := tmuxCmd("list-panes", "-t", "am_"+id, "-f", "#{==:#{pane_index},0}", "-F", "#{pane_width} #{pane_height}").CombinedOutput()

--- a/internal/ui/mouseguard_test.go
+++ b/internal/ui/mouseguard_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestGuardedMouseCommandWrapsTheSend(t *testing.T) {
 	command, args := guardedMouseCommand("abc", "\x1b[<64;3;2M")
-	if !strings.HasPrefix(command, "if-shell -F -t "+tmux.SessionName("abc")+" '#{mouse_any_flag}' 'send-keys") {
+	if !strings.HasPrefix(command, "if-shell -F -t "+tmux.PaneTarget("abc")+" '#{mouse_any_flag}' 'send-keys") {
 		t.Fatalf("control-pipe command = %q", command)
 	}
 	if len(args) != 6 || args[0] != "if-shell" || args[4] != "#{mouse_any_flag}" {
@@ -52,7 +52,7 @@ func TestGuardedMouseCommandFollowsTheLiveFlag(t *testing.T) {
 
 	// cat holds the line until a newline arrives, and only what it echoes
 	// reaches the pane's terminal to turn mouse reporting off.
-	if err := driver.SendRaw("send-keys -t " + tmux.SessionName(sessID) +
+	if err := driver.SendRaw("send-keys -t " + tmux.PaneTarget(sessID) +
 		" -H 1b 5b 3f 31 30 30 33 6c 1b 5b 3f 31 30 30 36 6c 0a"); err != nil {
 		t.Fatalf("disable: %v", err)
 	}
@@ -73,7 +73,7 @@ func waitForMouseFlag(t *testing.T, driver *tmux.Driver, sessID, want string) {
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		out, err := exec.Command("tmux", "-L", driver.SocketName(),
-			"display-message", "-p", "-t", tmux.SessionName(sessID), "#{mouse_any_flag}").Output()
+			"display-message", "-p", "-t", tmux.PaneTarget(sessID), "#{mouse_any_flag}").Output()
 		if err == nil && strings.TrimSpace(string(out)) == want {
 			return
 		}

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -237,8 +237,8 @@ func (p *poller) refreshOnce() tea.Msg {
 	}
 	var livePIDs []int
 	for _, sess := range sessions {
-		if !sess.Archived && panes[sess.ID] > 0 {
-			livePIDs = append(livePIDs, panes[sess.ID])
+		if !sess.Archived && panes[sess.ID].PID > 0 {
+			livePIDs = append(livePIDs, panes[sess.ID].PID)
 		}
 	}
 	trees := sysstat.Trees(livePIDs)
@@ -271,7 +271,7 @@ func (p *poller) refreshOnce() tea.Msg {
 			return errMsg{err}
 		}
 		newStatus := status.Dead
-		if pid := panes[sess.ID]; pid > 0 {
+		if pid := panes[sess.ID].PID; pid > 0 {
 			stat := trees[pid]
 			if stat.OK {
 				nextTreeCPU[pid] = stat.CPUSeconds
@@ -363,7 +363,7 @@ func (p *poller) refreshOnce() tea.Msg {
 	}
 	if preview == "" && selectedID != "" {
 		for _, sess := range sessions {
-			if sess.ID == selectedID && (sess.Archived || panes[sess.ID] == 0) {
+			if sess.ID == selectedID && (sess.Archived || panes[sess.ID].PID == 0) {
 				snapshot, err := storedPreview(p.store, p.tmux, sess.ID)
 				if err != nil {
 					return errMsg{err}
@@ -424,6 +424,7 @@ func (p *poller) refreshOnce() tea.Msg {
 		preview:        preview,
 		agents:         agents,
 		queuedMessages: queued,
+		panes:          panes,
 	}
 	if sampleStats {
 		msg.snap = sysstat.Sample("/")
@@ -434,8 +435,8 @@ func (p *poller) refreshOnce() tea.Msg {
 
 // idMinting reports whether a live, not-yet-captured session belongs to a
 // tool that mints its own conversation id.
-func (p *poller) idMinting(sess store.Session, panes map[string]int) bool {
-	return !sess.Archived && panes[sess.ID] != 0 && sess.AgentSessionID == "" &&
+func (p *poller) idMinting(sess store.Session, panes map[string]tmux.Pane) bool {
+	return !sess.Archived && panes[sess.ID].PID != 0 && sess.AgentSessionID == "" &&
 		p.sessionStores[sess.Tool] != ""
 }
 
@@ -445,7 +446,7 @@ func (p *poller) idMinting(sess store.Session, panes map[string]int) bool {
 // including a freshly submitted session's first appearance. One pass runs at
 // a time, on a snapshot, and a pass that captures anything pokes a refresh so
 // the UI and store pick up the new ids.
-func (p *poller) startCaptureIfIdle(sessions []store.Session, panes map[string]int) {
+func (p *poller) startCaptureIfIdle(sessions []store.Session, panes map[string]tmux.Pane) {
 	hasWork := false
 	for _, sess := range sessions {
 		if p.idMinting(sess, panes) {
@@ -478,7 +479,7 @@ func (p *poller) startCaptureIfIdle(sessions []store.Session, panes map[string]i
 // started in the same directory then skips that one via claimed and captures
 // its own. Launch times carry nanosecond precision, so sessions launched a
 // moment apart in the same directory still order deterministically.
-func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[string]int) (int, error) {
+func (p *poller) captureAgentSessionIDs(sessions []store.Session, panes map[string]tmux.Pane) (int, error) {
 	claimed := make(map[string]bool, len(sessions))
 	for _, sess := range sessions {
 		if sess.AgentSessionID != "" {

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/YoanWai/agent-manager/internal/launch"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -788,7 +789,7 @@ func TestCaptureAgentSessionIDsAssignsInLaunchOrder(t *testing.T) {
 
 	sessions := []store.Session{sessB, sessA} // store order, not launch order
 	p := &poller{store: st, sessionStores: map[string]string{"codex": "codex"}}
-	panes := map[string]int{"sess-A": 123, "sess-B": 456}
+	panes := map[string]tmux.Pane{"sess-A": {PID: 123}, "sess-B": {PID: 456}}
 	captured, err := p.captureAgentSessionIDs(sessions, panes)
 	if err != nil {
 		t.Fatal(err)
@@ -847,7 +848,7 @@ func TestCaptureAgentSessionIDsSkipsARetiredConversation(t *testing.T) {
 	}
 
 	p := &poller{store: st, sessionStores: map[string]string{"codex": "codex"}}
-	if _, err := p.captureAgentSessionIDs([]store.Session{sess}, map[string]int{"sess": 42}); err != nil {
+	if _, err := p.captureAgentSessionIDs([]store.Session{sess}, map[string]tmux.Pane{"sess": {PID: 42}}); err != nil {
 		t.Fatal(err)
 	}
 	got, err := st.Get("sess")
@@ -890,7 +891,7 @@ func TestCaptureAgentSessionIDsDropsAnAnswerARestartOutran(t *testing.T) {
 	}
 
 	p := &poller{store: st, sessionStores: map[string]string{"codex": "codex"}}
-	captured, err := p.captureAgentSessionIDs([]store.Session{snapshot}, map[string]int{"sess": 7})
+	captured, err := p.captureAgentSessionIDs([]store.Session{snapshot}, map[string]tmux.Pane{"sess": {PID: 7}})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What

Every tmux command the manager aims at a session now addresses that session's agent pane, `am_<id>:^.0`, instead of the bare session name.

- `CapturePane`, `Cursor`, `SendText`, `SendKeys`, `Paste`, `PanePID`, `PaneCurrentPath` and the focus path's control-pipe commands take the pane target.
- `Panes` filters the liveness listing to pane 0.
- `EnsureBindings` pins `pane-base-index` to 0 on the manager's server, which is what makes `.0` the agent's pane on any tmux config.
- `Resize` grows a split window until the agent's pane is the preview box, adding the shortfall to the window so no other pane loses room.
- The pane geometry cache is re-read each pass for split windows, since the agent opens those panes with no manager action for the cache to follow.

## Why

A bare session name resolves to whichever pane is active. An agent is free to split its own window and hand focus to the new pane: Claude Code's agent teams do exactly that, running each teammate as a full CLI in a pane beside the leader.

The manager then read and typed into the teammate. Measured on a live session with two teammates: `capture-pane -t am_116f7675` returned the teammate's screen, and the agent's own pane held 84 of the window's 168 columns, so the preview drew half a panel of the wrong agent.

`pane-base-index` carries the same weight as the target itself: tmux answers a pane index that does not exist with the active pane rather than an error, so on a config that numbers panes from 1 the target would have followed focus exactly as before, silently.

## Verified

- `TestManagerStaysOnTheAgentPaneAfterASplit` splits a session, leaves the teammate focused, and asserts the pid, the message and the capture all stay on the agent. It fails on main: `PanePID after split = 40481, want 40471`.
- `TestEnsureBindingsPinsPaneNumbering` covers the numbering pin.
- `TestResizeFitsTheAgentPaneInASplitWindow` and `TestResizeNeverShrinksATeammatePane` cover the geometry.
- Full `go test ./...` green.
- Against the live three-pane session: `PanePID` returns the leader (74987, which tmux confirms for pane 0), the capture returns the leader's rows, and `Resize` brings its pane to the full 168x50 preview box while both teammates keep their 83 columns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-pane handling so agent panes remain correctly targeted and sized.
  * Restored agent pane dimensions after internal splits reduce available space.
  * Prevented teammate panes from being unintentionally resized.
  * Ensured pane numbering and window selection remain consistent.
  * Improved focus, scrolling, mouse, cursor, and content capture in split layouts.
  * Improved refresh behavior and error reporting when pane geometry cannot be read.

* **Tests**
  * Added coverage for pane targeting, resizing, pane numbering, split layouts, and refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->