### PR TITLE
fix(ui): drop deleted and archived rows the moment they are confirmed

### DIFF
--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -730,6 +730,67 @@ func (m *Model) applyConfirmedArchived(archived bool) error {
 	return nil
 }
 
+// removeSessionLocally takes a deleted row off the loaded list right away,
+// so it leaves the screen on this frame instead of waiting for the next
+// poll to confirm what the store already knows.
+func (m *Model) removeSessionLocally(id string) {
+	for i := range m.sessions {
+		if m.sessions[i].ID == id {
+			m.sessions = append(m.sessions[:i], m.sessions[i+1:]...)
+			break
+		}
+	}
+	m.markGone(id, false)
+	m.rebuildRows()
+}
+
+// markArchivedLocally flags the confirmed sessions archived in the loaded
+// rows, so they leave the active view on this frame instead of first
+// showing the dead state their kill just gave them.
+func (m *Model) markArchivedLocally(sessions []store.Session) {
+	changed := false
+	for i := range m.sessions {
+		if m.sessions[i].Archived {
+			continue
+		}
+		for _, sess := range sessions {
+			if m.sessions[i].ID != sess.ID {
+				continue
+			}
+			m.sessions[i].Archived = true
+			m.markGone(sess.ID, true)
+			changed = true
+			break
+		}
+	}
+	if changed {
+		m.rebuildRows()
+	}
+}
+
+// pruneGroupsLocally drops the removed group paths from the loaded tree,
+// so a deleted group's header goes with its sessions instead of hanging
+// around empty until the next poll.
+func (m *Model) pruneGroupsLocally(removed []string) {
+	gone := make(map[string]bool, len(removed))
+	for _, path := range removed {
+		gone[path] = true
+	}
+	groups := make([]string, 0, len(m.groups))
+	for _, group := range m.groups {
+		if !gone[group] {
+			groups = append(groups, group)
+		}
+	}
+	m.groups = groups
+	for _, path := range removed {
+		delete(m.groupPaths, path)
+		delete(m.groupWorktrees, path)
+		delete(m.archivedGroups, path)
+	}
+	m.rebuildRows()
+}
+
 func (m *Model) sessionAndChildren(sess store.Session) ([]store.Session, error) {
 	kids, err := m.store.Children(sess.ID)
 	if err != nil {
@@ -872,6 +933,7 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.errBar.text = err.Error()
 				return m, nil
 			}
+			m.markArchivedLocally(m.confirm.sessions)
 			m.errBar.text = ""
 		case actionRestore:
 			// Each session leaves the archive as it comes back, so a later
@@ -890,11 +952,15 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.errBar.text = err.Error()
 					return m, nil
 				}
+				m.unmarkGone(sess.ID)
 			}
 			if m.confirm.isGroup {
 				if err := m.applyConfirmedArchived(false); err != nil {
 					m.errBar.text = err.Error()
 					return m, nil
+				}
+				for _, sess := range m.confirm.sessions {
+					m.unmarkGone(sess.ID)
 				}
 			}
 			m.errBar.text = ""
@@ -960,6 +1026,7 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.errBar.text = err.Error()
 					return m, nil
 				}
+				m.removeSessionLocally(sess.ID)
 				if sess.WorktreeRepo != "" && m.gitDrv != nil {
 					used, err := m.sessionUsesDir(sess.Cwd)
 					if err != nil {
@@ -983,6 +1050,7 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					delete(m.collapsed, path)
 				}
 				m.persistCollapsed()
+				m.pruneGroupsLocally(removed)
 			}
 		default:
 			m.errBar.text = fmt.Sprintf("unknown confirm action %q", m.confirm.action)

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -744,10 +744,11 @@ func (m *Model) removeSessionLocally(id string) {
 	m.rebuildRows()
 }
 
