### PR TITLE
feat(config): add Command Code fork_command

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ Rules match top-down against the visible pane text; first match wins, and `defau
 - `{new_id}`: A new UUID that Agent Manager records for exact revival.
 - `{name}`: The new Agent Manager session name.
 
-A `fork_command` references its source through `{id}` or `{session_file}`, so one of those two is required. Claude Code, OpenCode, Codex, Grok, Gemini CLI, and Pi include default fork commands. A custom tool can omit `{new_id}` when its `session_store` captures the generated ID.
+A `fork_command` references its source through `{id}` or `{session_file}`, so one of those two is required. Claude Code, OpenCode, Codex, Grok, Gemini CLI, Pi, and Command Code include default fork commands. A custom tool can omit `{new_id}` when its `session_store` captures the generated ID.
 
 **Prompts.** `prompt_flag` controls how the new-session form's optional prompt is embedded into the launch command. Tools that take the prompt as a positional argument (Claude Code: `claude 'the prompt'`) leave it empty; tools whose positional argument means something else declare the flag (OpenCode: `prompt_flag = "--prompt"`, since its positional argument is the project path). `prompt_mode = "send"` handles a persistent CLI that accepts no startup prompt: Agent Manager waits until `activity_cutoff` finds its input box, then submits the prompt there (Hermes uses this). Set it to `"argument"` if a custom Hermes wrapper accepts a launch argument instead. The prompt setting only affects a new launch; revive (`v`) uses the revive commands untouched.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -135,7 +135,7 @@ It asks to confirm first, and it works on a live session too: the running agent 
 
 The fork uses the source session's tool, group, working directory, and conversation history.
 
-Claude Code, OpenCode, Codex, Grok, Gemini CLI, and Pi include default fork commands. A custom tool needs a `fork_command` in its configuration. The source session must have a captured conversation ID.
+Claude Code, OpenCode, Codex, Grok, Gemini CLI, Pi, and Command Code include default fork commands. A custom tool needs a `fork_command` in its configuration. The source session must have a captured conversation ID.
 
 A fork shares its source session's managed worktree. Agent Manager keeps the worktree until you delete the last session that uses it. You cannot rename the worktree while another session uses it.
 

--- a/internal/agentsession/capture.go
+++ b/internal/agentsession/capture.go
@@ -134,14 +134,24 @@ func commandCodeMeta(path string) (id, cwd string, ok bool) {
 		return "", "", false
 	}
 	var line struct {
-		Type string `json:"type"`
-		ID   string `json:"id"`
-		Cwd  string `json:"cwd"`
+		Type      string `json:"type"`
+		ID        string `json:"id"`
+		SessionID string `json:"sessionId"`
+		Cwd       string `json:"cwd"`
 	}
 	if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
 		return "", "", false
 	}
-	if line.Type != "session" || !sessionIDPattern.MatchString(line.ID) {
+	if line.Type != "session" {
+		return "", "", false
+	}
+	// A forked transcript keeps the parent's id in "id" and mints its own in
+	// "sessionId" (cmd 1.32.2); prefer it so a fork is never mistaken for its
+	// parent, whose id is already claimed.
+	if sessionIDPattern.MatchString(line.SessionID) {
+		return line.SessionID, line.Cwd, true
+	}
+	if !sessionIDPattern.MatchString(line.ID) {
 		return "", "", false
 	}
 	return line.ID, line.Cwd, true

--- a/internal/agentsession/capture_test.go
+++ b/internal/agentsession/capture_test.go
@@ -108,6 +108,27 @@ func commandCodeSession(sessionID, cwd string) string {
 		`{"role":"user","content":[{"type":"text","text":"hi"}]}` + "\n"
 }
 
+// A forked transcript keeps the parent's id and mints its own under
+// sessionId, the shape cmd 1.32.2 writes for `--fork-session`.
+func commandCodeForkSession(parentID, sessionID, cwd string) string {
+	return `{"type":"session","version":3,"id":"` + parentID +
+		`","timestamp":"2026-08-25T17:03:30.026Z","cwd":"` + cwd +
+		`","sessionId":"` + sessionID + `"}` + "\n" +
+		`{"role":"user","content":[{"type":"text","text":"hi"}]}` + "\n"
+}
+
+func TestCaptureCommandCodeForkPrefersSessionID(t *testing.T) {
+	root := t.TempDir()
+	launch := time.Now()
+	writeFile(t, filepath.Join(root, "a", "fork.jsonl"),
+		commandCodeForkSession("parent-uuid", "fork-uuid", "/repo"), launch.Add(time.Second))
+
+	id, ok := captureCommandCode(root, "/repo", launch, map[string]bool{"parent-uuid": true})
+	if !ok || id != "fork-uuid" {
+		t.Fatalf("got id=%q ok=%v, want fork-uuid true", id, ok)
+	}
+}
+
 func TestCaptureCommandCodePicksSessionAfterLaunchInCwd(t *testing.T) {
 	root := t.TempDir()
 	launch := time.Now()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -547,6 +547,7 @@ command = "cmd"
 # command-code mints its own session id; capture it after launch and resume it
 session_store = "command-code"
 resume_by_id_command = "cmd --session {id}"
+fork_command = "cmd --session {id} --fork-session --name {name}"
 # fallback: resumes the most recent conversation for the directory
 revive_command = "cmd --continue"
 default_status = "idle"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -90,6 +90,9 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if commandCode.SessionStore != "command-code" || commandCode.ResumeByIDCommand != "cmd --session {id}" {
 		t.Fatalf("command-code resume config = %+v", commandCode)
 	}
+	if got := commandCode.ForkCommand; got != "cmd --session {id} --fork-session --name {name}" {
+		t.Fatalf("command-code fork_command = %q want \"cmd --session {id} --fork-session --name {name}\"", got)
+	}
 	if got := commandCode.PromptFlag; got != "" {
 		t.Fatalf("command-code prompt_flag = %q want empty (positional prompt)", got)
 	}
@@ -447,7 +450,8 @@ func TestDefaultResumeByIDFields(t *testing.T) {
 
 func TestBackfillFillsResumeFields(t *testing.T) {
 	cfg := Config{Tools: map[string]Tool{
-		"claude": {Command: "claude", ReviveCommand: "claude --continue"},
+		"claude":       {Command: "claude", ReviveCommand: "claude --continue"},
+		"command-code": {Command: "cmd"},
 	}}
 	if err := cfg.backfillToolDefaults(); err != nil {
 		t.Fatalf("backfill: %v", err)
@@ -461,5 +465,8 @@ func TestBackfillFillsResumeFields(t *testing.T) {
 	}
 	if tool.ForkCommand == "" {
 		t.Fatal("claude fork_command was not backfilled")
+	}
+	if got := cfg.Tools["command-code"].ForkCommand; got != "cmd --session {id} --fork-session --name {name}" {
+		t.Fatalf("command-code fork_command = %q want backfilled", got)
 	}
 }


### PR DESCRIPTION
## What changed

Command Code now has a default `fork_command`, so `f` on a Command Code session with a captured conversation id starts a named sibling on that history.

The command is `cmd --session {id} --fork-session --name {name}`. Command Code mints the forked conversation id; the existing `session_store = "command-code"` capturer reads it back, the same shape as OpenCode and Codex.

Existing configs pick the field up on load.

## Why

Command Code 1.32.1 already forks at launch (`--fork-session` with `--session` / `--resume` / `--continue`) and in the TUI (`/fork`). Agent Manager's `f` key had nothing to run.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` except `TestPendingInputWaitsForTheLaunchPrompt` (pre-existing 500ms launch-prompt race on origin/main under `-race`; not in this diff)
- [x] `TestShippedForkCommandsValidate` now includes Command Code
- [x] Backfill fills `fork_command` on an older `[tools.command-code]` block
- [x] Command Code 1.32.1 help: `--fork-session` works with `--session`; `-n, --name` sets the display name
- [x] Live fork on cmd 1.32.2: `cmd --session <id> --fork-session --name <n>` forks a real conversation (new transcript, `parentSessionId` set, original untouched)
- [x] A forked transcript keeps the parent id in `"id"` and mints its own under `"sessionId"`; the capturer now prefers `"sessionId"` (16fe595) and a regression test pins the exact live header shape
- [x] The fixed capturer, pointed at the real `~/.commandcode/projects` root with the parent claimed, returns the fork's new id

## Visual evidence

**Not applicable because:** this is a default config template for an existing `f` flow. The fork form is unchanged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added built-in support for forking Command Code sessions with a new session name.
  - Forked Command Code transcripts now correctly use the new session identifier, including when the original session is already in use.

- **Documentation**
  - Updated configuration and usage guides to document Command Code as a tool with a default fork command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->