### PR TITLE
feat(update): read the release's own highlights into the messages panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,13 @@ The notes carry more than the generated list of pull requests:
   someone who installs it. Two or three sentences, the change first and the
   mechanism second. The generated list says which pull requests landed; it
   does not say what is different now.
+- **A `## Highlights` section above `## What's Changed`**, holding short
+  bullets, one per thing the release gives someone. The manager reads
+  exactly those bullets into its messages panel, so write them for a modal:
+  a sentence each, feature and fix language, no pull request numbers. Prose
+  in that section stays on the web page; only bullets travel. A release
+  without the section falls back to the generated list, filtered to
+  `feat`, `fix` and `perf`.
 - **Thanks to every contributor in the range, by handle.** Read the merged
   pull requests, not only the generated list, and name what each one did.
 - **Thanks to whoever reported what got fixed, by handle.** A bug someone
@@ -64,9 +71,9 @@ write the summary and leave it at that rather than manufacturing one.
 rather than sitting above it, so a file passed that way has to carry the
 list itself. Publishing first and then editing is the simpler order: take
 what goreleaser published with `gh release view <tag> --json body -q .body`,
-put the summary and thanks above its `## What's Changed`, and send it back
-with `gh release edit <tag> --notes-file notes.md`. The header and footer
-from `.goreleaser.yaml` come along either way.
+put the summary, the highlights and the thanks above its `## What's Changed`,
+and send it back with `gh release edit <tag> --notes-file notes.md`. The
+header and footer from `.goreleaser.yaml` come along either way.
 
 ## Layout
 

