### PR TITLE
fix(status): let pi rules absorb extra footer lines

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -192,6 +193,23 @@ const (
 	oldCmdChromeLine = `^\s*[─]{4,}\s*$|^# .*$|^[ \t█]*$|^\s*\? for shortcuts.*$`
 )
 
+// The pi matching rules used to pin the pane tail at exactly two footer
+// lines under the composer, so a pi extension drawing a taller footer kept
+// every rule from matching in every state. A stored config.toml
+// carries these old strings verbatim and keeps them over any new default,
+// so mergeTool rewrites exactly these stale values the way the command-code
+// rules are rewritten.
+const (
+	oldPiIdleRule      = `(?ms)^[ \t]*Resumed session[ \t]*\n[ \t]*\n─{8,}[ \t]*\n(?:[ \t]*\n)*─{8,}[ \t]*` + oldPiFooterTail
+	oldPiErrorRule     = `(?ms)^[ \t]*Error:[^\n]*(?:\n[ \t]+[^ \t\n][^\n]*){0,8}\n[ \t]*\n─{8,}[ \t]*\n(?:[ \t]*\n)*─{8,}[ \t]*` + oldPiFooterTail
+	oldPiRateLimitRule = `(?ms)^[ \t]*[^\n]*rate limit reached[^\n]*\n[ \t]*\n─{8,}[ \t]*\n(?:[ \t]*\n)*─{8,}[ \t]*` + oldPiFooterTail
+	oldPiQuestionRule  = `(?ms)\?[ \t]*\n[ \t]*\n─{8,}[ \t]*\n(?:[ \t]*\n)*─{8,}[ \t]*` + oldPiFooterTail
+	oldPiWorkingRule   = `(?ms)^[ \t]*[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \t]+(?:Working|Running|Retrying|Compacting context|Auto-compacting|Context overflow detected, Auto-compacting|Summarizing branch)\b[^\n]*\n[ \t]*\n─{8,}[ \t]*\n(?:[ \t]*\n)*─{8,}[ \t]*` + oldPiFooterTail
+
+	oldPiFooterTail = `\n[^\n]*\n[^\n]*[ \t]*(?:\n[ \t]*)*\z`
+	newPiFooterTail = `(?:\n[^\n]*){2,5}[ \t]*(?:\n[ \t]*)*\z`
+)
+
 // mergeTool returns user with any zero-value field filled from def.
 //
 // Shell is deliberately not among them. "terminal" is a plausible name for
@@ -244,6 +262,14 @@ func mergeTool(name string, user, def Tool) Tool {
 					user.Rules[i] = current
 					break
 				}
+			}
+		}
+	}
+	if name == "pi" {
+		for i, rule := range user.Rules {
+			switch rule.Pattern {
+			case oldPiIdleRule, oldPiErrorRule, oldPiRateLimitRule, oldPiQuestionRule, oldPiWorkingRule:
+				user.Rules[i].Pattern = strings.Replace(rule.Pattern, oldPiFooterTail, newPiFooterTail, 1)
 			}
 		}
 	}
