### PR TITLE
docs(readme): add the Peerlist Launchpad badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
 
 <p align="center"><b>The fastest workflow for every AI coding agent.</b></p>
 
-<p align="center"><a href="https://trendshift.io/repositories/89312?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-89312" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/89312/daily?language=Go" alt="agent-manager on Trendshift" width="250" height="55"></a></p>
+<p align="center">
+  <a href="https://trendshift.io/repositories/89312?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-89312" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/89312/daily?language=Go" alt="agent-manager on Trendshift" width="250" height="55"></a>
+  <a href="https://peerlist.io/yoanwai/project/agent-manager" target="_blank" rel="noopener noreferrer"><img src="https://peerlist.io/api/v1/projects/embed/PRJHLKLOOER7EER9D1L6RPED7N8M8J?showUpvote=false&amp;theme=dark" alt="agent-manager on Peerlist Launchpad" width="187" height="55"></a>
+</p>
 
 <p align="center">
   <a href="https://github.com/YoanWai/agent-manager/stargazers"><img src="https://img.shields.io/github/stars/YoanWai/agent-manager?style=for-the-badge&label=stars&labelColor=1f2328&color=96591f" alt="stars"></a>
@@ -117,5 +120,6 @@ Bug reports, feature ideas, and pull requests are welcome. See [CONTRIBUTING.md]
 ---
 
 <p align="center">
+  <a href="https://peerlist.io/yoanwai/project/agent-manager" target="_blank" rel="noopener noreferrer"><img src="https://peerlist.io/api/v1/projects/embed/PRJHLKLOOER7EER9D1L6RPED7N8M8J?showUpvote=true&amp;theme=dark" alt="Upvote agent-manager on Peerlist Launchpad" width="222" height="54"></a>
   <a href="https://www.producthunt.com/products/agent-manager?utm_source=badge-review&amp;utm_medium=badge" target="_blank" rel="noopener noreferrer"><img src="https://api.producthunt.com/widgets/embed-image/v1/review.svg?post_id=1212310&amp;theme=dark" alt="Review agent-manager on Product Hunt" width="250" height="54"></a>
 </p>


### PR DESCRIPTION
## What changed

Two Peerlist Launchpad badges in `README.md`:

- Header: the project badge beside Trendshift, Trendshift first.
- Footer: the upvote badge beside the Product Hunt review badge, matching the site footer.

## Why

agent-manager went live on the Peerlist Launchpad in week 35. The site carries the laurel in the hero and the embed in the footer; the README carried neither.

## How it was verified

Both badges render through GitHub's camo proxy, checked on the pushed branch rather than from the source URL, since Peerlist answers a plain request with a Cloudflare challenge:

- `showUpvote=false&theme=dark` → `200 image/svg+xml`, 46,695 bytes, intrinsic 245x72.
- `showUpvote=true&theme=dark` → `200 image/svg+xml`, 65,321 bytes, intrinsic 296x72.

The declared sizes hold each aspect ratio and match the badge beside them: header 187x55 against Trendshift's 250x55, footer 222x54 against Product Hunt's 250x54. Rendered the branch README in a browser and read every `img` back: both Peerlist images report `complete: true` with those natural dimensions.

Markdown only, so no Go checks apply.

## Visual evidence

GitHub renders both rows on the branch: <https://github.com/YoanWai/agent-manager/tree/docs/readme-peerlist>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Trendshift promotional badge alongside the Peerlist Launchpad badge.
  * Added a Peerlist upvote badge to the documentation footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->