### PR TITLE
docs(feed): announce v0.33.0

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "command-code-joins-built-in-tools",
+    "banner": "new: Command Code joins the built-in tools",
+    "title": "Command Code gets live status and exact revival out of the box",
+    "body": [
+      "Command Code sessions now run as a built-in tool: status rules captured from its real TUI, prompt delivery, approvals.",
+      "`revive` resumes the exact conversation through Command Code's own session store, reading the id from its transcript.",
+      "Deleting or archiving a session clears its row on the same frame instead of lingering until the next poll.",
+      "A working pane whose turn died without an end marker settles after a quiet window instead of showing working forever.",
+      "Thanks to @dolutech: asked for Command Code (#380), then built it (#385); #388 on reboot recovery is next.",
+      "Update with `agent-manager update`, `brew upgrade yoanwai/tap/agent-manager`, or your package manager."
+    ],
+    "url": "https://github.com/YoanWai/agent-manager/releases/tag/v0.33.0",
+    "max_version": "0.33.0"
+  },
+  {
     "id": "agent-teams-split-the-window",
     "banner": "fix: previews follow the agent, not its teammates",
     "title": "An agent that splits its own window keeps the preview on itself",


### PR DESCRIPTION
One `docs/messages.json` entry announcing v0.33.0, first in the file so running installs see it above the older ones.

## What
- Command Code as a built-in tool with live status and exact revival (#385), credited to @dolutech (#380, #385) with #388 named as what comes next.
- The two list fixes: same-frame delete/archive rows, and a stuck working pane settling after its quiet window.

## Verified
- `max_version` is `0.33.0`, so the entry retires with the release it announces.
- `go test ./internal/feed/` passes against the real file (caught a 122-char body line, shortened it).
- `gofmt -l .` prints nothing, `go vet ./...` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Command Code integration with live status updates, prompt delivery, approval support, and session recovery.
  * Added exact session revival and cleanup of completed session rows.
* **Documentation**
  * Documented update commands and credited contributors in the 0.33.0 release message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->