### PR TITLE
docs(readme): show the Product Hunt featured badge beside Trendshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@
   </a>
 </p>
 
-<p align="center"><a href="https://trendshift.io/repositories/89312?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-89312" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/89312/daily?language=Go" alt="agent-manager on Trendshift" width="250" height="55"></a></p>
+<p align="center">
+  <a href="https://trendshift.io/repositories/89312?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-89312" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/89312/daily?language=Go" alt="agent-manager on Trendshift" width="250" height="55"></a>
+  <a href="https://www.producthunt.com/products/agent-manager?utm_source=badge-featured&amp;utm_medium=badge" target="_blank" rel="noopener noreferrer"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1212310&amp;theme=dark" alt="agent-manager on Product Hunt" width="250" height="54"></a>
+</p>
 
 <p align="center">
   <a href="https://github.com/YoanWai/agent-manager/stargazers"><img src="https://img.shields.io/github/stars/YoanWai/agent-manager?style=for-the-badge&label=stars&labelColor=1f2328&color=96591f" alt="stars"></a>


### PR DESCRIPTION
## What changed

The Product Hunt featured badge joins the Trendshift badge on one centred row near the top of `README.md`.

## Why

The launch crossed 100 upvotes. `featured.svg` renders the count live, so the row shows the current number rather than a claim that goes stale.

The two sit together because they are the same kind of thing, a third-party scoreboard, at the same size. The Peerlist laurel stays on its own line above them, since it announces something live rather than reporting a standing.

## How it was verified

`featured.svg?post_id=1212310&theme=dark` answers `200 image/svg+xml`, 2,079 bytes, intrinsic 250x54, and the rendered SVG carries `100`.

Rendered the pushed branch in a browser and read the images back: Trendshift 250x55 and Product Hunt 250x54 both report `complete: true`, level on one row, well inside the 758px README column.

Markdown only, so no Go checks apply.

## Visual evidence

The row renders on the branch: <https://github.com/YoanWai/agent-manager/tree/docs/readme-ph-featured>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README badge section to display Trendshift and Product Hunt badges together in a centered layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->