### PR TITLE
fix(ui): settle a working pane whose spinner row outlived its turn

### DIFF
--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -908,9 +908,12 @@ func (p *poller) derivePaneStatus(sess store.Session, pane string, agentAlive bo
 				}
 				delete(p.quietSince, sess.ID)
 			} else if turnInFlight(sess.Status) {
-				// Already resting: re-infer finished vs waiting without delay.
 				if sess.Status != status.Working {
-					newStatus = p.engine.TurnEndedState(sess.Tool, region)
+					// Already resting: re-infer finished vs waiting without
+					// delay, unless the rules now read the pane as working.
+					if !stuck {
+						newStatus = p.engine.TurnEndedState(sess.Tool, region)
+					}
 				} else {
 					// Mid-turn pauses (thinking, between tools) look quiet for
 					// a poll or two; wait before treating that as turn end.
@@ -934,7 +937,7 @@ func (p *poller) derivePaneStatus(sess store.Session, pane string, agentAlive bo
 					}
 				}
 			}
-		} else if turnInFlight(sess.Status) {
+		} else if turnInFlight(sess.Status) && !stuck {
 			newStatus = sess.Status
 		}
 	} else {

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -60,7 +60,8 @@ type poller struct {
 	runMu      sync.Mutex
 	paneHashes map[string]uint64
 	// quietSince is when each session's activity region last stopped
-	// changing while unmatched; used to debounce marker-less turn ends.
+	// changing while the pane read as working; used to debounce both
+	// marker-less turn ends and spinner rows that never resolve.
 	quietSince map[string]time.Time
 	// heartbeatAt is when this manager last stamped its liveness row.
 	heartbeatAt time.Time
@@ -77,6 +78,13 @@ type poller struct {
 // One poll is not enough: agents pause between tools (and a fast poll
 // interval would flap working/finished every few ticks).
 var quietEndGrace = time.Second
+
+// stuckEndGrace is the longer stability a rule-matched working pane needs
+// before the same quiet path may settle it. A live agent animates its pane
+// (spinner frames, ticking timers) within a poll or two, so a spinner row
+// that sits unchanged this long belongs to a turn that died without ever
+// printing its end marker.
+var stuckEndGrace = 15 * time.Second
 
 // startingGrace caps how long a session may show the launch state before the
 // poll derives its real status regardless, so a tool that never paints its
@@ -852,9 +860,11 @@ func (p *poller) reflowSessions(ids []string, reflow func()) {
 // transition closes marker-less turns: a session that was mid-turn whose
 // region stopped changing has ended its turn even when the tool printed
 // no turn_end line, so the region's last content line decides finished
-// versus waiting. Finished is an alert: entering the session acknowledges
-// it (acked), and the pane keeps deriving finished until the next turn,
-// so acked maps it back to idle.
+// versus waiting. A matched working verdict gets the same treatment after
+// a longer stability window, since a spinner row can outlive its turn
+// when the turn died before printing any end marker. Finished is an
+// alert: entering the session acknowledges it (acked), and the pane keeps
+// deriving finished until the next turn, so acked maps it back to idle.
 //
 // A missing prior hash (first observation, or post-resize rebaseline)
 // never invents working and never collapses finished/waiting to the tool
@@ -879,10 +889,13 @@ func (p *poller) derivePaneStatus(sess store.Session, pane string, agentAlive bo
 		}
 	}
 	newStatus, matched := p.engine.Match(sess.Tool, text)
-	if hasRegion && !matched {
+	stuck := matched && newStatus == status.Working
+	if hasRegion && (!matched || stuck) {
 		if previous, seen := p.paneHashes[sess.ID]; seen {
 			if previous != regionHash {
-				newStatus = status.Working
+				if !matched {
+					newStatus = status.Working
+				}
 				delete(p.quietSince, sess.ID)
 			} else if turnInFlight(sess.Status) {
 				// Already resting: re-infer finished vs waiting without delay.
@@ -891,13 +904,17 @@ func (p *poller) derivePaneStatus(sess store.Session, pane string, agentAlive bo
 				} else {
 					// Mid-turn pauses (thinking, between tools) look quiet for
 					// a poll or two; wait before treating that as turn end.
+					grace := quietEndGrace
+					if stuck {
+						grace = stuckEndGrace
+					}
 					now := time.Now()
 					since, ok := p.quietSince[sess.ID]
 					if !ok {
 						p.quietSince[sess.ID] = now
 						since = now
 					}
-					if now.Sub(since) >= quietEndGrace {
+					if now.Sub(since) >= grace {
 						newStatus = p.engine.TurnEndedState(sess.Tool, region)
 						if newStatus != status.Working {
 							delete(p.quietSince, sess.ID)

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -61,8 +61,10 @@ type poller struct {
 	paneHashes map[string]uint64
 	// quietSince is when each session's activity region last stopped
 	// changing while the pane read as working; used to debounce both
-	// marker-less turn ends and spinner rows that never resolve.
-	quietSince map[string]time.Time
+	// marker-less turn ends and spinner rows that never resolve. The stuck
+	// flag travels with the timer so a rule classification change restarts
+	// the grace instead of inheriting the previous one.
+	quietSince map[string]quietTimer
 	// heartbeatAt is when this manager last stamped its liveness row.
 	heartbeatAt time.Time
 	tick        int
@@ -85,6 +87,14 @@ var quietEndGrace = time.Second
 // that sits unchanged this long belongs to a turn that died without ever
 // printing its end marker.
 var stuckEndGrace = 15 * time.Second
+
+// quietTimer pairs the quiet timestamp with the rule classification it
+// started under, so an unmatched-to-working flip cannot spend the previous
+// classification's grace.
+type quietTimer struct {
+	since time.Time
+	stuck bool
+}
 
 // startingGrace caps how long a session may show the launch state before the
 // poll derives its real status regardless, so a tool that never paints its
@@ -111,7 +121,7 @@ func newPoller(st *store.Store, driver *tmux.Driver, engine *status.Engine, hook
 		interval:      interval,
 		poke:          make(chan struct{}, 1),
 		paneHashes:    map[string]uint64{},
-		quietSince:    map[string]time.Time{},
+		quietSince:    map[string]quietTimer{},
 		notifyFn:      notify.Notify,
 	}
 }
@@ -909,12 +919,12 @@ func (p *poller) derivePaneStatus(sess store.Session, pane string, agentAlive bo
 						grace = stuckEndGrace
 					}
 					now := time.Now()
-					since, ok := p.quietSince[sess.ID]
-					if !ok {
-						p.quietSince[sess.ID] = now
-						since = now
+					timer, ok := p.quietSince[sess.ID]
+					if !ok || timer.stuck != stuck {
+						timer = quietTimer{since: now, stuck: stuck}
+						p.quietSince[sess.ID] = timer
 					}
-					if now.Sub(since) >= grace {
+					if now.Sub(timer.since) >= grace {
 						newStatus = p.engine.TurnEndedState(sess.Tool, region)
 						if newStatus != status.Working {
 							delete(p.quietSince, sess.ID)

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -540,6 +541,22 @@ func TestStuckSpinnerHoldsWorkingUntilGrace(t *testing.T) {
 	seedRegionHash(t, m, sess, pane)
 	if got := deriveStatus(t, m, sess, pane, true); got != status.Working {
 		t.Fatalf("matched spinner within the grace should stay working, got %q", got)
+	}
+}
+
+// A rule-matched working verdict wins over a resting stored status: a
+// session that already read finished or waiting but whose newest turn now
+// matches a working rule is working again, on the first stable observation.
+func TestMatchedWorkingWinsOverRestingStatus(t *testing.T) {
+	m := buildModel(t)
+	defaultEngine(t, m)
+	pane := "▣  Build · Ox Alpha Free (Unlimited)\n┃\n╹▀▀▀▀\n"
+	for i, stored := range []string{status.Finished, status.Waiting} {
+		sess := store.Session{ID: fmt.Sprintf("win-%d", i), Tool: "opencode", Status: stored}
+		seedRegionHash(t, m, sess, pane)
+		if got := deriveStatus(t, m, sess, pane, true); got != status.Working {
+			t.Fatalf("stored %s with a matched working pane should read working, got %q", stored, got)
+		}
 	}
 }
 

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -543,6 +543,33 @@ func TestStuckSpinnerHoldsWorkingUntilGrace(t *testing.T) {
 	}
 }
 
+// A tool without turn_end matches its rules over the whole pane, so a pane
+// can flip from unmatched to rule-matched working while the activity-region
+// hash stays put (the change lives below the cutoff, as gemini's status line
+// does). The stuck grace must start fresh rather than inherit the unmatched
+// quiet timer.
+func TestMatchedWorkingAfterQuietRestartsGrace(t *testing.T) {
+	prevQuiet, prevStuck := quietEndGrace, stuckEndGrace
+	quietEndGrace = time.Hour
+	stuckEndGrace = time.Nanosecond
+	t.Cleanup(func() {
+		quietEndGrace = prevQuiet
+		stuckEndGrace = prevStuck
+	})
+	m := buildModel(t)
+	defaultEngine(t, m)
+	sess := store.Session{ID: "flip-gemini", Tool: "gemini", Status: status.Working}
+	quietPane := "completed output\n> \n"
+	spinnerPane := "completed output\n> \nesc to cancel\n"
+	seedRegionHash(t, m, sess, quietPane)
+	if got := deriveStatus(t, m, sess, quietPane, true); got != status.Working {
+		t.Fatalf("quiet unmatched pane within its grace should stay working, got %q", got)
+	}
+	if got := deriveStatus(t, m, sess, spinnerPane, true); got != status.Working {
+		t.Fatalf("a fresh stuck grace should hold working, got %q", got)
+	}
+}
+
 // A live agent animates its pane every poll or two; a changing region must
 // keep a rule-matched working verdict working no matter how long it runs.
 func TestAnimatedMatchedWorkingStaysWorking(t *testing.T) {

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -436,6 +436,26 @@ func disableQuietEndGrace(t *testing.T) {
 	t.Cleanup(func() { quietEndGrace = prev })
 }
 
+func disableStuckEndGrace(t *testing.T) {
+	t.Helper()
+	prev := stuckEndGrace
+	stuckEndGrace = 0
+	t.Cleanup(func() { stuckEndGrace = prev })
+}
+
+func defaultEngine(t *testing.T, m *Model) {
+	t.Helper()
+	cfg, err := config.Default()
+	if err != nil {
+		t.Fatalf("default config: %v", err)
+	}
+	engine, err := status.NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("status engine: %v", err)
+	}
+	m.poller.engine = engine
+}
+
 func TestQuietPaneAfterWorkingDerivesFinished(t *testing.T) {
 	disableQuietEndGrace(t)
 	m := buildModel(t)
@@ -450,14 +470,7 @@ func TestQuietPaneAfterWorkingDerivesFinished(t *testing.T) {
 func TestQuietCodexPaneQuotingInterruptHintDerivesFinished(t *testing.T) {
 	disableQuietEndGrace(t)
 	m := buildModel(t)
-	cfg, err := config.Default()
-	if err != nil {
-		t.Fatalf("default config: %v", err)
-	}
-	m.poller.engine, err = status.NewEngine(cfg)
-	if err != nil {
-		t.Fatalf("status engine: %v", err)
-	}
+	defaultEngine(t, m)
 	sess := store.Session{ID: "quiet-codex", Tool: "codex", Status: status.Working}
 	pane := "Output:\n\ntool: mytool\nresult: working\npattern: esc to interrupt\ndefault: idle\n\n› Summarize recent commits\n"
 	seedRegionHash(t, m, sess, pane)
@@ -497,6 +510,50 @@ func TestQuietPaneAfterIdleStaysIdle(t *testing.T) {
 	seedRegionHash(t, m, sess, pane)
 	if got := deriveStatus(t, m, sess, pane, true); got != status.Idle {
 		t.Fatalf("quiet pane after idle should stay idle, got %q", got)
+	}
+}
+
+// An opencode turn that dies before its header row gains a duration leaves
+// a bare spinner row behind, which keeps matching the working rule forever.
+// Once the region stops changing for the stuck grace the quiet-region path
+// settles it from the region's own last content line.
+func TestStuckOpencodeSpinnerSettlesFinished(t *testing.T) {
+	disableStuckEndGrace(t)
+	m := buildModel(t)
+	defaultEngine(t, m)
+	sess := store.Session{ID: "stuck-oc", Tool: "opencode", Status: status.Working}
+	pane := "▣  Build · Ox Alpha Free (Unlimited)\n┃\n╹▀▀▀▀\n"
+	seedRegionHash(t, m, sess, pane)
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Finished {
+		t.Fatalf("stuck spinner past the grace should settle finished, got %q", got)
+	}
+}
+
+func TestStuckSpinnerHoldsWorkingUntilGrace(t *testing.T) {
+	prev := stuckEndGrace
+	stuckEndGrace = time.Hour
+	t.Cleanup(func() { stuckEndGrace = prev })
+	m := buildModel(t)
+	defaultEngine(t, m)
+	sess := store.Session{ID: "stuck-hold", Tool: "opencode", Status: status.Working}
+	pane := "▣  Build · Ox Alpha Free (Unlimited)\n┃\n╹▀▀▀▀\n"
+	seedRegionHash(t, m, sess, pane)
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Working {
+		t.Fatalf("matched spinner within the grace should stay working, got %q", got)
+	}
+}
+
+// A live agent animates its pane every poll or two; a changing region must
+// keep a rule-matched working verdict working no matter how long it runs.
+func TestAnimatedMatchedWorkingStaysWorking(t *testing.T) {
+	m := buildModel(t)
+	defaultEngine(t, m)
+	sess := store.Session{ID: "anim-oc", Tool: "opencode", Status: status.Working}
+	still := "⠋ listing files\n▣  Build · Ox Alpha Free (Unlimited)\n┃\n╹▀▀▀▀\n"
+	moved := "⠙ listing files\n▣  Build · Ox Alpha Free (Unlimited)\n┃\n╹▀▀▀▀\n"
+	seedRegionHash(t, m, sess, still)
+	if got := deriveStatus(t, m, sess, moved, true); got != status.Working {
+		t.Fatalf("an animating matched-working pane should stay working, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## What

A rule-matched working pane whose activity region stops changing now settles through the same quiet-region path the unmatched case already used, after a longer stability window (`stuckEndGrace`, 15s). A live agent animates its pane (spinner frames, ticking timers) within a poll or two, so a spinner row frozen that long belongs to a turn that died before printing its end marker.

## Why

opencode draws its turn header (`▣ Build · <model>`) when a turn starts and appends a duration only when the turn completes. A turn that dies first leaves the bare header behind, and it keeps matching the working rule on every poll, so the session showed "working" indefinitely. The quiet-region fallback in `derivePaneStatus` only ran when no rule matched, so a rule-matched working verdict could never settle. The stuck path reuses `TurnEndedState`, so the region's last content line still decides finished versus waiting.

## Verified

From this branch:

- `TestStuckOpencodeSpinnerSettlesFinished`: bare opencode spinner row past the grace settles finished.
- `TestStuckSpinnerHoldsWorkingUntilGrace`: within the grace the matched verdict holds.
- `TestAnimatedMatchedWorkingStaysWorking`: a region that keeps changing keeps working.
- Live check against opencode 1.18.21: a completed turn gains `· 13.7s`, an interrupted one `· interrupted`, and a hung turn leaves the bare row this fix targets.
- `gofmt -l .` prints nothing, `go vet ./...` is clean, and the full `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...` suite passes on an isolated tmux socket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane status detection to avoid prematurely marking active work as finished.
  * Added a 15-second grace period for unchanged panes that still indicate active work.
  * Improved spinner handling so panes remain marked as working during expected activity and settle as finished when a spinner becomes stuck.
  * Preserved faster completion detection for quiet panes without active-work indicators.
  * Status detection now correctly resumes working state when activity reappears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->