### PR TITLE
feat(update): show Thank you bullets in the messages panel

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,8 +58,8 @@ docs: document the review-base subcommand
 
 Release notes are generated from merged pull request titles, so give the PR the title you want readers to see in the changelog.
 
-The TUI turns those generated notes into cumulative update summaries
-automatically. Do not duplicate feature and fix notes in the maintainer message
+The TUI reads **Highlights** and **Thank you** from the GitHub release notes
+into the messages panel. Do not duplicate those notes in the maintainer message
 feed; see [Release summaries and messages](../docs/notifications.md) for the two
 publishing paths.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,15 +57,14 @@ The notes carry more than the generated list of pull requests:
   in that section stays on the web page; only bullets travel. A release
   without the section falls back to the generated list, filtered to
   `feat`, `fix` and `perf`.
-- **Thanks to every contributor in the range, by handle.** Read the merged
-  pull requests, not only the generated list, and name what each one did.
-- **Thanks to whoever reported what got fixed, by handle.** A bug someone
-  took the time to write up is why the fix exists, and the reporter is
-  usually not the author. Credit the release a feature builds on, too, when
-  it extends someone else's work.
-
-A range with nobody outside the maintainer in it carries no thanks line;
-write the summary and leave it at that rather than manufacturing one.
+- **A `## Thank you` section**, one bullet per person: handle, what they
+  did, PR or issue number. The manager reads those bullets into the
+  messages panel under the highlights, labelled Thank you. Prose in that
+  section stays on the web page; only bullets travel. Cover PR authors and
+  issue reporters: the generated changelog names authors only, and a fix
+  exists because someone wrote the bug up. Credit the release a feature
+  builds on, too, when it extends someone else's work. A range with nobody
+  outside the maintainer omits the section.
 
 `--release-notes=notes.md` replaces the generated list of pull requests
 rather than sitting above it, so a file passed that way has to carry the

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -13,9 +13,18 @@ fix(groups): make group creation immediate and reliable
 ```
 
 GitHub adds merged pull request titles to the release's generated **What's
-Changed** section. agent-manager reads that section, removes the commit prefix,
-author, and pull request URL, then shows the result in the messages modal. There
-is no second changelog or message entry to maintain.
+Changed** section.
+
+The messages panel prefers two authored sections from the same notes:
+
+- **Highlights**: short bullets naming what the release gives someone. A
+  sentence each, feature and fix language, no pull request numbers.
+- **Thank you**: one bullet per contributor or reporter, with handle and the
+  PR or issue. The panel paints these under a Thank you label.
+
+A release without Highlights falls back to What's Changed, filtered to `feat`,
+`fix`, and `perf`. There is no second changelog in `docs/messages.json` to
+maintain.
 
 When an install skips releases, the modal groups the intervening releases in the
 retained catalog into one summary. If the installed version is older than that
@@ -24,9 +33,9 @@ Updating remains one operation straight to the latest version. After restart,
 the same cached catalog explains what was installed.
 
 The client bounds remote data to keep rendering predictable: 100 stable
-releases, 12 summarized changes per release, and 120 characters per change.
-The full release page remains one keypress away when a release exceeds those
-limits.
+releases, 6 highlights and 8 thanks per release, 12 summarized changes per
+release, and 120 characters per line. The full release page remains one
+keypress away when a release exceeds those limits.
 
 ## Publishing an editorial message
 
@@ -68,6 +77,6 @@ Rules:
 
 Pressing `r` in the messages modal bypasses both local cache ages and refreshes
 the release catalog and editorial feed from GitHub. Normal background checks do
-no network or parsing work on the render path. The release catalog checks every
-10 minutes with an HTTP ETag, while the editorial feed's cache lasts 6 hours;
-both schedules are independent of the installed version.
+no network or parsing work on the render path. The release catalog and the
+editorial feed both check every 10 minutes with an HTTP ETag, independent of
+the installed version.

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -798,6 +798,12 @@ func noticeInnerWidth(notices []notice, terminalWidth int) int {
 			for _, change := range release.Changes {
 				lines = append(lines, "• "+change)
 			}
+			if len(release.Thanks) > 0 {
+				lines = append(lines, "Thank you")
+			}
+			for _, change := range release.Thanks {
+				lines = append(lines, "• "+change)
+			}
 		}
 		for _, line := range lines {
 			if w := lipgloss.Width(line); w > inner {
@@ -828,24 +834,28 @@ func renderNoticeBody(n notice, width int) []string {
 		if len(release.Highlights) > 0 {
 			body = append(body, lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(release.Version))
 			body = appendNoticeBullets(body, release.Highlights, width)
-			continue
+		} else {
+			count := release.TotalChanges
+			label := "change"
+			if count != 1 {
+				label = "changes"
+			}
+			heading := release.Version
+			if count > 0 {
+				heading += fmt.Sprintf(" · %d %s", count, label)
+			}
+			body = append(body, lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(heading))
+			if len(release.Changes) == 0 {
+				body = append(body, subtleStyle.Render("  No summarized changes."))
+			}
+			body = appendNoticeBullets(body, release.Changes, width)
+			if omitted := release.TotalChanges - len(release.Changes); omitted > 0 {
+				body = append(body, subtleStyle.Render(fmt.Sprintf("  +%d more in the full notes", omitted)))
+			}
 		}
-		count := release.TotalChanges
-		label := "change"
-		if count != 1 {
-			label = "changes"
-		}
-		heading := release.Version
-		if count > 0 {
-			heading += fmt.Sprintf(" · %d %s", count, label)
-		}
-		body = append(body, lipgloss.NewStyle().Foreground(colorBright).Bold(true).Render(heading))
-		if len(release.Changes) == 0 {
-			body = append(body, subtleStyle.Render("  No summarized changes."))
-		}
-		body = appendNoticeBullets(body, release.Changes, width)
-		if omitted := release.TotalChanges - len(release.Changes); omitted > 0 {
-			body = append(body, subtleStyle.Render(fmt.Sprintf("  +%d more in the full notes", omitted)))
+		if len(release.Thanks) > 0 {
+			body = append(body, "", subtleStyle.Render("Thank you"))
+			body = appendNoticeBullets(body, release.Thanks, width)
 		}
 	}
 	if len(n.releases) > 0 && !n.rangeComplete {

--- a/internal/ui/notices_test.go
+++ b/internal/ui/notices_test.go
@@ -1265,6 +1265,49 @@ func TestReleaseSummaryPrefersAuthoredHighlights(t *testing.T) {
 	}
 }
 
+func TestReleaseSummaryShowsThanksUnderHighlights(t *testing.T) {
+	release := uiReleaseWithTotal("v0.35.0", 7, "UI: Add header and stats visibility settings")
+	release.Highlights = []string{"Revive without a captured id opens the tool's own picker"}
+	release.Thanks = []string{
+		"@dolutech asked in #388 and built the picker (#400)",
+		"@fruch reported that a live rename moved the worktree (#418)",
+	}
+	body := ansi.Strip(strings.Join(renderNoticeBody(notice{releases: []update.Release{release}, rangeComplete: true}, noticeModalInner), "\n"))
+
+	for _, want := range []string{
+		"• Revive without a captured id opens the tool's own picker",
+		"Thank you",
+		"• @dolutech asked in #388 and built the picker (#400)",
+		"• @fruch reported that a live rename moved the worktree (#418)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("thanks under highlights missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "Add header and stats visibility settings") {
+		t.Fatalf("generated list should stay hidden when highlights exist:\n%s", body)
+	}
+}
+
+func TestReleaseSummaryShowsThanksUnderGeneratedList(t *testing.T) {
+	release := uiRelease("v0.33.0", "UI: A change")
+	release.Thanks = []string{"@pandysp asked for a way to put the preview away in #357"}
+	body := ansi.Strip(strings.Join(renderNoticeBody(notice{
+		releases:      []update.Release{release},
+		rangeComplete: true,
+	}, noticeModalInner), "\n"))
+	for _, want := range []string{
+		"v0.33.0 · 1 change",
+		"• UI: A change",
+		"Thank you",
+		"• @pandysp asked for a way to put the preview away in #357",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("thanks under generated list missing %q:\n%s", want, body)
+		}
+	}
+}
+
 func TestReleaseSummaryFallsBackToTheGeneratedList(t *testing.T) {
 	body := ansi.Strip(strings.Join(renderNoticeBody(notice{
 		releases:      []update.Release{uiRelease("v0.33.0", "UI: A change")},

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -33,6 +33,7 @@ const (
 	maxChangesPerRelease = 12
 	maxChangeLength      = 120
 	maxHighlights        = 6
+	maxThanks            = 8
 )
 
 const (
@@ -40,6 +41,7 @@ const (
 	// short bullets naming what the release gives someone. The generated
 	// list says which branches merged, which is not the same question.
 	highlightsHeading = "## Highlights"
+	thanksHeading     = "## Thank you"
 	changesHeading    = "## What's Changed"
 )
 
@@ -65,6 +67,7 @@ type Release struct {
 	Version      string   `json:"version"`
 	URL          string   `json:"url"`
 	Highlights   []string `json:"highlights,omitempty"`
+	Thanks       []string `json:"thanks,omitempty"`
 	Changes      []string `json:"changes"`
 	TotalChanges int      `json:"total_changes"`
 }
@@ -250,6 +253,7 @@ func fetchReleases(ctx context.Context, etag string, budget time.Duration) ([]Re
 			Version:      item.TagName,
 			URL:          item.HTMLURL,
 			Highlights:   extractHighlights(item.Body),
+			Thanks:       extractThanks(item.Body),
 			Changes:      changes,
 			TotalChanges: total,
 		})
@@ -295,11 +299,11 @@ func bulletText(line string) (string, bool) {
 	return strings.TrimSpace(line[2:]), true
 }
 
-// Prose under the highlights heading is the release page's own copy,
-// written for a browser rather than a modal, so only bullets travel.
-func extractHighlights(body string) []string {
-	var highlights []string
-	for _, line := range sectionLines(body, highlightsHeading) {
+// Prose under an authored heading is the release page's own copy, written
+// for a browser rather than a modal, so only bullets travel.
+func extractSectionBullets(body, heading string, limit int) []string {
+	var bullets []string
+	for _, line := range sectionLines(body, heading) {
 		text, ok := bulletText(line)
 		if !ok {
 			continue
@@ -307,12 +311,20 @@ func extractHighlights(body string) []string {
 		if text = plainText(text); text == "" {
 			continue
 		}
-		highlights = append(highlights, sentenceCase(truncateChange(text)))
-		if len(highlights) == maxHighlights {
+		bullets = append(bullets, sentenceCase(truncateChange(text)))
+		if len(bullets) == limit {
 			break
 		}
 	}
-	return highlights
+	return bullets
+}
+
+func extractHighlights(body string) []string {
+	return extractSectionBullets(body, highlightsHeading, maxHighlights)
+}
+
+func extractThanks(body string) []string {
+	return extractSectionBullets(body, thanksHeading, maxThanks)
 }
 
 func extractChanges(body string) ([]string, int) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -460,8 +460,56 @@ func TestExtractHighlightsStopsAtTheCap(t *testing.T) {
 	}
 }
 
+func TestExtractThanksReadsTheAuthoredBullets(t *testing.T) {
+	body := strings.Join([]string{
+		"## Highlights",
+		"- the session list can take the whole terminal",
+		"",
+		"## Thank you",
+		"",
+		"A closing paragraph stays on the web page.",
+		"",
+		"- @dolutech asked for reboot recovery in #388 and then built the picker (#400)",
+		"* @pandysp asked to hide the stats foot and the header in #408 and #409",
+		"- [@fruch](https://github.com/fruch) reported that a live rename moved the worktree (#418)",
+		"",
+		"## What's Changed",
+		"* feat(config): revive without an id opens the tool's session picker",
+	}, "\n")
+
+	want := []string{
+		"@dolutech asked for reboot recovery in #388 and then built the picker (#400)",
+		"@pandysp asked to hide the stats foot and the header in #408 and #409",
+		"@fruch reported that a live rename moved the worktree (#418)",
+	}
+	if got := extractThanks(body); fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("extractThanks() = %q, want %q", got, want)
+	}
+	if got := extractHighlights(body); len(got) != 1 {
+		t.Fatalf("highlights leaked thanks: %q", got)
+	}
+}
+
+func TestExtractThanksIsEmptyWithoutTheSection(t *testing.T) {
+	body := "## Highlights\n- a feature\n\n## What's Changed\n* feat(ui): a feature\n"
+	if got := extractThanks(body); len(got) != 0 {
+		t.Fatalf("extractThanks() = %q, want none", got)
+	}
+}
+
+func TestExtractThanksStopsAtTheCap(t *testing.T) {
+	lines := []string{"## Thank you"}
+	for i := 0; i < maxThanks+3; i++ {
+		lines = append(lines, fmt.Sprintf("- @someone%d filed #%d", i, i))
+	}
+	got := extractThanks(strings.Join(lines, "\n"))
+	if len(got) != maxThanks {
+		t.Fatalf("extractThanks() kept %d, want %d", len(got), maxThanks)
+	}
+}
+
 func TestCatalogCarriesHighlightsThroughTheCache(t *testing.T) {
-	body := `## Highlights\n- the list can take the whole terminal\n\n## What's Changed\n* feat(ui): full screen sessions mode`
+	body := `## Highlights\n- the list can take the whole terminal\n\n## Thank you\n- @pandysp asked for full screen in #357\n\n## What's Changed\n* feat(ui): full screen sessions mode`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, `[{"tag_name":"v0.34.0","html_url":"https://github.com/YoanWai/agent-manager/releases/tag/v0.34.0","body":"%s","draft":false,"prerelease":false}]`, body)
 	}))
