### PR TITLE
fix(ui): honor hidden pane cursors

### DIFF
--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -347,7 +347,7 @@ func TestFocusModeForwardsArrowKeys(t *testing.T) {
 		if err != nil {
 			t.Fatalf("capture: %v", err)
 		}
-		if strings.Contains(pane, "1b  5b  41  1b  5b  42  0a") {
+		if strings.Contains(strings.Join(strings.Fields(pane), " "), "1b 5b 41 1b 5b 42 0a") {
 			return
 		}
 		if time.Now().After(deadline) {

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -290,6 +292,68 @@ func TestFocusModeForwardsKeys(t *testing.T) {
 	*m = *updated.(*Model)
 	if m.mode != modeList {
 		t.Fatalf("ctrl+q left mode = %v", m.mode)
+	}
+}
+
+func TestFocusModeForwardsArrowKeys(t *testing.T) {
+	m := buildModel(t)
+	createSessionOn(t, m, "focus-arrows", "quietchat", t.TempDir())
+	m.selectSessionRow(t, "focus-arrows")
+	sess := m.rows[m.cursor].sess
+	quitAgent(t, m, sess.ID)
+	m.focus = newFocusWatch(m.tmux, func(tea.Msg) {})
+	t.Cleanup(m.focus.Close)
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+	if m.mode != modeFocus {
+		t.Fatalf("after enter, mode = %v, err = %q", m.mode, m.errBar.text)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for !m.focus.serving(sess.ID) {
+		if time.Now().After(deadline) {
+			t.Fatal("focus control client never became ready")
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	ready := filepath.Join(t.TempDir(), "ready")
+	reader := "touch " + tmux.ShellQuote(ready) + "; od -An -tx1 -N7"
+	command := "sh -c " + tmux.ShellQuote(reader)
+	if err := m.tmux.SendKeys(sess.ID, command, "Enter"); err != nil {
+		t.Fatalf("start key reader: %v", err)
+	}
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("check key reader: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("key reader never became ready")
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	for _, key := range []tea.KeyType{tea.KeyUp, tea.KeyDown, tea.KeyEnter} {
+		updated, _ = m.handleKey(tea.KeyMsg{Type: key})
+		*m = *updated.(*Model)
+	}
+
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		pane, err := m.tmux.CapturePane(sess.ID)
+		if err != nil {
+			t.Fatalf("capture: %v", err)
+		}
+		if strings.Contains(pane, "1b  5b  41  1b  5b  42  0a") {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("arrow bytes never reached pane: %q", pane)
+		}
+		time.Sleep(30 * time.Millisecond)
 	}
 }
 

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -553,7 +553,7 @@ func TestBottomParkedCaretSurvivesControlCapture(t *testing.T) {
 
 func TestApplyPaneState(t *testing.T) {
 	var msg focusPreviewMsg
-	applyPaneState(&msg, "12,34,010,250,0,1\n")
+	applyPaneState(&msg, "12,34,1,010,250,0,1\n")
 	if !msg.cursorOK || msg.cursorX != 12 || msg.cursorY != 34 {
 		t.Fatalf("cursor = (%d,%d,%v)", msg.cursorX, msg.cursorY, msg.cursorOK)
 	}
@@ -570,15 +570,21 @@ func TestApplyPaneState(t *testing.T) {
 	// tmux reports 1003 in mouse_all_flag, the apps that want a pointer
 	// move with every event.
 	var motion focusPreviewMsg
-	applyPaneState(&motion, "0,0,100,0,1,1")
+	applyPaneState(&motion, "0,0,1,100,0,1,1")
 	if !motion.paneMouse || !motion.paneMotion {
 		t.Fatalf("all-motion pane state = %+v", motion)
 	}
 
 	var plain focusPreviewMsg
-	applyPaneState(&plain, "0,0,000,0,0,0")
+	applyPaneState(&plain, "0,0,1,000,0,0,0")
 	if plain.paneMouse || plain.paneMotion || plain.historySize != 0 || !plain.cursorOK {
 		t.Fatalf("plain pane state = %+v", plain)
+	}
+
+	var hidden focusPreviewMsg
+	applyPaneState(&hidden, "7,8,0,000,0,0,0")
+	if hidden.cursorOK {
+		t.Fatalf("hidden cursor was accepted at %d,%d", hidden.cursorX, hidden.cursorY)
 	}
 
 	// tmux answers an unquoted format with its default status message;

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -551,55 +551,6 @@ func TestBottomParkedCaretSurvivesControlCapture(t *testing.T) {
 	}
 }
 
-func TestApplyPaneState(t *testing.T) {
-	var msg focusPreviewMsg
-	applyPaneState(&msg, "12,34,1,010,250,0,1\n")
-	if !msg.cursorOK || msg.cursorX != 12 || msg.cursorY != 34 {
-		t.Fatalf("cursor = (%d,%d,%v)", msg.cursorX, msg.cursorY, msg.cursorOK)
-	}
-	if !msg.paneMouse {
-		t.Fatal("mouse flag 1 not read as pane-owned mouse")
-	}
-	if msg.historySize != 250 {
-		t.Fatalf("historySize = %d, want 250", msg.historySize)
-	}
-	if msg.paneMotion {
-		t.Fatal("a button-tracking pane read as tracking all motion")
-	}
-
-	// tmux reports 1003 in mouse_all_flag, the apps that want a pointer
-	// move with every event.
-	var motion focusPreviewMsg
-	applyPaneState(&motion, "0,0,1,100,0,1,1")
-	if !motion.paneMouse || !motion.paneMotion {
-		t.Fatalf("all-motion pane state = %+v", motion)
-	}
-
-	var plain focusPreviewMsg
-	applyPaneState(&plain, "0,0,1,000,0,0,0")
-	if plain.paneMouse || plain.paneMotion || plain.historySize != 0 || !plain.cursorOK {
-		t.Fatalf("plain pane state = %+v", plain)
-	}
-
-	var hidden focusPreviewMsg
-	applyPaneState(&hidden, "7,8,0,000,0,0,0")
-	if hidden.cursorOK {
-		t.Fatalf("hidden cursor was accepted at %d,%d", hidden.cursorX, hidden.cursorY)
-	}
-
-	// tmux answers an unquoted format with its default status message;
-	// that must never read as pane state.
-	var bogus focusPreviewMsg
-	applyPaneState(&bogus, "[am_x] 0:zsh, current pane 0 - (00:43)")
-	if bogus.cursorOK || bogus.paneMouse || bogus.historySize != 0 {
-		t.Fatal("applyPaneState accepted tmux's default message")
-	}
-	applyPaneState(&bogus, "nonsense")
-	if bogus.cursorOK {
-		t.Fatal("applyPaneState accepted junk")
-	}
-}
-
 // The cursor is drawn at the pane cell tmux reported, shifted when the
 // capture is taller than the panel showing its bottom rows.
 func TestCursorCellMapsIntoVisibleRows(t *testing.T) {

--- a/internal/ui/focuswatch.go
+++ b/internal/ui/focuswatch.go
@@ -225,7 +225,7 @@ func (w *focusWatch) watch(id string, stop chan struct{}) {
 		// back as its default status message instead of coordinates.
 		if state, err := control.Command(
 			`display-message -p -t ` + target +
-				` "#{cursor_x},#{cursor_y},#{mouse_any_flag}#{mouse_button_flag}#{mouse_standard_flag},#{history_size},#{mouse_all_flag},#{mouse_sgr_flag}"`); err == nil {
+				` "#{cursor_x},#{cursor_y},#{cursor_flag},#{mouse_any_flag}#{mouse_button_flag}#{mouse_standard_flag},#{history_size},#{mouse_all_flag},#{mouse_sgr_flag}"`); err == nil {
 			applyPaneState(&msg, state)
 		}
 		// Skip the send once stopped: it could block on the UI loop for
@@ -279,23 +279,23 @@ func matchExecShape(pane string) string {
 	return pane + "\n"
 }
 
-// applyPaneState reads "x,y,mouseflags,history,allmotion,sgr" from
+// applyPaneState reads "x,y,cursor,mouseflags,history,allmotion,sgr" from
 // display-message into the preview message. A malformed reply leaves the
 // zero values: no cursor, no mouse claim, no history.
 func applyPaneState(msg *focusPreviewMsg, reply string) {
 	parts := strings.Split(strings.TrimSpace(reply), ",")
-	if len(parts) != 6 {
+	if len(parts) != 7 {
 		return
 	}
 	x, errX := strconv.Atoi(strings.TrimSpace(parts[0]))
 	y, errY := strconv.Atoi(strings.TrimSpace(parts[1]))
-	if errX == nil && errY == nil {
+	if errX == nil && errY == nil && strings.TrimSpace(parts[2]) == "1" {
 		msg.cursorX, msg.cursorY, msg.cursorOK = x, y, true
 	}
-	msg.paneMouse = strings.Contains(parts[2], "1")
-	if size, err := strconv.Atoi(strings.TrimSpace(parts[3])); err == nil && size > 0 {
+	msg.paneMouse = strings.Contains(parts[3], "1")
+	if size, err := strconv.Atoi(strings.TrimSpace(parts[4])); err == nil && size > 0 {
 		msg.historySize = size
 	}
-	msg.paneMotion = strings.TrimSpace(parts[4]) == "1"
-	msg.paneSGR = strings.TrimSpace(parts[5]) == "1"
+	msg.paneMotion = strings.TrimSpace(parts[5]) == "1"
+	msg.paneSGR = strings.TrimSpace(parts[6]) == "1"
 }

--- a/internal/ui/focuswatch.go
+++ b/internal/ui/focuswatch.go
@@ -14,11 +14,12 @@ import (
 // with the pane's cursor cell so the focused view can show where typing
 // will land. Process stats stay on the poller cadence.
 type focusPreviewMsg struct {
-	sessID   string
-	preview  string
-	cursorX  int
-	cursorY  int
-	cursorOK bool
+	sessID      string
+	preview     string
+	cursorX     int
+	cursorY     int
+	cursorOK    bool
+	paneStateOK bool
 	// paneMouse and historySize let the wheel route without asking tmux
 	// mid-Update: whether the pane's application owns the mouse, and how
 	// far back its history goes. paneMotion narrows that to the apps that
@@ -279,9 +280,8 @@ func matchExecShape(pane string) string {
 	return pane + "\n"
 }
 
-// applyPaneState reads "x,y,cursor,mouseflags,history,allmotion,sgr" from
-// display-message into the preview message. A malformed reply leaves the
-// zero values: no cursor, no mouse claim, no history.
+// applyPaneState ignores malformed replies because tmux can substitute its
+// default status text when it does not receive the format expression.
 func applyPaneState(msg *focusPreviewMsg, reply string) {
 	parts := strings.Split(strings.TrimSpace(reply), ",")
 	if len(parts) != 7 {
@@ -289,12 +289,17 @@ func applyPaneState(msg *focusPreviewMsg, reply string) {
 	}
 	x, errX := strconv.Atoi(strings.TrimSpace(parts[0]))
 	y, errY := strconv.Atoi(strings.TrimSpace(parts[1]))
-	if errX == nil && errY == nil && strings.TrimSpace(parts[2]) == "1" {
+	historySize, errHistory := strconv.Atoi(strings.TrimSpace(parts[4]))
+	if errX != nil || errY != nil || errHistory != nil {
+		return
+	}
+	msg.paneStateOK = true
+	if strings.TrimSpace(parts[2]) == "1" {
 		msg.cursorX, msg.cursorY, msg.cursorOK = x, y, true
 	}
 	msg.paneMouse = strings.Contains(parts[3], "1")
-	if size, err := strconv.Atoi(strings.TrimSpace(parts[4])); err == nil && size > 0 {
-		msg.historySize = size
+	if historySize > 0 {
+		msg.historySize = historySize
 	}
 	msg.paneMotion = strings.TrimSpace(parts[5]) == "1"
 	msg.paneSGR = strings.TrimSpace(parts[6]) == "1"

--- a/internal/ui/focuswatch_test.go
+++ b/internal/ui/focuswatch_test.go
@@ -329,6 +329,17 @@ func TestApplyPaneState(t *testing.T) {
 	if bogus.paneStateOK || bogus.cursorOK {
 		t.Fatal("applyPaneState accepted junk")
 	}
+
+	var badCursor focusPreviewMsg
+	applyPaneState(&badCursor, "12,y,1,010,250,0,1")
+	if badCursor.paneStateOK || badCursor.cursorOK {
+		t.Fatal("applyPaneState accepted a non-numeric cursor")
+	}
+	var badHistory focusPreviewMsg
+	applyPaneState(&badHistory, "12,34,1,010,n,0,1")
+	if badHistory.paneStateOK || badHistory.historySize != 0 {
+		t.Fatal("applyPaneState accepted a non-numeric history size")
+	}
 }
 
 // Trailing blank pane rows are content: dropping them shifts every line

--- a/internal/ui/focuswatch_test.go
+++ b/internal/ui/focuswatch_test.go
@@ -272,13 +272,62 @@ func TestFocusWatchHonorsHiddenCursor(t *testing.T) {
 			if !ok || preview.sessID != id || !strings.Contains(preview.preview, "hidden-cursor") {
 				continue
 			}
-			if preview.cursorOK {
+			if !preview.paneStateOK || preview.cursorOK {
 				continue
 			}
 			return
 		case <-deadline:
 			t.Fatal("no hidden-cursor preview reported the cursor hidden")
 		}
+	}
+}
+
+func TestApplyPaneState(t *testing.T) {
+	var msg focusPreviewMsg
+	applyPaneState(&msg, "12,34,1,010,250,0,1\n")
+	if !msg.paneStateOK || !msg.cursorOK || msg.cursorX != 12 || msg.cursorY != 34 {
+		t.Fatalf("pane state = %+v", msg)
+	}
+	if !msg.paneMouse {
+		t.Fatal("mouse flag 1 not read as pane-owned mouse")
+	}
+	if msg.historySize != 250 {
+		t.Fatalf("historySize = %d, want 250", msg.historySize)
+	}
+	if msg.paneMotion {
+		t.Fatal("a button-tracking pane read as tracking all motion")
+	}
+
+	// tmux reports 1003 in mouse_all_flag, the apps that want a pointer
+	// move with every event.
+	var motion focusPreviewMsg
+	applyPaneState(&motion, "0,0,1,100,0,1,1")
+	if !motion.paneStateOK || !motion.paneMouse || !motion.paneMotion {
+		t.Fatalf("all-motion pane state = %+v", motion)
+	}
+
+	var plain focusPreviewMsg
+	applyPaneState(&plain, "0,0,1,000,0,0,0")
+	if !plain.paneStateOK || plain.paneMouse || plain.paneMotion || plain.historySize != 0 || !plain.cursorOK {
+		t.Fatalf("plain pane state = %+v", plain)
+	}
+
+	var hidden focusPreviewMsg
+	applyPaneState(&hidden, "7,8,0,000,0,0,0")
+	if !hidden.paneStateOK || hidden.cursorOK {
+		t.Fatalf("hidden cursor pane state = %+v", hidden)
+	}
+
+	// tmux answers an unquoted format with its default status message;
+	// that must never read as pane state.
+	var bogus focusPreviewMsg
+	applyPaneState(&bogus, "[am_x] 0:zsh, current pane 0 - (00:43)")
+	if bogus.paneStateOK || bogus.cursorOK || bogus.paneMouse || bogus.historySize != 0 {
+		t.Fatal("applyPaneState accepted tmux's default message")
+	}
+	applyPaneState(&bogus, "nonsense")
+	if bogus.paneStateOK || bogus.cursorOK {
+		t.Fatal("applyPaneState accepted junk")
 	}
 }
 

--- a/internal/ui/focuswatch_test.go
+++ b/internal/ui/focuswatch_test.go
@@ -250,6 +250,38 @@ func TestFocusWatchReportsCursor(t *testing.T) {
 	}
 }
 
+func TestFocusWatchHonorsHiddenCursor(t *testing.T) {
+	driver := requireFocusDriver(t)
+	id := "hidecur" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	command := "printf '\\033[?25lhidden-cursor'; exec sleep 10"
+	if err := driver.Create(id, "/tmp", command, nil, 80, 24); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+
+	msgs := make(chan tea.Msg, 64)
+	watch := newFocusWatch(driver, func(msg tea.Msg) { msgs <- msg })
+	t.Cleanup(watch.Close)
+	watch.setFocus(id)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case msg := <-msgs:
+			preview, ok := msg.(focusPreviewMsg)
+			if !ok || preview.sessID != id || !strings.Contains(preview.preview, "hidden-cursor") {
+				continue
+			}
+			if preview.cursorOK {
+				continue
+			}
+			return
+		case <-deadline:
+			t.Fatal("no hidden-cursor preview reported the cursor hidden")
+		}
+	}
+}
+
 // Trailing blank pane rows are content: dropping them shifts every line
 // up, which is what made the pushed and polled captures disagree. The
 // input is shaped like the control client's reply, a newline JOIN of the


### PR DESCRIPTION
## What

- Honor tmux's cursor-visibility flag when rendering focused pane previews.
- Add real-tmux regressions for hidden cursors and focused arrow-key forwarding.

## Why

Interactive terminal pickers can hide the real cursor. Agent Manager was still painting a synthetic caret from the pane coordinates alone, making those pickers appear frozen even when input forwarding was working.

## Verified

- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...`
- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./internal/ui -run 'TestFocusModeForwardsArrowKeys|TestFocusWatchHonorsHiddenCursor|TestFocusWatchReportsCursor|TestApplyPaneState' -count=1`
- `go build ./...`
- `go vet ./...`
- `gofmt -l .` (clean)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Focused sessions now correctly forward Up, Down, and Enter keys.
  * Hidden cursors no longer appear visible in previews.
  * Mouse, history, and pane interaction states are interpreted more reliably.
  * Malformed pane-state responses are handled safely.

* **Quality Improvements**
  * Expanded coverage for keyboard forwarding, cursor visibility, pane state handling, and malformed responses to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->