--- a/internal/feed/feed.go
+++ b/internal/feed/feed.go
@@ -24,8 +24,12 @@ import (
 )
 
 const (
-	cacheFile     = "message-feed.json"
-	checkInterval = 6 * time.Hour
+	cacheFile = "message-feed.json"
+	// checkInterval matches the release check. The feed exists to reach
+	// installs that are already running, so a floor longer than that one
+	// lets a release notice arrive hours before the message announcing it,
+	// and a known-issue warning arrive long after it was needed.
+	checkInterval = 10 * time.Minute
 	requestBudget = 4 * time.Second
 
 	maxPayload    = 64 << 10

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -507,11 +507,11 @@ func (m *Model) handleBrowserOpen(msg browserOpenMsg) {
 	m.errBar.text = fmt.Sprintf("could not open %s: %v; copying URL: %v", msg.target, msg.err, msg.copyErr)
 }
 
+// openNotices shows the panel even with nothing in it: a fresh install and
+// the first run after an update both retire every message, and that is
+// exactly when someone reaches for r to look again.
 func (m *Model) openNotices(selectID string) {
 	notices := m.activeNotices()
-	if len(notices) == 0 {
-		return
-	}
 	m.noticeCursor = 0
 	m.noticeScroll = 0
 	for i, n := range notices {
@@ -698,22 +698,9 @@ func (m *Model) noticeScrollLimit(notices []notice) int {
 	if m.noticeCursor >= len(notices) {
 		return 0
 	}
-	selected := notices[m.noticeCursor]
-	bodyRows := len(renderNoticeBody(selected, noticeInnerWidth(notices, m.width)))
-	tailRows := 1
-	if selected.url != "" {
-		tailRows++
-	}
-	if m.update.refreshing {
-		tailRows++
-	}
-	if m.update.applying {
-		tailRows++
-	}
-	if m.errBar.text != "" {
-		tailRows++
-	}
-	bodyRoom := noticeBodyRoom(m.height, len(notices), tailRows)
+	inner := noticeInnerWidth(notices, m.width)
+	bodyRows := len(renderNoticeBody(notices[m.noticeCursor], inner))
+	bodyRoom := noticeBodyRoom(m.height, len(notices), len(m.noticeTail(notices, inner))+1)
 	return max(0, bodyRows-bodyRoom)
 }
 
@@ -721,12 +708,35 @@ func noticeBodyRoom(height, noticeCount, tailRows int) int {
 	return max(1, height-2-(noticeCount+2)-tailRows)
 }
 
+// noticeTail is what sits under the body: where the selected notice leads,
+// and whatever the panel is doing or failed to do.
+func (m *Model) noticeTail(notices []notice, inner int) []string {
+	var tail []string
+	if m.noticeCursor < len(notices) {
+		if url := notices[m.noticeCursor].url; url != "" {
+			tail = append(tail, subtleStyle.Render("↗ "+truncateTail(strings.TrimPrefix(url, "https://"), inner-2)))
+		}
+	}
+	if m.update.refreshing {
+		tail = append(tail, lipgloss.NewStyle().Foreground(colorAccent2).Render("↻ refreshing releases and messages…"))
+	}
+	if m.update.applying {
+		tail = append(tail, lipgloss.NewStyle().Foreground(colorAccent).Render("↓ downloading "+m.update.latest+"…"))
+	}
+	if m.errBar.text != "" {
+		tail = append(tail, m.statusMessage("✕", "●"))
+	}
+	return tail
+}
+
 func (m *Model) viewNotices() string {
 	notices := m.activeNotices()
 	inner := noticeInnerWidth(notices, m.width)
 	if len(notices) == 0 {
-		frame := noticeFrame([]string{subtleStyle.Render("nothing new")}, inner,
-			noticeLegend(), keyCap("esc", "close"))
+		rows := []string{subtleStyle.Render("nothing new")}
+		rows = append(rows, m.noticeTail(notices, inner)...)
+		frame := noticeFrame(rows, inner, noticeLegend(),
+			mutedStyle.Render("r refresh · esc "))
 		return m.centerOnBackdrop(frame)
 	}
 	var rows []string
@@ -744,19 +754,7 @@ func (m *Model) viewNotices() string {
 	rows = append(rows, noticeBorderStyle().Render(strings.Repeat("┄", inner)))
 
 	body := renderNoticeBody(selected, inner)
-	var tail []string
-	if selected.url != "" {
-		tail = append(tail, subtleStyle.Render("↗ "+truncateTail(strings.TrimPrefix(selected.url, "https://"), inner-2)))
-	}
-	if m.update.refreshing {
-		tail = append(tail, lipgloss.NewStyle().Foreground(colorAccent2).Render("↻ refreshing releases and messages…"))
-	}
-	if m.update.applying {
-		tail = append(tail, lipgloss.NewStyle().Foreground(colorAccent).Render("↓ downloading "+m.update.latest+"…"))
-	}
-	if m.errBar.text != "" {
-		tail = append(tail, m.statusMessage("✕", "●"))
-	}
+	tail := m.noticeTail(notices, inner)
 	tail = append(tail, "")
 
 	rows = append(rows, fitBody(body, noticeBodyRoom(m.height, len(notices), len(tail)), m.noticeScroll)...)
@@ -778,6 +776,9 @@ func noticeInnerWidth(notices []notice, terminalWidth int) int {
 		lines := append(append([]string{}, n.body...), n.after...)
 		for _, release := range n.releases {
 			lines = append(lines, release.Version)
+			for _, change := range release.Highlights {
+				lines = append(lines, "• "+change)
+			}
 			for _, change := range release.Changes {
 				lines = append(lines, "• "+change)
 			}
@@ -806,6 +807,13 @@ func renderNoticeBody(n notice, width int) []string {
 		if i > 0 {
 			body = append(body, "")
 		}
+		// Authored bullets are the release in its own words, so they
+		// replace the generated list rather than being counted against it.
+		if len(release.Highlights) > 0 {
+			body = append(body, lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(release.Version))
+			body = appendNoticeBullets(body, release.Highlights, width)
+			continue
+		}
 		count := release.TotalChanges
 		label := "change"
 		if count != 1 {
@@ -819,16 +827,7 @@ func renderNoticeBody(n notice, width int) []string {
 		if len(release.Changes) == 0 {
 			body = append(body, subtleStyle.Render("  No summarized changes."))
 		}
-		for _, change := range release.Changes {
-			wrapped := strings.Split(ansi.Wordwrap(change, max(width-2, 1), "-"), "\n")
-			for lineIndex, line := range wrapped {
-				prefix := "  "
-				if lineIndex == 0 {
-					prefix = "• "
-				}
-				body = append(body, mutedStyle.Render(prefix+line))
-			}
-		}
+		body = appendNoticeBullets(body, release.Changes, width)
 		if omitted := release.TotalChanges - len(release.Changes); omitted > 0 {
 			body = append(body, subtleStyle.Render(fmt.Sprintf("  +%d more in the full notes", omitted)))
 		}
@@ -843,6 +842,20 @@ func renderNoticeBody(n notice, width int) []string {
 		}
 	}
 	return body
+}
+
+func appendNoticeBullets(lines []string, items []string, width int) []string {
+	for _, item := range items {
+		wrapped := strings.Split(ansi.Wordwrap(item, max(width-2, 1), "-"), "\n")
+		for lineIndex, line := range wrapped {
+			prefix := "  "
+			if lineIndex == 0 {
+				prefix = "• "
+			}
+			lines = append(lines, mutedStyle.Render(prefix+line))
+		}
+	}
+	return lines
 }
 
 func appendStyledWrap(lines []string, text string, width int, style lipgloss.Style) []string {

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -708,8 +708,6 @@ func noticeBodyRoom(height, noticeCount, tailRows int) int {
 	return max(1, height-2-(noticeCount+2)-tailRows)
 }
 
-// noticeTail is what sits under the body: where the selected notice leads,
-// and whatever the panel is doing or failed to do.
 func (m *Model) noticeTail(notices []notice, inner int) []string {
 	var tail []string
 	if m.noticeCursor < len(notices) {

--- a/internal/ui/notices_test.go
+++ b/internal/ui/notices_test.go
@@ -1176,3 +1176,58 @@ func TestFullLayoutFootLineCountsMessages(t *testing.T) {
 		t.Fatalf("full screen frame lost the messages count:\n%s", full)
 	}
 }
+
+func TestReleaseSummaryPrefersAuthoredHighlights(t *testing.T) {
+	release := uiReleaseWithTotal("v0.34.0", 17, "UI: Full screen sessions mode")
+	release.Highlights = []string{"The session list can take the whole terminal"}
+	body := ansi.Strip(strings.Join(renderNoticeBody(notice{releases: []update.Release{release}, rangeComplete: true}, noticeModalInner), "\n"))
+
+	if !strings.Contains(body, "• The session list can take the whole terminal") {
+		t.Fatalf("highlights missing:\n%s", body)
+	}
+	for _, unwanted := range []string{"Full screen sessions mode", "17 changes", "more in the full notes"} {
+		if strings.Contains(body, unwanted) {
+			t.Fatalf("highlights should stand alone, found %q:\n%s", unwanted, body)
+		}
+	}
+}
+
+func TestReleaseSummaryFallsBackToTheGeneratedList(t *testing.T) {
+	body := ansi.Strip(strings.Join(renderNoticeBody(notice{
+		releases:      []update.Release{uiRelease("v0.33.0", "UI: A change")},
+		rangeComplete: true,
+	}, noticeModalInner), "\n"))
+	if !strings.Contains(body, "v0.33.0 · 1 change") || !strings.Contains(body, "• UI: A change") {
+		t.Fatalf("release without highlights lost its generated list:\n%s", body)
+	}
+}
+
+func TestEmptyNoticesPanelStillOpensAndOffersRefresh(t *testing.T) {
+	m := footModel(t)
+	m.width, m.height = 100, 34
+	m.mode = modeList
+	for _, n := range m.activeNotices() {
+		m.dismissNotice(n.id)
+	}
+	if len(m.activeNotices()) != 0 {
+		t.Fatal("test needs an empty panel")
+	}
+
+	m.handleKey(key("M"))
+	if m.mode != modeNotices {
+		t.Fatalf("M should open an empty panel, mode=%v", m.mode)
+	}
+	frame := ansi.Strip(m.View())
+	for _, want := range []string{"nothing new", "r refresh"} {
+		if !strings.Contains(frame, want) {
+			t.Fatalf("empty panel missing %q:\n%s", want, frame)
+		}
+	}
+
+	if _, cmd := m.handleNoticesKey(key("r")); cmd == nil || !m.update.refreshing {
+		t.Fatalf("r unreachable on an empty panel: refreshing=%v", m.update.refreshing)
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "refreshing releases and messages") {
+		t.Fatalf("empty panel hides the refresh it started:\n%s", ansi.Strip(m.View()))
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -37,6 +37,12 @@ const (
 // releasesURL is a var so tests can point the fetch at a local server.
 var releasesURL = "https://api.github.com/repos/YoanWai/agent-manager/releases?per_page=100"
 
+// userFacingTypes are the conventional commit types that change what the
+// program does for the person reading the digest. The rest are real work
+// that leaves the running program identical, and every row one of them
+// takes is a row a feature or a fix does not get.
+var userFacingTypes = map[string]bool{"feat": true, "fix": true, "perf": true}
+
 var (
 	conventionalTitle = regexp.MustCompile(`(?i)^(feat|fix|docs|refactor|perf|test|build|ci|chore|style)(?:\(([^)]+)\))?!?:\s*(.+)$`)
 	pullSuffix        = regexp.MustCompile(`\s+by\s+(@[A-Za-z0-9-]+(?:\[bot])?)\s+in\s+https://github\.com/\S+\s*$`)
@@ -269,8 +275,12 @@ func extractChanges(body string) ([]string, int) {
 		if !strings.HasPrefix(trimmed, "* ") && !strings.HasPrefix(trimmed, "- ") {
 			continue
 		}
-		change := cleanChange(strings.TrimSpace(trimmed[2:]))
+		change, kind := cleanChange(strings.TrimSpace(trimmed[2:]))
 		if change == "" {
+			continue
+		}
+		// A bullet that names no type cannot be judged, so it stays.
+		if kind != "" && !userFacingTypes[kind] {
 			continue
 		}
 		total++
@@ -281,7 +291,9 @@ func extractChanges(body string) ([]string, int) {
 	return changes, total
 }
 
-func cleanChange(change string) string {
+// cleanChange returns the digest row for a generated bullet and the
+// conventional type it declared, empty when it declared none.
+func cleanChange(change string) (string, string) {
 	// Credit outside contributors on their digest lines; the maintainer's
 	// own handle and bot handles would be noise on every row.
 	author := ""
@@ -294,7 +306,9 @@ func cleanChange(change string) string {
 	change = markdownLink.ReplaceAllString(change, "$1")
 	change = strings.ReplaceAll(change, "`", "")
 	change = cleanText(change)
+	kind := ""
 	if match := conventionalTitle.FindStringSubmatch(change); match != nil {
+		kind = strings.ToLower(match[1])
 		description := sentenceCase(match[3])
 		if scope := labelCase(match[2]); scope != "" {
 			change = scope + ": " + description
@@ -311,7 +325,7 @@ func cleanChange(change string) string {
 	if author != "" {
 		change += " · " + author
 	}
-	return change
+	return change, kind
 }
 
 func cleanText(text string) string {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -59,12 +59,11 @@ var (
 )
 
 // Release is one stable GitHub release with a compact, terminal-safe summary.
-// TotalChanges may exceed len(Changes) when a large release was bounded.
+// Highlights stand in for Changes when the notes carry them. TotalChanges may
+// exceed len(Changes) when a large release was bounded.
 type Release struct {
-	Version string `json:"version"`
-	URL     string `json:"url"`
-	// Highlights are the maintainer's own bullets for this release, empty
-	// when the notes carry none. They stand in for Changes when present.
+	Version      string   `json:"version"`
+	URL          string   `json:"url"`
 	Highlights   []string `json:"highlights,omitempty"`
 	Changes      []string `json:"changes"`
 	TotalChanges int      `json:"total_changes"`
@@ -269,9 +268,6 @@ func safeReleaseURL(raw string) bool {
 	return err == nil && parsed.Scheme == "https" && parsed.Host == "github.com"
 }
 
-// sectionLines returns the trimmed lines under a level-two heading. It
-// stops at the next heading or at the generated changelog footer, so a
-// section never bleeds into the install instructions below it.
 func sectionLines(body, heading string) []string {
 	var lines []string
 	inside := false
@@ -292,7 +288,6 @@ func sectionLines(body, heading string) []string {
 	return lines
 }
 
-// bulletText returns the text of a markdown bullet; any other line is not one.
 func bulletText(line string) (string, bool) {
 	if !strings.HasPrefix(line, "* ") && !strings.HasPrefix(line, "- ") {
 		return "", false
@@ -300,9 +295,8 @@ func bulletText(line string) (string, bool) {
 	return strings.TrimSpace(line[2:]), true
 }
 
-// extractHighlights reads the authored bullets. Prose in that section is
-// the release page's own copy, written for a browser rather than for a
-// modal, so only bullets reach the panel.
+// Prose under the highlights heading is the release page's own copy,
+// written for a browser rather than a modal, so only bullets travel.
 func extractHighlights(body string) []string {
 	var highlights []string
 	for _, line := range sectionLines(body, highlightsHeading) {
@@ -345,9 +339,7 @@ func extractChanges(body string) ([]string, int) {
 	return changes, total
 }
 
-// cleanChange returns the digest row for a generated bullet and the
-// conventional type it declared, empty when it declared none.
-func cleanChange(change string) (string, string) {
+func cleanChange(change string) (row, kind string) {
 	// Credit outside contributors on their digest lines; the maintainer's
 	// own handle and bot handles would be noise on every row.
 	author := ""
@@ -356,29 +348,25 @@ func cleanChange(change string) (string, string) {
 			author = handle
 		}
 	}
-	change = plainText(pullSuffix.ReplaceAllString(change, ""))
-	kind := ""
-	if match := conventionalTitle.FindStringSubmatch(change); match != nil {
+	row = plainText(pullSuffix.ReplaceAllString(change, ""))
+	if match := conventionalTitle.FindStringSubmatch(row); match != nil {
 		kind = strings.ToLower(match[1])
 		description := sentenceCase(match[3])
 		if scope := labelCase(match[2]); scope != "" {
-			change = scope + ": " + description
+			row = scope + ": " + description
 		} else {
-			change = description
+			row = description
 		}
 	} else {
-		change = sentenceCase(change)
+		row = sentenceCase(row)
 	}
-	change = truncateChange(change)
+	row = truncateChange(row)
 	if author != "" {
-		change += " · " + author
+		row += " · " + author
 	}
-	return change, kind
+	return row, kind
 }
 
-// plainText renders a markdown fragment as the text the panel paints: a
-// link becomes its label, a code span loses its fences, and any control
-// sequence the notes carried is dropped.
 func plainText(text string) string {
 	text = markdownLink.ReplaceAllString(text, "$1")
 	text = strings.ReplaceAll(text, "`", "")

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -32,6 +32,15 @@ const (
 	maxReleases          = 100
 	maxChangesPerRelease = 12
 	maxChangeLength      = 120
+	maxHighlights        = 6
+)
+
+const (
+	// highlightsHeading is the section the maintainer writes for this panel:
+	// short bullets naming what the release gives someone. The generated
+	// list says which branches merged, which is not the same question.
+	highlightsHeading = "## Highlights"
+	changesHeading    = "## What's Changed"
 )
 
 // releasesURL is a var so tests can point the fetch at a local server.
@@ -52,8 +61,11 @@ var (
 // Release is one stable GitHub release with a compact, terminal-safe summary.
 // TotalChanges may exceed len(Changes) when a large release was bounded.
 type Release struct {
-	Version      string   `json:"version"`
-	URL          string   `json:"url"`
+	Version string `json:"version"`
+	URL     string `json:"url"`
+	// Highlights are the maintainer's own bullets for this release, empty
+	// when the notes carry none. They stand in for Changes when present.
+	Highlights   []string `json:"highlights,omitempty"`
 	Changes      []string `json:"changes"`
 	TotalChanges int      `json:"total_changes"`
 }
@@ -238,6 +250,7 @@ func fetchReleases(ctx context.Context, etag string, budget time.Duration) ([]Re
 		releases = append(releases, Release{
 			Version:      item.TagName,
 			URL:          item.HTMLURL,
+			Highlights:   extractHighlights(item.Body),
 			Changes:      changes,
 			TotalChanges: total,
 		})
@@ -256,26 +269,67 @@ func safeReleaseURL(raw string) bool {
 	return err == nil && parsed.Scheme == "https" && parsed.Host == "github.com"
 }
 
-func extractChanges(body string) ([]string, int) {
-	var changes []string
-	total := 0
-	inChanges := false
+// sectionLines returns the trimmed lines under a level-two heading. It
+// stops at the next heading or at the generated changelog footer, so a
+// section never bleeds into the install instructions below it.
+func sectionLines(body, heading string) []string {
+	var lines []string
+	inside := false
 	for _, line := range strings.Split(body, "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.EqualFold(trimmed, "## What's Changed") {
-			inChanges = true
+		if strings.EqualFold(trimmed, heading) {
+			inside = true
 			continue
 		}
-		if !inChanges {
+		if !inside {
 			continue
 		}
 		if strings.HasPrefix(trimmed, "## ") || strings.HasPrefix(trimmed, "**Full Changelog**") {
 			break
 		}
-		if !strings.HasPrefix(trimmed, "* ") && !strings.HasPrefix(trimmed, "- ") {
+		lines = append(lines, trimmed)
+	}
+	return lines
+}
+
+// bulletText returns the text of a markdown bullet; any other line is not one.
+func bulletText(line string) (string, bool) {
+	if !strings.HasPrefix(line, "* ") && !strings.HasPrefix(line, "- ") {
+		return "", false
+	}
+	return strings.TrimSpace(line[2:]), true
+}
+
+// extractHighlights reads the authored bullets. Prose in that section is
+// the release page's own copy, written for a browser rather than for a
+// modal, so only bullets reach the panel.
+func extractHighlights(body string) []string {
+	var highlights []string
+	for _, line := range sectionLines(body, highlightsHeading) {
+		text, ok := bulletText(line)
+		if !ok {
 			continue
 		}
-		change, kind := cleanChange(strings.TrimSpace(trimmed[2:]))
+		if text = plainText(text); text == "" {
+			continue
+		}
+		highlights = append(highlights, sentenceCase(truncateChange(text)))
+		if len(highlights) == maxHighlights {
+			break
+		}
+	}
+	return highlights
+}
+
+func extractChanges(body string) ([]string, int) {
+	var changes []string
+	total := 0
+	for _, line := range sectionLines(body, changesHeading) {
+		bullet, ok := bulletText(line)
+		if !ok {
+			continue
+		}
+		change, kind := cleanChange(bullet)
 		if change == "" {
 			continue
 		}
@@ -302,10 +356,7 @@ func cleanChange(change string) (string, string) {
 			author = handle
 		}
 	}
-	change = pullSuffix.ReplaceAllString(change, "")
-	change = markdownLink.ReplaceAllString(change, "$1")
-	change = strings.ReplaceAll(change, "`", "")
-	change = cleanText(change)
+	change = plainText(pullSuffix.ReplaceAllString(change, ""))
 	kind := ""
 	if match := conventionalTitle.FindStringSubmatch(change); match != nil {
 		kind = strings.ToLower(match[1])
@@ -318,14 +369,28 @@ func cleanChange(change string) (string, string) {
 	} else {
 		change = sentenceCase(change)
 	}
-	runes := []rune(change)
-	if len(runes) > maxChangeLength {
-		change = strings.TrimSpace(string(runes[:maxChangeLength-1])) + "…"
-	}
+	change = truncateChange(change)
 	if author != "" {
 		change += " · " + author
 	}
 	return change, kind
+}
+
+// plainText renders a markdown fragment as the text the panel paints: a
+// link becomes its label, a code span loses its fences, and any control
+// sequence the notes carried is dropped.
+func plainText(text string) string {
+	text = markdownLink.ReplaceAllString(text, "$1")
+	text = strings.ReplaceAll(text, "`", "")
+	return cleanText(text)
+}
+
+func truncateChange(text string) string {
+	runes := []rune(text)
+	if len(runes) <= maxChangeLength {
+		return text
+	}
+	return strings.TrimSpace(string(runes[:maxChangeLength-1])) + "…"
 }
 
 func cleanText(text string) string {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -410,3 +410,74 @@ func TestExtractChangesKeepsWhatAReaderCanAct(t *testing.T) {
 		t.Fatalf("extractChanges() = %q total %d, want %q", changes, total, want)
 	}
 }
+
+func TestExtractHighlightsReadsTheAuthoredBullets(t *testing.T) {
+	body := strings.Join([]string{
+		"A one line pitch nobody put a heading on.",
+		"",
+		"## Highlights",
+		"",
+		"The panel takes bullets, so this paragraph stays on the web page.",
+		"",
+		"- the session list can take the whole terminal",
+		"* rows carry the agent's `last message` beside the name",
+		"- [Full notes](https://example.com/notes) explain the rest",
+		"",
+		"## What's Changed",
+		"* feat(ui): full screen sessions mode",
+		"",
+		"**Full Changelog**: https://example.com/compare",
+	}, "\n")
+
+	want := []string{
+		"The session list can take the whole terminal",
+		"Rows carry the agent's last message beside the name",
+		"Full notes explain the rest",
+	}
+	if got := extractHighlights(body); fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("extractHighlights() = %q, want %q", got, want)
+	}
+}
+
+func TestExtractHighlightsIsEmptyWithoutTheSection(t *testing.T) {
+	body := "## What's Changed\n* feat(ui): a feature\n"
+	if got := extractHighlights(body); len(got) != 0 {
+		t.Fatalf("extractHighlights() = %q, want none", got)
+	}
+}
+
+func TestExtractHighlightsStopsAtTheCap(t *testing.T) {
+	lines := []string{"## Highlights"}
+	for i := 0; i < maxHighlights+3; i++ {
+		lines = append(lines, fmt.Sprintf("- highlight %d", i))
+	}
+	got := extractHighlights(strings.Join(lines, "\n"))
+	if len(got) != maxHighlights {
+		t.Fatalf("extractHighlights() kept %d, want %d", len(got), maxHighlights)
+	}
+	if got[maxHighlights-1] != fmt.Sprintf("Highlight %d", maxHighlights-1) {
+		t.Fatalf("extractHighlights() last = %q", got[maxHighlights-1])
+	}
+}
+
+func TestCatalogCarriesHighlightsThroughTheCache(t *testing.T) {
+	body := `## Highlights\n- the list can take the whole terminal\n\n## What's Changed\n* feat(ui): full screen sessions mode`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `[{"tag_name":"v0.34.0","html_url":"https://github.com/YoanWai/agent-manager/releases/tag/v0.34.0","body":"%s","draft":false,"prerelease":false}]`, body)
+	}))
+	defer server.Close()
+	defer swapReleasesURL(server.URL)()
+
+	dir := t.TempDir()
+	want := []string{"The list can take the whole terminal"}
+	fetched, err := Check(context.Background(), dir, "v0.33.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fetched.Releases[0].Highlights; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("fetched highlights = %q, want %q", got, want)
+	}
+	if got := Cached(dir, "v0.33.0").Releases[0].Highlights; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("cached highlights = %q, want %q", got, want)
+	}
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -63,6 +63,7 @@ func TestExtractChangesHumanizesGeneratedNotes(t *testing.T) {
 		"* fix(groups): make group creation immediate and reliable by @YoanWai in https://github.com/YoanWai/agent-manager/pull/191",
 		"* feat(config): add Pi as a built-in tool by @steveprentice in https://github.com/YoanWai/agent-manager/pull/201",
 		"* chore(deps): bump gopsutil by @dependabot[bot] in https://github.com/YoanWai/agent-manager/pull/210",
+		"* docs(readme): add a badge by @YoanWai in https://github.com/YoanWai/agent-manager/pull/211",
 		"- feat(ui): add a [message browser](https://example.com) with `scrolling`",
 		"- feat(mcp-editor): expose tool capabilities",
 		"",
@@ -74,7 +75,6 @@ func TestExtractChangesHumanizesGeneratedNotes(t *testing.T) {
 	want := []string{
 		"Groups: Make group creation immediate and reliable",
 		"Config: Add Pi as a built-in tool · @steveprentice",
-		"Deps: Bump gopsutil",
 		"UI: Add a message browser with scrolling",
 		"MCP editor: Expose tool capabilities",
 	}
@@ -381,4 +381,32 @@ func swapReleasesURL(url string) func() {
 	previous := releasesURL
 	releasesURL = url
 	return func() { releasesURL = previous }
+}
+
+func TestExtractChangesKeepsWhatAReaderCanAct(t *testing.T) {
+	body := strings.Join([]string{
+		"## What's Changed",
+		"* feat(ui): a feature",
+		"* fix(ui): a fix",
+		"* perf(ui): a speedup",
+		"* docs(readme): a badge",
+		"* chore(deps): a bump",
+		"* ci: a workflow tweak",
+		"* build: a build tweak",
+		"* style: a reformat",
+		"* test: a case",
+		"* refactor(ui): a rename",
+		"* Ship the two agent skills for install via skills.sh",
+	}, "\n")
+
+	changes, total := extractChanges(body)
+	want := []string{
+		"UI: A feature",
+		"UI: A fix",
+		"UI: A speedup",
+		"Ship the two agent skills for install via skills.sh",
+	}
+	if total != len(want) || fmt.Sprint(changes) != fmt.Sprint(want) {
+		t.Fatalf("extractChanges() = %q total %d, want %q", changes, total, want)
+	}
 }


### PR DESCRIPTION
## What

The messages panel now shows the release in the maintainer's own words, and opens even when it has nothing to show.

- **A `## Highlights` section in the release notes travels with the catalog.** Its bullets replace the generated pull request list for that release, with no change count and no omitted tail: authored bullets are the whole release, not a sample of it. A release without the section keeps the generated list.
- **The generated list, when it is used, holds only `feat`, `fix` and `perf`.** A bullet naming no conventional type is kept, since it cannot be judged.
- **`M` opens an empty panel.** Every message retires at the version it announced, so the first run after an update is exactly when nothing is left to show, and the early return made `r` unreachable at that moment. The empty frame carries `r` and reports the refresh it started.
- **The feed checks as often as the release check.** It was throttled to six hours against the release check's ten minutes.

`AGENTS.md` carries the `## Highlights` contract, so every release cut fills it in.

## Why

The panel is what someone reads after updating, and it was answering a different question than the one they asked. `docs(readme): show the Peerlist badge` and `refactor(ui): rename a helper` are real work that leaves the running program identical, and every row one takes is a row a feature or a fix does not get. On the real v0.34.0 notes that was 5 of 17 rows, enough to push `+5 more in the full notes` under a list that had already spent its budget on badges.

Filtering makes the list shorter, not different in kind: it still names branches. The notes already carry a summary written for a person, and the client read past it. Now that summary reaches the panel.

The empty panel and the feed floor are the same bug seen twice: the moment right after an update, when the release notice has arrived and the message announcing it has not. One made the refresh key unreachable; the other let the notice beat its own announcement by up to six hours.

## Verified

- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...` passes, every package.
- Run against the real published v0.34.0 notes, the digest goes from 17 changes / 12 shown / `+5 more` to 12 changes with all 12 shown.
- With a `## Highlights` section prepended to those same notes, the three bullets parse out and the generated list still parses to the same 12.
- Live in a dev build on an isolated tmux socket and config dir, version stamped `0.34.0` against a seeded catalog: the update notice paints `v0.35.0` with its two authored bullets and no change count; dismissing every message and pressing `M` opens the empty frame reading `nothing new` over `r refresh · esc`; `r` there reports `↻ refreshing releases and messages…` and repopulates the panel from the live feed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notices now display curated highlights when available, making important updates easier to scan.
  * The notices panel opens even when there are no active notices and provides refresh guidance.
* **Bug Fixes**
  * Release summaries now prioritize user-facing features, fixes, and performance improvements.
* **Improvements**
  * Release information refreshes every 10 minutes, reducing delays before new notices appear.
  * Empty notice panels clearly communicate their status and support manual refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->