### PR TITLE
chore(review): make pull request scope a written contract

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -89,12 +89,26 @@ reviews:
       - name: "Scope fidelity"
         mode: warning
         instructions: >-
-          Read the Scope section of the PR description: Required behavior,
-          Non-goals, and Why this approach. Fail when the diff adds
-          user-visible behavior, public CLI, config or MCP surface, unrelated
-          refactoring, or new persisted state that none of them asks for.
-          Return Inconclusive when the section is absent or too thin to judge;
-          never infer a requirement that no human wrote down.
+          Read the Scope section of the PR description: Required behavior
+          and Why this approach. Fail when the diff adds user-visible
+          behavior, public CLI, config or MCP surface, unrelated refactoring,
+          or new persisted state that neither asks for. Return Inconclusive
+          when the section is absent or too thin to judge; never infer a
+          requirement that no human wrote down.
+      - name: "Tool and platform coverage"
+        mode: warning
+        instructions: >-
+          This project supports every agent CLI in defaultConfig
+          (internal/config/config.go) and every platform .goreleaser.yaml
+          builds. Fail when new behavior reaches only some of them: a
+          runtime.GOOS branch or a command that exists on one platform, a
+          path built from one platform's separator or home layout, a switch
+          or lookup keyed on tool name that handles a subset of the tools it
+          affects, or a field or status rule added to one [tools.*] block
+          that the others need too. A PR description that names the excluded
+          values and what supporting them would take passes. Adding support
+          for a new tool is itself coverage, so pass it. Return Inconclusive
+          when the diff carries no evidence either way.
       - name: "No speculative fallbacks"
         mode: warning
         instructions: >-

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,7 @@ language: en-US
 early_access: false
 
 reviews:
-  profile: assertive
+  profile: chill
   request_changes_workflow: true
   high_level_summary: true
   review_details: true
@@ -15,7 +15,7 @@ reviews:
     enabled: true
     drafts: false
     auto_incremental_review: true
-    auto_pause_after_reviewed_commits: 0
+    auto_pause_after_reviewed_commits: 3
   finishing_touches:
     docstrings:
       enabled: false
@@ -86,6 +86,15 @@ reviews:
           change with no meaningful visual state, accept an explicit reason
           that visual evidence is not applicable. Fail when the description
           provides neither useful visual evidence nor an explanation.
+      - name: "Scope fidelity"
+        mode: warning
+        instructions: >-
+          Compare the diff with the linked issue and the Scope section of the
+          PR description: Required behavior, Non-goals, and Why this approach.
+          Fail when the diff adds user-visible behavior, public CLI, config or
+          MCP surface, unrelated refactoring, or new persisted state that none
+          of them asks for. Return Inconclusive when the written scope is too
+          thin to judge; never infer a requirement that no human wrote down.
       - name: "No speculative fallbacks"
         mode: warning
         instructions: >-
@@ -189,3 +198,10 @@ knowledge_base:
   automatic_repository_linking: true
   code_guidelines:
     enabled: true
+    filePatterns:
+      - files: "PRODUCT.md"
+        applyTo: "**/*"
+      - files: "REVIEW.md"
+        applyTo: "**/*"
+      - files: "DESIGN.md"
+        applyTo: "internal/ui/**"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,7 +15,7 @@ reviews:
     enabled: true
     drafts: false
     auto_incremental_review: true
-    auto_pause_after_reviewed_commits: 3
+    auto_pause_after_reviewed_commits: 0
   finishing_touches:
     docstrings:
       enabled: false
@@ -89,12 +89,12 @@ reviews:
       - name: "Scope fidelity"
         mode: warning
         instructions: >-
-          Compare the diff with the linked issue and the Scope section of the
-          PR description: Required behavior, Non-goals, and Why this approach.
-          Fail when the diff adds user-visible behavior, public CLI, config or
-          MCP surface, unrelated refactoring, or new persisted state that none
-          of them asks for. Return Inconclusive when the written scope is too
-          thin to judge; never infer a requirement that no human wrote down.
+          Read the Scope section of the PR description: Required behavior,
+          Non-goals, and Why this approach. Fail when the diff adds
+          user-visible behavior, public CLI, config or MCP surface, unrelated
+          refactoring, or new persisted state that none of them asks for.
+          Return Inconclusive when the section is absent or too thin to judge;
+          never infer a requirement that no human wrote down.
       - name: "No speculative fallbacks"
         mode: warning
         instructions: >-

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Two clauses are worth knowing as a contributor. Section 3 licenses the patent cl
 
 ## Review
 
