### PR TITLE
feat: copy the full turn text with y, not just the last message_start block

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,6 +30,7 @@ Tell your agent what you want to review in Agent Manager. Your agent will set up
 | `K` / `J` (or `shift+↑` / `shift+↓`) | Reorder session or group among its visible siblings |
 | `m` | Move a session to a group, a terminal into a session, or a group under another group |
 | `r` | Rename session / edit tool; edit group name and default path |
+| `y` | Copy the selected session's newest reply to the system clipboard, without attaching |
 | `x` | Kill the selected session, or every live session under a group: frees the RAM their agents hold, and the rows stay for `v` |
 | `X` | Kill every live session in view |
 | `v` | Revive a dead session, or every dead session under a group |

--- a/internal/agentsession/claude.go
+++ b/internal/agentsession/claude.go
@@ -23,6 +23,21 @@ func ClaudeTranscriptPath(cwd, sessionID string) (string, error) {
 	return filepath.Join(home, ".claude", "projects", claudeProjectSlug(resolvePath(cwd)), sessionID+".jsonl"), nil
 }
 
+// ClaudeProjectDir is the folder ClaudeTranscriptPath's transcript lives
+// in: every transcript Claude Code has ever written for this working
+// directory, one file per conversation. Claude Code opens a new one on
+// its own context compaction, so a session id captured once can go
+// stale mid-conversation - listing the directory (sorted newest first,
+// say) is how a caller finds the transcript actually being written to
+// now instead of trusting a possibly-stale id.
+func ClaudeProjectDir(cwd string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "projects", claudeProjectSlug(resolvePath(cwd))), nil
+}
+
 // claudeProjectSlug names the per-directory folder Claude Code files a
 // transcript under: the resolved working directory with every character
 // outside [A-Za-z0-9] turned into a dash.
@@ -106,6 +121,67 @@ func ClaudeTranscriptTail(cwd, sessionID string, cleanUser func(string) string) 
 		}
 	}
 	return prompt, reply, true
