### PR TITLE
docs(feed): announce v0.32.2

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "agent-teams-split-the-window",
+    "banner": "fix: previews follow the agent, not its teammates",
+    "title": "An agent that splits its own window keeps the preview on itself",
+    "body": [
+      "Claude Code's agent teams run each teammate as a full CLI in a pane beside the leader, splitting the session's window.",
+      "The preview, your keystrokes and the pane stats now address the agent's own pane, wherever the agent moves focus.",
+      "A split window is sized from the room its teammates already hold, so the agent's pane fills the preview panel again.",
+      "Update with `agent-manager update`, `brew upgrade yoanwai/tap/agent-manager`, or your package manager."
+    ],
+    "url": "https://github.com/YoanWai/agent-manager/releases/tag/v0.32.2",
+    "max_version": "0.32.2"
+  },
+  {
     "id": "update-itself-and-review-that-remembers",
     "banner": "new: agent-manager updates itself",
     "title": "One command updates the binary, and review remembers every round",


### PR DESCRIPTION
## What

One `docs/messages.json` entry announcing v0.32.2, first in the file so running installs see it above the older ones.

## Why

The release fixes what a running install cannot see for itself: with Claude Code's agent teams on, a teammate pane took over the preview and the keystrokes, and the agent's own pane drew at a fraction of the panel.

## Verified

`max_version` is `0.32.2`, so the entry retires with the release it announces rather than following users into the next one. `go test ./internal/feed/` passes, which is what checks the real file for renderable bounds, line counts and lengths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.32.2 covering agent-pane previews, input, statistics, sizing behavior, update instructions, and the release link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->