-// markArchivedLocally flags the confirmed sessions archived in the loaded
-// rows, so they leave the active view on this frame instead of first
-// showing the dead state their kill just gave them.
-func (m *Model) markArchivedLocally(sessions []store.Session) {
+// markArchivedLocally flags the confirmed archive in the loaded rows, so
+// they leave the active view on this frame instead of first showing the
+// dead state their kill just gave them. A group archive also flags the
+// group itself, which is what hides the whole subtree from the active view.
+func (m *Model) markArchivedLocally(sessions []store.Session, groupPath string) {
 	changed := false
 	for i := range m.sessions {
 		if m.sessions[i].Archived {
@@ -762,6 +763,13 @@ func (m *Model) markArchivedLocally(sessions []store.Session) {
 			changed = true
 			break
 		}
+	}
+	if groupPath != "" {
+		if m.archivedGroups == nil {
+			m.archivedGroups = map[string]bool{}
+		}
+		m.archivedGroups[groupPath] = true
+		changed = true
 	}
 	if changed {
 		m.rebuildRows()
@@ -805,11 +813,16 @@ func (m *Model) markRestoredLocally(restored []store.Session, groupPath string) 
 
 // pruneGroupsLocally drops the removed group paths from the loaded tree,
 // so a deleted group's header goes with its sessions instead of hanging
-// around empty until the next poll.
+// around empty until the next poll. Each path is recorded for the stale
+// listing filter, which is what keeps an in-flight poll from restoring it.
 func (m *Model) pruneGroupsLocally(removed []string) {
 	gone := make(map[string]bool, len(removed))
 	for _, path := range removed {
 		gone[path] = true
+		if m.goneGroups == nil {
+			m.goneGroups = map[string]time.Time{}
+		}
+		m.goneGroups[path] = time.Now()
 	}
 	groups := make([]string, 0, len(m.groups))
 	for _, group := range m.groups {
@@ -863,6 +876,15 @@ func followConfirmLabel(verb, name string, extra int, one, many string) string {
 		unit = "terminals"
 	}
 	return fmt.Sprintf("%s %s and %d %s? %s", verb, name, extra, unit, many)
+}
+
+// groupPath is the subtree path a confirmed archive or delete targets,
+// empty when the confirmation names sessions rather than a group.
+func groupPath(confirm confirmTarget) string {
+	if confirm.isGroup {
+		return confirm.path
+	}
+	return ""
 }
 
 func (m *Model) prepareDelete() {
@@ -968,7 +990,7 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.errBar.text = err.Error()
 				return m, nil
 			}
-			m.markArchivedLocally(m.confirm.sessions)
+			m.markArchivedLocally(m.confirm.sessions, groupPath(m.confirm))
 			m.errBar.text = ""
 		case actionRestore:
 			// Each session leaves the archive as it comes back, so a later

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -780,7 +780,6 @@ func (m *Model) markArchivedLocally(sessions []store.Session, groupPath string) 
 	}
 }
 
-// subgroupPaths lists the stored groups nested under a path.
 func (m *Model) subgroupPaths(path string) []string {
 	var out []string
 	prefix := path + "/"
@@ -902,8 +901,6 @@ func followConfirmLabel(verb, name string, extra int, one, many string) string {
 	return fmt.Sprintf("%s %s and %d %s? %s", verb, name, extra, unit, many)
 }
 
-// groupPath is the subtree path a confirmed archive or delete targets,
-// empty when the confirmation names sessions rather than a group.
 func groupPath(confirm confirmTarget) string {
 	if confirm.isGroup {
 		return confirm.path

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -740,14 +740,15 @@ func (m *Model) removeSessionLocally(id string) {
 			break
 		}
 	}
-	m.markGone(id, false)
+	m.markSession(id, goneMark{deleted: true})
 	m.rebuildRows()
 }
 
 // markArchivedLocally flags the confirmed archive in the loaded rows, so
 // they leave the active view on this frame instead of first showing the
 // dead state their kill just gave them. A group archive also flags the
-// group itself, which is what hides the whole subtree from the active view.
+// group itself and every group under it, which is what hides the whole
+// subtree from the active view.
 func (m *Model) markArchivedLocally(sessions []store.Session, groupPath string) {
 	changed := false
 	for i := range m.sessions {
@@ -759,21 +760,36 @@ func (m *Model) markArchivedLocally(sessions []store.Session, groupPath string) 
 				continue
 			}
 			m.sessions[i].Archived = true
-			m.markGone(sess.ID, true)
+			m.markSession(sess.ID, goneMark{archived: true})
 			changed = true
 			break
 		}
 	}
 	if groupPath != "" {
-		if m.archivedGroups == nil {
-			m.archivedGroups = map[string]bool{}
+		for _, path := range append([]string{groupPath}, m.subgroupPaths(groupPath)...) {
+			if m.archivedGroups == nil {
+				m.archivedGroups = map[string]bool{}
+			}
+			m.archivedGroups[path] = true
+			m.markGroup(path, goneMark{archived: true})
 		}
-		m.archivedGroups[groupPath] = true
 		changed = true
 	}
 	if changed {
 		m.rebuildRows()
 	}
+}
+
+// subgroupPaths lists the stored groups nested under a path.
+func (m *Model) subgroupPaths(path string) []string {
+	var out []string
+	prefix := path + "/"
+	for _, group := range m.groups {
+		if strings.HasPrefix(group, prefix) {
+			out = append(out, group)
+		}
+	}
+	return out
 }
 
 // markRestoredLocally mirrors a completed restore in the loaded rows and
@@ -792,23 +808,34 @@ func (m *Model) markRestoredLocally(restored []store.Session, groupPath string) 
 		}
 		if byID[m.sessions[i].ID] || (groupPath != "" && inGroupSubtree(m.sessions[i].Group, groupPath)) {
 			m.sessions[i].Archived = false
+			m.markSession(m.sessions[i].ID, goneMark{archived: false})
 		}
 	}
 	if groupPath != "" {
-		delete(m.archivedGroups, groupPath)
-		for name := range m.archivedGroups {
-			if strings.HasPrefix(name, groupPath+"/") {
-				delete(m.archivedGroups, name)
-			}
+		for _, path := range append([]string{groupPath}, m.subgroupPaths(groupPath)...) {
+			delete(m.archivedGroups, path)
+			m.markGroup(path, goneMark{archived: false})
 		}
 	} else {
 		for _, sess := range restored {
 			for path := sess.Group; path != ""; path = parentGroup(path) {
 				delete(m.archivedGroups, path)
+				m.markGroup(path, goneMark{archived: false})
 			}
 		}
 	}
 	m.rebuildRows()
+}
+
+// markGroup records the archive state this run just gave a group path,
+// so stale polls predating the change are reconciled on arrival instead
+// of undoing it for a frame.
+func (m *Model) markGroup(path string, mark goneMark) {
+	if m.goneGroups == nil {
+		m.goneGroups = map[string]goneMark{}
+	}
+	mark.at = time.Now()
+	m.goneGroups[path] = mark
 }
 
 // pruneGroupsLocally drops the removed group paths from the loaded tree,
@@ -819,10 +846,7 @@ func (m *Model) pruneGroupsLocally(removed []string) {
 	gone := make(map[string]bool, len(removed))
 	for _, path := range removed {
 		gone[path] = true
-		if m.goneGroups == nil {
-			m.goneGroups = map[string]time.Time{}
-		}
-		m.goneGroups[path] = time.Now()
+		m.markGroup(path, goneMark{deleted: true})
 	}
 	groups := make([]string, 0, len(m.groups))
 	for _, group := range m.groups {
@@ -1009,20 +1033,15 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.errBar.text = err.Error()
 					return m, nil
 				}
-				m.unmarkGone(sess.ID)
+				m.markSession(sess.ID, goneMark{archived: false})
 			}
 			if m.confirm.isGroup {
 				if err := m.applyConfirmedArchived(false); err != nil {
 					m.errBar.text = err.Error()
 					return m, nil
 				}
-				for _, sess := range m.confirm.sessions {
-					m.unmarkGone(sess.ID)
-				}
-				m.markRestoredLocally(nil, m.confirm.path)
-			} else {
-				m.markRestoredLocally(m.confirm.sessions, "")
 			}
+			m.markRestoredLocally(m.confirm.sessions, groupPath(m.confirm))
 			m.errBar.text = ""
 		case actionKill:
 			for _, sess := range m.confirm.sessions {

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -768,6 +768,41 @@ func (m *Model) markArchivedLocally(sessions []store.Session) {
 	}
 }
 
+// markRestoredLocally mirrors a completed restore in the loaded rows and
+// group flags, so what came back changes views on this frame rather than
+// waiting for the next poll. A group restore unarchives the subtree; a
+// single restore also clears its group's ancestors, which is what the
+// store write just did to keep a restored session under a live home.
+func (m *Model) markRestoredLocally(restored []store.Session, groupPath string) {
+	byID := make(map[string]bool, len(restored))
+	for _, sess := range restored {
+		byID[sess.ID] = true
+	}
+	for i := range m.sessions {
+		if !m.sessions[i].Archived {
+			continue
+		}
+		if byID[m.sessions[i].ID] || (groupPath != "" && inGroupSubtree(m.sessions[i].Group, groupPath)) {
+			m.sessions[i].Archived = false
+		}
+	}
+	if groupPath != "" {
+		delete(m.archivedGroups, groupPath)
+		for name := range m.archivedGroups {
+			if strings.HasPrefix(name, groupPath+"/") {
+				delete(m.archivedGroups, name)
+			}
+		}
+	} else {
+		for _, sess := range restored {
+			for path := sess.Group; path != ""; path = parentGroup(path) {
+				delete(m.archivedGroups, path)
+			}
+		}
+	}
+	m.rebuildRows()
+}
+
 // pruneGroupsLocally drops the removed group paths from the loaded tree,
 // so a deleted group's header goes with its sessions instead of hanging
 // around empty until the next poll.
@@ -962,6 +997,9 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				for _, sess := range m.confirm.sessions {
 					m.unmarkGone(sess.ID)
 				}
+				m.markRestoredLocally(nil, m.confirm.path)
+			} else {
+				m.markRestoredLocally(m.confirm.sessions, "")
 			}
 			m.errBar.text = ""
 		case actionKill:

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -1862,3 +1862,27 @@ func TestConfirmedGroupRestoreShowsTheSubtreeAtOnce(t *testing.T) {
 		t.Fatalf("active view after group restore = %v", got)
 	}
 }
