### PR TITLE
fix(status): read pi's spinner inside the composer border

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,6 +234,13 @@ const (
 	newPiFooterTail = `(?:\n[^\n]*){2,5}[ \t]*(?:\n[ \t]*)*\z`
 )
 
+// pi 0.85 moved the streaming indicator into the composer's top border, and
+// the working rule wanted the spinner on a line of its own above that
+// border. This is the widened-footer form a config written on 0.34 or 0.35
+// carries; it and the two-line form above are rewritten to the current
+// working default.
+const oldPiOwnLineWorkingRule = `(?ms)^[ \t]*[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \t]+(?:Working|Running|Retrying|Compacting context|Auto-compacting|Context overflow detected, Auto-compacting|Summarizing branch)\b[^\n]*\n[ \t]*\n─{8,}[ \t]*\n(?:[ \t]*\n)*─{8,}[ \t]*` + newPiFooterTail
+
 // mergeTool returns user with any zero-value field filled from def.
 //
 // Shell is deliberately not among them. "terminal" is a plausible name for
@@ -302,8 +309,15 @@ func mergeTool(name string, user, def Tool) Tool {
 	if name == "pi" {
 		for i, rule := range user.Rules {
 			switch rule.Pattern {
-			case oldPiIdleRule, oldPiErrorRule, oldPiRateLimitRule, oldPiQuestionRule, oldPiWorkingRule:
+			case oldPiIdleRule, oldPiErrorRule, oldPiRateLimitRule, oldPiQuestionRule:
 				user.Rules[i].Pattern = strings.Replace(rule.Pattern, oldPiFooterTail, newPiFooterTail, 1)
+			case oldPiWorkingRule, oldPiOwnLineWorkingRule:
+				for _, current := range def.Rules {
+					if current.State == "working" {
+						user.Rules[i].Pattern = current.Pattern
+						break
+					}
+				}
 			}
 		}
 	}
@@ -676,7 +690,10 @@ rules = [
   { state = "errored", pattern = "(?ms)^[ \\t]*Error:[^\\n]*(?:\\n[ \\t]+[^ \\t\\n][^\\n]*){0,8}\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
   { state = "errored", pattern = "(?ms)^[ \\t]*[^\\n]*rate limit reached[^\\n]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
   { state = "waiting", pattern = "(?ms)\\?[ \\t]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
-  { state = "working", pattern = "(?ms)^[ \\t]*[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \\t]+(?:Working|Running|Retrying|Compacting context|Auto-compacting|Context overflow detected, Auto-compacting|Summarizing branch)\\b[^\\n]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
+  # The spinner sits on a line of its own above the composer, or since pi
+  # 0.85 inside the composer's top border ("── ⠹ Working ───"); custom
+  # editors keep the standalone shape, so both are live.
+  { state = "working", pattern = "(?ms)^[ \\t]*(?:─+[ \\t]+)?[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \\t]+(?:Working|Running|Retrying|Compacting context|Auto-compacting|Context overflow detected, Auto-compacting|Summarizing branch)\\b[^\\n]*(?:\\n[ \\t]*\\n─{8,}[ \\t]*)?\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
 ]
 
 [tools.command-code]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -692,8 +692,9 @@ rules = [
   { state = "waiting", pattern = "(?ms)\\?[ \\t]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
   # The spinner sits on a line of its own above the composer, or since pi
   # 0.85 inside the composer's top border ("── ⠹ Working ───"); custom
-  # editors keep the standalone shape, so both are live.
-  { state = "working", pattern = "(?ms)^[ \\t]*(?:─+[ \\t]+)?[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \\t]+(?:Working|Running|Retrying|Compacting context|Auto-compacting|Context overflow detected, Auto-compacting|Summarizing branch)\\b[^\\n]*(?:\\n[ \\t]*\\n─{8,}[ \\t]*)?\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
+  # editors keep the standalone shape, so both are live. The composer may
+  # hold a draft typed mid-turn.
+  { state = "working", pattern = "(?ms)^[ \\t]*(?:[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \\t]+(?:Working|Running|Retrying|Compacting context|Auto-compacting|Context overflow detected, Auto-compacting|Summarizing branch)\\b[^\\n]*\\n[ \\t]*\\n─{8,}[ \\t]*|─+[ \\t]+[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \\t]+(?:Working|Running|Retrying|Compacting context|Auto-compacting|Context overflow detected, Auto-compacting|Summarizing branch)\\b[^\\n]*)\\n(?:(?:[^─\\n][^\\n]*)?\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },
 ]
 
 [tools.command-code]

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -594,8 +594,10 @@ func TestMigratesStaleCommandCodePatterns(t *testing.T) {
 
 // A config.toml written before the pi footer widened carries rules that pin
 // exactly two footer lines, so a pi extension drawing more keeps every rule
-// from matching. The stale strings are rewritten to the current defaults;
-// a rule the user edited by hand is kept as written.
+// from matching. A config written on 0.34 or 0.35 carries the widened
+// working rule that still wants the spinner on a line of its own, which pi
+// 0.85 no longer draws. The stale strings are rewritten to the current
+// defaults; a rule the user edited by hand is kept as written.
 func TestMigratesStalePiFooterRules(t *testing.T) {
 	handEdited := `(?ms)my own waiting rule\z`
 	cfg := Config{Tools: map[string]Tool{
@@ -607,6 +609,7 @@ func TestMigratesStalePiFooterRules(t *testing.T) {
 				{State: "errored", Pattern: oldPiRateLimitRule},
 				{State: "waiting", Pattern: oldPiQuestionRule},
 				{State: "working", Pattern: oldPiWorkingRule},
+				{State: "working", Pattern: oldPiOwnLineWorkingRule},
 				{State: "waiting", Pattern: handEdited},
 			},
 		},
@@ -623,12 +626,12 @@ func TestMigratesStalePiFooterRules(t *testing.T) {
 		defaults[rule.Pattern] = true
 	}
 	tool := cfg.Tools["pi"]
-	for _, rule := range tool.Rules[:5] {
+	for _, rule := range tool.Rules[:6] {
 		if !defaults[rule.Pattern] {
 			t.Fatalf("stale %s rule was not rewritten to the current default: %q", rule.State, rule.Pattern)
 		}
 	}
-	if got := tool.Rules[5].Pattern; got != handEdited {
+	if got := tool.Rules[6].Pattern; got != handEdited {
 		t.Fatalf("hand-edited rule = %q, want kept as written", got)
 	}
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -549,6 +549,10 @@ func TestPiPanes(t *testing.T) {
 			" ⠴ Working...\n\n─────────────────────────────────\n \n─────────────────────────────────\n~/scratch/2026-08-26-agent-man...\n↑12 ↓7.7k R77k W16k CH99.2% $0...\nhydra:navigator hit 89.0% (las...\nmodel anthropic/claude-sonnet-4\ncontext 41.2k of 200k used\nbranch fix/pi-footer-lines", Finished},
 		{"resting turn behind a 3-line extension footer",
 			"Implementation complete." + editor + "\nhydra:navigator hit 89.0% (last hour)", Finished},
+		{"active turn with the spinner in the composer border",
+			"── ⠹ Working ─────────────────────────────────────\n\n──────────────────────────────────────────────────\n~\n↑116 ↓26k R1.4M W61k CH96.6% $2.862 (sub) 6.2%/1.\nhydra:navigator+simplifier hit 97.1% (last 98.8%)", Working},
+		{"historical border spinner frame",
+			"── ⠹ Working ─────────────────────────────────────\n\n──────────────────────────────\n~/dev/project (main)\nanthropic/claude-sonnet-4\n\nImplementation complete." + editor, Finished},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -551,8 +551,16 @@ func TestPiPanes(t *testing.T) {
 			"Implementation complete." + editor + "\nhydra:navigator hit 89.0% (last hour)", Finished},
 		{"active turn with the spinner in the composer border",
 			"── ⠹ Working ─────────────────────────────────────\n\n──────────────────────────────────────────────────\n~\n↑116 ↓26k R1.4M W61k CH96.6% $2.862 (sub) 6.2%/1.\nhydra:navigator+simplifier hit 97.1% (last 98.8%)", Working},
+		{"active turn with a draft typed into the composer",
+			"── ⠹ Working ─────────────────────────────────────\nfollow-up I am typing\n──────────────────────────────────────────────────\n~\n↑116 ↓26k R1.4M W61k CH96.6% $2.862 (sub) 6.2%/1.\nhydra:navigator+simplifier hit 97.1% (last 98.8%)", Working},
+		{"active turn with a multiline draft in the composer",
+			"── ⠹ Working ─────────────────────────────────────\nfollow-up I am typing\n\nsecond paragraph\n──────────────────────────────────────────────────\n~/dev/project (main)\n0.1%/128k (auto) slow", Working},
+		{"active turn with a draft under a standalone spinner",
+			" ⠴ Working...\n\n─────────────────────────────────\nfollow-up I am typing\n─────────────────────────────────\n~/scratch/2026-08-26-agent-man...\n↑12 ↓7.7k R77k W16k CH99.2% $0...", Working},
 		{"historical border spinner frame",
 			"── ⠹ Working ─────────────────────────────────────\n\n──────────────────────────────\n~/dev/project (main)\nanthropic/claude-sonnet-4\n\nImplementation complete." + editor, Finished},
+		{"historical border spinner with a draft in the resting composer",
+			"── ⠹ Working ─────────────────────────────────────\nold draft\n──────────────────────────────\n~/dev/project (main)\nanthropic/claude-sonnet-4\n\nImplementation complete.\n\n──────────────────────────────\nnew draft\n──────────────────────────────\n~/dev/project (main)\nanthropic/claude-sonnet-4", Finished},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -110,6 +110,8 @@ var stuckEndGrace = 15 * time.Second
 type quietTimer struct {
 	since time.Time
 	stuck bool
+	// pane hashes the whole pane while stuck: pi animates its spinner below the activity region.
+	pane uint64
 }
 
 // startingGrace caps how long a session may show the launch state before the
@@ -1211,13 +1213,15 @@ func (p *poller) derivePaneStatus(sess store.Session, pane string, agentAlive bo
 					// Mid-turn pauses (thinking, between tools) look quiet for
 					// a poll or two; wait before treating that as turn end.
 					grace := quietEndGrace
+					var paneHash uint64
 					if stuck {
 						grace = stuckEndGrace
+						paneHash = hashString(text)
 					}
 					now := time.Now()
 					timer, ok := p.quietSince[sess.ID]
-					if !ok || timer.stuck != stuck {
-						timer = quietTimer{since: now, stuck: stuck}
+					if !ok || timer.stuck != stuck || timer.pane != paneHash {
+						timer = quietTimer{since: now, stuck: stuck, pane: paneHash}
 						p.quietSince[sess.ID] = timer
 					}
 					if now.Sub(timer.since) >= grace {

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -797,6 +797,31 @@ func TestMatchedWorkingAfterQuietRestartsGrace(t *testing.T) {
 	}
 }
 
+// pi anchors its activity region at the pane origin, so the region never
+// changes and the spinner animates below it. The stuck grace restarts on
+// any pane change, and only a pane frozen for the whole grace settles.
+func TestSpinnerAnimatingBelowTheRegionStaysWorking(t *testing.T) {
+	prev := stuckEndGrace
+	stuckEndGrace = time.Minute
+	t.Cleanup(func() { stuckEndGrace = prev })
+	m := buildModel(t)
+	defaultEngine(t, m)
+	sess := store.Session{ID: "anim-pi", Tool: "pi", Status: status.Working}
+	footer := "\n──────────────────────────────\n~/dev/project (main)\n↑116 ↓26k $2.862 (sub) 6.2%/1.0M (auto)\n"
+	still := "── ⠋ Working ─────────────────" + footer
+	moved := "── ⠹ Working ─────────────────" + footer
+	seedRegionHash(t, m, sess, still)
+	expired := quietTimer{since: time.Now().Add(-2 * time.Minute), stuck: true, pane: hashString(still)}
+	m.poller.quietSince[sess.ID] = expired
+	if got := deriveStatus(t, m, sess, moved, true); got != status.Working {
+		t.Fatalf("a spinner frame change past the grace should restart it and stay working, got %q", got)
+	}
+	m.poller.quietSince[sess.ID] = expired
+	if got := deriveStatus(t, m, sess, still, true); got != status.Finished {
+		t.Fatalf("a pane frozen for the whole grace should settle finished, got %q", got)
+	}
+}
+
 // A live agent animates its pane every poll or two; a changing region must
 // keep a rule-matched working verdict working no matter how long it runs.
 func TestAnimatedMatchedWorkingStaysWorking(t *testing.T) {


### PR DESCRIPTION
## What changed

The `[tools.pi]` working rule accepts the spinner in the composer's top border (`── ⠹ Working ───`) as well as on a line of its own above it. Both shapes are live: pi 0.85 embeds the indicator by default, custom editors keep the standalone one.

Stored configs carry the old working rule verbatim, so `mergeTool` rewrites it to the current default, same as the #414 footer migration. Both old forms are covered: the pre-#414 two-line footer and the widened-footer form a config written on 0.34 or 0.35 carries. A hand-edited rule stays as written.

## Why

pi 0.85 moved the streaming indicator into the editor border (their changelog, earendil-works/pi#8799). The working rule wanted the spinner at the start of its own line, then a blank line, then the rule. That shape is gone, so the rule never matched and a pi session sat at `finished` through its whole turn.

Closes #443

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes, except `internal/ui` `TestReviveStartsTheAgentAgainInALivePane`, which fails the same way on untouched `main` in my environment (claude-hooks live pane, unrelated to this change)
- [x] `go build ./...` passes
- [x] Ran it against real sessions

Tests: `TestPiPanes` gets the reporter's pane verbatim (border spinner, 3-line footer) deriving `working`, and a historical border-spinner frame followed by a resting editor deriving `finished`. Both fail on the old rule. `TestMigratesStalePiFooterRules` gets the 0.34/0.35 working rule and checks it is rewritten to the current default.

Real sessions: a throwaway program loaded my real `config.toml` (written by 0.35.0, so it carries the old rule) through `config.Load` and `status.NewEngine`, then ran `Match("pi", ...)` on live `tmux capture-pane` output. Two pi 0.85 sessions mid-turn read `working` where the running 0.35.0 manager showed `idle`; the on-disk rule came back migrated. Three resting pi panes read `finished`, not matched.

## Visual evidence

Text captures; the fix is a status string, and I run the manager over mosh, so a screenshot would show the same word.

**Before:** manager 0.35.0 on a pi 0.85 session mid-turn

```
$ agent-manager sessions --json | jq '.[] | select(.id=="c0ff356c") | .status'
"idle"
$ tmux capture-pane -p -t %42 | tail -5
── ⠦ Working ───────────────────────────────────────────────
────────────────────────────────────────────────────────────
~
↑135k ↓15k R4.4M CH99.8% $3.338 (sub) 46.7%/272k (auto)
hydra:navigator hit 98.2% (last 99.2%) $2.8636 (50 obs)
```

**After:** patched engine, same pane, real on-disk config

```
on-disk working rule migrated: true
%42: state=working matched=true
```

**Not applicable because:** see above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer pi versions by automatically updating older working-rule configurations.
  * Correctly recognizes activity indicators displayed inside or above the composer border as an active working state.
  * Correctly identifies historical composer-border indicators as finished when the associated turn is complete.
  * Prevents changing spinner activity from being treated as a completed or stuck turn during status detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->