### PR TITLE
fix(config): treat a WSL interop Windows-mount hit as not installed

### DIFF
--- a/internal/config/install.go
+++ b/internal/config/install.go
@@ -3,12 +3,22 @@ package config
 import (
 	"errors"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/YoanWai/agent-manager/internal/deps"
+	"github.com/YoanWai/agent-manager/internal/wsl"
 )
 
 var lookPath = exec.LookPath
+var wslDetect = wsl.Detect
+
+// windowsMountPath matches a WSL interop mount, e.g. /mnt/c/Users/... .
+// exec.LookPath happily resolves a Windows-side launcher through one of
+// these because WSL2 appends the Windows PATH to the Linux PATH by
+// default, but a pane spawned inside the distro cannot run it the way a
+// tool installed in the distro runs.
+var windowsMountPath = regexp.MustCompile(`^/mnt/[a-zA-Z](/|$)`)
 
 type MissingToolError struct {
 	Binary string
@@ -24,8 +34,11 @@ func CheckInstalled(command string) error {
 		return nil
 	}
 	binary := fields[0]
-	_, err := lookPath(binary)
+	path, err := lookPath(binary)
 	if err == nil {
+		if wslDetect() && windowsMountPath.MatchString(path) {
+			return MissingToolError{Binary: binary}
+		}
 		return nil
 	}
 	if !errors.Is(err, exec.ErrNotFound) {

--- a/internal/config/install_test.go
+++ b/internal/config/install_test.go
@@ -55,6 +55,48 @@ func TestCheckInstalledNamesOfficialInstaller(t *testing.T) {
 	}
 }
 
+func TestCheckInstalledRejectsWindowsMountUnderWSL(t *testing.T) {
+	origLookPath, origWSLDetect := lookPath, wslDetect
+	lookPath = func(string) (string, error) {
+		return "/mnt/c/Users/dev/AppData/Roaming/npm/claude", nil
+	}
+	wslDetect = func() bool { return true }
+	t.Cleanup(func() { lookPath, wslDetect = origLookPath, origWSLDetect })
+
+	err := CheckInstalled("claude")
+	var missing MissingToolError
+	if !errors.As(err, &missing) {
+		t.Fatalf("a Windows-mount hit under WSL should read as not installed in the distro, got %v", err)
+	}
+	if missing.Binary != "claude" {
+		t.Fatalf("binary = %q", missing.Binary)
+	}
+}
+
+func TestCheckInstalledAcceptsWindowsMountOutsideWSL(t *testing.T) {
+	origLookPath, origWSLDetect := lookPath, wslDetect
+	lookPath = func(string) (string, error) {
+		return "/mnt/c/Users/dev/AppData/Roaming/npm/claude", nil
+	}
+	wslDetect = func() bool { return false }
+	t.Cleanup(func() { lookPath, wslDetect = origLookPath, origWSLDetect })
+
+	if err := CheckInstalled("claude"); err != nil {
+		t.Fatalf("a /mnt/c path outside WSL is an ordinary mounted path, not a distro miss: %v", err)
+	}
+}
+
+func TestCheckInstalledAcceptsDistroBinaryUnderWSL(t *testing.T) {
+	origLookPath, origWSLDetect := lookPath, wslDetect
+	lookPath = func(string) (string, error) { return "/usr/local/bin/claude", nil }
+	wslDetect = func() bool { return true }
+	t.Cleanup(func() { lookPath, wslDetect = origLookPath, origWSLDetect })
+
+	if err := CheckInstalled("claude"); err != nil {
+		t.Fatalf("a distro-installed binary under WSL must still pass: %v", err)
+	}
+}
+
 func TestCheckInstalledKeepsLookupErrors(t *testing.T) {
 	orig := lookPath
 	denied := errors.New("permission denied")


### PR DESCRIPTION
Fixes #428.

## What breaks

`config.CheckInstalled` resolves a tool with `exec.LookPath` and treats any hit as installed. Under WSL2, the Windows PATH is appended to the Linux PATH by default (interop `appendWindowsPath`), so a Windows-side install of claude/codex/gemini/pi/etc. under `/mnt/c/...` satisfies `LookPath` even when nothing is installed in the distro. The setup dialog with the Linux install command never fires, and the tmux pane spawns that Windows-side launcher from the distro shell instead.

## Fix

`internal/wsl.Detect` already exists (used the same way by `internal/sysstat` for host probing), and `internal/sysstat/host_linux.go` already has a working `/mnt/c/...` pattern for this same interop mount. Reused both here: `CheckInstalled` now treats a `LookPath` hit as installed unless it's both running under WSL *and* the resolved path sits on a WSL interop mount (`/mnt/<drive-letter>/...`), in which case it returns the same `MissingToolError` a genuinely-absent binary gets — so the existing setup dialog fires instead of launching the Windows binary.

The fix is at the single choke point (`internal/launch` calls `config.CheckInstalled` for every tool), so it covers every built-in tool the issue names, not just `claude`, without per-tool changes.

## Scope note

The issue also asks for a per-tool WSL2 matrix (what `exec.LookPath` resolves to and what the pane does when it runs, per tool) to record before a fix. I don't have a WSL2 box with a Windows-side agent CLI install to gather that matrix, so I couldn't complete that part — happy to if it's still wanted.

## Verification

**Before** (against the pre-fix `CheckInstalled`, mocked `lookPath` returning `/mnt/c/Users/dev/AppData/Roaming/npm/claude, nil`, no WSL awareness at all):

```
--- PASS: TestCheckInstalled_PREFIX_WronglyAcceptsWindowsMountPath
    BUG: CheckInstalled reports claude installed via a Windows-mount path with no WSL check at all
```

(This was a throwaway test I ran directly against the reverted file to confirm the bug, not part of this PR's diff.)

**After**:

```
--- PASS: TestCheckInstalledRejectsWindowsMountUnderWSL
--- PASS: TestCheckInstalledAcceptsWindowsMountOutsideWSL
--- PASS: TestCheckInstalledAcceptsDistroBinaryUnderWSL
--- PASS: TestCheckInstalledRejectsMissingBinary
--- PASS: TestCheckInstalledNamesOfficialInstaller
--- PASS: TestCheckInstalledKeepsLookupErrors
--- PASS: TestCheckInstalledSkipsEmptyCommand
ok  	github.com/YoanWai/agent-manager/internal/config
```

`gofmt -l ./internal/config` and `go vet ./internal/config/...` are clean. `go build ./...` is clean. `go test -race ./...` isn't runnable in my environment (no cgo toolchain configured here) — the added logic is a pure function over a mocked `exec.LookPath` result and a mocked `wsl.Detect`, no goroutines or shared state, so this shouldn't be a race surface, but I'm flagging the gap rather than claiming coverage I couldn't run. The rest of the suite has pre-existing failures on this Windows checkout unrelated to this change (no `tmux` binary on PATH, Windows symlink privilege requirements, `/proc`-based process-tree tests) — confirmed unrelated by running them with this diff stashed out, same failures either way.

## Visual evidence

None — this is a pure backend check (`exec.LookPath` result classification), no UI change. The observable effect (setup dialog firing instead of the Windows binary launching) needs an actual WSL2 box with a Windows-side agent install, which I don't have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool detection in WSL environments by correctly identifying Windows-mounted executables as unavailable.
  - Continued to recognize tools installed natively within the Linux environment and tools outside WSL as available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->