+}
+
+// ClaudeTranscriptFullTurn reads every assistant text block written
+// since the transcript's last user entry, joined as separate paragraphs
+// - the whole current turn, not just its last block. ClaudeTranscriptTail
+// only keeps the newest assistant entry (reply = text, overwritten each
+// time), right for a one-line row quote but wrong here: a turn with
+// several marker-led paragraphs writes as several separate assistant
+// entries, and only concatenating all of them since the last user entry
+// reconstructs it whole. ok is false when the transcript cannot be read
+// at all, same as ClaudeTranscriptTail.
+func ClaudeTranscriptFullTurn(cwd, sessionID string) (reply string, ok bool) {
+	path, err := ClaudeTranscriptPath(cwd, sessionID)
+	if err != nil {
+		return "", false
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return "", false
+	}
+	offset := int64(0)
+	if info.Size() > claudeTailBytes {
+		offset = info.Size() - claudeTailBytes
+	}
+	raw := make([]byte, info.Size()-offset)
+	if _, err := file.ReadAt(raw, offset); err != nil {
+		return "", false
+	}
+	lines := strings.Split(string(raw), "\n")
+	if offset > 0 && len(lines) > 0 {
+		lines = lines[1:]
+	}
+	var turn []string
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry claudeEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.IsSidechain || entry.IsMeta {
+			continue
+		}
+		text := entryText(entry)
+		if text == "" {
+			continue
+		}
+		switch entry.Type {
+		case "user":
+			turn = turn[:0]
+		case "assistant":
+			turn = append(turn, text)
+		}
+	}
+	return strings.Join(turn, "\n\n"), true
 }
 
 // entryText is the first plain-text block of an entry's content: a bare

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,6 +207,10 @@ const busyLineAgentsOnly = `^[✻✳✶✽✢·✦✧+*] Waiting for \d+ backgro
 // banner beneath completed turns. Hand-edited patterns remain untouched.
 const oldClaudeChromeLine = `^\s*[─q]{4,}.*$|^[\s─q]*$`
 
+// The same pattern once the updater banner was added, but before Claude
+// started printing its "new task?" nudge above the composer.
+const oldClaudeChromeLineNoHint = `^\s*[─q]{4,}.*$|^[\s─q]*$|^\s*✔ Update installed · Restart to update\s*$`
+
 // The command-code matching rules #385 shipped, which no longer match the
 // shapes current Command Code draws. A stored config.toml carries these
 // verbatim and keeps them over any new default, so mergeTool rewrites
@@ -276,7 +280,7 @@ func mergeTool(name string, user, def Tool) Tool {
 		if user.BusyLine == busyLineAgentsOnly {
 			user.BusyLine = def.BusyLine
 		}
-		if user.ChromeLine == oldClaudeChromeLine {
+		if user.ChromeLine == oldClaudeChromeLine || user.ChromeLine == oldClaudeChromeLineNoHint {
 			user.ChromeLine = def.ChromeLine
 		}
 	}
@@ -426,7 +430,7 @@ status_source = "claude-hooks"
 default_status = "idle"
 activity_cutoff = "(?m)^❯"
 turn_end = "^[✻✳✶✽✢·✦✧+*] \\S+ for \\d.*$"
-chrome_line = "^\\s*[─q]{4,}.*$|^[\\s─q]*$|^\\s*✔ Update installed · Restart to update\\s*$"
+chrome_line = "^\\s*[─q]{4,}.*$|^[\\s─q]*$|^\\s*✔ Update installed · Restart to update\\s*$|^\\s*new task\\? /clear to save .*$"
 blocked_line = "Interrupted ·"
 # recap blocks ("※ recap: …") render below the turn-end summary
 trailing_note = "^※"

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -349,31 +349,102 @@ func (e *Engine) ActivityRegion(tool, pane string) (string, bool) {
 // the captured text. ok is false when the tool has no activity_cutoff to
 // find the box with, or the cutoff is absent from the pane.
 func (e *Engine) LastMessage(tool, pane string) (line string, anchored, ok bool) {
+	parts, anchored, ok := e.lastMessageParts(tool, pane)
+	if !ok || parts == nil {
+		return "", anchored, ok
+	}
+	return strings.TrimSpace(strings.Join(parts, " ")), anchored, ok
+}
+
+// LastMessageText is LastMessage with its line breaks intact: LastMessage
+// flattens a reply to one line for a row quote, this keeps it as the
+// agent wrote it for a full copy (auto-copy-on-finish and similar).
+func (e *Engine) LastMessageText(tool, pane string) (text string, anchored, ok bool) {
+	parts, anchored, ok := e.lastMessageParts(tool, pane)
+	if !ok || parts == nil {
+		return "", anchored, ok
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n")), anchored, ok
+}
+
+// FullTurnText is the whole turn's content above the input box, not just
+// the newest message_start block LastMessageText anchors to: a reply with
+// several marker-led paragraphs (Claude's bulleted sections, for example)
+// has several message_start matches, and LastMessageText only keeps the
+// last one. This keeps every line of the region instead, chrome, busy
+// spinners and turn_end markers dropped the same way isStructural drops
+// them for LastMessage, blank lines collapsed to single paragraph breaks.
+// A tool that echoes the submitted prompt back into its own transcript
+// (user_echo) has that line dropped too: LastMessage never needed to,
+// its marker anchor already starts past it, but nothing bounds this
+// method's start. ok is false under the same conditions as
+// ActivityRegion: no activity_cutoff configured, or none found in pane.
+func (e *Engine) FullTurnText(tool, pane string) (text string, ok bool) {
 	tr, ok := e.tools[tool]
 	if !ok {
-		return "", false, false
+		return "", false
 	}
 	region, ok := tr.activityRegion(pane)
 	if !ok {
-		return "", false, false
+		return "", false
 	}
 	lines := strings.Split(region, "\n")
-	structural := func(line string) bool {
-		if tr.chromeLine != nil && tr.chromeLine.MatchString(line) {
-			return true
+	out := make([]string, 0, len(lines))
+	for _, raw := range lines {
+		line := strings.TrimRight(raw, " \t")
+		if strings.TrimSpace(line) == "" {
+			if len(out) > 0 && out[len(out)-1] != "" {
+				out = append(out, "")
+			}
+			continue
 		}
-		if tr.busyLine != nil && tr.busyLine.MatchString(line) {
-			return true
+		if tr.isStructural(line) {
+			continue
 		}
-		if tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
-			return true
+		if tr.userEcho != nil && tr.userEcho.MatchString(line) {
+			continue
 		}
-		return tr.matchesWorkingRule(line)
+		out = append(out, line)
 	}
+	return strings.TrimSpace(strings.Join(out, "\n")), true
+}
+
+// isStructural reports whether line is chrome, a busy spinner, or a
+// turn-end summary rather than message content: the one check shared by
+// LastMessage's marker search and FullTurnText's whole-region copy, so a
+// rule added to one is never missed by the other.
+func (tr toolRules) isStructural(line string) bool {
+	if tr.chromeLine != nil && tr.chromeLine.MatchString(line) {
+		return true
+	}
+	if tr.busyLine != nil && tr.busyLine.MatchString(line) {
+		return true
+	}
+	if tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
+		return true
+	}
+	return tr.matchesWorkingRule(line)
+}
+
+// lastMessageParts finds the newest message's content lines, trimmed but
+// not yet joined, from its message_start marker to the next structural
+// line: a turn summary or a rule closes it, so a notice printed after the
+// turn (a plugin banner, a warning) is not glued onto the reply. A tool
+// without a marker yields the newest content line alone, unanchored.
+func (e *Engine) lastMessageParts(tool, pane string) (parts []string, anchored, ok bool) {
+	tr, ok := e.tools[tool]
+	if !ok {
+		return nil, false, false
+	}
+	region, ok := tr.activityRegion(pane)
+	if !ok {
+		return nil, false, false
+	}
+	lines := strings.Split(region, "\n")
 	start, lastContent := -1, -1
 	for i, raw := range lines {
 		line := strings.TrimRight(raw, " \t")
-		if strings.TrimSpace(line) == "" || structural(line) {
+		if strings.TrimSpace(line) == "" || tr.isStructural(line) {
 			continue
 		}
 		lastContent = i
@@ -382,29 +453,26 @@ func (e *Engine) LastMessage(tool, pane string) (line string, anchored, ok bool)
 		}
 	}
 	if lastContent == -1 {
-		return "", false, true
+		return nil, false, true
 	}
 	if start == -1 {
-		return strings.TrimSpace(lines[lastContent]), false, true
+		return []string{strings.TrimSpace(lines[lastContent])}, false, true
 	}
-	// The message runs from its marker until the next structural line: a
-	// turn summary or a rule closes it, so a notice printed after the
-	// turn (a plugin banner, a warning) is not glued onto the reply.
 	first := strings.TrimRight(lines[start], " \t")
 	marker := tr.messageStart.FindStringIndex(first)
 	first = first[marker[1]:]
-	parts := []string{strings.TrimSpace(first)}
+	parts = []string{strings.TrimSpace(first)}
 	for _, raw := range lines[start+1:] {
 		line := strings.TrimRight(raw, " \t")
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		if structural(line) {
+		if tr.isStructural(line) {
 			break
 		}
 		parts = append(parts, strings.TrimSpace(line))
 	}
-	return strings.TrimSpace(strings.Join(parts, " ")), true, true
+	return parts, true, true
 }
 
 // HasMessageStart reports whether the tool declared a message_start

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -367,6 +367,16 @@ func (e *Engine) LastMessageText(tool, pane string) (text string, anchored, ok b
 	return strings.TrimSpace(strings.Join(parts, "\n")), anchored, ok
 }
 
+// composerHint matches Claude Code's own "start a new task" nudge,
+// right-padded and printed near the input box once context use gets
+// high enough to suggest /clear - a UI element, not part of any reply,
+// but not covered by any tool's own chrome/busy/turn_end rules either
+// (it sits inside the activity_cutoff region, above the "❯" line those
+// rules are built around, not below it where the rest of the composer
+// chrome lives). Checked directly here rather than added to config.toml
+// since it names its own token count and so never repeats byte-for-byte.
+var composerHint = regexp.MustCompile(`new task\? /clear to save`)
+
 // FullTurnText is the whole turn's content above the input box, not just
 // the newest message_start block LastMessageText anchors to: a reply with
 // several marker-led paragraphs (Claude's bulleted sections, for example)
@@ -402,6 +412,9 @@ func (e *Engine) FullTurnText(tool, pane string) (text string, ok bool) {
 			continue
 		}
 		if tr.userEcho != nil && tr.userEcho.MatchString(line) {
+			continue
+		}
+		if composerHint.MatchString(line) {
 			continue
 		}
 		out = append(out, line)

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -356,39 +356,25 @@ func (e *Engine) LastMessage(tool, pane string) (line string, anchored, ok bool)
 	return strings.TrimSpace(strings.Join(parts, " ")), anchored, ok
 }
 
-// LastMessageText is LastMessage with its line breaks intact: LastMessage
-// flattens a reply to one line for a row quote, this keeps it as the
-// agent wrote it for a full copy (auto-copy-on-finish and similar).
-func (e *Engine) LastMessageText(tool, pane string) (text string, anchored, ok bool) {
-	parts, anchored, ok := e.lastMessageParts(tool, pane)
-	if !ok || parts == nil {
-		return "", anchored, ok
-	}
-	return strings.TrimSpace(strings.Join(parts, "\n")), anchored, ok
-}
+// toolResultRow matches the row a tool call's result is drawn under.
+// Only claude's own glyph: the box-drawing characters a table is built
+// from open rows too, and those are content.
+var toolResultRow = regexp.MustCompile(`^\s*⎿`)
 
-// composerHint matches Claude Code's own "start a new task" nudge,
-// right-padded and printed near the input box once context use gets
-// high enough to suggest /clear - a UI element, not part of any reply,
-// but not covered by any tool's own chrome/busy/turn_end rules either
-// (it sits inside the activity_cutoff region, above the "❯" line those
-// rules are built around, not below it where the rest of the composer
-// chrome lives). Checked directly here rather than added to config.toml
-// since it names its own token count and so never repeats byte-for-byte.
-var composerHint = regexp.MustCompile(`new task\? /clear to save`)
-
-// FullTurnText is the whole turn's content above the input box, not just
-// the newest message_start block LastMessageText anchors to: a reply with
-// several marker-led paragraphs (Claude's bulleted sections, for example)
-// has several message_start matches, and LastMessageText only keeps the
-// last one. This keeps every line of the region instead, chrome, busy
-// spinners and turn_end markers dropped the same way isStructural drops
-// them for LastMessage, blank lines collapsed to single paragraph breaks.
-// A tool that echoes the submitted prompt back into its own transcript
-// (user_echo) has that line dropped too: LastMessage never needed to,
-// its marker anchor already starts past it, but nothing bounds this
-// method's start. ok is false under the same conditions as
-// ActivityRegion: no activity_cutoff configured, or none found in pane.
+// FullTurnText is the newest turn's prose: everything the agent wrote
+// after the last prompt, with tool calls, their results and the tool's
+// own chrome left out.
+//
+// The turn starts after the last user_echo (the prompt the tool echoed
+// back), or after the last turn_end for a tool that echoes nothing.
+// Without that bound this would return every turn still on screen, since
+// activityRegion is only bounded below, by the composer. A wrapped
+// prompt's continuation rows are dropped with it: user_echo only matches
+// the first row, so anything between it and the first real content row
+// belongs to the prompt too.
+//
+// ok is false under the same conditions as ActivityRegion: no
+// activity_cutoff configured, or none found in pane.
 func (e *Engine) FullTurnText(tool, pane string) (text string, ok bool) {
 	tr, ok := e.tools[tool]
 	if !ok {
@@ -399,8 +385,24 @@ func (e *Engine) FullTurnText(tool, pane string) (text string, ok bool) {
 		return "", false
 	}
 	lines := strings.Split(region, "\n")
-	out := make([]string, 0, len(lines))
-	for _, raw := range lines {
+	start := 0
+	sawPrompt := false
+	for i, raw := range lines {
+		line := strings.TrimRight(raw, " \t")
+		if tr.userEcho != nil && tr.userEcho.MatchString(line) {
+			start, sawPrompt = i+1, true
+			continue
+		}
+		if tr.userEcho == nil && tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
+			start = i + 1
+		}
+	}
+	out := make([]string, 0, len(lines)-start)
+	// A reply long enough to outrun the capture leaves its prompt off the
+	// top of it. Nothing was skipped, so nothing below is prompt tail
+	// either: the region opens mid-reply and every row of it is content.
+	started := !sawPrompt
+	for _, raw := range lines[start:] {
 		line := strings.TrimRight(raw, " \t")
 		if strings.TrimSpace(line) == "" {
 			if len(out) > 0 && out[len(out)-1] != "" {
@@ -408,15 +410,25 @@ func (e *Engine) FullTurnText(tool, pane string) (text string, ok bool) {
 			}
 			continue
 		}
+		if toolResultRow.MatchString(line) {
+			continue
+		}
 		if tr.isStructural(line) {
+			// A turn_end after content closes the turn: a notice printed
+			// below it (a plugin banner, an update note) is not the reply.
+			if started && tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
+				break
+			}
 			continue
 		}
-		if tr.userEcho != nil && tr.userEcho.MatchString(line) {
+		if !started && strings.HasPrefix(raw, " ") {
+			// Still inside the prompt: a wrapped user_echo's own
+			// continuation rows are indented under it, and nothing else
+			// marks them. Only before the turn's first content row - a
+			// reply's own wrapped lines are indented the same way.
 			continue
 		}
-		if composerHint.MatchString(line) {
-			continue
-		}
+		started = true
 		out = append(out, line)
 	}
 	return strings.TrimSpace(strings.Join(out, "\n")), true

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -902,6 +902,50 @@ func TestLastMessage(t *testing.T) {
 	}
 }
 
+// FullTurnText keeps every marker-led paragraph in the turn, where
+// LastMessage/LastMessageText anchor to only the newest one.
+func TestFullTurnText(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ Reply with exactly this sentence and nothing else: some prompt text\n" +
+		"⏺ First paragraph about the topic.\n" +
+		"  continued content of first paragraph.\n" +
+		"\n" +
+		"\n" +
+		"⏺ Second paragraph, a different topic.\n" +
+		"\n" +
+		"⏺ Third and final paragraph.\n" +
+		"\n" +
+		"✻ Crunched for 3s\n" +
+		"────────────────────\n" +
+		"❯ "
+	want := "⏺ First paragraph about the topic.\n" +
+		"  continued content of first paragraph.\n" +
+		"\n" +
+		"⏺ Second paragraph, a different topic.\n" +
+		"\n" +
+		"⏺ Third and final paragraph."
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("claude has an activity cutoff, ok should be true")
+	}
+	if text != want {
+		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
+	}
+
+	// Sanity check against the exact same pane: LastMessageText only
+	// keeps the last paragraph, the difference FullTurnText exists for.
+	if last, _, ok := engine.LastMessageText("claude", pane); !ok || last != "Third and final paragraph." {
+		t.Fatalf("LastMessageText = %q ok=%v, want just the last paragraph for contrast", last, ok)
+	}
+
+	if _, ok := engine.FullTurnText("no-such-tool", pane); ok {
+		t.Fatal("unknown tool should report it cannot tell")
+	}
+	if _, ok := engine.FullTurnText("claude", "just text, no input box"); ok {
+		t.Fatal("pane without the cutoff should report it cannot tell")
+	}
+}
+
 // InputDraft reads what the user has typed after the composer marker, and
 // refuses the placeholder wording a composer paints on its empty row.
 func TestInputDraft(t *testing.T) {

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -932,17 +932,127 @@ func TestFullTurnText(t *testing.T) {
 		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
 	}
 
-	// Sanity check against the exact same pane: LastMessageText only
-	// keeps the last paragraph, the difference FullTurnText exists for.
-	if last, _, ok := engine.LastMessageText("claude", pane); !ok || last != "Third and final paragraph." {
-		t.Fatalf("LastMessageText = %q ok=%v, want just the last paragraph for contrast", last, ok)
-	}
-
 	if _, ok := engine.FullTurnText("no-such-tool", pane); ok {
 		t.Fatal("unknown tool should report it cannot tell")
 	}
 	if _, ok := engine.FullTurnText("claude", "just text, no input box"); ok {
 		t.Fatal("pane without the cutoff should report it cannot tell")
+	}
+}
+
+// FullTurnText copies the newest turn, not every turn still on screen:
+// a pane holding two exchanges must return only the second one's prose.
+func TestFullTurnTextStopsAtPreviousTurn(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ first prompt\n" +
+		"⏺ first answer\n" +
+		"✻ Crunched for 1s\n" +
+		"❯ second prompt\n" +
+		"⏺ second answer\n" +
+		"✻ Crunched for 2s\n" +
+		"❯ "
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != "⏺ second answer" {
+		t.Fatalf("FullTurnText = %q, want only the newest turn", text)
+	}
+}
+
+// A prompt long enough to wrap echoes over several rows, but user_echo
+// only matches the first: the rest are still the prompt, not the reply.
+// Tool calls and their result rows are not prose either, and a notice
+// printed after the turn-end summary is past the reply entirely.
+func TestFullTurnTextDropsPromptTailAndToolRows(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ a prompt long enough that the composer wrapped it onto\n" +
+		"  a second row and then a third row as well\n" +
+		"⏺ Read(internal/status/status.go)\n" +
+		"  ⎿  Read 120 lines\n" +
+		"⏺ The answer itself.\n" +
+		"✻ Crunched for 3s\n" +
+		"✔ Update installed · Restart to update\n" +
+		"❯ "
+	want := "⏺ Read(internal/status/status.go)\n" +
+		"⏺ The answer itself."
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != want {
+		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
+	}
+}
+
+// Claude prints a "new task?" nudge above the composer once context use
+// runs high. It is chrome, and belongs to no turn.
+func TestFullTurnTextDropsComposerHint(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ a prompt\n" +
+		"⏺ The answer.\n" +
+		"                          new task? /clear to save 421.3k tokens\n" +
+		"❯ "
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != "⏺ The answer." {
+		t.Fatalf("FullTurnText = %q, want the nudge dropped", text)
+	}
+}
+
+// Not every reply opens on a message_start marker: a turn can render as
+// plain unmarked prose, and dropping it as prompt tail would copy
+// nothing at all.
+func TestFullTurnTextKeepsUnmarkedReply(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ a prompt\n" +
+		"Regression test. Some unmarked prose.\n" +
+		"  its own wrapped continuation row.\n" +
+		"\n" +
+		"Docs. A second unmarked paragraph.\n" +
+		"✻ Baked for 1m 33s\n" +
+		"❯ "
+	want := "Regression test. Some unmarked prose.\n" +
+		"  its own wrapped continuation row.\n" +
+		"\n" +
+		"Docs. A second unmarked paragraph."
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != want {
+		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
+	}
+}
+
+// A table's rows open on the same box-drawing characters a tool result
+// is drawn under, and they are content: only claude's own ⎿ marks a
+// result row.
+func TestFullTurnTextKeepsTableRows(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ a prompt\n" +
+		"⏺ Here is the table.\n" +
+		"  ┌───────┬───────┐\n" +
+		"  │ Raw   │ Under │\n" +
+		"  ├───────┼───────┤\n" +
+		"  │ 0.50  │ 23.00 │\n" +
+		"  └───────┴───────┘\n" +
+		"  ⎿  Read 120 lines\n" +
+		"❯ "
+	want := "⏺ Here is the table.\n" +
+		"  ┌───────┬───────┐\n" +
+		"  │ Raw   │ Under │\n" +
+		"  ├───────┼───────┤\n" +
+		"  │ 0.50  │ 23.00 │\n" +
+		"  └───────┴───────┘"
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != want {
+		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
 	}
 }
 

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -87,6 +87,7 @@ func helpSections() []helpSection {
 			{"R", "restart it on an empty context (same name, group, dir, tool)"},
 			{"x / X", "kill it / kill every live session (frees their RAM)"},
 			{"v / V", "revive it, its pane included / revive every dead session"},
+			{"y", "copy its newest reply to the clipboard"},
 			{"a / u", "archive / restore (archive kills, restore revives)"},
 			{"d", "delete it"},
 		}},

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -123,6 +123,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openFork()
 	case "v":
 		return m.reviveSelected()
+	case "y":
+		return m.copyLastOutput()
 	case ".":
 		return m.acknowledgeSelected()
 	case "V", "shift+v":

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -3,9 +3,12 @@ package ui
 import (
 	"errors"
 	"fmt"
+	"os"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/agentsession"
 	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/launch"
@@ -123,14 +126,13 @@ func (m *Model) reattach(id string, diffGen int) tea.Cmd {
 // screen, plus real scrollback for a tool that keeps any. An alt-screen,
 // mouse-tracking tool (Claude Code, for one) keeps none of its own for
 // tmux to walk, so a reply longer than the viewport truncates at
-// whatever's on screen when y is pressed. Reading the on-disk transcript
-// instead was tried and reverted: AgentSessionID is captured once and
-// trusted as still pointing at the live file, but Claude Code opens a
-// new transcript on its own compaction, invisibly to agent-manager, and
-// a stale id then reads a real but unrelated past conversation with no
-// signal that anything is wrong. Silently wrong beats silently short,
-// but it's still wrong, so this waits on a way to tell a stale id from a
-// live one before it's worth the risk again.
+// whatever's on screen when y is pressed. deepCopyFallback covers that
+// case for claude by reading the on-disk transcript instead, gated on
+// the tail-match check documented there: AgentSessionID is captured
+// once and can go stale (Claude Code opens a new transcript on its own
+// compaction, invisibly to agent-manager), so the fallback is only
+// trusted when its own tail provably continues what's already on
+// screen, not just because the id is set.
 func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
 	entry, ok := m.selectedRow()
 	if !ok || entry.isGroup || m.engine == nil || m.tmux == nil {
@@ -150,12 +152,150 @@ func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
 		m.errBar.text = "nothing to copy"
 		return m, nil
 	}
+	if deep, ok := m.deepCopyFallback(sess, text); ok {
+		text = deep
+	}
 	if err := clipboard.WriteText(text); err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
 	m.reportDone(fmt.Sprintf("copied %d chars from %s", len([]rune(text)), sess.Name))
 	return m, nil
+}
+
+// staleCheckRunes is how much of the viewport-captured text has to show
+// up, verbatim, at the end of the on-disk transcript's reply before
+// deepCopyFallback trusts that reply. Long enough that an unrelated past
+// conversation won't match it by coincidence, short enough to tolerate
+// FullTurnText's own normalizing (collapsed blank lines, trimmed
+// trailing spaces) not lining up byte-for-byte with the raw transcript
+// text.
+const staleCheckRunes = 80
+
+// rescanTranscripts caps how many of the project's other transcripts
+// deepCopyFallback checks once the stored AgentSessionID's own file
+// fails the tail-match: newest first, most-likely-current one tried
+// first, and a compacted session is rarely more than one or two rotations
+// past the id agent-manager last captured.
+const rescanTranscripts = 5
+
+// deepCopyFallback returns the full reply from Claude Code's own on-disk
+// transcript when the pane's captured viewport only got the tail of it -
+// see copyLastOutput's doc comment for why that happens. viewportText is
+// what copyLastOutput already has and trusts as current.
+//
+// AgentSessionID is captured once and never re-verified, and Claude Code
+// opens a new transcript on its own context compaction, invisibly to
+// agent-manager, leaving the stored id pointing at a real but unrelated
+// past conversation - trusting it just because it's set would silently
+// hand back the wrong task. So every candidate, the stored id included,
+// is checked the same way: its transcript's reply has to provably
+// continue viewportText, its own tail found inside the file's reply.
+// Nothing here is used unless that holds.
+//
+// When the stored id fails but a newer transcript in the same project
+// directory passes, that id replaces it in the store (SetAgentSessionID)
+// so the next call - and the poller's own row-quote fallback, which
+// trusts the stored id the same way - don't pay for the rescan again.
+func (m *Model) deepCopyFallback(sess store.Session, viewportText string) (text string, ok bool) {
+	if m.poller == nil || m.poller.mcpStyles[sess.Tool] != "claude" || sess.AgentSessionID == "" {
+		return "", false
+	}
+	anchor := stripMarkdownPunct(tailRunes(strings.TrimSpace(viewportText), staleCheckRunes))
+	if anchor == "" {
+		return "", false
+	}
+	if reply, ok := claudeTranscriptReplyMatching(sess.Cwd, sess.AgentSessionID, anchor); ok {
+		return reply, true
+	}
+	for _, id := range m.otherClaudeTranscripts(sess.Cwd, sess.AgentSessionID) {
+		reply, ok := claudeTranscriptReplyMatching(sess.Cwd, id, anchor)
+		if !ok {
+			continue
+		}
+		if m.store != nil {
+			_ = m.store.SetAgentSessionID(sess.ID, id)
+		}
+		return reply, true
+	}
+	return "", false
+}
+
+// claudeTranscriptReplyMatching reads sessionID's transcript tail and
+// reports it only if its reply contains anchor - see deepCopyFallback.
+// The comparison is on stripMarkdownPunct'd text on both sides: the raw
+// transcript keeps Claude's own markdown (a code span's backticks, for
+// one) that the terminal renders as styling rather than characters, so
+// anchor - built from what actually painted on screen - would otherwise
+// never match a reply that's really the same text.
+func claudeTranscriptReplyMatching(cwd, sessionID, anchor string) (reply string, ok bool) {
+	reply, tailOK := agentsession.ClaudeTranscriptFullTurn(cwd, sessionID)
+	if !tailOK || strings.TrimSpace(reply) == "" || !strings.Contains(stripMarkdownPunct(reply), anchor) {
+		return "", false
+	}
+	return reply, true
+}
+
+// otherClaudeTranscripts lists up to rescanTranscripts other session ids
+// Claude Code has ever written a transcript for in cwd's project
+// directory, newest first, skip is excluded (the id already tried).
+func (m *Model) otherClaudeTranscripts(cwd, skip string) []string {
+	dir, err := agentsession.ClaudeProjectDir(cwd)
+	if err != nil {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	type candidate struct {
+		id      string
+		modTime time.Time
+	}
+	candidates := make([]candidate, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		id := strings.TrimSuffix(name, ".jsonl")
+		if id == name || id == skip {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, candidate{id: id, modTime: info.ModTime()})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].modTime.After(candidates[j].modTime)
+	})
+	if len(candidates) > rescanTranscripts {
+		candidates = candidates[:rescanTranscripts]
+	}
+	ids := make([]string, len(candidates))
+	for i, c := range candidates {
+		ids[i] = c.id
+	}
+	return ids
+}
+
+// tailRunes returns the last n runes of s, or the whole string if it has
+// n or fewer.
+func tailRunes(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[len(runes)-n:])
+}
+
+// stripMarkdownPunct drops the characters Claude's own markdown uses for
+// inline styling - a code span's backticks, emphasis's asterisks and
+// underscores - that the terminal renders as color or weight rather
+// than painting the character itself. Comparing text captured off
+// screen against the raw transcript needs both sides free of them, or a
+// styled word never matches its own unstyled-looking rendering.
+func stripMarkdownPunct(s string) string {
+	return strings.NewReplacer("`", "", "*", "", "_", "").Replace(s)
 }
 
 // reviveSelected relaunches a dead session's tmux session under the same

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/YoanWai/agent-manager/internal/agentsession"
 	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/launch"
