### PR TITLE
fix(stats): show Windows host figures on WSL2

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -314,7 +314,7 @@ The Computer block in the sessions panel shows machine gauges:
 - **Network**: up/down rates on real NICs only (loopback, utun, bridges, and similar virtual interfaces are excluded)
 - **Temperature**: `cpu`, `gpu` and `soc` readings in °C, each the hottest sensor in its category, sampled every 5s. Apple Silicon draws no CPU/GPU line, so its dies report as one `soc` figure. A reading appears when the machine exposes that sensor.
 
-On Windows under WSL2, agent-manager runs inside the Linux guest, whose `/proc` describes the VM rather than the machine. There the CPU, memory, disk, and agent-percentage figures come from the Windows host instead, sampled through PowerShell interop every 10 seconds; swap, network, and temperatures remain the guest's own. If interop is unavailable, the guest numbers show unchanged.
+On Windows under WSL2, agent-manager runs inside the Linux guest, whose `/proc` describes the VM rather than the machine. There the CPU, memory, disk, and agent-percentage figures come from the Windows host instead, sampled through PowerShell interop every 30 seconds; swap, network, and temperatures remain the guest's own. If interop is unavailable, the guest numbers show unchanged.
 
 ## Themes
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -314,6 +314,8 @@ The Computer block in the sessions panel shows machine gauges:
 - **Network**: up/down rates on real NICs only (loopback, utun, bridges, and similar virtual interfaces are excluded)
 - **Temperature**: `cpu`, `gpu` and `soc` readings in °C, each the hottest sensor in its category, sampled every 5s. Apple Silicon draws no CPU/GPU line, so its dies report as one `soc` figure. A reading appears when the machine exposes that sensor.
 
+On Windows under WSL2, agent-manager runs inside the Linux guest, whose `/proc` describes the VM rather than the machine. There the CPU, memory, disk, and agent-percentage figures come from the Windows host instead, sampled through PowerShell interop every 10 seconds; swap, network, and temperatures remain the guest's own. If interop is unavailable, the guest numbers show unchanged.
+
 ## Themes
 
 `s` opens Settings, where `↑↓` move between fields and `←→` change the focused one.

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -19,6 +19,7 @@ import (
 	"unicode/utf16"
 
 	"github.com/YoanWai/agent-manager/internal/termseq"
+	"github.com/YoanWai/agent-manager/internal/wsl"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -46,7 +47,7 @@ var (
 	}
 	// wslProbe reports whether we are running under WSL (Windows clipboard
 	// bridge needed when Linux tools cannot see the host clipboard).
-	wslProbe = detectWSL
+	wslProbe = wsl.Detect
 	getenv   = os.Getenv
 	// emitSeq writes a control sequence to the terminal drawing the app.
 	emitSeq = termseq.Emit
@@ -289,19 +290,6 @@ func saveWSLWindowsImage() (string, error) {
 		return "", ErrNoImage
 	}
 	return path, nil
-}
-
-// detectWSL reports WSL via env or the kernel release string.
-func detectWSL() bool {
-	if os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSL_INTEROP") != "" {
-		return true
-	}
-	data, err := os.ReadFile("/proc/sys/kernel/osrelease")
-	if err != nil {
-		return false
-	}
-	release := strings.ToLower(string(data))
-	return strings.Contains(release, "microsoft") || strings.Contains(release, "wsl")
 }
 
 // newPasteFile creates an empty paste-* file under pastesDir and returns

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -595,15 +595,3 @@ func TestWriteTextNativeFailureFallsBackToOSC52(t *testing.T) {
 		t.Fatalf("emitted = %q, want %q", emitted, want)
 	}
 }
-
-func TestDetectWSLEnv(t *testing.T) {
-	t.Setenv("WSL_DISTRO_NAME", "Ubuntu")
-	if !detectWSL() {
-		t.Fatal("WSL_DISTRO_NAME should mark WSL")
-	}
-	t.Setenv("WSL_DISTRO_NAME", "")
-	t.Setenv("WSL_INTEROP", "/run/WSL/1_interop")
-	if !detectWSL() {
-		t.Fatal("WSL_INTEROP should mark WSL")
-	}
-}