+
+func TestConfirmedGroupArchiveHidesTheSubtreeAtOnce(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("zone", dir); err != nil {
+		t.Fatalf("group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "in-zone", dir, "zone")
+	sess := m.sessionRows()[0]
+
+	m.selectGroupRow(t, "zone")
+	m.archiveSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	if !m.groupEffectivelyArchived("zone") {
+		t.Fatal("archived group still reads as active before the next poll")
+	}
+	for _, got := range m.visibleSessions() {
+		if got.ID == sess.ID {
+			t.Fatalf("archived session still on the active tree before the next poll")
+		}
+	}
+}

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -1736,3 +1736,107 @@ func TestReviveStartsTheAgentAgainInALivePane(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 }
+
+func TestConfirmedDeleteDropsTheRowBeforeTheNextPoll(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "doomed", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+
+	deleteSession(t, m, "doomed")
+
+	for _, row := range m.sessionRows() {
+		if row.ID == sess.ID {
+			t.Fatalf("deleted session still on screen before the next poll: %+v", row)
+		}
+	}
+}
+
+func TestConfirmedArchiveLeavesTheActiveViewAtOnce(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "shelved", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+
+	m.selectSessionRow(t, "shelved")
+	m.archiveSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	if _, err := m.store.Get(sess.ID); err != nil {
+		t.Fatalf("archive did not reach the store: %v", err)
+	}
+	for _, row := range m.sessionRows() {
+		if row.ID == sess.ID {
+			t.Fatalf("archived session still on the active tree before the next poll, status %q", row.Status)
+		}
+	}
+
+	// The archived view still holds it once a fresh listing has run.
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	if len(m.sessionRows()) != 1 || !m.sessionRows()[0].Archived {
+		t.Fatalf("archived session should show in the archived view, rows = %v", sessionNames(m))
+	}
+}
+
+// A poll that listed the store before the delete delivers its full list
+// afterwards; that stale copy must not put the row back on screen.
+func TestAStalePollCannotResurrectADeletedRow(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "doomed", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+	listedAt := time.Now()
+
+	deleteSession(t, m, "doomed")
+
+	stale := sess
+	stale.Status = status.Dead
+	updated, _ := m.Update(refreshMsg{sessions: []store.Session{stale}, listedAt: listedAt})
+	*m = *updated.(*Model)
+
+	for _, row := range m.sessionRows() {
+		if row.ID == sess.ID {
+			t.Fatalf("a stale poll brought the deleted row back as %q", row.Status)
+		}
+	}
+}
+
+func TestAStalePollCannotBringAnArchivedRowBackLive(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "shelved", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+	listedAt := time.Now()
+
+	m.selectSessionRow(t, "shelved")
+	m.archiveSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	stale := sess
+	stale.Status = status.Dead
+	updated, _ := m.Update(refreshMsg{sessions: []store.Session{stale}, listedAt: listedAt})
+	*m = *updated.(*Model)
+
+	for _, row := range m.sessionRows() {
+		if row.ID == sess.ID {
+			t.Fatalf("a stale poll brought the archived row back on the live tree")
+		}
+	}
+}
+
+func TestConfirmedGroupDeleteDropsTheGroupRowAtOnce(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("zone", dir); err != nil {
+		t.Fatalf("group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "in-zone", dir, "zone")
+
+	m.selectGroupRow(t, "zone")
+	m.prepareDelete()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	for _, r := range m.rows {
+		if r.isGroup && r.group == "zone" {
+			t.Fatalf("deleted group still on screen before the next poll")
+		}
+	}
+}

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -1777,50 +1777,6 @@ func TestConfirmedArchiveLeavesTheActiveViewAtOnce(t *testing.T) {
 	}
 }
 
-// A poll that listed the store before the delete delivers its full list
-// afterwards; that stale copy must not put the row back on screen.
-func TestAStalePollCannotResurrectADeletedRow(t *testing.T) {
-	m := buildModel(t)
-	createSession(t, m, "doomed", t.TempDir(), "")
-	sess := m.sessionRows()[0]
-	listedAt := time.Now()
-
-	deleteSession(t, m, "doomed")
-
-	stale := sess
-	stale.Status = status.Dead
-	updated, _ := m.Update(refreshMsg{sessions: []store.Session{stale}, listedAt: listedAt})
-	*m = *updated.(*Model)
-
-	for _, row := range m.sessionRows() {
-		if row.ID == sess.ID {
-			t.Fatalf("a stale poll brought the deleted row back as %q", row.Status)
-		}
-	}
-}
-
-func TestAStalePollCannotBringAnArchivedRowBackLive(t *testing.T) {
-	m := buildModel(t)
-	createSession(t, m, "shelved", t.TempDir(), "")
-	sess := m.sessionRows()[0]
-	listedAt := time.Now()
-
-	m.selectSessionRow(t, "shelved")
-	m.archiveSelected()
-	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
-
-	stale := sess
-	stale.Status = status.Dead
-	updated, _ := m.Update(refreshMsg{sessions: []store.Session{stale}, listedAt: listedAt})
-	*m = *updated.(*Model)
-
-	for _, row := range m.sessionRows() {
-		if row.ID == sess.ID {
-			t.Fatalf("a stale poll brought the archived row back on the live tree")
-		}
-	}
-}
-
 func TestConfirmedGroupDeleteDropsTheGroupRowAtOnce(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()
@@ -1838,5 +1794,71 @@ func TestConfirmedGroupDeleteDropsTheGroupRowAtOnce(t *testing.T) {
 		if r.isGroup && r.group == "zone" {
 			t.Fatalf("deleted group still on screen before the next poll")
 		}
+	}
+}
+
+func TestConfirmedRestoreLeavesTheArchivedViewAtOnce(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "returning", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+
+	m.selectSessionRow(t, "returning")
+	m.archiveSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	m.selectSessionRow(t, "returning")
+	m.restoreSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	for _, row := range m.sessionRows() {
+		if row.ID == sess.ID {
+			t.Fatalf("restored session stayed in the archived view before the next poll")
+		}
+	}
+	if _, err := m.store.Get(sess.ID); err != nil {
+		t.Fatalf("restore did not reach the store: %v", err)
+	}
+
+	// The active view takes it back without waiting for a poll.
+	m.showArchived = false
+	if got := m.visibleSessions(); len(got) != 1 || got[0].ID != sess.ID {
+		t.Fatalf("active view after restore = %v", got)
+	}
+}
+
+func TestConfirmedGroupRestoreShowsTheSubtreeAtOnce(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("zone", dir); err != nil {
+		t.Fatalf("group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "in-zone", dir, "zone")
+	sess := m.sessionRows()[0]
+
+	m.selectGroupRow(t, "zone")
+	m.archiveSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	m.selectGroupRow(t, "zone")
+	m.restoreSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	for _, row := range m.sessionRows() {
+		if row.ID == sess.ID {
+			t.Fatalf("restored session stayed in the archived view before the next poll")
+		}
+	}
+	m.showArchived = false
+	if m.groupEffectivelyArchived("zone") {
+		t.Fatal("restored group still reads as archived before the next poll")
+	}
+	got := m.visibleSessions()
+	if len(got) != 1 || got[0].ID != sess.ID {
+		t.Fatalf("active view after group restore = %v", got)
 	}
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -190,6 +190,10 @@ type Model struct {
 	// by deleting or archiving it, so a poll that listed the store before
 	// that moment cannot put the row back on screen for a frame.
 	gone map[string]goneMark
+	// goneGroups is the group-path counterpart of gone: when this run
+	// deleted a group, a poll that listed the store before that moment
+	// must not hang the group's header back onto the tree.
+	goneGroups map[string]time.Time
 	// terminalKeyAt is when the last T finished being handled. Held down it
 	// autorepeats into a burst of keystrokes, and T is the only key that
 	// spawns on the keystroke itself rather than opening a form that would
@@ -1138,6 +1142,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// The focused session can die or vanish under us; fall back to the
 		// list rather than typing into nothing.
 		sessions := m.dropRecentlyRemoved(m.keepPendingLaunches(msg.sessions, msg.listedAt), msg.listedAt)
+		stripDeletedGroups(&msg, m.goneGroups)
 		var focusExit tea.Cmd
 		if m.mode == modeFocus {
 			if sess, ok := m.selected(); !ok || sessionGone(sessions, sess.ID) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -186,6 +186,10 @@ type Model struct {
 	// launched is when this run recorded each session it spawned. A poll
 	// that listed the store before that has nothing to say about the row.
 	launched map[string]time.Time
+	// gone is when this run took each session off the loaded list itself,
+	// by deleting or archiving it, so a poll that listed the store before
+	// that moment cannot put the row back on screen for a frame.
+	gone map[string]goneMark
 	// terminalKeyAt is when the last T finished being handled. Held down it
 	// autorepeats into a burst of keystrokes, and T is the only key that
 	// spawns on the keystroke itself rather than opening a form that would
@@ -1133,7 +1137,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.ageError()
 		// The focused session can die or vanish under us; fall back to the
 		// list rather than typing into nothing.
-		sessions := m.keepPendingLaunches(msg.sessions, msg.listedAt)
+		sessions := m.dropRecentlyRemoved(m.keepPendingLaunches(msg.sessions, msg.listedAt), msg.listedAt)
 		var focusExit tea.Cmd
 		if m.mode == modeFocus {
 			if sess, ok := m.selected(); !ok || sessionGone(sessions, sess.ID) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -191,9 +191,9 @@ type Model struct {
 	// that moment cannot put the row back on screen for a frame.
 	gone map[string]goneMark
 	// goneGroups is the group-path counterpart of gone: when this run
-	// deleted a group, a poll that listed the store before that moment
-	// must not hang the group's header back onto the tree.
-	goneGroups map[string]time.Time
+	// archived, restored, or deleted a group, a poll that listed the store
+	// before that moment must not put the old state back on the tree.
+	goneGroups map[string]goneMark
 	// terminalKeyAt is when the last T finished being handled. Held down it
 	// autorepeats into a burst of keystrokes, and T is the only key that
 	// spawns on the keystroke itself rather than opening a form that would

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -101,8 +101,10 @@ func (m *Model) markGone(id string, archived bool) {
 // took them off the list itself: without it, a pass in flight across a
 // delete or an archive delivers its pre-change listing afterwards and the
 // row blinks back for one more frame. A poll whose listing postdates the
-// removal is the authority on the new state and retires the record; an
-// archived row reported as archived belongs in the archived view and stays.
+// removal is the authority on the new state and retires every record it
+// postdates, including ones for rows the listing no longer carries at
+// all; an archived row reported as archived belongs in the archived view
+// and stays.
 func (m *Model) dropRecentlyRemoved(polled []store.Session, listedAt time.Time) []store.Session {
 	if len(m.gone) == 0 {
 		return polled
@@ -111,11 +113,12 @@ func (m *Model) dropRecentlyRemoved(polled []store.Session, listedAt time.Time) 
 	for _, sess := range polled {
 		mark, gone := m.gone[sess.ID]
 		if !gone || listedAt.After(mark.at) || (mark.archived && sess.Archived) {
-			if gone {
-				delete(m.gone, sess.ID)
-			}
 			kept = append(kept, sess)
-			continue
+		}
+	}
+	for id, mark := range m.gone {
+		if listedAt.After(mark.at) {
+			delete(m.gone, id)
 		}
 	}
 	return kept

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -129,3 +129,33 @@ func (m *Model) dropRecentlyRemoved(polled []store.Session, listedAt time.Time) 
 func (m *Model) unmarkGone(id string) {
 	delete(m.gone, id)
 }
+
+// stripDeletedGroups drops a stale listing's group rows and metadata for
+// groups this run deleted after the listing was taken, so the deleted
+// header cannot hang back onto the tree for a frame. A listing that
+// postdates a deletion retires its marker instead.
+func stripDeletedGroups(msg *refreshMsg, gone map[string]time.Time) {
+	removed := make(map[string]bool, len(gone))
+	for path, at := range gone {
+		if msg.listedAt.After(at) {
+			delete(gone, path)
+			continue
+		}
+		removed[path] = true
+	}
+	if len(removed) == 0 {
+		return
+	}
+	groups := make([]string, 0, len(msg.groups))
+	for _, group := range msg.groups {
+		if !removed[group] {
+			groups = append(groups, group)
+		}
+	}
+	msg.groups = groups
+	for path := range removed {
+		delete(msg.groupPaths, path)
+		delete(msg.groupWorktrees, path)
+		delete(msg.archivedGroups, path)
+	}
+}

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -80,3 +80,49 @@ func (m *Model) keepPendingLaunches(polled []store.Session, listedAt time.Time) 
 	}
 	return polled
 }
+
+// goneMark records how a session left the loaded list: deleted outright,
+// or archived out of the active view while the archived view keeps it.
+type goneMark struct {
+	at       time.Time
+	archived bool
+}
+
+// markGone records that this run just removed a row from the list, so
+// stale polls predating the removal are dropped on arrival.
+func (m *Model) markGone(id string, archived bool) {
+	if m.gone == nil {
+		m.gone = map[string]goneMark{}
+	}
+	m.gone[id] = goneMark{at: time.Now(), archived: archived}
+}
+
+// dropRecentlyRemoved filters out the rows a poll listed before this run
+// took them off the list itself: without it, a pass in flight across a
+// delete or an archive delivers its pre-change listing afterwards and the
+// row blinks back for one more frame. A poll whose listing postdates the
+// removal is the authority on the new state and retires the record; an
+// archived row reported as archived belongs in the archived view and stays.
+func (m *Model) dropRecentlyRemoved(polled []store.Session, listedAt time.Time) []store.Session {
+	if len(m.gone) == 0 {
+		return polled
+	}
+	kept := make([]store.Session, 0, len(polled))
+	for _, sess := range polled {
+		mark, gone := m.gone[sess.ID]
+		if !gone || listedAt.After(mark.at) || (mark.archived && sess.Archived) {
+			if gone {
+				delete(m.gone, sess.ID)
+			}
+			kept = append(kept, sess)
+			continue
+		}
+	}
+	return kept
+}
+
+// unmarkGone forgets a removal record, for a session brought back before
+// any poll has had the chance to retire it.
+func (m *Model) unmarkGone(id string) {
+	delete(m.gone, id)
+}

--- a/internal/ui/sessionlaunch.go
+++ b/internal/ui/sessionlaunch.go
@@ -81,38 +81,49 @@ func (m *Model) keepPendingLaunches(polled []store.Session, listedAt time.Time) 
 	return polled
 }
 
-// goneMark records how a session left the loaded list: deleted outright,
-// or archived out of the active view while the archived view keeps it.
+// goneMark is the list state this run most recently gave a row, and when
+// it gave it. deleted means the row must not appear at all; otherwise
+// archived is the value the row's Archived flag should carry.
 type goneMark struct {
 	at       time.Time
 	archived bool
+	deleted  bool
 }
 
-// markGone records that this run just removed a row from the list, so
-// stale polls predating the removal are dropped on arrival.
-func (m *Model) markGone(id string, archived bool) {
+// markSession records the loaded-list state this run just gave a session,
+// so stale polls predating the change are reconciled on arrival instead
+// of undoing it for a frame.
+func (m *Model) markSession(id string, mark goneMark) {
 	if m.gone == nil {
 		m.gone = map[string]goneMark{}
 	}
-	m.gone[id] = goneMark{at: time.Now(), archived: archived}
+	mark.at = time.Now()
+	m.gone[id] = mark
 }
 
-// dropRecentlyRemoved filters out the rows a poll listed before this run
-// took them off the list itself: without it, a pass in flight across a
-// delete or an archive delivers its pre-change listing afterwards and the
-// row blinks back for one more frame. A poll whose listing postdates the
-// removal is the authority on the new state and retires every record it
-// postdates, including ones for rows the listing no longer carries at
-// all; an archived row reported as archived belongs in the archived view
-// and stays.
+// dropRecentlyRemoved reconciles the rows a poll lists against what this
+// run has just done to them: without it, a pass in flight across a delete,
+// an archive, or a restore delivers its pre-change listing afterwards and
+// blinks the old state back for one more frame. A stale copy of a deleted
+// row is dropped; a stale copy of an archive or restore has its flag
+// corrected to what the store was just written to say. A listing that
+// postdates every recorded change retires those records instead.
 func (m *Model) dropRecentlyRemoved(polled []store.Session, listedAt time.Time) []store.Session {
 	if len(m.gone) == 0 {
 		return polled
 	}
 	kept := make([]store.Session, 0, len(polled))
 	for _, sess := range polled {
-		mark, gone := m.gone[sess.ID]
-		if !gone || listedAt.After(mark.at) || (mark.archived && sess.Archived) {
+		mark, known := m.gone[sess.ID]
+		switch {
+		case !known || listedAt.After(mark.at):
+			if known {
+				delete(m.gone, sess.ID)
+			}
+			kept = append(kept, sess)
+		case mark.deleted:
+		default:
+			sess.Archived = mark.archived
 			kept = append(kept, sess)
 		}
 	}
@@ -124,24 +135,25 @@ func (m *Model) dropRecentlyRemoved(polled []store.Session, listedAt time.Time) 
 	return kept
 }
 
-// unmarkGone forgets a removal record, for a session brought back before
-// any poll has had the chance to retire it.
-func (m *Model) unmarkGone(id string) {
-	delete(m.gone, id)
-}
-
-// stripDeletedGroups drops a stale listing's group rows and metadata for
-// groups this run deleted after the listing was taken, so the deleted
-// header cannot hang back onto the tree for a frame. A listing that
-// postdates a deletion retires its marker instead.
-func stripDeletedGroups(msg *refreshMsg, gone map[string]time.Time) {
+// stripDeletedGroups reconciles a stale listing's group rows, metadata,
+// and archive flags against what this run has just done: a deleted group's
+// header cannot hang back onto the tree, and an archive or restore of a
+// group keeps its flag until a newer listing confirms it. A listing that
+// postdates a change retires its marker instead.
+func stripDeletedGroups(msg *refreshMsg, gone map[string]goneMark) {
 	removed := make(map[string]bool, len(gone))
-	for path, at := range gone {
-		if msg.listedAt.After(at) {
+	for path, mark := range gone {
+		switch {
+		case msg.listedAt.After(mark.at):
 			delete(gone, path)
-			continue
+		case mark.deleted:
+			removed[path] = true
+		default:
+			if msg.archivedGroups == nil {
+				msg.archivedGroups = map[string]bool{}
+			}
+			msg.archivedGroups[path] = mark.archived
 		}
-		removed[path] = true
 	}
 	if len(removed) == 0 {
 		return

--- a/internal/ui/sessionlaunch_test.go
+++ b/internal/ui/sessionlaunch_test.go
@@ -199,10 +199,12 @@ func TestAStalePollCannotRestoreADeletedGroupHeader(t *testing.T) {
 	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 
 	stale := refreshMsg{
-		sessions:   []store.Session{sess},
-		listedAt:   listedAt,
-		groups:     []string{"zone"},
-		groupPaths: map[string]string{"zone": dir},
+		sessions:       []store.Session{sess},
+		listedAt:       listedAt,
+		groups:         []string{"zone"},
+		groupPaths:     map[string]string{"zone": dir},
+		groupWorktrees: map[string]string{"zone": dir},
+		archivedGroups: map[string]bool{"zone": true},
 	}
 	updated, _ := m.Update(stale)
 	*m = *updated.(*Model)
@@ -216,6 +218,14 @@ func TestAStalePollCannotRestoreADeletedGroupHeader(t *testing.T) {
 		if g == "zone" {
 			t.Fatal("a stale poll restored the deleted group path")
 		}
+	}
+	for _, meta := range []map[string]string{m.groupPaths, m.groupWorktrees} {
+		if _, ok := meta["zone"]; ok {
+			t.Fatal("a stale poll restored deleted group metadata")
+		}
+	}
+	if _, ok := m.archivedGroups["zone"]; ok {
+		t.Fatal("a stale poll restored the deleted group's archive flag")
 	}
 }
 

--- a/internal/ui/sessionlaunch_test.go
+++ b/internal/ui/sessionlaunch_test.go
@@ -182,3 +182,39 @@ func TestAFreshListingRetiresDeletionMarkers(t *testing.T) {
 		t.Fatalf("deletion markers outlived a listing that postdates them: %v", m.gone)
 	}
 }
+
+func TestAStalePollCannotRestoreADeletedGroupHeader(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("zone", dir); err != nil {
+		t.Fatalf("group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "in-zone", dir, "zone")
+	sess := m.sessionRows()[0]
+	listedAt := time.Now()
+
+	m.selectGroupRow(t, "zone")
+	m.prepareDelete()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	stale := refreshMsg{
+		sessions:   []store.Session{sess},
+		listedAt:   listedAt,
+		groups:     []string{"zone"},
+		groupPaths: map[string]string{"zone": dir},
+	}
+	updated, _ := m.Update(stale)
+	*m = *updated.(*Model)
+
+	for _, r := range m.rows {
+		if r.isGroup && r.group == "zone" {
+			t.Fatalf("a stale poll brought the deleted group header back")
+		}
+	}
+	for _, g := range m.groups {
+		if g == "zone" {
+			t.Fatal("a stale poll restored the deleted group path")
+		}
+	}
+}

--- a/internal/ui/sessionlaunch_test.go
+++ b/internal/ui/sessionlaunch_test.go
@@ -5,6 +5,9 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
 )
 
 func TestAStaleRefreshKeepsASessionLaunchedAfterItWasListed(t *testing.T) {
@@ -117,5 +120,65 @@ func TestAStaleRefreshDoesNotBringBackASessionJustArchived(t *testing.T) {
 		if row.ID == sess.ID {
 			t.Fatalf("an archived session came back on the live tree as %q", row.Status)
 		}
+	}
+}
+
+// A poll that listed the store before the delete delivers its full list
+// afterwards; that stale copy must not put the row back on screen.
+func TestAStalePollCannotResurrectADeletedRow(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "doomed", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+	listedAt := time.Now()
+
+	deleteSession(t, m, "doomed")
+
+	stale := sess
+	stale.Status = status.Dead
+	updated, _ := m.Update(refreshMsg{sessions: []store.Session{stale}, listedAt: listedAt})
+	*m = *updated.(*Model)
+
+	for _, row := range m.sessionRows() {
+		if row.ID == sess.ID {
+			t.Fatalf("a stale poll brought the deleted row back as %q", row.Status)
+		}
+	}
+}
+
+func TestAStalePollCannotBringAnArchivedRowBackLive(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "shelved", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+	listedAt := time.Now()
+
+	m.selectSessionRow(t, "shelved")
+	m.archiveSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	stale := sess
+	stale.Status = status.Dead
+	updated, _ := m.Update(refreshMsg{sessions: []store.Session{stale}, listedAt: listedAt})
+	*m = *updated.(*Model)
+
+	for _, row := range m.sessionRows() {
+		if row.ID == sess.ID {
+			t.Fatalf("a stale poll brought the archived row back on the live tree")
+		}
+	}
+}
+
+func TestAFreshListingRetiresDeletionMarkers(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "doomed", t.TempDir(), "")
+	listedAt := time.Now()
+
+	deleteSession(t, m, "doomed")
+
+	fresh := refreshMsg{listedAt: listedAt.Add(time.Second)}
+	updated, _ := m.Update(fresh)
+	*m = *updated.(*Model)
+
+	if len(m.gone) != 0 {
+		t.Fatalf("deletion markers outlived a listing that postdates them: %v", m.gone)
 	}
 }

--- a/internal/ui/sessionlaunch_test.go
+++ b/internal/ui/sessionlaunch_test.go
@@ -218,3 +218,69 @@ func TestAStalePollCannotRestoreADeletedGroupHeader(t *testing.T) {
 		}
 	}
 }
+
+// A poll that listed the store before a restore still says the row is
+// archived; that stale copy must not undo the restore for a frame.
+func TestAStalePollCannotUndoARestore(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "returning", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+
+	m.selectSessionRow(t, "returning")
+	m.archiveSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	listedAt := time.Now()
+
+	m.showArchived = true
+	m.applyCmd(t, m.refreshCmd())
+	m.selectSessionRow(t, "returning")
+	m.restoreSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	stale := sess
+	stale.Archived = true
+	updated, _ := m.Update(refreshMsg{sessions: []store.Session{stale}, listedAt: listedAt})
+	*m = *updated.(*Model)
+
+	for _, row := range m.sessionRows() {
+		if row.ID == sess.ID {
+			t.Fatalf("a stale poll put the restored session back in the archived view")
+		}
+	}
+	m.showArchived = false
+	if got := m.visibleSessions(); len(got) != 1 || got[0].Archived {
+		t.Fatalf("restored session should read live after a stale listing, got %+v", got)
+	}
+}
+
+func TestAStalePollCannotBringAnArchivedGroupBackLive(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("zone", dir); err != nil {
+		t.Fatalf("group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "in-zone", dir, "zone")
+	sess := m.sessionRows()[0]
+	listedAt := time.Now()
+
+	m.selectGroupRow(t, "zone")
+	m.archiveSelected()
+	m.handleConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	stale := refreshMsg{
+		sessions:   []store.Session{sess},
+		listedAt:   listedAt,
+		groups:     []string{"zone"},
+		groupPaths: map[string]string{"zone": dir},
+	}
+	updated, _ := m.Update(stale)
+	*m = *updated.(*Model)
+
+	if !m.groupEffectivelyArchived("zone") {
+		t.Fatal("a stale poll brought the archived group back on the active tree")
+	}
+	if got := m.visibleSessions(); len(got) != 0 {
+		t.Fatalf("archived subtree should stay out of the active view, got %v", got)
+	}
+}


### PR DESCRIPTION
## What

A confirmed delete or archive now takes the row off the list on the same frame instead of leaving it on screen until the next poll confirms the store.

- Deleting a session splices it out of the loaded rows immediately.
- Archiving flags the rows archived locally, so they leave the active view at once rather than first flashing the dead state their kill produced (which also reset a waiting row's prompt-preview name back to its generated one).
- A poll that listed the store before the removal can no longer put the row back for a stray frame: `dropRecentlyRemoved` filters stale listings on arrival, mirroring the existing `keepPendingLaunches` guard for launches.
- A confirmed group delete prunes the group header and its path maps locally too, so an emptied group does not hang around until the next pass.

## Why

Deleting or archiving looked broken: the row lingered up to a poll interval, sometimes turned dead and renamed itself right before vanishing, and an in-flight poll could blink it back after it was gone.

## Verified

- Five new tests in `internal/ui/lifecycle_test.go`, all failing before the change and passing after: delete drops the row before any poll, archive leaves the active view at once while the archived view still holds it, a stale poll cannot resurrect a deleted row or bring an archived row back live, and a group delete drops its header at once.
- Full `go test ./...` green on an isolated tmux socket (`env -u TMUX TMUX_TMPDIR=/tmp/amtest`), `gofmt -l .` prints nothing, `go vet ./...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session and group archive, restore, and deletion actions now update the interface immediately.
  * Archived groups hide their entire subtree, while restored groups reappear correctly.
  * Deleted sessions and groups no longer return after stale refreshes.
  * Archived sessions remain available in archived views and reappear correctly when restored.
  * Restored sessions and groups are protected from outdated refresh results.

* **Tests**
  * Added coverage for immediate lifecycle updates, group visibility, and stale refresh protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->