@@ -119,6 +118,19 @@ func (m *Model) reattach(id string, diffGen int) tea.Cmd {
 // same write. FullTurnText keeps every line of the turn, not just the
 // last message_start block, so a reply with several marker-led
 // paragraphs copies whole.
+//
+// This is bounded by whatever tmux capture-pane can see: the current
+// screen, plus real scrollback for a tool that keeps any. An alt-screen,
+// mouse-tracking tool (Claude Code, for one) keeps none of its own for
+// tmux to walk, so a reply longer than the viewport truncates at
+// whatever's on screen when y is pressed. Reading the on-disk transcript
+// instead was tried and reverted: AgentSessionID is captured once and
+// trusted as still pointing at the live file, but Claude Code opens a
+// new transcript on its own compaction, invisibly to agent-manager, and
+// a stale id then reads a real but unrelated past conversation with no
+// signal that anything is wrong. Silently wrong beats silently short,
+// but it's still wrong, so this waits on a way to tell a stale id from a
+// live one before it's worth the risk again.
 func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
 	entry, ok := m.selectedRow()
 	if !ok || entry.isGroup || m.engine == nil || m.tmux == nil {
@@ -127,20 +139,16 @@ func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
 	sess := entry.sess
 	// quoteHistoryLines matches the poller's own row-quote capture depth:
 	// past what's currently on screen when the tool keeps real tmux
-	// scrollback to walk (unlike Claude Code - see deepCopyFallback).
+	// scrollback to walk.
 	pane, err := m.tmux.CapturePaneHistory(sess.ID, quoteHistoryLines)
 	if err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
-	clean := ansi.Strip(pane)
-	text, ok := m.engine.FullTurnText(sess.Tool, clean)
+	text, ok := m.engine.FullTurnText(sess.Tool, ansi.Strip(pane))
 	if !ok || strings.TrimSpace(text) == "" {
 		m.errBar.text = "nothing to copy"
 		return m, nil
-	}
-	if deep, ok := m.deepCopyFallback(sess, clean); ok {
-		text = deep
 	}
 	if err := clipboard.WriteText(text); err != nil {
 		m.errBar.text = err.Error()
@@ -148,33 +156,6 @@ func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
 	}
 	m.reportDone(fmt.Sprintf("copied %d chars from %s", len([]rune(text)), sess.Name))
 	return m, nil
-}
-
-// deepCopyFallback returns the full reply from Claude Code's own on-disk
-// transcript when the pane's captured viewport has scrolled the reply's
-// start away and FullTurnText only got the tail of it: tmux only ever
-// sees what's currently rendered for an alt-screen, mouse-tracking tool
-// like Claude Code, which keeps no scrollback of its own for
-// capture-pane to walk (see FullTurnText's doc comment - same
-// limitation the drag-to-scroll work ran into). Same adrift check the
-// poller already uses for the one-line row quote (claudeTail): no
-// message_start marker anchored in the capture at all means the true
-// start of the reply isn't in it. ok is false whenever the capture
-// already had the whole reply, or nothing more can be done - the
-// caller keeps what FullTurnText found instead.
-func (m *Model) deepCopyFallback(sess store.Session, clean string) (text string, ok bool) {
-	if m.poller == nil || m.poller.mcpStyles[sess.Tool] != "claude" || sess.AgentSessionID == "" {
-		return "", false
-	}
-	_, anchored, msgOK := m.engine.LastMessage(sess.Tool, clean)
-	if !msgOK || anchored || !m.engine.HasMessageStart(sess.Tool) {
-		return "", false
-	}
-	_, reply, tailOK := agentsession.ClaudeTranscriptTail(sess.Cwd, sess.AgentSessionID, func(s string) string { return s })
-	if !tailOK || strings.TrimSpace(reply) == "" {
-		return "", false
-	}
-	return reply, true
 }
 
 // reviveSelected relaunches a dead session's tmux session under the same

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/agentsession"
 	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/launch"
@@ -124,15 +125,22 @@ func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	sess := entry.sess
-	pane, err := m.tmux.CapturePane(sess.ID)
+	// quoteHistoryLines matches the poller's own row-quote capture depth:
+	// past what's currently on screen when the tool keeps real tmux
+	// scrollback to walk (unlike Claude Code - see deepCopyFallback).
+	pane, err := m.tmux.CapturePaneHistory(sess.ID, quoteHistoryLines)
 	if err != nil {
 		m.errBar.text = err.Error()
 		return m, nil
 	}
-	text, ok := m.engine.FullTurnText(sess.Tool, ansi.Strip(pane))
+	clean := ansi.Strip(pane)
+	text, ok := m.engine.FullTurnText(sess.Tool, clean)
 	if !ok || strings.TrimSpace(text) == "" {
 		m.errBar.text = "nothing to copy"
 		return m, nil
+	}
+	if deep, ok := m.deepCopyFallback(sess, clean); ok {
+		text = deep
 	}
 	if err := clipboard.WriteText(text); err != nil {
 		m.errBar.text = err.Error()
@@ -140,6 +148,33 @@ func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
 	}
 	m.reportDone(fmt.Sprintf("copied %d chars from %s", len([]rune(text)), sess.Name))
 	return m, nil
+}
+
+// deepCopyFallback returns the full reply from Claude Code's own on-disk
+// transcript when the pane's captured viewport has scrolled the reply's
+// start away and FullTurnText only got the tail of it: tmux only ever
+// sees what's currently rendered for an alt-screen, mouse-tracking tool
+// like Claude Code, which keeps no scrollback of its own for
+// capture-pane to walk (see FullTurnText's doc comment - same
+// limitation the drag-to-scroll work ran into). Same adrift check the
+// poller already uses for the one-line row quote (claudeTail): no
+// message_start marker anchored in the capture at all means the true
+// start of the reply isn't in it. ok is false whenever the capture
+// already had the whole reply, or nothing more can be done - the
+// caller keeps what FullTurnText found instead.
+func (m *Model) deepCopyFallback(sess store.Session, clean string) (text string, ok bool) {
+	if m.poller == nil || m.poller.mcpStyles[sess.Tool] != "claude" || sess.AgentSessionID == "" {
+		return "", false
+	}
+	_, anchored, msgOK := m.engine.LastMessage(sess.Tool, clean)
+	if !msgOK || anchored || !m.engine.HasMessageStart(sess.Tool) {
+		return "", false
+	}
+	_, reply, tailOK := agentsession.ClaudeTranscriptTail(sess.Cwd, sess.AgentSessionID, func(s string) string { return s })
+	if !tailOK || strings.TrimSpace(reply) == "" {
+		return "", false
+	}
+	return reply, true
 }
 
 // reviveSelected relaunches a dead session's tmux session under the same

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -6,12 +6,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/launch"
 	"github.com/YoanWai/agent-manager/internal/sessioncmd"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/google/uuid"
 )
 