--- a/internal/sysstat/host_linux.go
+++ b/internal/sysstat/host_linux.go
@@ -18,13 +18,15 @@ import (
 // On WSL2 /proc describes the guest VM (half the Windows RAM by default,
 // fewer cores, a virtual disk), while the Computer block is labeled as the
 // machine. These probes read the real figures through PowerShell interop;
-// each call costs about a second, so a background loop samples slowly and
-// Sample() overlays the freshest reading onto the guest numbers.
+// each call spawns a Windows process and costs about a second, so a
+// background loop samples slowly and Sample() overlays the freshest
+// reading onto the guest numbers.
 
 const (
-	probeTimeout    = 15 * time.Second
-	hostInterval    = 10 * time.Second
-	hostFreshWindow = 30 * time.Second
+	probeTimeout = 15 * time.Second
+	hostInterval = 30 * time.Second
+	// Two missed probes still show host figures; past that, guest ones.
+	hostFreshWindow = 3 * hostInterval
 )
 
 type HostSample struct {
@@ -64,17 +66,13 @@ var hostProbe = func(path string, timeout time.Duration) (string, error) {
 
 const hostProbeCommand = `[System.Threading.Thread]::CurrentThread.CurrentCulture=[cultureinfo]::InvariantCulture;` +
 	`$cs=Get-CimInstance Win32_ComputerSystem;` +
-	`$os=Get-CimInstance Win32_OperatingSystem;` +
-	`$p=(Get-CimInstance Win32_Processor|Measure-Object -Property LoadPercentage -Average).Average;` +
-	`$c=Get-CimInstance Win32_PerfFormattedData_PerfOS_Processor -Filter "Name='_Total'";` +
+	`$u=Get-CimInstance Win32_PerfFormattedData_Counters_ProcessorInformation -Filter "Name='_Total'";` +
+	// Task Manager reads % Processor Utility; % Processor Time is the older busy-time counter, kept as a stand-in.
+	`$cpu=if($null -ne $u){$u.PercentProcessorUtility}else{(Get-CimInstance Win32_PerfFormattedData_PerfOS_Processor -Filter "Name='_Total'").PercentProcessorTime};` +
 	`$m=Get-CimInstance Win32_PerfFormattedData_PerfOS_Memory;` +
-	`$d=Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'";` +
-	// PercentProcessorTime is the perf-counter figure behind Task Manager's
-	// CPU dial; LoadPercentage is a coarse WMI estimate that lags real load.
-	`"{0} {1} {2} {3} {4} {5}" -f ` +
-	`$(if($null -ne $c){$c.PercentProcessorTime}elseif($null -ne $p){$p}else{0}),` +
-	`$cs.NumberOfLogicalProcessors,$cs.TotalPhysicalMemory,` +
-	`$(if($null -ne $m){$m.AvailableBytes}else{($os.FreePhysicalMemory*1KB)}),$d.Size,$d.FreeSpace`
+	`$d=Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$env:SystemDrive'";` +
+	`"{0} {1} {2} {3} {4} {5}" -f $cpu,$cs.NumberOfLogicalProcessors,$cs.TotalPhysicalMemory,` +
+	`$m.AvailableBytes,$d.Size,$d.FreeSpace`
 
 func parseHostSample(line string) (HostSample, error) {
 	fields := strings.Fields(line)
@@ -153,29 +151,31 @@ func startHostSampler() {
 		if !hostProbed() {
 			return
 		}
-		path, ok := hostLookupPowerShell()
-		if !ok {
-			return
-		}
-		go runHostSampler(path, hostProbe)
+		go runHostSampler(hostProbe)
 	})
 }
 
-func runHostSampler(path string, probe func(string, time.Duration) (string, error)) {
-	tick := func() {
-		out, err := probe(path, probeTimeout)
-		if err != nil {
-			return
-		}
-		if s, err := parseHostSample(out); err == nil {
-			storeHost(s)
-		}
-	}
-	tick()
+func runHostSampler(probe func(string, time.Duration) (string, error)) {
+	sampleHostOnce(probe)
 	ticker := time.NewTicker(hostInterval)
 	defer ticker.Stop()
 	for range ticker.C {
-		tick()
+		sampleHostOnce(probe)
+	}
+}
+
+// PowerShell is resolved every pass, so interop that appears later still counts.
+func sampleHostOnce(probe func(string, time.Duration) (string, error)) {
+	path, ok := hostLookupPowerShell()
+	if !ok {
+		return
+	}
+	out, err := probe(path, probeTimeout)
+	if err != nil {
+		return
+	}
+	if s, err := parseHostSample(out); err == nil {
+		storeHost(s)
 	}
 }
 
@@ -193,7 +193,7 @@ func overlayHost(snap *Snapshot) {
 	snap.DiskTotal = s.DiskTotal
 	snap.DiskUsed = s.DiskTotal - s.DiskFree
 	snap.DiskFree = s.DiskFree
-	snap.DiskPercent = usedPercent(snap.DiskUsed, snap.DiskUsed+snap.DiskFree)
+	snap.DiskPercent = usedPercent(snap.DiskUsed, s.DiskTotal)
 	snap.DiskOK = true
 }
 

--- a/internal/sysstat/host_linux.go
+++ b/internal/sysstat/host_linux.go
@@ -1,0 +1,199 @@
+//go:build linux
+
+package sysstat
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/wsl"
+)
+
+// On WSL2 /proc describes the guest VM (half the Windows RAM by default,
+// fewer cores, a virtual disk), while the Computer block is labeled as the
+// machine. These probes read the real figures through PowerShell interop;
+// each call costs about a second, so a background loop samples slowly and
+// Sample() overlays the freshest reading onto the guest numbers.
+
+const (
+	probeTimeout    = 15 * time.Second
+	hostInterval    = 10 * time.Second
+	hostFreshWindow = 30 * time.Second
+)
+
+type HostSample struct {
+	CPUPercent float64
+	NCPU       int
+	MemTotal   uint64
+	MemFree    uint64
+	DiskTotal  uint64
+	DiskFree   uint64
+}
+
+var hostProbed = wsl.Detect
+
+var hostLookupPowerShell = func() (string, bool) {
+	if path, err := exec.LookPath("powershell.exe"); err == nil {
+		return path, true
+	}
+	const systemPath = "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+	if _, err := os.Stat(systemPath); err == nil {
+		return systemPath, true
+	}
+	return "", false
+}
+
+var hostProbe = func(path string, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, "-NoProfile", "-Command", hostProbeCommand)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+const hostProbeCommand = `[System.Threading.Thread]::CurrentThread.CurrentCulture=[cultureinfo]::InvariantCulture;` +
+	`$cs=Get-CimInstance Win32_ComputerSystem;` +
+	`$os=Get-CimInstance Win32_OperatingSystem;` +
+	`$p=Get-CimInstance Win32_Processor|Measure-Object -Property LoadPercentage -Average;` +
+	`$d=Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'";` +
+	`"{0} {1} {2} {3} {4} {5}" -f $(if($null -ne $p.Average){$p.Average}else{0}),` +
+	`$cs.NumberOfLogicalProcessors,$cs.TotalPhysicalMemory,($os.FreePhysicalMemory*1KB),$d.Size,$d.FreeSpace`
+
+func parseHostSample(line string) (HostSample, error) {
+	fields := strings.Fields(line)
+	if len(fields) != 6 {
+		return HostSample{}, errors.New("host sample wants 6 fields")
+	}
+	cpu, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil || cpu < 0 {
+		return HostSample{}, errors.New("bad cpu field")
+	}
+	ncpu, err := strconv.Atoi(fields[1])
+	if err != nil || ncpu < 1 {
+		return HostSample{}, errors.New("bad ncpu field")
+	}
+	memTotal, err := strconv.ParseUint(fields[2], 10, 64)
+	if err != nil {
+		return HostSample{}, errors.New("bad mem total field")
+	}
+	memFree, err := strconv.ParseUint(fields[3], 10, 64)
+	if err != nil {
+		return HostSample{}, errors.New("bad mem free field")
+	}
+	diskTotal, err := strconv.ParseUint(fields[4], 10, 64)
+	if err != nil {
+		return HostSample{}, errors.New("bad disk total field")
+	}
+	diskFree, err := strconv.ParseUint(fields[5], 10, 64)
+	if err != nil {
+		return HostSample{}, errors.New("bad disk free field")
+	}
+	return HostSample{
+		CPUPercent: cpu,
+		NCPU:       ncpu,
+		MemTotal:   memTotal,
+		MemFree:    memFree,
+		DiskTotal:  diskTotal,
+		DiskFree:   diskFree,
+	}, nil
+}
+
+type hostCache struct {
+	mu     sync.Mutex
+	sample HostSample
+	at     time.Time
+}
+
+var hostState hostCache
+
+var hostSamplerStart sync.Once
+
+func storeHost(s HostSample) {
+	hostState.mu.Lock()
+	hostState.sample = s
+	hostState.at = time.Now()
+	hostState.mu.Unlock()
+}
+
+func freshHostSample() (HostSample, bool) {
+	hostState.mu.Lock()
+	defer hostState.mu.Unlock()
+	if hostState.at.IsZero() || time.Since(hostState.at) > hostFreshWindow {
+		return HostSample{}, false
+	}
+	return hostState.sample, true
+}
+
+func startHostSampler() {
+	hostSamplerStart.Do(func() {
+		if !hostProbed() {
+			return
+		}
+		path, ok := hostLookupPowerShell()
+		if !ok {
+			return
+		}
+		go runHostSampler(path, hostProbe)
+	})
+}
+
+func runHostSampler(path string, probe func(string, time.Duration) (string, error)) {
+	tick := func() {
+		out, err := probe(path, probeTimeout)
+		if err != nil {
+			return
+		}
+		if s, err := parseHostSample(out); err == nil {
+			storeHost(s)
+		}
+	}
+	tick()
+	ticker := time.NewTicker(hostInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		tick()
+	}
+}
+
+func overlayHost(snap *Snapshot) {
+	s, ok := freshHostSample()
+	if !ok {
+		return
+	}
+	snap.CPUPercent = s.CPUPercent
+	snap.CPUOK = true
+	snap.MemTotal = s.MemTotal
+	snap.MemUsed = s.MemTotal - s.MemFree
+	snap.MemPercent = usedPercent(snap.MemUsed, s.MemTotal)
+	snap.MemOK = true
+	snap.DiskTotal = s.DiskTotal
+	snap.DiskUsed = s.DiskTotal - s.DiskFree
+	snap.DiskFree = s.DiskFree
+	snap.DiskPercent = usedPercent(snap.DiskUsed, snap.DiskUsed+snap.DiskFree)
+	snap.DiskOK = true
+}
+
+func hostMemTotal() (uint64, bool) {
+	s, ok := freshHostSample()
+	if !ok || s.MemTotal == 0 {
+		return 0, false
+	}
+	return s.MemTotal, true
+}
+
+func hostNCPU() (int, bool) {
+	s, ok := freshHostSample()
+	if !ok || s.NCPU < 1 {
+		return 0, false
+	}
+	return s.NCPU, true
+}

--- a/internal/sysstat/host_linux.go
+++ b/internal/sysstat/host_linux.go
@@ -31,9 +31,11 @@ type HostSample struct {
 	CPUPercent float64
 	NCPU       int
 	MemTotal   uint64
-	MemFree    uint64
-	DiskTotal  uint64
-	DiskFree   uint64
+	// MemAvailable is what Windows calls available: free plus standby.
+	// Task Manager's "in use" is total minus this figure.
+	MemAvailable uint64
+	DiskTotal    uint64
+	DiskFree     uint64
 }
 
 var hostProbed = wsl.Detect
@@ -63,10 +65,16 @@ var hostProbe = func(path string, timeout time.Duration) (string, error) {
 const hostProbeCommand = `[System.Threading.Thread]::CurrentThread.CurrentCulture=[cultureinfo]::InvariantCulture;` +
 	`$cs=Get-CimInstance Win32_ComputerSystem;` +
 	`$os=Get-CimInstance Win32_OperatingSystem;` +
-	`$p=Get-CimInstance Win32_Processor|Measure-Object -Property LoadPercentage -Average;` +
+	`$p=(Get-CimInstance Win32_Processor|Measure-Object -Property LoadPercentage -Average).Average;` +
+	`$c=Get-CimInstance Win32_PerfFormattedData_PerfOS_Processor -Filter "Name='_Total'";` +
+	`$m=Get-CimInstance Win32_PerfFormattedData_PerfOS_Memory;` +
 	`$d=Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'";` +
-	`"{0} {1} {2} {3} {4} {5}" -f $(if($null -ne $p.Average){$p.Average}else{0}),` +
-	`$cs.NumberOfLogicalProcessors,$cs.TotalPhysicalMemory,($os.FreePhysicalMemory*1KB),$d.Size,$d.FreeSpace`
+	// PercentProcessorTime is the perf-counter figure behind Task Manager's
+	// CPU dial; LoadPercentage is a coarse WMI estimate that lags real load.
+	`"{0} {1} {2} {3} {4} {5}" -f ` +
+	`$(if($null -ne $c){$c.PercentProcessorTime}elseif($null -ne $p){$p}else{0}),` +
+	`$cs.NumberOfLogicalProcessors,$cs.TotalPhysicalMemory,` +
+	`$(if($null -ne $m){$m.AvailableBytes}else{($os.FreePhysicalMemory*1KB)}),$d.Size,$d.FreeSpace`
 
 func parseHostSample(line string) (HostSample, error) {
 	fields := strings.Fields(line)
@@ -85,9 +93,9 @@ func parseHostSample(line string) (HostSample, error) {
 	if err != nil {
 		return HostSample{}, errors.New("bad mem total field")
 	}
-	memFree, err := strconv.ParseUint(fields[3], 10, 64)
+	memAvail, err := strconv.ParseUint(fields[3], 10, 64)
 	if err != nil {
-		return HostSample{}, errors.New("bad mem free field")
+		return HostSample{}, errors.New("bad mem available field")
 	}
 	diskTotal, err := strconv.ParseUint(fields[4], 10, 64)
 	if err != nil {
@@ -97,20 +105,20 @@ func parseHostSample(line string) (HostSample, error) {
 	if err != nil {
 		return HostSample{}, errors.New("bad disk free field")
 	}
-	// A free figure above its total would underflow the used math below.
-	if memFree > memTotal {
-		return HostSample{}, errors.New("mem free exceeds total")
+	// An available figure above its total would underflow the used math below.
+	if memAvail > memTotal {
+		return HostSample{}, errors.New("mem available exceeds total")
 	}
 	if diskFree > diskTotal {
 		return HostSample{}, errors.New("disk free exceeds total")
 	}
 	return HostSample{
-		CPUPercent: cpu,
-		NCPU:       ncpu,
-		MemTotal:   memTotal,
-		MemFree:    memFree,
-		DiskTotal:  diskTotal,
-		DiskFree:   diskFree,
+		CPUPercent:   clampPct(cpu),
+		NCPU:         ncpu,
+		MemTotal:     memTotal,
+		MemAvailable: memAvail,
+		DiskTotal:    diskTotal,
+		DiskFree:     diskFree,
 	}, nil
 }
 
@@ -179,7 +187,7 @@ func overlayHost(snap *Snapshot) {
 	snap.CPUPercent = s.CPUPercent
 	snap.CPUOK = true
 	snap.MemTotal = s.MemTotal
-	snap.MemUsed = s.MemTotal - s.MemFree
+	snap.MemUsed = s.MemTotal - s.MemAvailable
 	snap.MemPercent = usedPercent(snap.MemUsed, s.MemTotal)
 	snap.MemOK = true
 	snap.DiskTotal = s.DiskTotal

--- a/internal/sysstat/host_linux.go
+++ b/internal/sysstat/host_linux.go
@@ -97,6 +97,13 @@ func parseHostSample(line string) (HostSample, error) {
 	if err != nil {
 		return HostSample{}, errors.New("bad disk free field")
 	}
+	// A free figure above its total would underflow the used math below.
+	if memFree > memTotal {
+		return HostSample{}, errors.New("mem free exceeds total")
+	}
+	if diskFree > diskTotal {
+		return HostSample{}, errors.New("disk free exceeds total")
+	}
 	return HostSample{
 		CPUPercent: cpu,
 		NCPU:       ncpu,

--- a/internal/sysstat/host_linux.go
+++ b/internal/sysstat/host_linux.go
@@ -88,7 +88,7 @@ func parseHostSample(line string) (HostSample, error) {
 		return HostSample{}, errors.New("bad ncpu field")
 	}
 	memTotal, err := strconv.ParseUint(fields[2], 10, 64)
-	if err != nil {
+	if err != nil || memTotal == 0 {
 		return HostSample{}, errors.New("bad mem total field")
 	}
 	memAvail, err := strconv.ParseUint(fields[3], 10, 64)
@@ -96,7 +96,7 @@ func parseHostSample(line string) (HostSample, error) {
 		return HostSample{}, errors.New("bad mem available field")
 	}
 	diskTotal, err := strconv.ParseUint(fields[4], 10, 64)
-	if err != nil {
+	if err != nil || diskTotal == 0 {
 		return HostSample{}, errors.New("bad disk total field")
 	}
 	diskFree, err := strconv.ParseUint(fields[5], 10, 64)

--- a/internal/sysstat/host_linux_test.go
+++ b/internal/sysstat/host_linux_test.go
@@ -1,0 +1,197 @@
+package sysstat
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func resetHostState(t *testing.T) {
+	t.Helper()
+	resetHost()
+	hostSamplerStart = sync.Once{}
+	t.Cleanup(resetHost)
+}
+
+func resetHost() {
+	hostState.mu.Lock()
+	hostState.sample = HostSample{}
+	hostState.at = time.Time{}
+	hostState.mu.Unlock()
+}
+
+// disableHostSampling keeps Sample() from launching the real PowerShell
+// probe loop while a test runs.
+func disableHostSampling(t *testing.T) {
+	t.Helper()
+	orig := hostProbed
+	hostProbed = func() bool { return false }
+	resetHostState(t)
+	t.Cleanup(func() { hostProbed = orig })
+}
+
+func seedHost(t *testing.T, s HostSample, age time.Duration) {
+	t.Helper()
+	resetHostState(t)
+	hostState.mu.Lock()
+	defer hostState.mu.Unlock()
+	hostState.sample = s
+	hostState.at = time.Now().Add(-age)
+}
+
+func TestParseHostSample(t *testing.T) {
+	s, err := parseHostSample("5 12 34301874176 17150937088 500203874304 250101936128")
+	if err != nil {
+		t.Fatalf("valid line: %v", err)
+	}
+	if s.CPUPercent != 5 || s.NCPU != 12 {
+		t.Fatalf("cpu/ncpu = %v %v", s.CPUPercent, s.NCPU)
+	}
+	if s.MemTotal != 34301874176 || s.MemFree != 17150937088 {
+		t.Fatalf("mem = %v %v", s.MemTotal, s.MemFree)
+	}
+	if s.DiskTotal != 500203874304 || s.DiskFree != 250101936128 {
+		t.Fatalf("disk = %v %v", s.DiskTotal, s.DiskFree)
+	}
+
+	for name, line := range map[string]string{
+		"too few fields":    "5 12 34301874176 17150937088",
+		"too many fields":   "1 2 3 4 5 6 7",
+		"non-numeric cpu":   "x 2 3 4 5 6",
+		"negative cpu":      "-1 2 3 4 5 6",
+		"zero ncpu":         "5 0 3 4 5 6",
+		"non-numeric ncpu":  "5 x 3 4 5 6",
+		"non-numeric memT":  "5 12 x 4 5 6",
+		"non-numeric memF":  "5 12 3 x 5 6",
+		"non-numeric diskT": "5 12 3 4 x 6",
+		"non-numeric diskF": "5 12 3 4 5 x",
+	} {
+		if _, err := parseHostSample(line); err == nil {
+			t.Errorf("%s: want error, got nil (%q)", name, line)
+		}
+	}
+}
+
+func TestOverlayHostFresh(t *testing.T) {
+	seedHost(t, HostSample{
+		CPUPercent: 7,
+		NCPU:       12,
+		MemTotal:   32000,
+		MemFree:    12000,
+		DiskTotal:  500000,
+		DiskFree:   100000,
+	}, 0)
+
+	var snap Snapshot
+	overlayHost(&snap)
+	if !snap.CPUOK || snap.CPUPercent != 7 {
+		t.Fatalf("cpu = %v %v", snap.CPUPercent, snap.CPUOK)
+	}
+	if !snap.MemOK || snap.MemTotal != 32000 || snap.MemUsed != 20000 {
+		t.Fatalf("mem = %v %v %v", snap.MemUsed, snap.MemTotal, snap.MemOK)
+	}
+	if snap.MemPercent != 62.5 {
+		t.Fatalf("mem%% = %v", snap.MemPercent)
+	}
+	if !snap.DiskOK || snap.DiskTotal != 500000 || snap.DiskUsed != 400000 || snap.DiskFree != 100000 {
+		t.Fatalf("disk = %v %v %v %v", snap.DiskUsed, snap.DiskTotal, snap.DiskFree, snap.DiskOK)
+	}
+	if snap.DiskPercent != 80 {
+		t.Fatalf("disk%% = %v", snap.DiskPercent)
+	}
+}
+
+func TestOverlayHostStaleFallsBackToGuest(t *testing.T) {
+	seedHost(t, HostSample{CPUPercent: 99, NCPU: 12, MemTotal: 32000, MemFree: 0, DiskTotal: 500000, DiskFree: 0}, 31*time.Second)
+
+	var snap Snapshot
+	snap.CPUPercent, snap.CPUOK = 11, true
+	snap.MemUsed, snap.MemTotal, snap.MemOK = 100, 16000, true
+	overlayHost(&snap)
+	if snap.CPUPercent != 11 || snap.MemTotal != 16000 {
+		t.Fatalf("stale host sample overwrote guest values: %+v", snap)
+	}
+}
+
+func TestHostAccessors(t *testing.T) {
+	resetHostState(t)
+
+	if _, ok := hostMemTotal(); ok {
+		t.Fatal("empty cache should report not-ok")
+	}
+	if _, ok := hostNCPU(); ok {
+		t.Fatal("empty cache should report not-ok")
+	}
+
+	seedHost(t, HostSample{CPUPercent: 1, NCPU: 12, MemTotal: 32000, MemFree: 100}, 0)
+	total, ok := hostMemTotal()
+	if !ok || total != 32000 {
+		t.Fatalf("hostMemTotal = %v %v", total, ok)
+	}
+	n, ok := hostNCPU()
+	if !ok || n != 12 {
+		t.Fatalf("hostNCPU = %v %v", n, ok)
+	}
+}
+
+func TestEnsureHostSamplerGating(t *testing.T) {
+	origProbed, origLookup, origProbe := hostProbed, hostLookupPowerShell, hostProbe
+	defer func() { hostProbed, hostLookupPowerShell, hostProbe = origProbed, origLookup, origProbe }()
+
+	probeCalled := make(chan string, 4)
+	hostProbe = func(path string, timeout time.Duration) (string, error) {
+		probeCalled <- path
+		return "", errors.New("unused")
+	}
+
+	t.Run("no wsl means no probe", func(t *testing.T) {
+		resetHostState(t)
+		hostProbed = func() bool { return false }
+		startHostSampler()
+		select {
+		case p := <-probeCalled:
+			t.Fatalf("probed without wsl via %q", p)
+		case <-time.After(150 * time.Millisecond):
+		}
+	})
+
+	t.Run("no powershell means no probe", func(t *testing.T) {
+		resetHostState(t)
+		hostProbed = func() bool { return true }
+		hostLookupPowerShell = func() (string, bool) { return "", false }
+		startHostSampler()
+		select {
+		case p := <-probeCalled:
+			t.Fatalf("probed without powershell via %q", p)
+		case <-time.After(150 * time.Millisecond):
+		}
+	})
+
+	t.Run("found powershell probes immediately", func(t *testing.T) {
+		resetHostState(t)
+		hostLookupPowerShell = func() (string, bool) { return "/fake/powershell.exe", true }
+		startHostSampler()
+		select {
+		case p := <-probeCalled:
+			if p != "/fake/powershell.exe" {
+				t.Fatalf("probe path = %q", p)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("probe never ran")
+		}
+	})
+}
+
+func TestStoreHostReplacesPreviousSample(t *testing.T) {
+	resetHostState(t)
+
+	storeHost(HostSample{CPUPercent: 1, NCPU: 4, MemTotal: 8, MemFree: 4})
+	storeHost(HostSample{CPUPercent: 2, NCPU: 8, MemTotal: 32, MemFree: 16})
+
+	hostState.mu.Lock()
+	defer hostState.mu.Unlock()
+	if hostState.sample.MemTotal != 32 || hostState.sample.NCPU != 8 {
+		t.Fatalf("stored sample = %+v", hostState.sample)
+	}
+}

--- a/internal/sysstat/host_linux_test.go
+++ b/internal/sysstat/host_linux_test.go
@@ -74,6 +74,8 @@ func TestParseHostSample(t *testing.T) {
 		"non-numeric memA":     "5 12 3 x 5 6",
 		"non-numeric diskT":    "5 12 3 4 x 6",
 		"non-numeric diskF":    "5 12 3 4 5 x",
+		"zero mem total":       "5 12 0 0 500 100",
+		"zero disk total":      "5 12 300 100 0 0",
 		"mem avail over total": "5 12 100 200 500 100",
 		"disk free over total": "5 12 300 100 500 900",
 	} {

--- a/internal/sysstat/host_linux_test.go
+++ b/internal/sysstat/host_linux_test.go
@@ -48,11 +48,19 @@ func TestParseHostSample(t *testing.T) {
 	if s.CPUPercent != 5 || s.NCPU != 12 {
 		t.Fatalf("cpu/ncpu = %v %v", s.CPUPercent, s.NCPU)
 	}
-	if s.MemTotal != 34301874176 || s.MemFree != 17150937088 {
-		t.Fatalf("mem = %v %v", s.MemTotal, s.MemFree)
+	if s.MemTotal != 34301874176 || s.MemAvailable != 17150937088 {
+		t.Fatalf("mem = %v %v", s.MemTotal, s.MemAvailable)
 	}
 	if s.DiskTotal != 500203874304 || s.DiskFree != 250101936128 {
 		t.Fatalf("disk = %v %v", s.DiskTotal, s.DiskFree)
+	}
+
+	s, err = parseHostSample("150 12 300 100 500 100")
+	if err != nil {
+		t.Fatalf("over-100 cpu should clamp, got %v", err)
+	}
+	if s.CPUPercent != 100 {
+		t.Fatalf("cpu clamp: got %v, want 100", s.CPUPercent)
 	}
 
 	for name, line := range map[string]string{
@@ -63,10 +71,10 @@ func TestParseHostSample(t *testing.T) {
 		"zero ncpu":            "5 0 3 4 5 6",
 		"non-numeric ncpu":     "5 x 3 4 5 6",
 		"non-numeric memT":     "5 12 x 4 5 6",
-		"non-numeric memF":     "5 12 3 x 5 6",
+		"non-numeric memA":     "5 12 3 x 5 6",
 		"non-numeric diskT":    "5 12 3 4 x 6",
 		"non-numeric diskF":    "5 12 3 4 5 x",
-		"mem free over total":  "5 12 100 200 500 100",
+		"mem avail over total": "5 12 100 200 500 100",
 		"disk free over total": "5 12 300 100 500 900",
 	} {
 		if _, err := parseHostSample(line); err == nil {
@@ -77,12 +85,12 @@ func TestParseHostSample(t *testing.T) {
 
 func TestOverlayHostFresh(t *testing.T) {
 	seedHost(t, HostSample{
-		CPUPercent: 7,
-		NCPU:       12,
-		MemTotal:   32000,
-		MemFree:    12000,
-		DiskTotal:  500000,
-		DiskFree:   100000,
+		CPUPercent:   7,
+		NCPU:         12,
+		MemTotal:     32000,
+		MemAvailable: 12000,
+		DiskTotal:    500000,
+		DiskFree:     100000,
 	}, 0)
 
 	var snap Snapshot
@@ -105,7 +113,7 @@ func TestOverlayHostFresh(t *testing.T) {
 }
 
 func TestOverlayHostStaleFallsBackToGuest(t *testing.T) {
-	seedHost(t, HostSample{CPUPercent: 99, NCPU: 12, MemTotal: 32000, MemFree: 0, DiskTotal: 500000, DiskFree: 0}, 31*time.Second)
+	seedHost(t, HostSample{CPUPercent: 99, NCPU: 12, MemTotal: 32000, MemAvailable: 0, DiskTotal: 500000, DiskFree: 0}, 31*time.Second)
 
 	var snap Snapshot
 	snap.CPUPercent, snap.CPUOK = 11, true
@@ -126,7 +134,7 @@ func TestHostAccessors(t *testing.T) {
 		t.Fatal("empty cache should report not-ok")
 	}
 
-	seedHost(t, HostSample{CPUPercent: 1, NCPU: 12, MemTotal: 32000, MemFree: 100}, 0)
+	seedHost(t, HostSample{CPUPercent: 1, NCPU: 12, MemTotal: 32000, MemAvailable: 100}, 0)
 	total, ok := hostMemTotal()
 	if !ok || total != 32000 {
 		t.Fatalf("hostMemTotal = %v %v", total, ok)
@@ -188,8 +196,8 @@ func TestEnsureHostSamplerGating(t *testing.T) {
 func TestStoreHostReplacesPreviousSample(t *testing.T) {
 	resetHostState(t)
 
-	storeHost(HostSample{CPUPercent: 1, NCPU: 4, MemTotal: 8, MemFree: 4})
-	storeHost(HostSample{CPUPercent: 2, NCPU: 8, MemTotal: 32, MemFree: 16})
+	storeHost(HostSample{CPUPercent: 1, NCPU: 4, MemTotal: 8, MemAvailable: 4})
+	storeHost(HostSample{CPUPercent: 2, NCPU: 8, MemTotal: 32, MemAvailable: 16})
 
 	hostState.mu.Lock()
 	defer hostState.mu.Unlock()

--- a/internal/sysstat/host_linux_test.go
+++ b/internal/sysstat/host_linux_test.go
@@ -113,7 +113,7 @@ func TestOverlayHostFresh(t *testing.T) {
 }
 
 func TestOverlayHostStaleFallsBackToGuest(t *testing.T) {
-	seedHost(t, HostSample{CPUPercent: 99, NCPU: 12, MemTotal: 32000, MemAvailable: 0, DiskTotal: 500000, DiskFree: 0}, 31*time.Second)
+	seedHost(t, HostSample{CPUPercent: 99, NCPU: 12, MemTotal: 32000, MemAvailable: 0, DiskTotal: 500000, DiskFree: 0}, hostFreshWindow+time.Second)
 
 	var snap Snapshot
 	snap.CPUPercent, snap.CPUOK = 11, true
@@ -145,15 +145,20 @@ func TestHostAccessors(t *testing.T) {
 	}
 }
 
-func TestEnsureHostSamplerGating(t *testing.T) {
+func TestStartHostSamplerGating(t *testing.T) {
 	origProbed, origLookup, origProbe := hostProbed, hostLookupPowerShell, hostProbe
 	defer func() { hostProbed, hostLookupPowerShell, hostProbe = origProbed, origLookup, origProbe }()
 
-	probeCalled := make(chan string, 4)
+	probeCalled := make(chan string, 1)
 	hostProbe = func(path string, timeout time.Duration) (string, error) {
-		probeCalled <- path
+		// The sampler goroutine outlives the test, so a blocking send would wedge it.
+		select {
+		case probeCalled <- path:
+		default:
+		}
 		return "", errors.New("unused")
 	}
+	hostLookupPowerShell = func() (string, bool) { return "/fake/powershell.exe", true }
 
 	t.Run("no wsl means no probe", func(t *testing.T) {
 		resetHostState(t)
@@ -166,21 +171,9 @@ func TestEnsureHostSamplerGating(t *testing.T) {
 		}
 	})
 
-	t.Run("no powershell means no probe", func(t *testing.T) {
+	t.Run("wsl probes immediately", func(t *testing.T) {
 		resetHostState(t)
 		hostProbed = func() bool { return true }
-		hostLookupPowerShell = func() (string, bool) { return "", false }
-		startHostSampler()
-		select {
-		case p := <-probeCalled:
-			t.Fatalf("probed without powershell via %q", p)
-		case <-time.After(150 * time.Millisecond):
-		}
-	})
-
-	t.Run("found powershell probes immediately", func(t *testing.T) {
-		resetHostState(t)
-		hostLookupPowerShell = func() (string, bool) { return "/fake/powershell.exe", true }
 		startHostSampler()
 		select {
 		case p := <-probeCalled:
@@ -191,6 +184,33 @@ func TestEnsureHostSamplerGating(t *testing.T) {
 			t.Fatal("probe never ran")
 		}
 	})
+}
+
+func TestSampleHostOnceRetriesAfterMissingPowerShell(t *testing.T) {
+	origLookup, origProbe := hostLookupPowerShell, hostProbe
+	defer func() { hostLookupPowerShell, hostProbe = origLookup, origProbe }()
+	resetHostState(t)
+
+	probes := 0
+	hostProbe = func(string, time.Duration) (string, error) {
+		probes++
+		return "5 12 32000 12000 500000 100000", nil
+	}
+
+	hostLookupPowerShell = func() (string, bool) { return "", false }
+	sampleHostOnce(hostProbe)
+	if probes != 0 {
+		t.Fatalf("probed without powershell %d times", probes)
+	}
+
+	hostLookupPowerShell = func() (string, bool) { return "/fake/powershell.exe", true }
+	sampleHostOnce(hostProbe)
+	if probes != 1 {
+		t.Fatalf("probes once powershell appeared = %d, want 1", probes)
+	}
+	if _, ok := freshHostSample(); !ok {
+		t.Fatal("a successful probe should land in the cache")
+	}
 }
 
 func TestStoreHostReplacesPreviousSample(t *testing.T) {

--- a/internal/sysstat/host_linux_test.go
+++ b/internal/sysstat/host_linux_test.go
@@ -56,16 +56,18 @@ func TestParseHostSample(t *testing.T) {
 	}
 
 	for name, line := range map[string]string{
-		"too few fields":    "5 12 34301874176 17150937088",
-		"too many fields":   "1 2 3 4 5 6 7",
-		"non-numeric cpu":   "x 2 3 4 5 6",
-		"negative cpu":      "-1 2 3 4 5 6",
-		"zero ncpu":         "5 0 3 4 5 6",
-		"non-numeric ncpu":  "5 x 3 4 5 6",
-		"non-numeric memT":  "5 12 x 4 5 6",
-		"non-numeric memF":  "5 12 3 x 5 6",
-		"non-numeric diskT": "5 12 3 4 x 6",
-		"non-numeric diskF": "5 12 3 4 5 x",
+		"too few fields":       "5 12 34301874176 17150937088",
+		"too many fields":      "1 2 3 4 5 6 7",
+		"non-numeric cpu":      "x 2 3 4 5 6",
+		"negative cpu":         "-1 2 3 4 5 6",
+		"zero ncpu":            "5 0 3 4 5 6",
+		"non-numeric ncpu":     "5 x 3 4 5 6",
+		"non-numeric memT":     "5 12 x 4 5 6",
+		"non-numeric memF":     "5 12 3 x 5 6",
+		"non-numeric diskT":    "5 12 3 4 x 6",
+		"non-numeric diskF":    "5 12 3 4 5 x",
+		"mem free over total":  "5 12 100 200 500 100",
+		"disk free over total": "5 12 300 100 500 900",
 	} {
 		if _, err := parseHostSample(line); err == nil {
 			t.Errorf("%s: want error, got nil (%q)", name, line)

--- a/internal/sysstat/host_other.go
+++ b/internal/sysstat/host_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package sysstat
+
+func startHostSampler() {}
+
+func overlayHost(*Snapshot) {}
+
+func hostMemTotal() (uint64, bool) {
+	return 0, false
+}
+
+func hostNCPU() (int, bool) {
+	return 0, false
+}

--- a/internal/sysstat/host_other_test.go
+++ b/internal/sysstat/host_other_test.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package sysstat
+
+import "testing"
+
+func disableHostSampling(*testing.T) {}

--- a/internal/sysstat/sysstat.go
+++ b/internal/sysstat/sysstat.go
@@ -76,6 +76,8 @@ func Sample(diskPath string) Snapshot {
 	sampleDisk(&snap, diskPath)
 	sampleNet(&snap)
 	sampleTemps(&snap)
+	startHostSampler()
+	overlayHost(&snap)
 
 	return snap
 }
@@ -279,6 +281,9 @@ func isDieSensor(key string) bool {
 // LogicalCPUs is the number of logical processors used as the denominator
 // when converting process-style pcpu into a share of the machine.
 func LogicalCPUs() int {
+	if n, ok := hostNCPU(); ok {
+		return n
+	}
 	if n, err := cpu.Counts(true); err == nil && n > 0 {
 		return n
 	}
@@ -290,6 +295,9 @@ func LogicalCPUs() int {
 
 // MemTotalBytes is installed RAM, used as the denominator for agent RAM %.
 func MemTotalBytes() (uint64, bool) {
+	if t, ok := hostMemTotal(); ok {
+		return t, true
+	}
 	vm, err := mem.VirtualMemory()
 	if err != nil || vm.Total == 0 {
 		return 0, false

--- a/internal/sysstat/sysstat_test.go
+++ b/internal/sysstat/sysstat_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestSample(t *testing.T) {
+	disableHostSampling(t)
 	snap := Sample("/")
 	if snap.MemOK && snap.MemTotal == 0 {
 		t.Fatal("mem reported OK but total is zero")

--- a/internal/wsl/detect.go
+++ b/internal/wsl/detect.go
@@ -1,0 +1,23 @@
+// Package wsl reports whether the process runs under WSL.
+package wsl
+
+import (
+	"os"
+	"strings"
+)
+
+var osReleaseFile = "/proc/sys/kernel/osrelease"
+
+// Detect reports whether the process runs under WSL (env markers or a
+// Microsoft kernel release string).
+func Detect() bool {
+	if os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSL_INTEROP") != "" {
+		return true
+	}
+	data, err := os.ReadFile(osReleaseFile)
+	if err != nil {
+		return false
+	}
+	release := strings.ToLower(string(data))
+	return strings.Contains(release, "microsoft") || strings.Contains(release, "wsl")
+}

--- a/internal/wsl/detect.go
+++ b/internal/wsl/detect.go
@@ -8,8 +8,6 @@ import (
 
 var osReleaseFile = "/proc/sys/kernel/osrelease"
 
-// Detect reports whether the process runs under WSL (env markers or a
-// Microsoft kernel release string).
 func Detect() bool {
 	if os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSL_INTEROP") != "" {
 		return true

--- a/internal/wsl/detect_test.go
+++ b/internal/wsl/detect_test.go
@@ -1,0 +1,53 @@
+package wsl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const origReleaseFile = "/proc/sys/kernel/osrelease"
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		release string
+		want    bool
+	}{
+		{name: "distro name env", env: map[string]string{"WSL_DISTRO_NAME": "Ubuntu"}, want: true},
+		{name: "interop env", env: map[string]string{"WSL_INTEROP": "/run/WSL/1_interop"}, want: true},
+		{name: "microsoft kernel", release: "6.6.87-microsoft-standard-WSL2", want: true},
+		{name: "wsl kernel", release: "5.15.90.1-wsl", want: true},
+		{name: "plain linux kernel", release: "6.8.0-generic", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() { osReleaseFile = origReleaseFile }()
+			t.Setenv("WSL_DISTRO_NAME", "")
+			t.Setenv("WSL_INTEROP", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			if tt.release != "" {
+				osReleaseFile = filepath.Join(t.TempDir(), "osrelease")
+				if err := os.WriteFile(osReleaseFile, []byte(tt.release), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := Detect(); got != tt.want {
+				t.Fatalf("Detect() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectUnreadableReleaseFile(t *testing.T) {
+	defer func() { osReleaseFile = origReleaseFile }()
+	t.Setenv("WSL_DISTRO_NAME", "")
+	t.Setenv("WSL_INTEROP", "")
+	osReleaseFile = filepath.Join(t.TempDir(), "missing")
+	if Detect() {
+		t.Fatal("unreadable release file should not mark WSL")
+	}
+}


### PR DESCRIPTION
## Summary
- On WSL2 the Computer block now reports the Windows machine: CPU, memory, and disk come from the host through PowerShell interop, sampled in a background loop every 30s and kept for three intervals, so two missed probes do not flip the block back; guest numbers remain as fallback when interop is unavailable.
- CPU reads `% Processor Utility` (`Win32_PerfFormattedData_Counters_ProcessorInformation`), the counter behind Task Manager's dial since Windows 8, falling back to `% Processor Time` where that class is absent. The drive comes from `$env:SystemDrive`.
- Agent RAM % and CPU-share denominators (installed RAM, logical processors) use host figures too, so fleet percentages are shares of the real machine.
- WSL detection moves from internal/clipboard into a shared `internal/wsl` package.

Fixes #320

## Testing
- New tests for WSL detection, probe-line parsing, overlay/staleness, accessor behavior, and sampler gating (`env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...` passes, including `-race` on the touched packages).
- Verified live on a WSL2 machine: first paint shows guest values, then host figures land (32 GB RAM / 12 cores / C: drive vs the guest's 16 GB / 8 cores / VHD).
- The probe script runs against stubbed CIM classes under PowerShell 7.4: both counter paths and `$env:SystemDrive` produce the six fields the parser wants, and a missing class yields a short line the parser rejects, leaving the guest numbers in place.
- `gofmt -l .` clean, `go vet ./...` clean, GOOS=darwin and GOOS=windows builds pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WSL2 host telemetry for CPU, processor count, memory, disk, and agent-percentage metrics.
  * Host metrics refresh every 30 seconds when Windows integration is available.
  * Guest metrics remain available as a fallback; swap, network, and temperature continue using guest data.

* **Documentation**
  * Documented WSL2 metric sources, refresh timing, and fallback behavior.

* **Bug Fixes**
  * Improved WSL detection consistency across clipboard and system monitoring features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
