### PR TITLE
fix(ui): align input methods with software cursors

### DIFF
--- a/internal/ui/diffrender.go
+++ b/internal/ui/diffrender.go
@@ -782,7 +782,7 @@ func (m *Model) viewDiffCode(width, height int) string {
 		num, _ := annotationLine(fdLine)
 		m.diff.annInput.SetWidth(width)
 		m.diff.annInput.SetHeight(m.annotationInputHeight(width))
-		bar = divider(fmt.Sprintf("Comment · %s:%d", escapeControlsInline(fd.File.Path), num), width) + "\n" + m.diff.annInput.View()
+		bar = divider(fmt.Sprintf("Comment · %s:%d", escapeControlsInline(fd.File.Path), num), width) + "\n" + textAreaView(m.diff.annInput)
 		height -= lipgloss.Height(bar) + 1
 		if height < 3 {
 			height = 3

--- a/internal/ui/editor.go
+++ b/internal/ui/editor.go
@@ -123,7 +123,7 @@ func (m *Model) launchEditor(path string) (tea.Model, tea.Cmd) {
 	}
 	m.errBar.text = ""
 	if !detachedEditors[editorName(line)] {
-		return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return m, execTerminalProcess(cmd, func(err error) tea.Msg {
 			return editorDoneMsg{err: err, tookScreen: true}
 		})
 	}

--- a/internal/ui/exec.go
+++ b/internal/ui/exec.go
@@ -1,0 +1,18 @@
+package ui
+
+import (
+	"os"
+	"os/exec"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// execTerminalProcess keeps interactive child programs attached to the real
+// terminal. Bubble Tea's program output is wrapped for IME cursor placement,
+// but os/exec only gives a child a TTY when Stdout is the actual *os.File.
+func execTerminalProcess(cmd *exec.Cmd, fn tea.ExecCallback) tea.Cmd {
+	if cmd.Stdout == nil {
+		cmd.Stdout = os.Stdout
+	}
+	return tea.ExecProcess(cmd, fn)
+}

--- a/internal/ui/exec.go
+++ b/internal/ui/exec.go
@@ -7,9 +7,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// execTerminalProcess keeps interactive child programs attached to the real
-// terminal. Bubble Tea's program output is wrapped for IME cursor placement,
-// but os/exec only gives a child a TTY when Stdout is the actual *os.File.
+// Bubble Tea's program output is wrapped for IME cursor placement, but
+// os/exec only gives a child a TTY when Stdout is the actual *os.File.
 func execTerminalProcess(cmd *exec.Cmd, fn tea.ExecCallback) tea.Cmd {
 	if cmd.Stdout == nil {
 		cmd.Stdout = os.Stdout

--- a/internal/ui/exec_test.go
+++ b/internal/ui/exec_test.go
@@ -1,13 +1,14 @@
 package ui
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"testing"
 )
 
 func TestExecTerminalProcessKeepsChildStdoutOnTheTerminal(t *testing.T) {
-	cmd := exec.Command("sh", "-c", "true")
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", "true")
 	execTerminalProcess(cmd, nil)
 	if cmd.Stdout != os.Stdout {
 		t.Fatal("interactive child stdout was not pinned to the terminal")
@@ -19,9 +20,13 @@ func TestExecTerminalProcessPreservesConfiguredStdout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			t.Errorf("close temporary stdout file: %v", err)
+		}
+	}()
 
-	cmd := exec.Command("sh", "-c", "true")
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", "true")
 	cmd.Stdout = file
 	execTerminalProcess(cmd, nil)
 	if cmd.Stdout != file {

--- a/internal/ui/exec_test.go
+++ b/internal/ui/exec_test.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestExecTerminalProcessKeepsChildStdoutOnTheTerminal(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "true")
+	execTerminalProcess(cmd, nil)
+	if cmd.Stdout != os.Stdout {
+		t.Fatal("interactive child stdout was not pinned to the terminal")
+	}
+}
+
+func TestExecTerminalProcessPreservesConfiguredStdout(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "stdout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	cmd := exec.Command("sh", "-c", "true")
+	cmd.Stdout = file
+	execTerminalProcess(cmd, nil)
+	if cmd.Stdout != file {
+		t.Fatal("preconfigured child stdout was overwritten")
+	}
+}

--- a/internal/ui/fork.go
+++ b/internal/ui/fork.go
@@ -165,6 +165,6 @@ func expandForkCommand(template, sourceID, newID, name, sessionFile string) stri
 func (m *Model) viewFork() string {
 	body := "  source  " + valueStyle.Render(m.fork.source.Name) + "\n" +
 		"  group   " + groupBadge(displayGroup(m.fork.source.Group)) + "\n" +
-		formField("name", m.fork.name.View(), true)
+		formField("name", textInputView(m.fork.name), true)
 	return m.card("⑂ Fork Session", body, [][2]string{{"↵", "create"}, {"esc", "cancel"}})
 }

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -354,7 +354,7 @@ func (m *Model) viewHelp() string {
 func (m *Model) helpSearchLine(sections []helpSection) string {
 	line := keyStyle.Render("search ") + valueStyle.Render(m.help.query)
 	if m.help.searching {
-		line += lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
+		line += cursorAnchorMarker + lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
 	}
 	count := helpRowCount(sections)
 	label := " keys"

--- a/internal/ui/ime.go
+++ b/internal/ui/ime.go
@@ -187,6 +187,10 @@ func (w *cursorOutputWriter) Write(p []byte) (int, error) {
 
 	n, err := w.out.Write(p)
 	if err != nil || n != len(p) {
+		w.resetTerminalState()
+		if err == nil {
+			err = io.ErrShortWrite
+		}
 		return n, err
 	}
 	if incomplete := w.trackAltScreen(p); !w.altScreen || incomplete {
@@ -197,7 +201,15 @@ func (w *cursorOutputWriter) Write(p []byte) (int, error) {
 		return n, nil
 	}
 	_, err = io.WriteString(w.out, ansi.CursorPosition(col, row))
+	if err != nil {
+		w.resetTerminalState()
+	}
 	return n, err
+}
+
+func (w *cursorOutputWriter) resetTerminalState() {
+	w.altScreen = false
+	w.altScreenPrefix = nil
 }
 
 func (w *cursorOutputWriter) trackAltScreen(p []byte) bool {

--- a/internal/ui/ime.go
+++ b/internal/ui/ime.go
@@ -1,0 +1,261 @@
+package ui
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+const (
+	cursorAnchorValid = uint64(1) << 63
+	// The marker never reaches the terminal. It travels through the same
+	// layout and clipping as the cursor cell, then View removes it after
+	// reading the cell's final screen coordinates.
+	cursorAnchorMarker = "\x1b]1337;agent-manager-ime-cursor\x07"
+)
+
+// cursorAnchor is the real terminal cell an input method should open beside.
+// Bubble Tea v1 finishes every alternate-screen render at the bottom-left,
+// while focus mode paints a pane caret elsewhere, so an IME otherwise follows
+// that renderer cursor instead of the caret the user is typing at.
+type cursorAnchor struct {
+	packed atomic.Uint64
+}
+
+func (a *cursorAnchor) set(col, row int, ok bool) {
+	if !ok || col < 1 || row < 1 {
+		a.packed.Store(0)
+		return
+	}
+	a.packed.Store(cursorAnchorValid | uint64(uint32(row))<<32 | uint64(uint32(col)))
+}
+
+func (a *cursorAnchor) get() (col, row int, ok bool) {
+	packed := a.packed.Load()
+	if packed&cursorAnchorValid == 0 {
+		return 0, 0, false
+	}
+	return int(uint32(packed)), int(uint32((packed &^ cursorAnchorValid) >> 32)), true
+}
+
+// syncCursorAnchor publishes the input coordinates in a finished frame and
+// removes the private marker before Bubble Tea writes the frame. Focus mode
+// uses its recorded pane box as a fallback because its caret is painted over
+// captured terminal output rather than by a Bubbles input widget.
+func (m *Model) syncCursorAnchor(frame string) string {
+	if m.imeCursor == nil {
+		return strings.ReplaceAll(frame, cursorAnchorMarker, "")
+	}
+	if m.mode == modeFocus {
+		col, row, ok := m.focusCursorAnchor()
+		m.imeCursor.set(col, row, ok)
+		return strings.ReplaceAll(frame, cursorAnchorMarker, "")
+	}
+	frame, col, row, ok := cursorMarkerPosition(frame)
+	m.imeCursor.set(col, row, ok)
+	return frame
+}
+
+func cursorMarkerPosition(frame string) (clean string, col, row int, ok bool) {
+	index := strings.Index(frame, cursorAnchorMarker)
+	if index < 0 {
+		return frame, 0, 0, false
+	}
+	clean = strings.ReplaceAll(frame, cursorAnchorMarker, "")
+	prefix := frame[:index]
+	row = strings.Count(prefix, "\n") + 1
+	if newline := strings.LastIndexByte(prefix, '\n'); newline >= 0 {
+		prefix = prefix[newline+1:]
+	}
+	return clean, ansi.StringWidth(prefix) + 1, row, true
+}
+
+// textInputView and textAreaView preserve the widgets' visual blink while
+// marking the cursor cell in both blink phases. A visible-cursor copy reveals
+// the exact rendered cell; when the real cursor is blinked off, the marker is
+// inserted at that same ANSI-aware cell in the normal view.
+func textInputView(input textinput.Model) string {
+	if !input.Focused() {
+		return input.View()
+	}
+	marked := input
+	marked.Cursor.Blink = false
+	marked.Cursor.Style = cursorMarkerStyle(marked.Cursor.Style)
+	markedView := marked.View()
+	if !input.Cursor.Blink {
+		return markedView
+	}
+	return insertMarkerAtCursor(input.View(), markedView)
+}
+
+func textAreaView(input textarea.Model) string {
+	if !input.Focused() {
+		return input.View()
+	}
+	marked := input
+	marked.Cursor.Blink = false
+	marked.Cursor.Style = cursorMarkerStyle(marked.Cursor.Style)
+	markedView := marked.View()
+	if !input.Cursor.Blink {
+		return markedView
+	}
+	return insertMarkerAtCursor(input.View(), markedView)
+}
+
+func cursorMarkerStyle(style lipgloss.Style) lipgloss.Style {
+	transform := style.GetTransform()
+	return style.Transform(func(value string) string {
+		if transform != nil {
+			value = transform(value)
+		}
+		return cursorAnchorMarker + value
+	})
+}
+
+func insertMarkerAtCursor(view, markedView string) string {
+	_, col, row, ok := cursorMarkerPosition(markedView)
+	if !ok {
+		return view
+	}
+	lines := strings.Split(view, "\n")
+	row--
+	col--
+	if row < 0 || row >= len(lines) {
+		return view
+	}
+	line := lines[row]
+	cell, state := 0, byte(ansi.NormalState)
+	for index := 0; index < len(line); {
+		_, width, n, nextState := ansi.GraphemeWidth.DecodeSequenceInString(line[index:], state, nil)
+		if n <= 0 {
+			break
+		}
+		if width > 0 && cell+width > col {
+			lines[row] = line[:index] + cursorAnchorMarker + line[index:]
+			return strings.Join(lines, "\n")
+		}
+		cell += width
+		index += n
+		state = nextState
+	}
+	if cell == col {
+		lines[row] += cursorAnchorMarker
+		return strings.Join(lines, "\n")
+	}
+	return view
+}
+
+func (m *Model) focusCursorAnchor() (col, row int, ok bool) {
+	if m.mode != modeFocus || m.scrolledBack() || !m.pane.box.ok || !m.pane.cursor.ok {
+		return 0, 0, false
+	}
+	sess, selected := m.selected()
+	if !selected || m.pane.forID != sess.ID {
+		return 0, 0, false
+	}
+	box := m.pane.box
+	row = m.pane.cursor.y - m.paneRowOffset(box.height)
+	if row < 0 || row >= box.height {
+		return 0, 0, false
+	}
+	col = min(max(m.pane.cursor.x, 0), box.width-1)
+	return box.x + col + 1, box.y + row + 1, true
+}
+
+// cursorOutputWriter appends the active input position after each Bubble Tea
+// render. It tracks alternate-screen lifecycle so an attached editor and the
+// restored shell receive their output untouched.
+type cursorOutputWriter struct {
+	out             io.Writer
+	anchor          *cursorAnchor
+	mu              sync.Mutex
+	altScreen       bool
+	altScreenPrefix []byte
+}
+
+func (w *cursorOutputWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	n, err := w.out.Write(p)
+	if err != nil || n != len(p) {
+		return n, err
+	}
+	if incomplete := w.trackAltScreen(p); !w.altScreen || incomplete {
+		return n, nil
+	}
+	col, row, ok := w.anchor.get()
+	if !ok {
+		return n, nil
+	}
+	_, err = io.WriteString(w.out, ansi.CursorPosition(col, row))
+	return n, err
+}
+
+func (w *cursorOutputWriter) trackAltScreen(p []byte) bool {
+	data := p
+	if len(w.altScreenPrefix) > 0 {
+		data = make([]byte, len(w.altScreenPrefix)+len(p))
+		copy(data, w.altScreenPrefix)
+		copy(data[len(w.altScreenPrefix):], p)
+	}
+	enterSequence := []byte(ansi.SetModeAltScreenSaveCursor)
+	exitSequence := []byte(ansi.ResetModeAltScreenSaveCursor)
+	enter := bytes.LastIndex(data, enterSequence)
+	exit := bytes.LastIndex(data, exitSequence)
+	if enter < 0 && exit < 0 {
+		w.altScreenPrefix = trailingAltScreenPrefix(data, enterSequence, exitSequence)
+		return len(w.altScreenPrefix) > 0
+	}
+	w.altScreen = enter > exit
+	w.altScreenPrefix = trailingAltScreenPrefix(data, enterSequence, exitSequence)
+	return len(w.altScreenPrefix) > 0
+}
+
+func trailingAltScreenPrefix(data, enter, exit []byte) []byte {
+	for size := min(len(data), len(enter)-1); size > 0; size-- {
+		suffix := data[len(data)-size:]
+		if bytes.Equal(suffix, enter[:size]) || bytes.Equal(suffix, exit[:size]) {
+			return bytes.Clone(suffix)
+		}
+	}
+	return nil
+}
+
+// cursorTTYOutput preserves stdout's terminal identity for Bubble Tea while
+// overriding writes with the cursor anchor behavior above.
+type cursorTTYOutput struct {
+	*os.File
+	writer *cursorOutputWriter
+}
+
+func (w *cursorTTYOutput) Write(p []byte) (int, error) { return w.writer.Write(p) }
+
+// *os.File's promoted WriteString would bypass Write when Bubble Tea emits
+// alternate-screen lifecycle sequences through io.WriteString.
+func (w *cursorTTYOutput) WriteString(s string) (int, error) {
+	return w.writer.Write([]byte(s))
+}
+
+// CursorOutput keeps native TTY detection and terminal sizing while placing
+// the host cursor at the active input caret after each rendered frame.
+func (m *Model) CursorOutput(output *os.File) io.Writer {
+	if m.imeCursor == nil {
+		m.imeCursor = &cursorAnchor{}
+	}
+	return &cursorTTYOutput{
+		File: output,
+		writer: &cursorOutputWriter{
+			out:    output,
+			anchor: m.imeCursor,
+		},
+	}
+}

--- a/internal/ui/ime.go
+++ b/internal/ui/ime.go
@@ -27,6 +27,9 @@ var (
 	altScreenExit  = []byte(ansi.ResetModeAltScreenSaveCursor)
 )
 
+// Bubble Tea v2 places the cursor itself through View.Cursor, so this file
+// and the marker plumbing in the input views go away with that migration.
+//
 // cursorAnchor is the real terminal cell an input method should open beside.
 // Bubble Tea v1 finishes every alternate-screen render at the bottom-left,
 // while focus mode paints a pane caret elsewhere, so an IME otherwise follows

--- a/internal/ui/ime.go
+++ b/internal/ui/ime.go
@@ -22,6 +22,11 @@ const (
 	cursorAnchorMarker = "\x1b]1337;agent-manager-ime-cursor\x07"
 )
 
+var (
+	altScreenEnter = []byte(ansi.SetModeAltScreenSaveCursor)
+	altScreenExit  = []byte(ansi.ResetModeAltScreenSaveCursor)
+)
+
 // cursorAnchor is the real terminal cell an input method should open beside.
 // Bubble Tea v1 finishes every alternate-screen render at the bottom-left,
 // while focus mode paints a pane caret elsewhere, so an IME otherwise follows
@@ -132,7 +137,7 @@ func insertMarkerAtCursor(view, markedView string) string {
 		return view
 	}
 	line := lines[row]
-	cell, state := 0, byte(ansi.NormalState)
+	cell, state := 0, ansi.NormalState
 	for index := 0; index < len(line); {
 		_, width, n, nextState := ansi.GraphemeWidth.DecodeSequenceInString(line[index:], state, nil)
 		if n <= 0 {
@@ -219,16 +224,14 @@ func (w *cursorOutputWriter) trackAltScreen(p []byte) bool {
 		copy(data, w.altScreenPrefix)
 		copy(data[len(w.altScreenPrefix):], p)
 	}
-	enterSequence := []byte(ansi.SetModeAltScreenSaveCursor)
-	exitSequence := []byte(ansi.ResetModeAltScreenSaveCursor)
-	enter := bytes.LastIndex(data, enterSequence)
-	exit := bytes.LastIndex(data, exitSequence)
+	enter := bytes.LastIndex(data, altScreenEnter)
+	exit := bytes.LastIndex(data, altScreenExit)
 	if enter < 0 && exit < 0 {
-		w.altScreenPrefix = trailingAltScreenPrefix(data, enterSequence, exitSequence)
+		w.altScreenPrefix = trailingAltScreenPrefix(data, altScreenEnter, altScreenExit)
 		return len(w.altScreenPrefix) > 0
 	}
 	w.altScreen = enter > exit
-	w.altScreenPrefix = trailingAltScreenPrefix(data, enterSequence, exitSequence)
+	w.altScreenPrefix = trailingAltScreenPrefix(data, altScreenEnter, altScreenExit)
 	return len(w.altScreenPrefix) > 0
 }
 

--- a/internal/ui/ime_test.go
+++ b/internal/ui/ime_test.go
@@ -372,7 +372,7 @@ func TestCursorOutputDisablesAnchoringAfterShortWrite(t *testing.T) {
 	out := &scriptedWriter{shortOn: 1}
 	w := &cursorOutputWriter{out: out, anchor: anchor, altScreen: true}
 
-	if _, err := w.Write([]byte("frame")); err != io.ErrShortWrite {
+	if _, err := w.Write([]byte("frame")); !errors.Is(err, io.ErrShortWrite) {
 		t.Fatalf("short write error = %v, want %v", err, io.ErrShortWrite)
 	}
 	if w.altScreen || len(w.altScreenPrefix) != 0 {

--- a/internal/ui/ime_test.go
+++ b/internal/ui/ime_test.go
@@ -122,6 +122,7 @@ func TestTextAreaCursorMarkerTracksWrappedWideText(t *testing.T) {
 	input.SetCursor(3)
 	input.Focus()
 
+	var position [2]int
 	for _, blink := range []bool{false, true} {
 		input.Cursor.Blink = blink
 		view := textAreaView(input)
@@ -129,9 +130,13 @@ func TestTextAreaCursorMarkerTracksWrappedWideText(t *testing.T) {
 		if !ok {
 			t.Fatalf("blink=%v: textarea view has no cursor marker", blink)
 		}
-		if row < 1 || col < 1 {
-			t.Fatalf("blink=%v: invalid textarea cursor = (%d, %d)", blink, col, row)
+		if col != 4 || row != 2 {
+			t.Fatalf("blink=%v: textarea cursor = (%d, %d), want (4, 2)", blink, col, row)
 		}
+		if blink && position != [2]int{col, row} {
+			t.Fatalf("blink-off textarea cursor moved from %v to (%d, %d)", position, col, row)
+		}
+		position = [2]int{col, row}
 	}
 }
 
@@ -338,5 +343,66 @@ func TestCursorOutputStopsWhenAnchorClears(t *testing.T) {
 	}
 	if want := "focused" + ansi.CursorPosition(4, 3) + "list"; out.String() != want {
 		t.Fatalf("output = %q, want %q", out.String(), want)
+	}
+}
+
+type scriptedWriter struct {
+	writes  [][]byte
+	failOn  int
+	shortOn int
+	call    int
+}
+
+func (w *scriptedWriter) Write(p []byte) (int, error) {
+	w.call++
+	w.writes = append(w.writes, append([]byte(nil), p...))
+	if w.call == w.failOn {
+		return 0, io.ErrClosedPipe
+	}
+	if w.call == w.shortOn {
+		return len(p) - 1, io.ErrShortWrite
+	}
+	return len(p), nil
+}
+
+func TestCursorOutputDisablesAnchoringAfterShortWrite(t *testing.T) {
+	anchor := &cursorAnchor{}
+	anchor.set(4, 3, true)
+	out := &scriptedWriter{shortOn: 1}
+	w := &cursorOutputWriter{out: out, anchor: anchor, altScreen: true}
+
+	if _, err := w.Write([]byte("frame")); err != io.ErrShortWrite {
+		t.Fatalf("short write error = %v, want %v", err, io.ErrShortWrite)
+	}
+	if w.altScreen || len(w.altScreenPrefix) != 0 {
+		t.Fatalf("short write left terminal state active: alt=%v prefix=%q", w.altScreen, w.altScreenPrefix)
+	}
+}
+
+func TestCursorOutputDisablesAnchoringAfterWriteFailure(t *testing.T) {
+	anchor := &cursorAnchor{}
+	anchor.set(4, 3, true)
+	out := &scriptedWriter{failOn: 1}
+	w := &cursorOutputWriter{out: out, anchor: anchor, altScreen: true}
+
+	if _, err := w.Write([]byte("frame")); err != io.ErrClosedPipe {
+		t.Fatalf("write error = %v, want %v", err, io.ErrClosedPipe)
+	}
+	if w.altScreen || len(w.altScreenPrefix) != 0 {
+		t.Fatalf("write failure left terminal state active: alt=%v prefix=%q", w.altScreen, w.altScreenPrefix)
+	}
+}
+
+func TestCursorOutputReturnsCursorPositionWriteFailure(t *testing.T) {
+	anchor := &cursorAnchor{}
+	anchor.set(4, 3, true)
+	out := &scriptedWriter{failOn: 2}
+	w := &cursorOutputWriter{out: out, anchor: anchor, altScreen: true}
+
+	if _, err := w.Write([]byte("frame")); err != io.ErrClosedPipe {
+		t.Fatalf("cursor position error = %v, want %v", err, io.ErrClosedPipe)
+	}
+	if len(out.writes) != 2 {
+		t.Fatalf("writes = %d, want initial frame and cursor position", len(out.writes))
 	}
 }

--- a/internal/ui/ime_test.go
+++ b/internal/ui/ime_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -385,7 +386,7 @@ func TestCursorOutputDisablesAnchoringAfterWriteFailure(t *testing.T) {
 	out := &scriptedWriter{failOn: 1}
 	w := &cursorOutputWriter{out: out, anchor: anchor, altScreen: true}
 
-	if _, err := w.Write([]byte("frame")); err != io.ErrClosedPipe {
+	if _, err := w.Write([]byte("frame")); !errors.Is(err, io.ErrClosedPipe) {
 		t.Fatalf("write error = %v, want %v", err, io.ErrClosedPipe)
 	}
 	if w.altScreen || len(w.altScreenPrefix) != 0 {
@@ -399,10 +400,13 @@ func TestCursorOutputReturnsCursorPositionWriteFailure(t *testing.T) {
 	out := &scriptedWriter{failOn: 2}
 	w := &cursorOutputWriter{out: out, anchor: anchor, altScreen: true}
 
-	if _, err := w.Write([]byte("frame")); err != io.ErrClosedPipe {
+	if _, err := w.Write([]byte("frame")); !errors.Is(err, io.ErrClosedPipe) {
 		t.Fatalf("cursor position error = %v, want %v", err, io.ErrClosedPipe)
 	}
 	if len(out.writes) != 2 {
 		t.Fatalf("writes = %d, want initial frame and cursor position", len(out.writes))
+	}
+	if w.altScreen || len(w.altScreenPrefix) != 0 {
+		t.Fatalf("cursor position failure left terminal state active: alt=%v prefix=%q", w.altScreen, w.altScreenPrefix)
 	}
 }

--- a/internal/ui/ime_test.go
+++ b/internal/ui/ime_test.go
@@ -1,0 +1,342 @@
+package ui
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestFocusCursorAnchorTracksMirroredCaret(t *testing.T) {
+	m := &Model{
+		mode:      modeFocus,
+		rows:      []treeRow{{sess: store.Session{ID: "focused"}}},
+		preview:   "first\nsecond\nthird\n",
+		cursorOn:  false,
+		imeCursor: &cursorAnchor{},
+		pane: paneMirror{
+			forID:  "focused",
+			box:    paneBox{x: 40, y: 8, width: 30, height: 3, ok: true},
+			cursor: paneCursor{x: 7, y: 1, ok: true},
+		},
+	}
+	m.syncCursorAnchor("frame")
+	col, row, ok := m.imeCursor.get()
+	if !ok || col != 48 || row != 10 {
+		t.Fatalf("cursor anchor = (%d, %d, %v), want (48, 10, true)", col, row, ok)
+	}
+
+	m.focusScroll = 1
+	m.syncCursorAnchor("frame")
+	if _, _, ok := m.imeCursor.get(); ok {
+		t.Fatal("scrolled pane kept a live IME cursor anchor")
+	}
+}
+
+func TestFocusCursorAnchorRemovesListSearchMarker(t *testing.T) {
+	m := &Model{
+		mode:      modeFocus,
+		searching: true,
+		search:    "active",
+		rows:      []treeRow{{sess: store.Session{ID: "focused"}}},
+		imeCursor: &cursorAnchor{},
+		pane: paneMirror{
+			forID:  "focused",
+			box:    paneBox{x: 40, y: 8, width: 30, height: 3, ok: true},
+			cursor: paneCursor{x: 7, y: 1, ok: true},
+		},
+	}
+	frame := m.syncCursorAnchor(m.searchFieldLine(40) + "\nfocused pane")
+	if strings.Contains(frame, cursorAnchorMarker) {
+		t.Fatal("private list search marker leaked from the focused frame")
+	}
+	col, row, ok := m.imeCursor.get()
+	if !ok || col != 48 || row != 10 {
+		t.Fatalf("cursor anchor = (%d, %d, %v), want (48, 10, true)", col, row, ok)
+	}
+}
+
+func TestFocusCursorAnchorAccountsForDroppedCaptureRows(t *testing.T) {
+	m := &Model{
+		mode:      modeFocus,
+		rows:      []treeRow{{sess: store.Session{ID: "focused"}}},
+		preview:   "one\ntwo\nthree\nfour\n",
+		imeCursor: &cursorAnchor{},
+		pane: paneMirror{
+			forID:  "focused",
+			box:    paneBox{x: 20, y: 5, width: 12, height: 2, ok: true},
+			cursor: paneCursor{x: 4, y: 3, ok: true},
+		},
+	}
+	m.syncCursorAnchor("frame")
+	col, row, ok := m.imeCursor.get()
+	if !ok || col != 25 || row != 7 {
+		t.Fatalf("cropped cursor anchor = (%d, %d, %v), want (25, 7, true)", col, row, ok)
+	}
+}
+
+func TestTextInputCursorMarkerSurvivesBothBlinkPhases(t *testing.T) {
+	input := textField("", 60)
+	input.Prompt = "» "
+	input.SetValue("甲x")
+	input.SetCursor(1)
+	input.Focus()
+
+	var position [2]int
+	for _, blink := range []bool{false, true} {
+		input.Cursor.Blink = blink
+		view := textInputView(input)
+		if !strings.Contains(view, cursorAnchorMarker) {
+			t.Fatalf("blink=%v: input view has no cursor marker", blink)
+		}
+		clean, col, row, ok := cursorMarkerPosition(view)
+		if !ok {
+			t.Fatalf("blink=%v: cursor marker was not found", blink)
+		}
+		if strings.Contains(clean, cursorAnchorMarker) {
+			t.Fatalf("blink=%v: cursor marker leaked into clean view", blink)
+		}
+		if row != 1 || col != 5 { // two prompt cells, then the two-cell CJK rune
+			t.Fatalf("blink=%v: cursor = (%d, %d), want (5, 1)", blink, col, row)
+		}
+		if blink {
+			if position != [2]int{col, row} {
+				t.Fatalf("blink-off cursor moved from %v to (%d, %d)", position, col, row)
+			}
+		} else {
+			position = [2]int{col, row}
+		}
+	}
+}
+
+func TestTextAreaCursorMarkerTracksWrappedWideText(t *testing.T) {
+	input := promptField().input
+	input.Placeholder = ""
+	input.SetWidth(6)
+	input.SetHeight(2)
+	input.SetValue("甲乙ab")
+	input.SetCursor(3)
+	input.Focus()
+
+	for _, blink := range []bool{false, true} {
+		input.Cursor.Blink = blink
+		view := textAreaView(input)
+		_, col, row, ok := cursorMarkerPosition(view)
+		if !ok {
+			t.Fatalf("blink=%v: textarea view has no cursor marker", blink)
+		}
+		if row < 1 || col < 1 {
+			t.Fatalf("blink=%v: invalid textarea cursor = (%d, %d)", blink, col, row)
+		}
+	}
+}
+
+func TestCursorMarkerPositionHandlesANSIAndWideGlyphs(t *testing.T) {
+	frame := "first\n\x1b[31m甲乙\x1b[0m" + cursorAnchorMarker + "x"
+	clean, col, row, ok := cursorMarkerPosition(frame)
+	if !ok || col != 5 || row != 2 {
+		t.Fatalf("cursor = (%d, %d, %v), want (5, 2, true)", col, row, ok)
+	}
+	if strings.Contains(clean, cursorAnchorMarker) || ansi.Strip(clean) != "first\n甲乙x" {
+		t.Fatalf("clean frame = %q", clean)
+	}
+}
+
+func TestPreviewLineStripsCapturedCursorMarker(t *testing.T) {
+	got := previewLine("pane"+cursorAnchorMarker+"output", 40)
+	if strings.Contains(got, cursorAnchorMarker) {
+		t.Fatal("captured pane retained the private cursor marker")
+	}
+	if plain := strings.TrimSpace(ansi.Strip(got)); plain != "paneoutput" {
+		t.Fatalf("sanitized pane = %q, want paneoutput", plain)
+	}
+}
+
+func TestCustomSearchCursorsEmitMarkersOnlyWhileTyping(t *testing.T) {
+	m := &Model{searching: true, search: "中文", help: helpState{searching: true, query: "定位"}}
+	if line := m.searchFieldLine(40); !strings.Contains(line, cursorAnchorMarker) {
+		t.Fatal("list search cursor has no marker")
+	}
+	if line := m.helpSearchLine(nil); !strings.Contains(line, cursorAnchorMarker) {
+		t.Fatal("help search cursor has no marker")
+	}
+
+	m.searching = false
+	m.help.searching = false
+	if line := m.searchFieldLine(40); strings.Contains(line, cursorAnchorMarker) {
+		t.Fatal("closed list search kept a cursor marker")
+	}
+	if line := m.helpSearchLine(nil); strings.Contains(line, cursorAnchorMarker) {
+		t.Fatal("closed help search kept a cursor marker")
+	}
+}
+
+func TestNoActiveInputClearsCursorAnchor(t *testing.T) {
+	m := &Model{imeCursor: &cursorAnchor{}}
+	m.imeCursor.set(9, 7, true)
+	if got := m.syncCursorAnchor("plain frame"); got != "plain frame" {
+		t.Fatalf("frame changed to %q", got)
+	}
+	if _, _, ok := m.imeCursor.get(); ok {
+		t.Fatal("inactive frame kept the previous cursor anchor")
+	}
+}
+
+func TestFinalHelpLayoutPublishesAndRemovesCursorMarker(t *testing.T) {
+	m := &Model{
+		width:     100,
+		height:    28,
+		mode:      modeHelp,
+		help:      helpState{searching: true, query: "中文"},
+		imeCursor: &cursorAnchor{},
+	}
+	frame := m.View()
+	if strings.Contains(frame, cursorAnchorMarker) {
+		t.Fatal("private cursor marker leaked from the final frame")
+	}
+	col, row, ok := m.imeCursor.get()
+	if !ok || col < 1 || col > m.width || row < 1 || row > m.height {
+		t.Fatalf("final cursor anchor = (%d, %d, %v), frame is %dx%d", col, row, ok, m.width, m.height)
+	}
+	plain := strings.Split(ansi.Strip(frame), "\n")
+	if row > len(plain) || !strings.Contains(plain[row-1], "search 中文▏") {
+		t.Fatalf("anchor row %d does not contain the help input: %q", row, plain[row-1])
+	}
+}
+
+func TestCursorOutputAnchorsOnlyInsideAlternateScreen(t *testing.T) {
+	var out bytes.Buffer
+	anchor := &cursorAnchor{}
+	anchor.set(14, 9, true)
+	w := &cursorOutputWriter{out: &out, anchor: anchor}
+
+	if _, err := w.Write([]byte("shell")); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != "shell" {
+		t.Fatalf("ordinary output changed to %q", got)
+	}
+
+	out.Reset()
+	if _, err := w.Write([]byte(ansi.SetModeAltScreenSaveCursor + "frame")); err != nil {
+		t.Fatal(err)
+	}
+	if want := ansi.SetModeAltScreenSaveCursor + "frame" + ansi.CursorPosition(14, 9); out.String() != want {
+		t.Fatalf("alternate-screen output = %q, want %q", out.String(), want)
+	}
+
+	out.Reset()
+	if _, err := w.Write([]byte(ansi.ResetModeAltScreenSaveCursor)); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != ansi.ResetModeAltScreenSaveCursor {
+		t.Fatalf("alternate-screen exit was anchored: %q", got)
+	}
+}
+
+func TestCursorOutputTracksSplitAlternateScreenEntry(t *testing.T) {
+	sequence := ansi.SetModeAltScreenSaveCursor
+	for split := 1; split < len(sequence); split++ {
+		t.Run(fmt.Sprintf("split_at_%d", split), func(t *testing.T) {
+			var out bytes.Buffer
+			anchor := &cursorAnchor{}
+			anchor.set(14, 9, true)
+			w := &cursorOutputWriter{out: &out, anchor: anchor}
+
+			if _, err := w.Write([]byte(sequence[:split])); err != nil {
+				t.Fatal(err)
+			}
+			if got := out.String(); got != sequence[:split] {
+				t.Fatalf("partial entry output = %q, want %q", got, sequence[:split])
+			}
+			if _, err := w.Write([]byte(sequence[split:] + "frame")); err != nil {
+				t.Fatal(err)
+			}
+			want := sequence + "frame" + ansi.CursorPosition(14, 9)
+			if got := out.String(); got != want {
+				t.Fatalf("completed entry output = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestCursorOutputTracksSplitAlternateScreenExit(t *testing.T) {
+	sequence := ansi.ResetModeAltScreenSaveCursor
+	for split := 1; split < len(sequence); split++ {
+		t.Run(fmt.Sprintf("split_at_%d", split), func(t *testing.T) {
+			var out bytes.Buffer
+			anchor := &cursorAnchor{}
+			anchor.set(14, 9, true)
+			w := &cursorOutputWriter{out: &out, anchor: anchor, altScreen: true}
+
+			if _, err := w.Write([]byte(sequence[:split])); err != nil {
+				t.Fatal(err)
+			}
+			if got := out.String(); got != sequence[:split] {
+				t.Fatalf("partial exit output = %q, want %q", got, sequence[:split])
+			}
+			if _, err := w.Write([]byte(sequence[split:] + "shell")); err != nil {
+				t.Fatal(err)
+			}
+			if got := out.String(); got != sequence+"shell" {
+				t.Fatalf("completed exit output = %q, want %q", got, sequence+"shell")
+			}
+		})
+	}
+}
+
+func TestCursorOutputAnchorsConsecutiveAlternateScreenWrites(t *testing.T) {
+	var out bytes.Buffer
+	anchor := &cursorAnchor{}
+	anchor.set(14, 9, true)
+	w := &cursorOutputWriter{out: &out, anchor: anchor, altScreen: true}
+
+	for _, frame := range []string{"first", "second"} {
+		if _, err := w.Write([]byte(frame)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want := "first" + ansi.CursorPosition(14, 9) + "second" + ansi.CursorPosition(14, 9)
+	if got := out.String(); got != want {
+		t.Fatalf("consecutive output = %q, want %q", got, want)
+	}
+}
+
+func TestCursorTTYOutputRoutesStringWritesThroughCursorWriter(t *testing.T) {
+	var out bytes.Buffer
+	anchor := &cursorAnchor{}
+	anchor.set(14, 9, true)
+	w := &cursorOutputWriter{out: &out, anchor: anchor}
+	tty := &cursorTTYOutput{writer: w}
+
+	if _, err := io.WriteString(tty, ansi.SetModeAltScreenSaveCursor); err != nil {
+		t.Fatal(err)
+	}
+	if !w.altScreen {
+		t.Fatal("alternate-screen string write bypassed cursor writer")
+	}
+	if want := ansi.SetModeAltScreenSaveCursor + ansi.CursorPosition(14, 9); out.String() != want {
+		t.Fatalf("output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestCursorOutputStopsWhenAnchorClears(t *testing.T) {
+	var out bytes.Buffer
+	anchor := &cursorAnchor{}
+	w := &cursorOutputWriter{out: &out, anchor: anchor, altScreen: true}
+	anchor.set(4, 3, true)
+	if _, err := w.Write([]byte("focused")); err != nil {
+		t.Fatal(err)
+	}
+	anchor.set(0, 0, false)
+	if _, err := w.Write([]byte("list")); err != nil {
+		t.Fatal(err)
+	}
+	if want := "focused" + ansi.CursorPosition(4, 3) + "list"; out.String() != want {
+		t.Fatalf("output = %q, want %q", out.String(), want)
+	}
+}

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -75,7 +75,7 @@ func (m *Model) attachCmd(id string) tea.Cmd {
 	if prepErr != nil {
 		m.errBar.text = prepErr.Error()
 	}
-	return tea.ExecProcess(m.tmux.AttachCommand(id), func(err error) tea.Msg {
+	return execTerminalProcess(m.tmux.AttachCommand(id), func(err error) tea.Msg {
 		return attachDoneMsg{sessID: id, err: err}
 	})
 }

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -192,7 +192,7 @@ func (m *Model) fullQuickLines(width, height int) []contentLine {
 func (m *Model) searchFieldLine(width int) string {
 	indent := strings.Repeat(" ", railInset)
 	glyph := keyStyle.Render("⌕ ")
-	caret := lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
+	caret := cursorAnchorMarker + lipgloss.NewStyle().Foreground(colorAccent).Render("▏")
 	hint := keyCapQuiet("esc", "close")
 	if !m.searching {
 		caret, hint = "", keyCapQuiet("esc", "clear")
@@ -1278,7 +1278,7 @@ func (m *Model) viewGroupDetail(group string, width int) string {
 		if fieldWidth := width - 12; fieldWidth >= 10 {
 			m.rename.dir.Width = fieldWidth
 		}
-		out := head + "\n" + pathLabel.Width(10).Render("path") + m.rename.dir.View()
+		out := head + "\n" + pathLabel.Width(10).Render("path") + textInputView(m.rename.dir)
 		if m.rename.focus == 1 && m.pathSugg.active() {
 			out += "\n" + m.viewPathSuggestions()
 		}
@@ -1447,7 +1447,7 @@ func (m *Model) viewQuickBar(width int) string {
 	m.quick.input.SetHeight(m.quickBarRows(width - 2))
 	// Chips are tokens inside the typed text, so they wrap and reflow with
 	// the words around them; painting happens on the rendered prompt.
-	return target + "\n" + m.quick.renderChips(m.quick.input.View())
+	return target + "\n" + m.quick.renderChips(textAreaView(m.quick.input))
 }
 
 // viewHeaderRows is the full-width band over both columns: the wordmark

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -147,14 +147,14 @@ func (m *Model) viewForm() string {
 	m.form.prompt.input.SetHeight(textareaRows(m.form.prompt.input, m.formValueWidth()-2, formPromptMaxRows))
 
 	var b strings.Builder
-	b.WriteString(formField("name", m.form.name.View(), m.form.focus == fieldName))
+	b.WriteString(formField("name", textInputView(m.form.name), m.form.focus == fieldName))
 
 	toolVal := "(none configured)"
 	if len(m.form.toolNames) > 0 {
 		toolVal = subtleStyle.Render("◂ ") + valueStyle.Render(m.form.toolNames[m.form.toolIndex]) + subtleStyle.Render(" ▸")
 	}
 	b.WriteString(formField("tool", toolVal, m.form.focus == fieldTool))
-	b.WriteString(formField("dir", m.form.dir.View(), m.form.focus == fieldDir))
+	b.WriteString(formField("dir", textInputView(m.form.dir), m.form.focus == fieldDir))
 	if m.form.focus == fieldDir && m.pathSugg.active() {
 		b.WriteString(m.viewPathSuggestions() + "\n")
 	}
@@ -169,7 +169,7 @@ func (m *Model) viewForm() string {
 	b.WriteString(formField("worktree", worktreeField, m.form.focus == fieldWorktree))
 	// Chips are tokens inside the typed text, so they wrap and reflow with
 	// the words around them; painting happens on the rendered prompt.
-	b.WriteString(formField("prompt", m.form.prompt.renderChips(m.form.prompt.input.View()), m.form.focus == fieldPrompt))
+	b.WriteString(formField("prompt", m.form.prompt.renderChips(textAreaView(m.form.prompt.input)), m.form.focus == fieldPrompt))
 	b.WriteString(formField("group", groupBadge(displayGroup(m.form.groups[m.form.groupIndex].path)), m.form.focus == fieldGroup))
 
 	if m.form.focus == fieldGroup {
@@ -241,9 +241,9 @@ func (m *Model) viewGroupPicker() string {
 
 func (m *Model) viewGroupForm() string {
 	var b strings.Builder
-	b.WriteString(formField("name", m.groupForm.name.View(), m.groupForm.focus == gfName))
+	b.WriteString(formField("name", textInputView(m.groupForm.name), m.groupForm.focus == gfName))
 	b.WriteString(formField("parent", groupBadge(displayGroup(m.selectedGroupPath())), m.groupForm.focus == gfParent))
-	b.WriteString(formField("path", m.groupForm.path.View(), m.groupForm.focus == gfPath))
+	b.WriteString(formField("path", textInputView(m.groupForm.path), m.groupForm.focus == gfPath))
 	if m.groupForm.focus == gfPath && m.pathSugg.active() {
 		b.WriteString(m.viewPathSuggestions() + "\n")
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -132,6 +132,9 @@ type Model struct {
 	pane    paneMirror
 	// cursorOn is the caret's blink phase while focused.
 	cursorOn bool
+	// imeCursor is shared with the terminal output writer so the host input
+	// method can follow whichever software caret the UI rendered.
+	imeCursor *cursorAnchor
 	// focusScroll is how many lines the focused pane is scrolled back into
 	// its history; zero is live at the bottom.
 	focusScroll int
@@ -697,6 +700,7 @@ func New(cfg config.Config, st *store.Store, driver *tmux.Driver, engine *status
 		fullLayout:          storedFullLayout(st),
 		hideHeader:          storedHideHeader(st),
 		hideStats:           storedHideStats(st),
+		imeCursor:           &cursorAnchor{},
 		mode:                modeList,
 		update:              updateInfo{version: version},
 		dismissed:           loadDismissed(st),

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1728,7 +1728,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.errBar.text = msg.warn
-		return m, tea.ExecProcess(m.tmux.AttachCommand(msg.sessID), func(err error) tea.Msg {
+		return m, execTerminalProcess(m.tmux.AttachCommand(msg.sessID), func(err error) tea.Msg {
 			return attachDoneMsg{sessID: msg.sessID, err: err}
 		})
 

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -639,7 +639,7 @@ func (m *Model) applyUpdateCmd() tea.Cmd {
 // prompt work as in a plain shell.
 func delegatedUpdateCmd(manager update.Manager, execPath string) tea.Cmd {
 	command := exec.Command(manager.Command[0], manager.Command[1:]...)
-	return tea.ExecProcess(command, func(err error) tea.Msg {
+	return execTerminalProcess(command, func(err error) tea.Msg {
 		return delegatedUpdateResult(manager, execPath, err)
 	})
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -15,7 +15,7 @@ import (
 
 func (m *Model) View() string {
 	if m.width == 0 {
-		return "loading..."
+		return m.syncCursorAnchor("loading...")
 	}
 	var frame string
 	switch m.mode {
@@ -44,7 +44,7 @@ func (m *Model) View() string {
 	default:
 		frame = m.viewListFrame()
 	}
-	return clampFrame(frame, m.height)
+	return m.syncCursorAnchor(clampFrame(frame, m.height))
 }
 
 // clampFrame pins a rendered frame to exactly height rows so the outer
@@ -252,7 +252,7 @@ func (m *Model) renameRowInput(entry treeRow, width int) string {
 	if fieldWidth := width - 4; fieldWidth >= 5 {
 		m.rename.input.Width = fieldWidth
 	}
-	return lead + " " + m.rename.input.View()
+	return lead + " " + textInputView(m.rename.input)
 }
 
 // divider renders a labeled section rule that fills the given width: an
@@ -365,6 +365,7 @@ var previewDangerSeqs = regexp.MustCompile(
 )
 
 func previewLine(line string, width int) string {
+	line = strings.ReplaceAll(line, cursorAnchorMarker, "")
 	line = previewDangerSeqs.ReplaceAllString(line, "")
 	line = strings.Map(func(r rune) rune {
 		if r < 0x20 && r != 0x1b && r != '\t' {

--- a/main.go
+++ b/main.go
@@ -153,7 +153,11 @@ func run() error {
 	// scrolls the host's scrollback out from under the manager nor arrives
 	// as an arrow key that walks the session cursor. Alternate scroll is
 	// cleared too: a crashed earlier run can leave it set.
-	program := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	program := tea.NewProgram(model,
+		tea.WithAltScreen(),
+		tea.WithMouseCellMotion(),
+		tea.WithOutput(model.CursorOutput(os.Stdout)),
+	)
 	if err := ui.DisableAlternateScroll(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What changed

- Anchor macOS input-method composition to the actual software cursor rendered by Agent Manager.
- Track text inputs, text areas, searches, diff comments, fork forms, and focused panes.
- Preserve cursor blinking and wide/ANSI-aware cell positions.
- Keep the terminal cursor wrapper limited to alternate-screen output.
- Handle alternate-screen enter/exit sequences split across multiple writes.
- Add regression coverage for IME anchors, wide text, wrapped text, blink phases, ANSI output, and split terminal sequences.

## Why

Bubble Tea leaves the native terminal cursor at the renderer position, while Agent Manager renders software cursors inside input widgets and focused panes. On macOS this can place IME composition candidates away from the text being edited.

## Verification

- `gofmt -l .` prints nothing
- `go vet ./...` passes
- `go build ./...` passes
- IME/cursor-focused tests pass
- `go test -race ./...` was run

The full race suite currently has a pre-existing failure in `TestReviveStartsTheAgentAgainInALivePane`. The same test fails repeatedly on an unmodified checkout of the current `main`, so it is not introduced by this PR.

## Visual evidence

Not included: the change affects native IME cursor placement and requires an interactive macOS input-method environment; the regression tests exercise the cursor coordinates and terminal output behavior directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cursor positioning and input-method support across text fields, search boxes, rename dialogs, forms, and text areas.
  - Kept cursor placement accurate during scrolling, wrapped text, wide characters, blinking states, and alternate-screen transitions.
  - Prevented internal cursor markers from appearing in previews or inactive views.
  - Improved terminal behavior when launching editors, attach sessions, and interactive upgrade commands.
- **Tests**
  - Added comprehensive coverage for cursor anchoring, ANSI output, search behavior, scrolling, wide-character handling, and alternate-screen rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->