@@ -107,6 +109,37 @@ func (m *Model) reattach(id string, diffGen int) tea.Cmd {
 		}
 		return reattachPreparedMsg{sessID: id, diffGen: diffGen, warn: warn}
 	}
+}
+
+// copyLastOutput copies the selected session's newest reply to the system
+// clipboard, on demand: an explicit key rather than a finish-triggered
+// write, which would silently overwrite whatever the user already had on
+// the clipboard, and race several sessions finishing in a row for the
+// same write. FullTurnText keeps every line of the turn, not just the
+// last message_start block, so a reply with several marker-led
+// paragraphs copies whole.
+func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
+	entry, ok := m.selectedRow()
+	if !ok || entry.isGroup || m.engine == nil || m.tmux == nil {
+		return m, nil
+	}
+	sess := entry.sess
+	pane, err := m.tmux.CapturePane(sess.ID)
+	if err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	text, ok := m.engine.FullTurnText(sess.Tool, ansi.Strip(pane))
+	if !ok || strings.TrimSpace(text) == "" {
+		m.errBar.text = "nothing to copy"
+		return m, nil
+	}
+	if err := clipboard.WriteText(text); err != nil {
+		m.errBar.text = err.Error()
+		return m, nil
+	}
+	m.reportDone(fmt.Sprintf("copied %d chars from %s", len([]rune(text)), sess.Name))
+	return m, nil
 }
 
 // reviveSelected relaunches a dead session's tmux session under the same

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -3,12 +3,9 @@ package ui
 import (
 	"errors"
 	"fmt"
-	"os"
-	"sort"
 	"strings"
 	"time"
 
-	"github.com/YoanWai/agent-manager/internal/agentsession"
 	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/launch"
@@ -114,189 +111,44 @@ func (m *Model) reattach(id string, diffGen int) tea.Cmd {
 	}
 }
 
