### PR TITLE
feat: show arrow step hints when enabled

### DIFF
--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -184,10 +185,19 @@ func reviewHelpSection() helpSection {
 }
 
 func (m *Model) visibleHelpSections() []helpSection {
-	if m.help.returnMode != modeDiff {
-		return helpSections()
+	if m.help.returnMode == modeDiff {
+		return []helpSection{reviewHelpSection()}
 	}
-	return []helpSection{reviewHelpSection()}
+	sections := helpSections()
+	if m.arrowStep {
+		return sections
+	}
+	for i := range sections {
+		sections[i].rows = slices.DeleteFunc(sections[i].rows, func(row [2]string) bool {
+			return row[0] == "→" || row[0] == "←"
+		})
+	}
+	return sections
 }
 
 // matchHelp narrows the catalog to the rows whose key or description

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -210,8 +210,37 @@ func TestGlobalHelpShowsAgentManagementGuidance(t *testing.T) {
 	}
 }
 
+func TestHelpArrowStepRowsFollowSetting(t *testing.T) {
+	hasRow := func(sections []helpSection, title, key string) bool {
+		for _, section := range sections {
+			if section.title != title {
+				continue
+			}
+			for _, row := range section.rows {
+				if row[0] == key {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	for _, enabled := range []bool{true, false} {
+		sections := (&Model{arrowStep: enabled}).visibleHelpSections()
+		for _, row := range []struct{ title, key string }{
+			{"list", "→"},
+			{"list", "←"},
+			{"inside a session (attached or focused)", "←"},
+		} {
+			if got := hasRow(sections, row.title, row.key); got != enabled {
+				t.Errorf("arrow step enabled = %v: %q in %q = %v", enabled, row.key, row.title, got)
+			}
+		}
+	}
+}
+
 func helpModel() *Model {
-	return &Model{width: 120, height: 30, mode: modeHelp}
+	return &Model{width: 120, height: 30, mode: modeHelp, arrowStep: true}
 }
 
 func TestHelpScrollClampsToContent(t *testing.T) {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -476,14 +476,19 @@ func (m *Model) viewFooter() string {
 	// tier, which would name keys the agent receives.
 	if m.mode == modeFocus {
 		pairs := [][2]string{
-			{"typing", "goes to the agent"},
-			{"ctrl+q / ctrl+\\", "back to manager"},
+			{"typing", "to agent"},
+			{"ctrl+q / ctrl+\\", "back"},
+		}
+		if m.arrowStep {
+			pairs = append(pairs, [2]string{"←", "prompt start: back"})
+		}
+		pairs = append(pairs, [][2]string{
 			{"ctrl+r", "review"},
 			{"f3", "editor"},
 			// The footer holds one row: the word and line gestures are in
 			// the key map, where there is room to name all three.
 			{"drag / click", "copy"},
-		}
+		}...)
 		if m.pane.mouse {
 			pairs = append(pairs, [2]string{"click / alt+drag", "agent UI"})
 		}
@@ -519,11 +524,16 @@ func (m *Model) rowLegend() legendSection {
 		if m.collapsed[row.group] {
 			foldAction = "unfold"
 		}
-		return legendSection{title: "Group", pairs: [][2]string{
-			{"↵", foldAction}, {"o", "editor"}, {"r", "rename"}, {"m", "move"},
+		pairs := [][2]string{{"↵", foldAction}}
+		if m.arrowStep {
+			pairs = append(pairs, [2]string{"←→", "close / open"})
+		}
+		pairs = append(pairs, [][2]string{
+			{"o", "editor"}, {"r", "rename"}, {"m", "move"},
 			{"x/X", "kill / all"}, {"v/V", "revive / all"},
 			{"a/u", "archive / restore"}, {"d", "delete"},
-		}}
+		}...)
+		return legendSection{title: "Group", pairs: pairs}
 	}
 	title := "Session"
 	conversation := [][2]string{{"space", "prompt"}, {"ctrl+r", "review"}, {"f", "fork"}}
@@ -533,6 +543,9 @@ func (m *Model) rowLegend() legendSection {
 		title, conversation = "Shell", nil
 	}
 	pairs := [][2]string{{"↵", enterHint}, {"A", attachHint}}
+	if m.arrowStep {
+		pairs = append(pairs, [2]string{"→", "focus"})
+	}
 	if row.sess.Status == status.Finished && !row.sess.Archived {
 		pairs = append(pairs, [2]string{".", "mark idle"})
 	}

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -479,7 +479,7 @@ func TestFooterInFocusMode(t *testing.T) {
 	if !strings.Contains(footer, "Focused") {
 		t.Fatalf("the tier should name the mode it describes:\n%s", footer)
 	}
-	if !strings.Contains(footer, "back to manager") || !strings.Contains(footer, "goes to the agent") {
+	if !strings.Contains(footer, "ctrl+q / ctrl+\\ back") || !strings.Contains(footer, "typing to agent") {
 		t.Fatalf("focus footer should carry the reserved keys:\n%s", footer)
 	}
 	if strings.Contains(footer, "navigate") || strings.Contains(footer, "View") {
@@ -497,6 +497,33 @@ func TestFooterInFocusMode(t *testing.T) {
 	m.pane.mouse = true
 	if footer := ansi.Strip(m.viewFooter()); !strings.Contains(footer, "click / alt+drag") || !strings.Contains(footer, "agent UI") {
 		t.Fatalf("a mouse-tracking pane should advertise pass-through:\n%s", footer)
+	}
+}
+
+func TestArrowStepFooterHintsFollowSetting(t *testing.T) {
+	m := buildModel(t)
+	if err := m.store.CreateGroup("arrow-group", ""); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "arrow-hints", t.TempDir(), "")
+	assertHint := func(context, hint string, enabled bool) {
+		t.Helper()
+		footer := ansi.Strip(m.viewFooter())
+		if got := strings.Contains(footer, hint); got != enabled {
+			t.Fatalf("arrow step enabled = %v: %s hint %q = %v:\n%s", enabled, context, hint, got, footer)
+		}
+	}
+
+	for _, enabled := range []bool{true, false} {
+		m.arrowStep = enabled
+		m.mode = modeList
+		m.selectSessionRow(t, "arrow-hints")
+		assertHint("session", "→ focus", enabled)
+		m.selectGroupRow(t, "arrow-group")
+		assertHint("group", "←→ close / open", enabled)
+		m.mode = modeFocus
+		assertHint("focus", "← prompt start: back", enabled)
 	}
 }
 


### PR DESCRIPTION
## What

- Show the arrow-step shortcut in session, group, and focused footers while the beta setting is enabled.
- Hide the arrow-step rows from the help menu when the setting is disabled.
- Cover enabled and disabled footer/help behavior with regression tests.

## Why

The arrow-step feature is enabled by default but its live footer did not advertise it, while help continued advertising it after opt-out. The visible key guidance should match the active setting.

## Verified

- `env -u TMUX TMUX_TMPDIR=/tmp/amtest-arrow-clean-final go test ./...`
- `go vet ./...`
- `gofmt -l .` prints nothing
- Live TUI checks at 140, 80, 60, and 40 columns, including toggling the setting off and back on


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **User Experience**
  - Updated help and footer legends to accurately reflect available navigation actions.
  - Added contextual arrow-key hints for step-by-step navigation, including moving back, opening or closing groups, and focusing sessions.
  - Help sections now consistently show or hide navigation bindings based on the active setting.
  - Refined focused-mode labels for clearer return and agent-input actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->