### PR TITLE
fix(launch): let the rename directive ride a prompt led by a pasted image

### DIFF
--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -46,7 +46,21 @@ func coordinationNote(toolName string, tool config.Tool) string {
 // session's first prompt; otherwise auto-named sessions get the rename
 // directive later as its own message.
 func DirectiveEmbeddable(prompt string) bool {
-	return prompt != "" && !strings.HasPrefix(prompt, "/")
+	return prompt != "" && !opensWithSlashCommand(prompt)
+}
+
+// opensWithSlashCommand separates a prompt the agent reads as a command,
+// which has to open the message, from one that merely starts with an
+// absolute path, as a prompt led by a pasted image does. A command name
+// is a single segment; a path carries further separators.
+func opensWithSlashCommand(prompt string) bool {
+	if !strings.HasPrefix(prompt, "/") {
+		return false
+	}
+	name := strings.TrimPrefix(prompt, "/")
+	name, _, _ = strings.Cut(name, " ")
+	name, _, _ = strings.Cut(name, "\n")
+	return name != "" && !strings.Contains(name, "/")
 }
 
 // Prompt prepends the short agent notes a first prompt can carry: auto-named

--- a/internal/launch/launch_test.go
+++ b/internal/launch/launch_test.go
@@ -238,3 +238,18 @@ func TestEnvironmentCarriesSessionIDAndHooks(t *testing.T) {
 		t.Fatalf("hooked command = %q", command)
 	}
 }
+
+func TestAssembleCarriesTheDirectiveOverAPastedImagePath(t *testing.T) {
+	flagged := config.Tool{Command: "claude", PromptFlag: "-p"}
+	prompt := "/var/folders/_b/T/agent-manager-pastes/paste-268.png why is this session working?"
+	plan := Assemble("claude", flagged, prompt, true)
+	if len(plan.PendingInputs) != 0 {
+		t.Fatalf("a prompt led by an image path is no slash command, got %v", plan.PendingInputs)
+	}
+	if !strings.Contains(plan.Command, RenameDirective) || !strings.Contains(plan.Command, prompt) {
+		t.Fatalf("directive should ride the prompt, got %q", plan.Command)
+	}
+	if DirectiveEmbeddable("/compact") || DirectiveEmbeddable("/land-pr now") {
+		t.Fatal("a slash command must still open its own message")
+	}
+}


### PR DESCRIPTION
## What

A launch prompt that opens with an absolute path now carries the rename directive and the coordination note on its first message. Only a real slash command, whose name is a single segment, still opens its own message and takes the notes as a follow-up.

## Why

Pasting an image as the first thing in the quick prompt puts the temp file path at the start of the message. `DirectiveEmbeddable` read any leading `/` as a slash command, so a spawn from that prompt deferred `DeferredRenameDirective` into a second message. That message arrived while the agent was already reading the image, landing in its queue ("Press up to edit queued messages") instead of riding the first prompt.

## Verified

- `TestAssembleCarriesTheDirectiveOverAPastedImagePath` covers both sides: a prompt led by a paste path embeds the directive with no pending inputs, and `/compact` / `/land-pr now` still defer.
- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./internal/launch/` passes; `gofmt -l .` is clean.
- Live spawn from a dev build (`agent-manager-dev spawn --tool claude --prompt "<paste path> describe this image…"`): the pane shows one message, the directive followed by the image path, the session renamed itself to `describe-pasted-image`, and no second message was queued.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prompts beginning with pasted image paths are now processed normally instead of being mistaken for slash commands.
  - Actual slash commands continue to receive their existing special handling.
- **Tests**
  - Added coverage to verify correct handling of pasted image paths and slash commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->