-// copyLastOutput copies the selected session's newest reply to the system
-// clipboard, on demand: an explicit key rather than a finish-triggered
-// write, which would silently overwrite whatever the user already had on
-// the clipboard, and race several sessions finishing in a row for the
-// same write. FullTurnText keeps every line of the turn, not just the
-// last message_start block, so a reply with several marker-led
-// paragraphs copies whole.
-//
-// This is bounded by whatever tmux capture-pane can see: the current
-// screen, plus real scrollback for a tool that keeps any. An alt-screen,
-// mouse-tracking tool (Claude Code, for one) keeps none of its own for
-// tmux to walk, so a reply longer than the viewport truncates at
-// whatever's on screen when y is pressed. deepCopyFallback covers that
-// case for claude by reading the on-disk transcript instead, gated on
-// the tail-match check documented there: AgentSessionID is captured
-// once and can go stale (Claude Code opens a new transcript on its own
-// compaction, invisibly to agent-manager), so the fallback is only
-// trusted when its own tail provably continues what's already on
-// screen, not just because the id is set.
+// copyLastOutput copies the selected session's newest reply to the
+// system clipboard without attaching to it. Capture and clipboard write
+// both run inside the returned command: WriteText can block for seconds,
+// which would freeze Update.
 func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
 	entry, ok := m.selectedRow()
 	if !ok || entry.isGroup || m.engine == nil || m.tmux == nil {
 		return m, nil
 	}
 	sess := entry.sess