@@ -469,15 +517,23 @@ func TestCatalogCarriesHighlightsThroughTheCache(t *testing.T) {
 	defer swapReleasesURL(server.URL)()
 
 	dir := t.TempDir()
-	want := []string{"The list can take the whole terminal"}
+	wantHighlights := []string{"The list can take the whole terminal"}
+	wantThanks := []string{"@pandysp asked for full screen in #357"}
 	fetched, err := Check(context.Background(), dir, "v0.33.0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := fetched.Releases[0].Highlights; fmt.Sprint(got) != fmt.Sprint(want) {
-		t.Fatalf("fetched highlights = %q, want %q", got, want)
+	if got := fetched.Releases[0].Highlights; fmt.Sprint(got) != fmt.Sprint(wantHighlights) {
+		t.Fatalf("fetched highlights = %q, want %q", got, wantHighlights)
 	}
-	if got := Cached(dir, "v0.33.0").Releases[0].Highlights; fmt.Sprint(got) != fmt.Sprint(want) {
-		t.Fatalf("cached highlights = %q, want %q", got, want)
+	if got := fetched.Releases[0].Thanks; fmt.Sprint(got) != fmt.Sprint(wantThanks) {
+		t.Fatalf("fetched thanks = %q, want %q", got, wantThanks)
+	}
+	cached := Cached(dir, "v0.33.0")
+	if got := cached.Releases[0].Highlights; fmt.Sprint(got) != fmt.Sprint(wantHighlights) {
+		t.Fatalf("cached highlights = %q, want %q", got, wantHighlights)
+	}
+	if got := cached.Releases[0].Thanks; fmt.Sprint(got) != fmt.Sprint(wantThanks) {
+		t.Fatalf("cached thanks = %q, want %q", got, wantThanks)
 	}
 }


### PR DESCRIPTION
## What changed

The messages panel reads a `## Thank you` section from the GitHub release notes and paints those bullets under the highlights, labelled Thank you.

`AGENTS.md`, `docs/notifications.md`, and `CONTRIBUTING.md` now say those bullets are part of the in-app update notice.

## Why

Contributor and reporter credits lived on the GitHub release page. The panel only took Highlights. Credits belong in the same notice as the release.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./internal/update ./internal/ui` passes
- [x] `go test -race ./internal/update` passes
- [x] `go test -race ./internal/ui -run 'TestReleaseSummary|TestExtract|TestCatalogCarries|TestEmptyNoticesPanel'` passes
- [x] `go build ./...` passes
- [ ] Ran it against real sessions

Parser tests cover authored bullets, the 8-line cap, cache round-trip, and that Highlights do not leak Thank you. Render tests cover thanks under Highlights and under the generated-list fallback.

## Visual evidence

**Before:** the update notice listed Highlights (or the generated change list) with no credits.

**After:** same notice, then a Thank you block:

```
v0.35.0
• Pressing v on a dead session with no captured id opens the tool's own picker
• Settings can hide the header and computer stats, and messages still appear
• Renaming a worktree session keeps the directory the agent is running in
• Claude's update banner no longer leaves a finished turn marked working
• A focused picker that hid its cursor no longer looks frozen
• A prompt that starts with a pasted image still carries the rename directive

Thank you
• @dolutech asked for reboot recovery in #388 and then built the picker (#400)
• @pandysp asked to hide the stats foot and the header in #408 and #409
• @fruch reported that a live rename moved the worktree out from under the agent (#418)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notices now display dedicated **Highlights** and **Thank you** sections from release notes.
  * Contributor acknowledgments appear directly in the messages panel.
  * Releases without authored highlights now show generated change summaries, including a clear empty-state message when applicable.
* **Bug Fixes**
  * Improved release notice formatting and content-width handling for longer summaries.
* **Documentation**
  * Updated contributor and release guidance to explain highlights, acknowledgments, fallback behavior, display limits, and feed refresh timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->