### PR TITLE
fix(status): ignore Claude update banner after turns

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,6 +203,10 @@ func (c *Config) backfillToolDefaults() error {
 // pattern; one edited by hand keeps what its author wrote.
 const busyLineAgentsOnly = `^[✻✳✶✽✢·✦✧+*] Waiting for \d+ background agents? to finish`
 
+// This exact chrome pattern was written before Claude added its updater
+// banner beneath completed turns. Hand-edited patterns remain untouched.
+const oldClaudeChromeLine = `^\s*[─q]{4,}.*$|^[\s─q]*$`
+
 // The command-code matching rules #385 shipped, which no longer match the
 // shapes current Command Code draws. A stored config.toml carries these
 // verbatim and keeps them over any new default, so mergeTool rewrites
@@ -268,8 +272,13 @@ func mergeTool(name string, user, def Tool) Tool {
 	fill(&user.DialogFooter, def.DialogFooter)
 	fill(&user.InputPrefix, def.InputPrefix)
 	fill(&user.ComposerPlaceholder, def.ComposerPlaceholder)
-	if name == "claude" && user.BusyLine == busyLineAgentsOnly {
-		user.BusyLine = def.BusyLine
+	if name == "claude" {
+		if user.BusyLine == busyLineAgentsOnly {
+			user.BusyLine = def.BusyLine
+		}
+		if user.ChromeLine == oldClaudeChromeLine {
+			user.ChromeLine = def.ChromeLine
+		}
 	}
 	if name == "command-code" {
 		if user.TurnEnd == oldCmdTurnEnd {
@@ -417,7 +426,7 @@ status_source = "claude-hooks"
 default_status = "idle"
 activity_cutoff = "(?m)^❯"
 turn_end = "^[✻✳✶✽✢·✦✧+*] \\S+ for \\d.*$"
-chrome_line = "^\\s*[─q]{4,}.*$|^[\\s─q]*$"
+chrome_line = "^\\s*[─q]{4,}.*$|^[\\s─q]*$|^\\s*✔ Update installed · Restart to update\\s*$"
 blocked_line = "Interrupted ·"
 # recap blocks ("※ recap: …") render below the turn-end summary
 trailing_note = "^※"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -193,13 +193,14 @@ rules = [
 	}
 }
 
-func TestLoadDirUpgradesLegacyClaudeBusyLine(t *testing.T) {
+func TestLoadDirUpgradesLegacyClaudeStatusPatterns(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	legacy := `
 [tools.claude]
 command = "claude"
 busy_line = '` + busyLineAgentsOnly + `'
+chrome_line = '` + oldClaudeChromeLine + `'
 `
 	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
 		t.Fatal(err)
@@ -210,6 +211,9 @@ busy_line = '` + busyLineAgentsOnly + `'
 	}
 	if !strings.Contains(cfg.Tools["claude"].BusyLine, "shells? still running") {
 		t.Fatalf("legacy claude busy_line was not upgraded: %q", cfg.Tools["claude"].BusyLine)
+	}
+	if !strings.Contains(cfg.Tools["claude"].ChromeLine, "Update installed") {
+		t.Fatalf("legacy claude chrome_line was not upgraded: %q", cfg.Tools["claude"].ChromeLine)
 	}
 }
 
@@ -258,13 +262,14 @@ func TestLoadDirBackfillsDialogFooter(t *testing.T) {
 	}
 }
 
-func TestLoadDirPreservesCustomClaudeBusyLine(t *testing.T) {
+func TestLoadDirPreservesCustomClaudeStatusPatterns(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	custom := `
 [tools.claude]
 command = "claude"
 busy_line = "my own busy signal"
+chrome_line = "my own chrome signal"
 `
 	if err := os.WriteFile(path, []byte(custom), 0o644); err != nil {
 		t.Fatal(err)
@@ -275,6 +280,9 @@ busy_line = "my own busy signal"
 	}
 	if got := cfg.Tools["claude"].BusyLine; got != "my own busy signal" {
 		t.Fatalf("claude busy_line = %q want the user's own pattern", got)
+	}
+	if got := cfg.Tools["claude"].ChromeLine; got != "my own chrome signal" {
+		t.Fatalf("claude chrome_line = %q want the user's own pattern", got)
 	}
 }
 

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -328,6 +328,21 @@ func TestHookWorkingReconcilesToFinishedOnEndedTurn(t *testing.T) {
 	}
 }
 
+func TestHookWorkingReconcilesPastClaudeUpdateBanner(t *testing.T) {
+	m := buildModel(t)
+	defaultEngine(t, m)
+	m.poller.statusSources["claude"] = hooks.StatusSourceClaude
+	sess := store.Session{ID: "hooked-update", Tool: "claude", Status: status.Working}
+	writeHookStatus(t, m, sess.ID, status.Working)
+
+	pane := "done\n\n✻ Sautéed for 2m 58s · done 23:03\n" +
+		"✔ Update installed · Restart to update\n" +
+		"────\n❯\u00a0\n────\n  ⏵⏵ auto mode on (shift+tab to cycle)"
+	if got := deriveStatus(t, m, sess, pane, true); got != status.Finished {
+		t.Fatalf("update banner left stale working hook at %q, want finished", got)
+	}
+}
+
 // Claude fires Stop when the main agent stops responding, so a turn that
 // leaves background agents running reports finished while they work. The
 // pane still shows the wait, and that verdict has to win.


### PR DESCRIPTION
## What

- Treat Claude's installed-update banner as UI chrome so a completed turn still resolves to `finished`.
- Migrate the exact legacy built-in chrome pattern while preserving user-customized patterns.
- Cover the stale-working-hook pane captured from the reported session.

## Why

Claude can leave a `working` hook behind when a submitted prompt never receives a matching stop event. The pane fallback normally reconciles that state, but the updater banner appeared beneath the completed-turn marker and made the marker look stale, pinning the session at `working`.

## Verified

- `env -u TMUX TMUX_TMPDIR=/tmp/amst20974008 go test ./...`
- `gofmt -l .`
- `go vet ./...`
- `go build ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Claude status detection to recognize the “Update installed · Restart to update” banner.
  - Legacy Claude status settings are upgraded automatically while custom settings remain unchanged.
  - Fixed completed Claude sessions being incorrectly reported as still working after an update.

- **Tests**
  - Added coverage for legacy configuration upgrades, custom status preservation, and update-banner session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->