-	// quoteHistoryLines matches the poller's own row-quote capture depth:
-	// past what's currently on screen when the tool keeps real tmux
-	// scrollback to walk.
-	pane, err := m.tmux.CapturePaneHistory(sess.ID, quoteHistoryLines)
-	if err != nil {
-		m.errBar.text = err.Error()
+	if !m.tmux.Exists(sess.ID) {
+		m.errBar.text = deadSessionHint
 		return m, nil
 	}
-	text, ok := m.engine.FullTurnText(sess.Tool, ansi.Strip(pane))
-	if !ok || strings.TrimSpace(text) == "" {
-		m.errBar.text = "nothing to copy"
-		return m, nil
-	}
-	if deep, ok := m.deepCopyFallback(sess, text); ok {
-		text = deep
-	}
-	if err := clipboard.WriteText(text); err != nil {
-		m.errBar.text = err.Error()
-		return m, nil
-	}
-	m.reportDone(fmt.Sprintf("copied %d chars from %s", len([]rune(text)), sess.Name))
-	return m, nil
-}
-
-// staleCheckRunes is how much of the viewport-captured text has to show
-// up, verbatim, at the end of the on-disk transcript's reply before
-// deepCopyFallback trusts that reply. Long enough that an unrelated past
-// conversation won't match it by coincidence, short enough to tolerate
-// FullTurnText's own normalizing (collapsed blank lines, trimmed
-// trailing spaces) not lining up byte-for-byte with the raw transcript
-// text.
-const staleCheckRunes = 80
-
-// rescanTranscripts caps how many of the project's other transcripts
-// deepCopyFallback checks once the stored AgentSessionID's own file
-// fails the tail-match: newest first, most-likely-current one tried
-// first, and a compacted session is rarely more than one or two rotations
-// past the id agent-manager last captured.
-const rescanTranscripts = 5
-
-// deepCopyFallback returns the full reply from Claude Code's own on-disk
-// transcript when the pane's captured viewport only got the tail of it -
-// see copyLastOutput's doc comment for why that happens. viewportText is
-// what copyLastOutput already has and trusts as current.
-//
-// AgentSessionID is captured once and never re-verified, and Claude Code
-// opens a new transcript on its own context compaction, invisibly to
-// agent-manager, leaving the stored id pointing at a real but unrelated
-// past conversation - trusting it just because it's set would silently
-// hand back the wrong task. So every candidate, the stored id included,
-// is checked the same way: its transcript's reply has to provably
-// continue viewportText, its own tail found inside the file's reply.
-// Nothing here is used unless that holds.
-//
-// When the stored id fails but a newer transcript in the same project
-// directory passes, that id replaces it in the store (SetAgentSessionID)
-// so the next call - and the poller's own row-quote fallback, which
-// trusts the stored id the same way - don't pay for the rescan again.
-func (m *Model) deepCopyFallback(sess store.Session, viewportText string) (text string, ok bool) {
-	if m.poller == nil || m.poller.mcpStyles[sess.Tool] != "claude" || sess.AgentSessionID == "" {
-		return "", false
-	}
-	anchor := stripMarkdownPunct(tailRunes(strings.TrimSpace(viewportText), staleCheckRunes))
-	if anchor == "" {
-		return "", false
-	}
-	if reply, ok := claudeTranscriptReplyMatching(sess.Cwd, sess.AgentSessionID, anchor); ok {
-		return reply, true
-	}
-	for _, id := range m.otherClaudeTranscripts(sess.Cwd, sess.AgentSessionID) {
-		reply, ok := claudeTranscriptReplyMatching(sess.Cwd, id, anchor)
-		if !ok {
-			continue
-		}
-		if m.store != nil {
-			_ = m.store.SetAgentSessionID(sess.ID, id)
-		}
-		return reply, true
-	}
-	return "", false
-}
-
-// claudeTranscriptReplyMatching reads sessionID's transcript tail and
-// reports it only if its reply contains anchor - see deepCopyFallback.
-// The comparison is on stripMarkdownPunct'd text on both sides: the raw
-// transcript keeps Claude's own markdown (a code span's backticks, for
-// one) that the terminal renders as styling rather than characters, so
-// anchor - built from what actually painted on screen - would otherwise
-// never match a reply that's really the same text.
-func claudeTranscriptReplyMatching(cwd, sessionID, anchor string) (reply string, ok bool) {
-	reply, tailOK := agentsession.ClaudeTranscriptFullTurn(cwd, sessionID)
-	if !tailOK || strings.TrimSpace(reply) == "" || !strings.Contains(stripMarkdownPunct(reply), anchor) {
-		return "", false
-	}
-	return reply, true
-}
-
-// otherClaudeTranscripts lists up to rescanTranscripts other session ids
-// Claude Code has ever written a transcript for in cwd's project
-// directory, newest first, skip is excluded (the id already tried).
-func (m *Model) otherClaudeTranscripts(cwd, skip string) []string {
-	dir, err := agentsession.ClaudeProjectDir(cwd)
-	if err != nil {
-		return nil
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	type candidate struct {
-		id      string
-		modTime time.Time
-	}
-	candidates := make([]candidate, 0, len(entries))
-	for _, entry := range entries {
-		name := entry.Name()
-		id := strings.TrimSuffix(name, ".jsonl")
-		if id == name || id == skip {
-			continue
-		}
-		info, err := entry.Info()
+	engine, driver := m.engine, m.tmux
+	return m, func() tea.Msg {
+		pane, err := driver.CapturePaneHistory(sess.ID, quoteHistoryLines)
 		if err != nil {
-			continue
+			return errMsg{err}
 		}
-		candidates = append(candidates, candidate{id: id, modTime: info.ModTime()})
+		text, ok := engine.FullTurnText(sess.Tool, ansi.Strip(pane))
+		if !ok || strings.TrimSpace(text) == "" {
+			return copyLastOutputMsg{}
+		}
+		if err := clipboard.WriteText(text); err != nil {
+			return errMsg{err}
+		}
+		return copyLastOutputMsg{chars: len([]rune(text)), name: sess.Name}
 	}
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].modTime.After(candidates[j].modTime)
-	})
-	if len(candidates) > rescanTranscripts {
-		candidates = candidates[:rescanTranscripts]
-	}
-	ids := make([]string, len(candidates))
-	for i, c := range candidates {
-		ids[i] = c.id
-	}
-	return ids
 }
 
