### PR TITLE
fix(cli): revive an agent inside the pane it left behind

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -190,7 +190,7 @@ Every session of an MCP-capable tool carries the agent-manager MCP server on spa
 
 Each field falls back the way the form does. The CLI defaults to the one the calling agent runs, the group and directory default to the caller's, an explicit group uses that group's nearest inherited default path, and an explicit directory wins over both. A name is the agent's to choose and should describe the work; leaving it empty generates a placeholder and asks the new session to rename itself, exactly as a promptless spawn from the form does. Passing `worktree: true` adds a git worktree and branch off the directory's repo, which is what keeps several agents working in one project from editing the same checkout; omitting it inherits the group's default, then the global setting.
 
-`read_session` returns the target's current screen, and its last captured screen once the session has stopped. `kill_session` ends the process and leaves the row dead with its last screen, `revive_session` brings it back on the conversation it held, and `archive_session` files a finished row away or restores it.
+`read_session` returns the target's current screen, and its last captured screen once the session has stopped. `kill_session` ends the process and leaves the row dead with its last screen, `revive_session` brings it back on the conversation it held, and `archive_session` files a finished row away or restores it. An agent that quit while its window stayed open is relaunched inside that pane, so the row keeps the screen its last life left there.
 
 ### Messages between agents
 

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -57,7 +57,7 @@ func sessionSection() section {
 			{name: "wait", usage: usageWait, about: "park until another session stops working, instead of reading its screen in a loop; exits non-zero when it timed out", run: bind(newSessions, runWait)},
 			{name: "message-status", usage: usageMessageStatus, about: "check whether a message you sent is queued, held, delivered, dropped or answered", run: bind(newSessions, runMessageStatus)},
 			{name: "kill", usage: usageKill, about: "stop another agent's process, ending whatever it is doing; its row keeps the last screen", run: bind(newSessions, runKill)},
-			{name: "revive", usage: usageRevive, about: "bring a dead session back on its old row, resuming the conversation it held", run: bind(newSessions, runRevive)},
+			{name: "revive", usage: usageRevive, about: "bring a dead session back on its old row, resuming the conversation it held; an agent that quit inside a live pane comes back there", run: bind(newSessions, runRevive)},
 			{name: "archive", usage: usageArchive, about: "file a finished session out of the active list, or restore it with --restore", run: bind(newSessions, runArchive)},
 			{name: "groups", usage: usageGroups, about: "list the groups sessions and terminals are filed under", run: bind(newSessions, runGroups)},
 			{name: "create-group", usage: usageCreateGroup, about: "create a group so a fleet you spawn stays together in the user's list", run: bind(newSessions, runCreateGroup)},

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -374,6 +374,7 @@ func newServer(configDir, sessionID, version string, terminals terminalCommands,
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "revive_session",
 		Description: "Bring a dead session back on its old row, resuming the conversation it held where its CLI supports that. " +
+			"An agent that quit while its window stayed open comes back inside that same pane. " +
 			"Call when list_sessions or send_session reports a session is not running and its work should continue.",
 		Annotations: toolAnnotations(false, false, true),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args sessionTargetArgs) (*mcp.CallToolResult, sessioncmd.Session, error) {

--- a/internal/sessioncmd/relaunch.go
+++ b/internal/sessioncmd/relaunch.go
@@ -14,11 +14,8 @@ import (
 )
 
 // RelaunchInPane starts a session's tool again inside the shell its pane
-// already holds, for a session whose window is alive because only the agent
-// exited. The command is typed into that shell rather than launched over a
-// fresh window, so nothing about the pane is lost and the agent comes back
-// as the shell's child, the shape every other session has. It carries the
-// session environment inline as well, since a pane opened by an older
+// already holds, so the pane keeps everything its last life left there. The
+// session environment rides along inline because a pane opened by an older
 // manager holds a shell that was never given it.
 func RelaunchInPane(driver *tmux.Driver, st *store.Store, hookManager *hooks.Manager, sess store.Session, tool config.Tool) (time.Time, error) {
 	running, err := AgentRunning(driver, sess.ID)

--- a/internal/sessioncmd/relaunch.go
+++ b/internal/sessioncmd/relaunch.go
@@ -1,0 +1,82 @@
+package sessioncmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/config"
+	"github.com/YoanWai/agent-manager/internal/hooks"
+	"github.com/YoanWai/agent-manager/internal/launch"
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/store"
+	"github.com/YoanWai/agent-manager/internal/sysstat"
+	"github.com/YoanWai/agent-manager/internal/tmux"
+)
+
+// RelaunchInPane starts a session's tool again inside the shell its pane
+// already holds, for a session whose window is alive because only the agent
+// exited. The command is typed into that shell rather than launched over a
+// fresh window, so nothing about the pane is lost and the agent comes back
+// as the shell's child, the shape every other session has. It carries the
+// session environment inline as well, since a pane opened by an older
+// manager holds a shell that was never given it.
+func RelaunchInPane(driver *tmux.Driver, st *store.Store, hookManager *hooks.Manager, sess store.Session, tool config.Tool) (time.Time, error) {
+	running, err := AgentRunning(driver, sess.ID)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if running {
+		return time.Time{}, fmt.Errorf("session %s is still running; revive brings back an agent that exited", sess.Name)
+	}
+	base := launch.ReviveCommand(tool, sess.AgentSessionID)
+	command, env, err := launch.Environment(hookManager, sess.Tool, tool, base, sess.ID)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if err := driver.SendKeys(sess.ID, tmux.ExportEnv(env, command), "Enter"); err != nil {
+		return time.Time{}, err
+	}
+	launchedAt := time.Now()
+	if err := st.SetAgentLaunchedAt(sess.ID, launchedAt); err != nil {
+		return time.Time{}, err
+	}
+	if err := st.UpdateStatus(sess.ID, status.Starting); err != nil {
+		return time.Time{}, err
+	}
+	// A leftover ack from the agent that exited must not swallow the first
+	// finished alert of the one taking its place.
+	if err := st.SetAcked(sess.ID, false); err != nil {
+		return time.Time{}, err
+	}
+	return launchedAt, nil
+}
+
+// paneSettle is how long a busy pane is given to come back empty. A shell
+// forks for its own startup work, and one sample cannot tell that apart
+// from an agent.
+const paneSettle = 250 * time.Millisecond
+
+// AgentRunning reports whether a live pane still holds an agent: the pane's
+// own pid is its shell, so anything under it is the agent. A sample that
+// could not be read counts as running, because typing a command into a pane
+// that turns out to hold an agent puts the text in its composer.
+func AgentRunning(driver *tmux.Driver, sessID string) (bool, error) {
+	busy, err := paneBusy(driver, sessID)
+	if err != nil || !busy {
+		return busy, err
+	}
+	time.Sleep(paneSettle)
+	return paneBusy(driver, sessID)
+}
+
+func paneBusy(driver *tmux.Driver, sessID string) (bool, error) {
+	pid, err := driver.PanePID(sessID)
+	if err != nil {
+		return true, err
+	}
+	stat, sampled := sysstat.Trees([]int{pid})[pid]
+	if !sampled || !stat.OK {
+		return true, fmt.Errorf("cannot read what session %s is running", sessID)
+	}
+	return stat.Procs > 1, nil
+}

--- a/internal/sessioncmd/relaunch_test.go
+++ b/internal/sessioncmd/relaunch_test.go
@@ -1,11 +1,9 @@
 package sessioncmd
 
 import (
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/tmux"
 )
 
@@ -30,46 +28,4 @@ func waitForAgentGone(t *testing.T, driver *tmux.Driver, sessID string) {
 		time.Sleep(25 * time.Millisecond)
 	}
 	t.Fatalf("session %s never came back to its shell", sessID)
-}
-
-// An agent that exits leaves its window open on the shell it was launched
-// from. Revive puts the tool back inside that pane instead of refusing the
-// row as still running, which is what the manager's own revive key does.
-func TestReviveRestartsTheAgentInsideItsLivePane(t *testing.T) {
-	h := newSessionHarness(t)
-	created, err := h.sessions.Create(h.caller.ID, CreateSessionOptions{Name: "worker", Prompt: "hold the line"})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	waitForSessionOutput(t, h.sessions, h.caller.ID, created.ID, "hold the line")
-	waitForAgentGone(t, h.driver, created.ID)
-
-	revived, err := h.sessions.Revive(h.caller.ID, created.ID)
-	if err != nil {
-		t.Fatalf("Revive: %v", err)
-	}
-	if !revived.Running || revived.Status != status.Starting {
-		t.Fatalf("revived session = %+v", revived)
-	}
-	screen := waitForSessionOutput(t, h.sessions, h.caller.ID, created.ID, "resumed")
-	if !strings.Contains(screen.Output, "hold the line") {
-		t.Fatalf("an in-pane revive keeps what the pane already held, got %q", screen.Output)
-	}
-	if !h.driver.Exists(created.ID) {
-		t.Fatal("revive should have left the window running")
-	}
-}
-
-func TestReviveRefusesWhileTheAgentIsStillRunning(t *testing.T) {
-	h := newSessionHarness(t)
-	created, err := h.sessions.Create(h.caller.ID, CreateSessionOptions{Name: "chatty", Tool: "resting"})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	waitForSessionOutput(t, h.sessions, h.caller.ID, created.ID, "❯")
-
-	if _, err := h.sessions.Revive(h.caller.ID, created.ID); err == nil ||
-		!strings.Contains(err.Error(), "still running") {
-		t.Fatalf("reviving a session whose agent is up = %v", err)
-	}
 }

--- a/internal/sessioncmd/relaunch_test.go
+++ b/internal/sessioncmd/relaunch_test.go
@@ -9,14 +9,23 @@ import (
 	"github.com/YoanWai/agent-manager/internal/tmux"
 )
 
+// waitForAgentGone waits for the pane to hold nothing but its shell, and
+// for that to still be true on a second reading: the launch script's own
+// exit leaves a process visible for a moment after the agent is done.
 func waitForAgentGone(t *testing.T, driver *tmux.Driver, sessID string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
+	quiet := 0
 	for time.Now().Before(deadline) {
 		running, err := AgentRunning(driver, sessID)
 		if err == nil && !running {
-			return
+			quiet++
+			if quiet == 2 {
+				return
+			}
+			continue
 		}
+		quiet = 0
 		time.Sleep(25 * time.Millisecond)
 	}
 	t.Fatalf("session %s never came back to its shell", sessID)

--- a/internal/sessioncmd/relaunch_test.go
+++ b/internal/sessioncmd/relaunch_test.go
@@ -1,0 +1,65 @@
+package sessioncmd
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoanWai/agent-manager/internal/status"
+	"github.com/YoanWai/agent-manager/internal/tmux"
+)
+
+func waitForAgentGone(t *testing.T, driver *tmux.Driver, sessID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		running, err := AgentRunning(driver, sessID)
+		if err == nil && !running {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("session %s never came back to its shell", sessID)
+}
+
+// An agent that exits leaves its window open on the shell it was launched
+// from. Revive puts the tool back inside that pane instead of refusing the
+// row as still running, which is what the manager's own revive key does.
+func TestReviveRestartsTheAgentInsideItsLivePane(t *testing.T) {
+	h := newSessionHarness(t)
+	created, err := h.sessions.Create(h.caller.ID, CreateSessionOptions{Name: "worker", Prompt: "hold the line"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	waitForSessionOutput(t, h.sessions, h.caller.ID, created.ID, "hold the line")
+	waitForAgentGone(t, h.driver, created.ID)
+
+	revived, err := h.sessions.Revive(h.caller.ID, created.ID)
+	if err != nil {
+		t.Fatalf("Revive: %v", err)
+	}
+	if !revived.Running || revived.Status != status.Starting {
+		t.Fatalf("revived session = %+v", revived)
+	}
+	screen := waitForSessionOutput(t, h.sessions, h.caller.ID, created.ID, "resumed")
+	if !strings.Contains(screen.Output, "hold the line") {
+		t.Fatalf("an in-pane revive keeps what the pane already held, got %q", screen.Output)
+	}
+	if !h.driver.Exists(created.ID) {
+		t.Fatal("revive should have left the window running")
+	}
+}
+
+func TestReviveRefusesWhileTheAgentIsStillRunning(t *testing.T) {
+	h := newSessionHarness(t)
+	created, err := h.sessions.Create(h.caller.ID, CreateSessionOptions{Name: "chatty", Tool: "resting"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	waitForSessionOutput(t, h.sessions, h.caller.ID, created.ID, "❯")
+
+	if _, err := h.sessions.Revive(h.caller.ID, created.ID); err == nil ||
+		!strings.Contains(err.Error(), "still running") {
+		t.Fatalf("reviving a session whose agent is up = %v", err)
+	}
+}

--- a/internal/sessioncmd/relaunch_test.go
+++ b/internal/sessioncmd/relaunch_test.go
@@ -23,6 +23,7 @@ func waitForAgentGone(t *testing.T, driver *tmux.Driver, sessID string) {
 			if quiet == 2 {
 				return
 			}
+			time.Sleep(25 * time.Millisecond)
 			continue
 		}
 		quiet = 0

--- a/internal/sessioncmd/session.go
+++ b/internal/sessioncmd/session.go
@@ -724,15 +724,22 @@ func (s *Sessions) Revive(sessionID, targetID string) (Session, error) {
 	if err != nil {
 		return Session{}, err
 	}
-	if runtime.driver.Exists(target.ID) {
-		return Session{}, fmt.Errorf("session %s is still running; revive only applies to dead sessions", target.ID)
-	}
 	tool, known := runtime.cfg.Tools[target.Tool]
 	if !known {
 		return Session{}, fmt.Errorf("tool %s is no longer configured", target.Tool)
 	}
 	if _, err := resolveTerminalDirectory(target.Cwd); err != nil {
 		return Session{}, fmt.Errorf("working directory no longer exists: %s", target.Cwd)
+	}
+	// A window whose agent exited is still open on its shell, so the tool
+	// comes back inside that pane and the row keeps the scrollback its last
+	// life left there.
+	if runtime.driver.Exists(target.ID) {
+		if _, err := RelaunchInPane(runtime.driver, runtime.store, hooks.NewManager(s.configDir), target, tool); err != nil {
+			return Session{}, err
+		}
+		target.Status = status.Starting
+		return runtime.sessionInfo(target, true, false), nil
 	}
 	base := launch.ReviveCommand(tool, target.AgentSessionID)
 	command, env, err := launch.Environment(hooks.NewManager(s.configDir), target.Tool, tool, base, target.ID)

--- a/internal/sessioncmd/session.go
+++ b/internal/sessioncmd/session.go
@@ -731,9 +731,8 @@ func (s *Sessions) Revive(sessionID, targetID string) (Session, error) {
 	if _, err := resolveTerminalDirectory(target.Cwd); err != nil {
 		return Session{}, fmt.Errorf("working directory no longer exists: %s", target.Cwd)
 	}
-	// A window whose agent exited is still open on its shell, so the tool
-	// comes back inside that pane and the row keeps the scrollback its last
-	// life left there.
+	// Reviving inside the surviving pane keeps the scrollback its last life
+	// left there.
 	if runtime.driver.Exists(target.ID) {
 		if _, err := RelaunchInPane(runtime.driver, runtime.store, hooks.NewManager(s.configDir), target, tool); err != nil {
 			return Session{}, err

--- a/internal/sessioncmd/session_test.go
+++ b/internal/sessioncmd/session_test.go
@@ -309,10 +309,6 @@ func TestSessionsKillKeepsTheScreenAndReviveBringsItBack(t *testing.T) {
 	if !revived.Running || !h.driver.Exists(created.ID) {
 		t.Fatalf("revived session = %+v", revived)
 	}
-	if _, err := h.sessions.Revive(h.caller.ID, created.ID); err == nil ||
-		!strings.Contains(err.Error(), "still running") {
-		t.Fatalf("reviving a live session error = %v", err)
-	}
 	if _, err := h.sessions.Kill(h.caller.ID, h.caller.ID); err == nil {
 		t.Fatal("a session must not kill itself")
 	}

--- a/internal/sessioncmd/session_test.go
+++ b/internal/sessioncmd/session_test.go
@@ -847,3 +847,45 @@ func TestDeleteGroupTakesItsSubtreeAndKeepsNesting(t *testing.T) {
 		t.Fatalf("moving the subtree unhooked the terminal from its agent: parent %q", after.ParentID)
 	}
 }
+
+// An agent that exits leaves its window open on the shell it was launched
+// from. Revive puts the tool back inside that pane instead of refusing the
+// row as still running, which is what the manager's own revive key does.
+func TestReviveRestartsTheAgentInsideItsLivePane(t *testing.T) {
+	h := newSessionHarness(t)
+	created, err := h.sessions.Create(h.caller.ID, CreateSessionOptions{Name: "worker", Prompt: "hold the line"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	waitForSessionOutput(t, h.sessions, h.caller.ID, created.ID, "hold the line")
+	waitForAgentGone(t, h.driver, created.ID)
+
+	revived, err := h.sessions.Revive(h.caller.ID, created.ID)
+	if err != nil {
+		t.Fatalf("Revive: %v", err)
+	}
+	if !revived.Running || revived.Status != status.Starting {
+		t.Fatalf("revived session = %+v", revived)
+	}
+	screen := waitForSessionOutput(t, h.sessions, h.caller.ID, created.ID, "resumed")
+	if !strings.Contains(screen.Output, "hold the line") {
+		t.Fatalf("an in-pane revive keeps what the pane already held, got %q", screen.Output)
+	}
+	if !h.driver.Exists(created.ID) {
+		t.Fatal("revive should have left the window running")
+	}
+}
+
+func TestReviveRefusesWhileTheAgentIsStillRunning(t *testing.T) {
+	h := newSessionHarness(t)
+	created, err := h.sessions.Create(h.caller.ID, CreateSessionOptions{Name: "chatty", Tool: "resting"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	waitForSessionOutput(t, h.sessions, h.caller.ID, created.ID, "❯")
+
+	if _, err := h.sessions.Revive(h.caller.ID, created.ID); err == nil ||
+		!strings.Contains(err.Error(), "still running") {
+		t.Fatalf("reviving a session whose agent is up = %v", err)
+	}
+}

--- a/internal/ui/helpers_test.go
+++ b/internal/ui/helpers_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/hooks"
+	"github.com/YoanWai/agent-manager/internal/sessioncmd"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	"github.com/YoanWai/agent-manager/internal/sysstat"
@@ -358,7 +359,7 @@ func waitForAgent(t *testing.T, m *Model, sessID string, want bool) {
 	t.Helper()
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		if running, err := agentRunning(m.tmux, sessID); err == nil && running == want {
+		if running, err := sessioncmd.AgentRunning(m.tmux, sessID); err == nil && running == want {
 			return
 		}
 		time.Sleep(50 * time.Millisecond)

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -8,10 +8,9 @@ import (
 
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/launch"
+	"github.com/YoanWai/agent-manager/internal/sessioncmd"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
-	"github.com/YoanWai/agent-manager/internal/sysstat"
-	"github.com/YoanWai/agent-manager/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/google/uuid"
 )
@@ -335,69 +334,13 @@ func (m *Model) relaunchInPane(sess store.Session) (tea.Cmd, error) {
 		return nil, fmt.Errorf("working directory no longer exists: %s", sess.Cwd)
 	}
 	driver, stor, hookManager := m.tmux, m.store, m.hooks
-	base := launch.ReviveCommand(tool, sess.AgentSessionID)
 	return func() tea.Msg {
-		failed := func(err error) tea.Msg {
+		launchedAt, err := sessioncmd.RelaunchInPane(driver, stor, hookManager, sess, tool)
+		if err != nil {
 			return relaunchedMsg{sessID: sess.ID, err: err}
-		}
-		running, err := agentRunning(driver, sess.ID)
-		if err != nil {
-			return failed(err)
-		}
-		if running {
-			return failed(fmt.Errorf("session %s is still running; revive brings back an agent that exited", sess.Name))
-		}
-		command, env, err := launch.Environment(hookManager, sess.Tool, tool, base, sess.ID)
-		if err != nil {
-			return failed(err)
-		}
-		if err := driver.SendKeys(sess.ID, tmux.ExportEnv(env, command), "Enter"); err != nil {
-			return failed(err)
-		}
-		launchedAt := time.Now()
-		if err := stor.SetAgentLaunchedAt(sess.ID, launchedAt); err != nil {
-			return failed(err)
-		}
-		if err := stor.UpdateStatus(sess.ID, status.Starting); err != nil {
-			return failed(err)
-		}
-		// A leftover ack from the agent that exited must not swallow the
-		// first finished alert of the one taking its place.
-		if err := stor.SetAcked(sess.ID, false); err != nil {
-			return failed(err)
 		}
 		return relaunchedMsg{sessID: sess.ID, launchedAt: launchedAt}
 	}, nil
-}
-
-// paneSettle is how long a busy pane is given to come back empty. A shell
-// forks for its own startup work, and one sample cannot tell that apart
-// from an agent.
-const paneSettle = 250 * time.Millisecond
-
-// agentRunning reports whether a live pane still holds an agent: the pane's
-// own pid is its shell, so anything under it is the agent. A sample that
-// could not be read counts as running, because typing a command into a pane
-// that turns out to hold an agent puts the text in its composer.
-func agentRunning(driver *tmux.Driver, sessID string) (bool, error) {
-	busy, err := paneBusy(driver, sessID)
-	if err != nil || !busy {
-		return busy, err
-	}
-	time.Sleep(paneSettle)
-	return paneBusy(driver, sessID)
-}
-
-func paneBusy(driver *tmux.Driver, sessID string) (bool, error) {
-	pid, err := driver.PanePID(sessID)
-	if err != nil {
-		return true, err
-	}
-	stat, sampled := sysstat.Trees([]int{pid})[pid]
-	if !sampled || !stat.OK {
-		return true, fmt.Errorf("cannot read what session %s is running", sessID)
-	}
-	return stat.Procs > 1, nil
 }
 
 // restartSelected asks to relaunch the selected session with an empty


### PR DESCRIPTION
`agent-manager revive <id>` refused any session whose window was still open:

```
agent-manager: session bbb22222 is still running; revive only applies to dead sessions
```

An agent that quits leaves its window open on the shell it was launched from, so that message covers the most common reason to reach for revive at all. The manager's own `v` key has always handled it (`reviveSelected` branches on `tmux.Exists` into `relaunchInPane`); the CLI and the MCP tool did not, so an agent whose CLI exited could only be brought back by typing its resume command into the pane by hand.

## What changed

- The in-pane relaunch moved to `sessioncmd.RelaunchInPane`, beside the other session commands, with the pane probe (`AgentRunning`) that decides whether the pane still holds an agent. The TUI now calls it instead of its own copy.
- `Sessions.Revive` takes the same three-way branch as the manager: a window that is gone gets a fresh one as before; a window alive with an agent in it is refused; a window alive at its shell has the tool typed back into it, keeping the pane's scrollback and its place in the tree. `revive_session` over MCP inherits this.
- The CLI's about line, the MCP tool description and the usage table say so.

## Test plan

- [x] `TestReviveRestartsTheAgentInsideItsLivePane`: the tool comes back, the row reads `starting`, the pane still shows what it held before, and the window is the same one
- [x] `TestReviveRefusesWhileTheAgentIsStillRunning` keeps the refusal for a pane whose agent is up. `TestSessionsKillKeepsTheScreenAndReviveBringsItBack` loses the assertion that any live pane is refused, which is the behaviour this changes
- [x] Live, on a throwaway `HOME` and an isolated `TMUX_TMPDIR`: the released binary answered `still running; revive only applies to dead sessions`, this build answered `revived revive-me (id bbb22222) running echoer in root`, and the pane kept its earlier output above the resumed command, in the window created before the revive
- [x] `go test ./...` green on an isolated socket; `gofmt` and `go vet` clean

- [x] Note: `internal/ui` is flaky on the machine this ran on, on unmodified `main` as well; every package this PR touches is green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Revive now relaunches exited agents in their existing live pane, preserving prior screen contents and scrollback.
  * Session status and output update correctly after an in-pane relaunch.
  * Revival remains blocked while an agent is still running.

* **Documentation**
  * Clarified that relaunching an exited agent preserves its existing pane and previous screen.
  * Updated command and tool help to explain in-pane relaunch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->