-CodeRabbit reviews every pull request automatically, usually within minutes. Work through its findings first: fix what it got right, and reply on the comment when you disagree, so the thread records why. Maintainer review starts once the CodeRabbit round is handled; a PR with open, unanswered findings waits.
+[REVIEW.md](../REVIEW.md) states what a review here covers, so you can see what a finding will be about before you open the PR. CodeRabbit reviews every pull request automatically, usually within minutes. Work through its findings first: fix what it got right, and reply on the comment when you disagree, so the thread records why. Maintainer review starts once the CodeRabbit round is handled; a PR with open, unanswered findings waits.
 
 @YoanWai reviews and merges everything (see [CODEOWNERS](CODEOWNERS)). Expect a first response within a few days.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,10 @@ feed; see [Release summaries and messages](../docs/notifications.md) for the two
 publishing paths.
 
 In the pull request description, say what changed and why, and how you verified
-it. Complete the Visual evidence section for every pull request. Include before
+it. Fill the Scope section: what the change has to do, what it leaves alone,
+and why this shape. A typo or a one-line fix answers all three in a sentence,
+and a review reads them to tell the change you meant from the change you made.
+Complete the Visual evidence section for every pull request. Include before
 and after screenshots whenever the change can be shown visually; use a short
 recording when interaction or motion is clearer that way. If useful visual
 evidence is not possible, say why. For example, a new UI may have no

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,9 +64,11 @@ feed; see [Release summaries and messages](../docs/notifications.md) for the two
 publishing paths.
 
 In the pull request description, say what changed and why, and how you verified
-it. Fill the Scope section: what the change has to do, what it leaves alone,
-and why this shape. A typo or a one-line fix answers all three in a sentence,
-and a review reads them to tell the change you meant from the change you made.
+it. Fill the Scope section: what the change has to do and why this shape. A typo
+or a one-line fix answers both in a sentence, and a review reads them to tell
+the change you meant from the change you made. Say there too when the change
+reaches only some of the agent CLIs or platforms we support, and what covering
+the rest would take.
 Complete the Visual evidence section for every pull request. Include before
 and after screenshots whenever the change can be shown visually; use a short
 recording when interaction or motion is clearer that way. If useful visual

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,13 +9,11 @@ Closes #
 ## Scope
 
 <!--
-What the change has to do, what it deliberately leaves alone, and why this
-shape. A typo or a one-line fix can answer all three in a sentence.
+What the change has to do and why this shape. A typo or a one-line fix
+answers both in a sentence.
 -->
 
 ### Required behavior
-
-### Non-goals
 
 ### Why this approach
 
@@ -28,6 +26,7 @@ shape. A typo or a one-line fix can answer all three in a sentence.
 - [ ] `go test -race ./...` passes
 - [ ] `go build ./...` passes
 - [ ] Ran it against real sessions
+- [ ] Holds for every supported agent CLI and platform, or the description names what it leaves out
 
 ## Visual evidence
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,21 @@
 
 Closes #
 
+## Scope
+
+### Required behavior
+
+### Non-goals
+
+### Why this approach
+
+### New guards or fallbacks
+
+<!--
+Name the reachable caller or external input that requires each one.
+Write "none" when the diff adds none.
+-->
+
 ## How it was verified
 
 <!-- Commands you ran, sessions you drove, and what you saw. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,11 @@ Closes #
 
 ## Scope
 
+<!--
+What the change has to do, what it deliberately leaves alone, and why this
+shape. A typo or a one-line fix can answer all three in a sentence.
+-->
+
 ### Required behavior
 
 ### Non-goals

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,13 +14,6 @@ Closes #
 
 ### Why this approach
 
-### New guards or fallbacks
-
-<!--
-Name the reachable caller or external input that requires each one.
-Write "none" when the diff adds none.
--->
-
 ## How it was verified
 
 <!-- Commands you ran, sessions you drove, and what you saw. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,3 +97,6 @@ header and footer from `.goreleaser.yaml` come along either way.
   shape first.
 - Tests live next to the file they cover: a test for `listview.go` belongs
   in `listview_test.go`.