@@ -571,12 +597,12 @@ input_prefix = "^"
 activity_cutoff = "(?ms)\\A.*^─{8,}[ \\t]*$"
 chrome_line = "^[ \\t]*─{8,}[ \\t]*$"
 rules = [
-  { state = "idle", pattern = "(?ms)^[ \\t]*Resumed session[ \\t]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*\\n[^\\n]*\\n[^\\n]*[ \\t]*(?:\\n[ \\t]*)*\\z" },
+  { state = "idle", pattern = "(?ms)^[ \\t]*Resumed session[ \\t]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
   { state = "waiting", pattern = "(?ms)^[ \\t]*Project trust[ \\t]*\\n.*\\n─{8,}[ \\t]*(?:\\n[ \\t]*)*\\z" },
-  { state = "errored", pattern = "(?ms)^[ \\t]*Error:[^\\n]*(?:\\n[ \\t]+[^ \\t\\n][^\\n]*){0,8}\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*\\n[^\\n]*\\n[^\\n]*[ \\t]*(?:\\n[ \\t]*)*\\z" },
-  { state = "errored", pattern = "(?ms)^[ \\t]*[^\\n]*rate limit reached[^\\n]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*\\n[^\\n]*\\n[^\\n]*[ \\t]*(?:\\n[ \\t]*)*\\z" },
-  { state = "waiting", pattern = "(?ms)\\?[ \\t]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*\\n[^\\n]*\\n[^\\n]*[ \\t]*(?:\\n[ \\t]*)*\\z" },
-  { state = "working", pattern = "(?ms)^[ \\t]*[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \\t]+(?:Working|Running|Retrying|Compacting context|Auto-compacting|Context overflow detected, Auto-compacting|Summarizing branch)\\b[^\\n]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*\\n[^\\n]*\\n[^\\n]*[ \\t]*(?:\\n[ \\t]*)*\\z" },
+  { state = "errored", pattern = "(?ms)^[ \\t]*Error:[^\\n]*(?:\\n[ \\t]+[^ \\t\\n][^\\n]*){0,8}\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
+  { state = "errored", pattern = "(?ms)^[ \\t]*[^\\n]*rate limit reached[^\\n]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
+  { state = "waiting", pattern = "(?ms)\\?[ \\t]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
+  { state = "working", pattern = "(?ms)^[ \\t]*[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \\t]+(?:Working|Running|Retrying|Compacting context|Auto-compacting|Context overflow detected, Auto-compacting|Summarizing branch)\\b[^\\n]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
 ]
 
 [tools.command-code]

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -529,3 +529,44 @@ func TestMigratesStaleCommandCodePatterns(t *testing.T) {
 		}
 	}
 }
+
+// A config.toml written before the pi footer widened carries rules that pin
+// exactly two footer lines, so a pi extension drawing more keeps every rule
+// from matching. The stale strings are rewritten to the current defaults;
+// a rule the user edited by hand is kept as written.
+func TestMigratesStalePiFooterRules(t *testing.T) {
+	handEdited := `(?ms)my own waiting rule\z`
+	cfg := Config{Tools: map[string]Tool{
+		"pi": {
+			Command: "pi",
+			Rules: []Rule{
+				{State: "idle", Pattern: oldPiIdleRule},
+				{State: "errored", Pattern: oldPiErrorRule},
+				{State: "errored", Pattern: oldPiRateLimitRule},
+				{State: "waiting", Pattern: oldPiQuestionRule},
+				{State: "working", Pattern: oldPiWorkingRule},
+				{State: "waiting", Pattern: handEdited},
+			},
+		},
+	}}
+	if err := cfg.backfillToolDefaults(); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	def, err := Default()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	defaults := make(map[string]bool)
+	for _, rule := range def.Tools["pi"].Rules {
+		defaults[rule.Pattern] = true
+	}
+	tool := cfg.Tools["pi"]
+	for _, rule := range tool.Rules[:5] {
+		if !defaults[rule.Pattern] {
+			t.Fatalf("stale %s rule was not rewritten to the current default: %q", rule.State, rule.Pattern)
+		}
+	}
+	if got := tool.Rules[5].Pattern; got != handEdited {
+		t.Fatalf("hand-edited rule = %q, want kept as written", got)
+	}
+}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -543,6 +543,10 @@ func TestPiPanes(t *testing.T) {
 			" ⠴ Working...\n\n─────────────────────────────────\n \n─────────────────────────────────\n~/scratch/2026-08-26-agent-man...\n↑12 ↓7.7k R77k W16k CH99.2% $0...\nhydra:navigator hit 89.0% (las...", Working},
 		{"active turn behind a 2-line footer stays covered",
 			" ⠴ Working...\n\n─────────────────────────────────\n \n─────────────────────────────────\n~/scratch/2026-08-26-agent-man...\n↑12 ↓7.7k R77k W16k CH99.2% $0...", Working},
+		{"active turn behind a 5-line extension footer",
+			" ⠴ Working...\n\n─────────────────────────────────\n \n─────────────────────────────────\n~/scratch/2026-08-26-agent-man...\n↑12 ↓7.7k R77k W16k CH99.2% $0...\nhydra:navigator hit 89.0% (las...\nmodel anthropic/claude-sonnet-4\ncontext 41.2k of 200k used", Working},
+		{"active turn behind a 6-line extension footer falls to the default",
+			" ⠴ Working...\n\n─────────────────────────────────\n \n─────────────────────────────────\n~/scratch/2026-08-26-agent-man...\n↑12 ↓7.7k R77k W16k CH99.2% $0...\nhydra:navigator hit 89.0% (las...\nmodel anthropic/claude-sonnet-4\ncontext 41.2k of 200k used\nbranch fix/pi-footer-lines", Finished},
 		{"resting turn behind a 3-line extension footer",
 			"Implementation complete." + editor + "\nhydra:navigator hit 89.0% (last hour)", Finished},
 	}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -539,6 +539,12 @@ func TestPiPanes(t *testing.T) {
 		{"error with trailing blanks", "Error: request failed" + editor + "\n\n", Errored},
 		{"old error", "Error: first attempt failed\n\nRetry completed." + editor, Finished},
 		{"historical error frame", "Error: request failed" + editor + "\n\nImplementation complete." + editor, Finished},
+		{"active turn behind a 3-line extension footer",
+			" ⠴ Working...\n\n─────────────────────────────────\n \n─────────────────────────────────\n~/scratch/2026-08-26-agent-man...\n↑12 ↓7.7k R77k W16k CH99.2% $0...\nhydra:navigator hit 89.0% (las...", Working},
+		{"active turn behind a 2-line footer stays covered",
+			" ⠴ Working...\n\n─────────────────────────────────\n \n─────────────────────────────────\n~/scratch/2026-08-26-agent-man...\n↑12 ↓7.7k R77k W16k CH99.2% $0...", Working},
+		{"resting turn behind a 3-line extension footer",
+			"Implementation complete." + editor + "\nhydra:navigator hit 89.0% (last hour)", Finished},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #407

## Bug

Every `[tools.pi]` rule anchors the pane tail as exactly two footer lines after the input box: `\n[^\n]*\n[^\n]*[ \t]*(?:\n[ \t]*)*\z`. A pi extension can draw extra footer lines (the reporter runs a 3-line footer), and then no rule matches in any state, so the status sticks at the `default_status` of `finished` even while pi is working.

## Fix

Each pi rule's footer tail widens from exactly two lines to two-to-five: `\n[^\n]*\n[^\n]*` becomes `(?:\n[^\n]*){2,5}`, with the rest of every pattern byte-identical. The bound is deliberate: an unbounded tail would let the rules match with the composer sitting high above the pane bottom, which is exactly what keeps historical frames from matching.

## Migration

A changed default never reaches an existing install, because the stored config.toml keeps the old rule strings verbatim. Following the `oldCmd*` treatment already in `mergeTool`: consts hold each old pi rule string verbatim (verified byte-identical to what the shipped TOML decodes to), and `mergeTool` rewrites a stored rule equal to an old string to the widened default. A rule the user edited by hand is kept as written.

## Tests

- `internal/status`: the reporter's failing pane, verbatim, derives `working`; the same pane with the extension line removed still derives `working` (2-line footers keep working); a finished-shape pane with a 3-line footer still derives `finished`.
- `internal/config`: a config carrying all five old pi rule strings is rewritten to the current defaults on load, and a hand-edited rule survives untouched.

Full suite green (`go test ./... -count=1` on an isolated tmux socket).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pi status detection when panes include multi-line footer information.
  * Correctly identifies active work as **Working** and completed turns as **Finished** in more layouts.
  * Automatically updates older Pi rule configurations to support expanded footer formats while preserving customized waiting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->