-// tailRunes returns the last n runes of s, or the whole string if it has
-// n or fewer.
-func tailRunes(s string, n int) string {
-	runes := []rune(s)
-	if len(runes) <= n {
-		return s
-	}
-	return string(runes[len(runes)-n:])
+// copyLastOutputMsg reports a finished y copy. A zero chars means the
+// turn held nothing to copy.
+type copyLastOutputMsg struct {
+	chars int
+	name  string
 }
 
-// stripMarkdownPunct drops the characters Claude's own markdown uses for
-// inline styling - a code span's backticks, emphasis's asterisks and
-// underscores - that the terminal renders as color or weight rather
-// than painting the character itself. Comparing text captured off
-// screen against the raw transcript needs both sides free of them, or a
-// styled word never matches its own unstyled-looking rendering.
-func stripMarkdownPunct(s string) string {
-	return strings.NewReplacer("`", "", "*", "", "_", "").Replace(s)
-}
 
 // reviveSelected relaunches a dead session's tmux session under the same
 // id, keeping its name, group, and history. Tools with a revive_command

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"hash/fnv"
 	"sort"
 	"strings"
@@ -1462,6 +1463,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case pasteSweepTickMsg:
 		return m, tea.Batch(m.sweepPastes, m.pasteSweepTick())
+
+	case copyLastOutputMsg:
+		if msg.chars == 0 {
+			m.errBar.text = "nothing to copy"
+			return m, nil
+		}
+		m.reportDone(fmt.Sprintf("copied %d chars from %s", msg.chars, msg.name))
+		return m, nil
 
 	case previewSettleMsg:
 		if msg.gen != m.previewGen {

--- a/skills/agent-manager/SKILL.md
+++ b/skills/agent-manager/SKILL.md
@@ -51,6 +51,7 @@ prebuilt binary from the releases page.
 | `alt+w` | Spawns the agent into a fresh git worktree and branch. |
 | `ctrl+r` | Opens a full-screen whole-file diff whose line comments go back to the agent as one review prompt. |
 | `v` | Revives a dead session on the conversation it held. |
+| `y` | Copies the selected session's newest reply to the system clipboard, without attaching. |
 
 ## Status colours
 


### PR DESCRIPTION
`LastMessage`/`LastMessageText` anchor to the newest `message_start` marker, built for a one-line row quote. A reply with several marker-led paragraphs (Claude's bulleted sections, for example) has several `message_start` matches, so anchoring to only the last one drops everything before it.

Adds `Engine.FullTurnText`: same `activity_cutoff`-bounded region, keeps every line instead of anchoring to one marker. Shares a new `toolRules.isStructural` helper with `LastMessage`'s marker search (chrome/busy/turn_end lines dropped the same way in both, extracted so a rule added to one is never missed by the other), additionally drops a `user_echo` line (LastMessage never needed to - its anchor already starts past it) and collapses consecutive blank lines to single paragraph breaks.

Wires it to a new `y` key on the session list: copies the selected session's full reply to the system clipboard without attaching. An explicit key rather than a finish-triggered write, which would silently overwrite whatever the user already had on the clipboard and race several sessions finishing in a row for the same write.

Covered by `TestFullTurnText` (a multi-paragraph reply, checked against `FullTurnText` keeping all of it and `LastMessageText` on the same pane keeping only the last paragraph, the difference this exists for) plus the existing `TestLastMessage` unchanged and passing, confirming the `isStructural` extraction didn't touch its behavior.

Tested locally against live claude/codex sessions, including a session where `pane.mouse` is on and tmux keeps no scrollback, and a long-running session with several bulleted sections in one reply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `y` keyboard shortcut to copy the selected session’s latest response to the clipboard.
  - Copies preserve paragraph breaks and exclude interface-only content.
  - Entire responses can be copied, including content beyond the currently visible portion.
  - Added clear feedback for successful copies, empty results, invalid selections, unavailable output, and clipboard errors.
- **Documentation**
  - Documented the new keyboard shortcut in the usage guide and keybinding reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->