+- A change holds for every tool in `defaultConfig` and every platform
+  `.goreleaser.yaml` builds; [REVIEW.md](REVIEW.md) says what to do when one
+  of them needs a workaround.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,4 +99,4 @@ header and footer from `.goreleaser.yaml` come along either way.
   in `listview_test.go`.
 - A change holds for every tool in `defaultConfig` and every platform
   `.goreleaser.yaml` builds; [REVIEW.md](REVIEW.md) says what to do when one
-  of them needs a workaround.
+  of them is left out.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,10 @@
 # Agent notes
 
 Project context for coding agents. Human setup and PR conventions live in
-[.github/CONTRIBUTING.md](.github/CONTRIBUTING.md).
+[.github/CONTRIBUTING.md](.github/CONTRIBUTING.md), and what a review looks
+for in [REVIEW.md](REVIEW.md). Fill the Scope section of the pull request
+template: a review reads it to tell the change you meant from the change you
+made.
 
 ## Build and test
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,34 +1,14 @@
 # Review policy
 
-This file states what a review of this repository is for. It applies to every
-reviewer, human or automated.
+What a review of this repository is for. It applies to every reviewer, human
+or automated. The per-path rules live in `.coderabbit.yaml`, the invariants in
+`AGENTS.md`, and the product intent in `PRODUCT.md`.
 
-## What a review covers
+A review finds defects the diff introduces or exposes.
 
-Review defects the diff introduces or exposes: a wrong result, a race, a leak,
-a lost session, a silent failure, a break in a documented contract. Read
-`PRODUCT.md` for what the product is for and `AGENTS.md` for the invariants the
-code already relies on.
-
-## Scope belongs to the maintainer
-
-A pull request carries a Scope section: required behavior, non-goals, and why
-this approach. Compare the diff against it. Behavior, public surface, or state
-that no one asked for is a finding, whatever its quality.
+Scope belongs to the maintainer. Every pull request carries a Scope section:
+required behavior, non-goals, and why this approach. Compare the diff against
+it, and report behavior, public surface, or state that none of them asks for.
 
 When the need for a change depends on product intent that nobody wrote down,
 ask for a maintainer decision. An unanswered question stays a question.
-
-## Prefer less code
-
-A guard, fallback, retry, helper, abstraction, or new field earns its place by
-a reachable caller or an external input that requires it. Name that caller or
-input in the review. Deletion and reuse beat new machinery.
-
-Treat the invariants in `AGENTS.md` and the package rules in `.coderabbit.yaml`
-as contracts: code that upholds them is finished, not thin.
-
-## Out of scope for review
-
-Formatting `gofmt` owns, import order, doc comments on exported identifiers,
-and renames of names whose meaning a reader can already recover.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,34 @@
+# Review policy
+
+This file states what a review of this repository is for. It applies to every
+reviewer, human or automated.
+
+## What a review covers
+
+Review defects the diff introduces or exposes: a wrong result, a race, a leak,
+a lost session, a silent failure, a break in a documented contract. Read
+`PRODUCT.md` for what the product is for and `AGENTS.md` for the invariants the
+code already relies on.
+
+## Scope belongs to the maintainer
+
+A pull request carries a Scope section: required behavior, non-goals, and why
+this approach. Compare the diff against it. Behavior, public surface, or state
+that no one asked for is a finding, whatever its quality.
+
+When the need for a change depends on product intent that nobody wrote down,
+ask for a maintainer decision. An unanswered question stays a question.
+
+## Prefer less code
+
+A guard, fallback, retry, helper, abstraction, or new field earns its place by
+a reachable caller or an external input that requires it. Name that caller or
+input in the review. Deletion and reuse beat new machinery.
+
+Treat the invariants in `AGENTS.md` and the package rules in `.coderabbit.yaml`
+as contracts: code that upholds them is finished, not thin.
+
+## Out of scope for review
+
+Formatting `gofmt` owns, import order, doc comments on exported identifiers,
+and renames of names whose meaning a reader can already recover.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -7,8 +7,14 @@ or automated. The per-path rules live in `.coderabbit.yaml`, the invariants in
 A review finds defects the diff introduces or exposes.
 
 Scope belongs to the maintainer. Every pull request carries a Scope section:
-required behavior, non-goals, and why this approach. Compare the diff against
-it, and report behavior, public surface, or state that none of them asks for.
+required behavior, and why this approach. Compare the diff against it, and
+report behavior, public surface, or state that it does not ask for.
+
+A change holds on every agent CLI and every platform this project supports:
+the tools in `defaultConfig` in `internal/config/config.go`, and the platforms
+`.goreleaser.yaml` builds. Verify it on all of them, or name the values you
+left out and what supporting them would take, and let the maintainer decide.
+Opening the pull request first and settling that in review is the right order.
 
 When the need for a change depends on product intent that nobody wrote down,
 ask for a maintainer decision. An unanswered question stays a question.


### PR DESCRIPTION
## What changed

- `.coderabbit.yaml`: review profile `chill`, a `Scope fidelity` check, a `Tool and platform coverage` check, and `PRODUCT.md`, `REVIEW.md`, `DESIGN.md` registered as code guidelines.
- `REVIEW.md`: what a review of this repository is for, including the CLI and platform coverage a change has to hold.
- PR template: a Scope section holding required behavior and why this approach, plus a coverage line in the verification list.
- `CONTRIBUTING.md` asks for both beside Visual evidence; `AGENTS.md` carries the coverage rule for agents.

## Why

A reviewer judges how well a change is built, against whatever context it has. Nothing in the repository recorded what a change was supposed to cover, so scope was the one thing a review could not check. The Scope section makes that record part of the pull request, and `Scope fidelity` compares the diff against it. Registering `PRODUCT.md` gives reviews the product purpose and anti-references, and `REVIEW.md` gives them a policy that asks for a maintainer decision when product intent is unwritten.

The second gap is coverage. A feature or a fix reaches every agent CLI in `defaultConfig` and every platform `.goreleaser.yaml` builds, and the machine and CLI a change was written on are one value of each. `Tool and platform coverage` reads the diff for behavior that lands on a subset, and a description that names what it leaves out and what covering it would take passes, so the maintainer settles it in review.

The `chill` profile belongs with that: `assertive` is documented as more feedback that "may feel nitpicky", and the sharp rules here live in the path instructions and the custom checks, which keep firing at full strength on either profile.

## Scope

### Required behavior

Reviews read a written scope and report a diff that exceeds it. Reviews report new behavior that reaches only some supported CLIs or platforms. Reviews keep reading `PRODUCT.md`, `DESIGN.md`, and `REVIEW.md`. Every push keeps its automatic review.

### Why this approach

CodeRabbit reads guideline files and pre-merge checks from the repository, so the scope contract lives in the repository and a human writes it. Both checks report `Inconclusive` rather than inventing a requirement, which leaves the decision with the maintainer. `Scope fidelity` reads the description alone, since `assess_linked_issues` and the `issue_assessment` check already cover the linked issue.

## How it was verified

- `.coderabbit.yaml` validates against `https://coderabbit.ai/integrations/schema.v2.json` with `jsonschema`.
- `filePatterns` supplements the default guideline patterns rather than replacing them, so `**/AGENTS.md` and `**/CLAUDE.md` keep applying. Confirmed in the code-guidelines documentation.
- `auto_pause_after_reviewed_commits` stays at `0`: at any other value automatic review stops after that many reviewed commits and only `@coderabbitai resume` restarts it, which would leave later commits on a contributor's branch unreviewed.
- The `Inconclusive` verdict and the linked-issue fields confirmed in the custom-checks and PR-validation documentation.
- Both checks name their source of truth by path (`defaultConfig` in `internal/config/config.go`, `.goreleaser.yaml`), so the supported matrix stays read from the repository rather than copied into the config.
- `gofmt -l .` prints nothing, `go vet ./...` passes, `go build ./...` passes.
- The race suite was not run: this branch changes no Go code.

## Visual evidence

**Not applicable because:** the change touches configuration and documents, with no rendered state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added review guidance defining how scope, product intent, supported tools, and platform coverage should be evaluated.
  * Expanded pull request instructions with Scope, rationale, visual evidence, and verification requirements.
  * Updated contributor and agent guidance to reference the new review expectations and coverage standards.

* **Chores**
  * Added automated pre-merge checks for scope fidelity and consistent tool and platform coverage.
  * Added guidance for applying documentation standards to relevant project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->