### PR TITLE
fix(ui): keep a stale wheel claim from clearing history scroll

### DIFF
--- a/internal/ui/focusscroll_test.go
+++ b/internal/ui/focusscroll_test.go
@@ -169,6 +169,17 @@ func TestFocusWheelScrollsHistory(t *testing.T) {
 	}
 }
 
+// The wheel entry point, not just scrollFocus, has to walk tmux history
+// on a plain pane: this is the path a real wheel notch takes.
+func TestWheelFocusWalksTmuxHistory(t *testing.T) {
+	m, _ := focusedWithHistory(t, "wheel-walk")
+
+	m.wheelFocus(true, m.pane.box.x+2, m.pane.box.y+1)
+	if m.focusScroll == 0 {
+		t.Fatal("wheel did not walk tmux history")
+	}
+}
+
 // A capture scheduled before the preview reflows must not blank the bottom
 // of the resized viewport when its reply arrives afterwards.
 func TestFocusScrollRecapturesAfterPreviewResize(t *testing.T) {
@@ -612,6 +623,36 @@ func TestAppMouseClearsScrollback(t *testing.T) {
 	}
 	if m.preview != "LIVE-FRAME\n" {
 		t.Fatalf("preview = %q, want the live frame", m.preview)
+	}
+}
+
+// The wheel claim a pushed capture carries can be stale: the cached flag
+// trails an app that left mouse mode by a debounce, and the pane's own
+// history is the tell, since a genuine wheel owner keeps none. A user
+// scrolled into that history must keep their place until the fresh flags
+// arrive.
+func TestStaleMouseClaimDoesNotClearHistoryScroll(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "stale-hold", t.TempDir(), "")
+	m.selectSessionRow(t, "stale-hold")
+	sess := m.rows[m.cursor].sess
+	m.mode = modeFocus
+	m.preview = "SCROLLED-FRAME\n"
+	m.focusScroll = 9
+	m.pane.history = 80
+
+	updated, _ := m.Update(focusPreviewMsg{
+		sessID:      sess.ID,
+		preview:     "LIVE-FRAME\n",
+		paneMouse:   true,
+		historySize: 80,
+	})
+	m = updated.(*Model)
+	if m.focusScroll != 9 {
+		t.Fatalf("focusScroll = %d, want the history offset kept", m.focusScroll)
+	}
+	if m.preview != "SCROLLED-FRAME\n" {
+		t.Fatalf("preview = %q, want the scrolled frame held", m.preview)
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1331,8 +1331,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pane.sgr = msg.paneSGR
 		m.pane.history = msg.historySize
 		// Once the app owns the wheel, nothing can walk a leftover offset
-		// back down, and holding it would freeze the view for good.
-		if m.pane.mouse && m.focusScroll != 0 {
+		// back down, and holding it would freeze the view for good. A
+		// mouse-tracking agent keeps no tmux history, though, so history
+		// beside a wheel claim is the cached flag trailing an app that
+		// just left mouse mode, and the offset stays reachable.
+		if m.pane.mouse && m.focusScroll != 0 && m.pane.history == 0 {
 			m.focusScroll = 0
 		}
 		// A scrolled-back pane holds still: live frames would yank the


### PR DESCRIPTION
## Problem

Scrolling back through a focused pane's tmux history could snap to the bottom mid-read. The focus watcher pushes captures with the pane's cached mouse flags, and those trail an app that left mouse mode by a debounce. While the stale `paneMouse` claim was still set, the preview handler wiped the scroll offset and applied the live frame, yanking the reader out of the history they were reading.

## Fix

The pane's own history tells the stale claim from a genuine wheel owner: a mouse-tracking agent runs on the alternate screen and keeps no tmux history, so history arriving beside a wheel claim means the cached flag is trailing reality. The leftover-offset wipe now only fires on a pane with no history, and a scrolled-back view holds its frame until fresh flags arrive.

## Tests

- `TestStaleMouseClaimDoesNotClearHistoryScroll`: a capture with a wheel claim beside real history keeps the offset and the held frame.
- `TestWheelFocusWalksTmuxHistory`: the real wheel entry point walks tmux history on a plain pane.
- `TestAppMouseClearsScrollback` still passes: a genuine owner (no history) still returns to the bottom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved scroll position when stale mouse-tracking information is received.
  * Prevented scrolled-back views from unexpectedly resetting to the latest content.
  * Improved wheel scrolling through terminal history in plain panes.
  * Added safeguards to ensure previews remain visible until fresh scrolling state is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The guard assumes a genuine wheel owner keeps no tmux history (alternate screen). An app that tracked the mouse on the primary screen would sit outside this rule, but no wheel-driven offset can exist while the mouse flag is set, so no behavior hangs on that shape.
