### PR TITLE
fix(ui): let Left leave focus when pi hides its cursor

### DIFF
--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -168,7 +168,10 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 // the composer is empty and its caret at the head of the prompt; a draft
 // replaces the placeholder and Left belongs to the agent.
 func (m *Model) caretAtInputStart(sessID, tool string) bool {
-	if m.engine == nil || !m.pane.cursor.ok || m.pane.forID != sessID || m.scrolledBack() {
+	if m.engine == nil || m.pane.forID != sessID || m.scrolledBack() {
+		return false
+	}
+	if !m.pane.cursor.ok && !(m.pane.cursor.positionOK && m.engine.ParksItsCaret(tool)) {
 		return false
 	}
 	rows := strings.Split(strings.TrimSuffix(m.preview, "\n"), "\n")

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -171,7 +171,9 @@ func (m *Model) caretAtInputStart(sessID, tool string) bool {
 	if m.engine == nil || m.pane.forID != sessID || m.scrolledBack() {
 		return false
 	}
-	if !m.pane.cursor.ok && !(m.pane.cursor.positionOK && m.engine.ParksItsCaret(tool)) {
+	caretCellKnown := m.pane.cursor.ok ||
+		(m.pane.cursor.positionOK && m.engine.ParksItsCaret(tool))
+	if !caretCellKnown {
 		return false
 	}
 	rows := strings.Split(strings.TrimSuffix(m.preview, "\n"), "\n")

--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -167,12 +167,17 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 // composer row instead: the placeholder being on screen is the evidence
 // the composer is empty and its caret at the head of the prompt; a draft
 // replaces the placeholder and Left belongs to the agent.
+//
+// A zero-width input_prefix declares a bare composer row (pi's). Its
+// painted cursor is the only thing locating that row, so tmux's position
+// stays meaningful when the application hides the terminal cursor.
 func (m *Model) caretAtInputStart(sessID, tool string) bool {
 	if m.engine == nil || m.pane.forID != sessID || m.scrolledBack() {
 		return false
 	}
+	_, bareInput := m.engine.InputPrefix(tool, "")
 	caretCellKnown := m.pane.cursor.ok ||
-		(m.pane.cursor.positionOK && m.engine.ParksItsCaret(tool))
+		(m.pane.cursor.positionOK && (m.engine.ParksItsCaret(tool) || bareInput))
 	if !caretCellKnown {
 		return false
 	}

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -664,6 +664,7 @@ func TestCaretAtInputStart(t *testing.T) {
 		{"tool without a marker", "unmarked", paneCursor{x: 2, y: 0, ok: true}, []string{"❯"}, false},
 		{"unknown tool", "nosuch", paneCursor{x: 2, y: 0, ok: true}, []string{"❯"}, false},
 		{"no cursor report", "claude", paneCursor{x: 2, y: 1}, []string{"output", "❯"}, false},
+		{"hidden cursor on marked prompt", "claude", paneCursor{x: 2, y: 1, positionOK: true}, []string{"output", "❯"}, false},
 		{"cursor row past the capture", "claude", paneCursor{x: 2, y: 9, ok: true}, []string{"❯"}, false},
 	}
 	for _, c := range cases {
@@ -685,11 +686,11 @@ func TestCaretAtInputStartMeasuresMarkerInCells(t *testing.T) {
 	}
 }
 
-// pi composes on a bare row between rules and marks the caret cell with a
-// reverse-video space, so the captured row strips to one blank at column
-// zero (shapes taken from a live pane). Its zero-width prefix reads that as
-// the prompt head; text before the caret, or a wrapped line continuing from
-// above, keeps Left with the agent.
+// pi composes on a bare row between rules, hides the terminal cursor and
+// paints its own reverse-video caret. tmux still reports the right cell, so
+// its zero-width prefix can read the hidden position as the prompt head;
+// text before it, or a wrapped line continuing from above, keeps Left with
+// the agent.
 func TestCaretOnPisBareComposerRow(t *testing.T) {
 	engine, err := status.NewEngine(config.Config{Tools: map[string]config.Tool{
 		"pi": {
@@ -704,7 +705,7 @@ func TestCaretOnPisBareComposerRow(t *testing.T) {
 		m := &Model{engine: engine, mode: modeFocus}
 		m.preview = strings.Join(rows, "\n") + "\n"
 		m.pane.forID = "s1"
-		m.pane.cursor = paneCursor{x: x, y: y, ok: true}
+		m.pane.cursor = paneCursor{x: x, y: y, positionOK: true}
 		return m
 	}
 
@@ -893,9 +894,17 @@ func TestFocusLeftUnfocusesOnPiBlankComposerRow(t *testing.T) {
 	}
 	sess := m.rows[m.cursor].sess
 	m.rows[m.cursor].sess.Tool = "pi-tool"
-	m.pane.forID = sess.ID
-	m.pane.cursor = paneCursor{x: 2, y: 1, ok: true}
-	m.preview = "────────────\nxy\n────────────\n"
+	setHiddenPane := func(x int, preview string) {
+		updated, _ := m.Update(focusPreviewMsg{
+			sessID: sess.ID, preview: preview,
+			cursorX: x, cursorY: 1, paneStateOK: true,
+		})
+		*m = *updated.(*Model)
+		if m.pane.cursor.ok || !m.pane.cursor.positionOK {
+			t.Fatalf("hidden pi cursor state = %+v, want known position without a visible cursor", m.pane.cursor)
+		}
+	}
+	setHiddenPane(2, "────────────\nxy\n────────────\n")
 
 	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
 	*m = *updated.(*Model)
@@ -903,8 +912,7 @@ func TestFocusLeftUnfocusesOnPiBlankComposerRow(t *testing.T) {
 		t.Fatalf("left inside typed pi input left focus, mode = %v", m.mode)
 	}
 
-	m.preview = "────────────\n\n────────────\n"
-	m.pane.cursor = paneCursor{x: 0, y: 1, ok: true}
+	setHiddenPane(0, "────────────\n\n────────────\n")
 	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
 	*m = *updated.(*Model)
 	if m.mode != modeList {

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -998,7 +998,7 @@ func TestCaretParkedBelowCommandCodesComposer(t *testing.T) {
 		m := &Model{engine: engine, mode: modeFocus}
 		m.preview = strings.Join(rows, "\n") + "\n"
 		m.pane.forID = "s1"
-		m.pane.cursor = paneCursor{x: x, y: y, ok: true}
+		m.pane.cursor = paneCursor{x: x, y: y, positionOK: true}
 		return m
 	}
 	footer := "  » accept edits on [shift+tab]\n  ? for shortcuts · taste on"
@@ -1064,9 +1064,14 @@ func TestFocusLeftUnfocusesOnCommandCodesParkedCaret(t *testing.T) {
 	}
 	sess := m.rows[m.cursor].sess
 	m.rows[m.cursor].sess.Tool = "command-code"
-	m.pane.forID = sess.ID
-	m.pane.cursor = paneCursor{x: 0, y: 6, ok: true}
-	m.preview = "✻ Thought for 2 seconds [ctrl+o to expand]\n\n────────────\n❯ Ask your question...\n────────────\n  ? for shortcuts\n\n\n\n"
+	updated, _ = m.Update(focusPreviewMsg{
+		sessID: sess.ID, paneStateOK: true, cursorX: 0, cursorY: 6,
+		preview: "✻ Thought for 2 seconds [ctrl+o to expand]\n\n────────────\n❯ Ask your question...\n────────────\n  ? for shortcuts\n\n\n\n",
+	})
+	*m = *updated.(*Model)
+	if m.pane.cursor.ok || !m.pane.cursor.positionOK {
+		t.Fatalf("hidden cursor state = %+v, want known position without a visible caret", m.pane.cursor)
+	}
 
 	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
 	*m = *updated.(*Model)
@@ -1079,7 +1084,7 @@ func TestFocusLeftUnfocusesOnCommandCodesParkedCaret(t *testing.T) {
 	if m.mode != modeFocus {
 		t.Fatalf("after re-enter, mode = %v", m.mode)
 	}
-	m.pane.cursor = paneCursor{x: 0, y: 6, ok: true}
+	m.pane.cursor = paneCursor{x: 0, y: 6, positionOK: true}
 	m.preview = "✻ Thought for 2 seconds [ctrl+o to expand]\n\n────────────\n❯ z\n────────────\n  ? for shortcuts\n\n\n\n"
 	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
 	*m = *updated.(*Model)
@@ -1097,7 +1102,7 @@ func TestFocusLeftUnfocusesOnCommandCodesParkedCaret(t *testing.T) {
 	if m.mode != modeFocus {
 		t.Fatalf("after re-enter, mode = %v", m.mode)
 	}
-	m.pane.cursor = paneCursor{x: 0, y: 9, ok: true}
+	m.pane.cursor = paneCursor{x: 0, y: 9, positionOK: true}
 	m.preview = "❯ did you forget about peerlist?\n" +
 		"⠶ No, it is queued.\n" +
 		" ✻ Worked for 19m 16s\n" +

--- a/internal/ui/focussel.go
+++ b/internal/ui/focussel.go
@@ -31,10 +31,12 @@ type paneBox struct {
 }
 
 // paneCursor is where the focused session's own cursor sits, in pane
-// cells, as tmux last reported it.
+// cells, as tmux last reported it. positionOK stays true when the
+// application hides that cursor but tmux still reports its coordinates.
 type paneCursor struct {
-	x, y int
-	ok   bool
+	x, y       int
+	ok         bool
+	positionOK bool
 }
 
 // cursorCell maps the pane cursor onto the rows the preview is painting.

--- a/internal/ui/focussel_test.go
+++ b/internal/ui/focussel_test.go
@@ -374,7 +374,7 @@ func TestSelectionOverlayKeepsWideGraphemesWhole(t *testing.T) {
 }
 
 func TestSelectionSurvivesShortLines(t *testing.T) {
-	m := paneAt(t, "ab", "")
+	m := paneAt(t, "ab", "", "later")
 	press(m, 10, 5)
 	drag(m, 40, 6)
 	if got := m.selectionText(); got != "ab\n" {

--- a/internal/ui/focuswatch.go
+++ b/internal/ui/focuswatch.go
@@ -294,9 +294,8 @@ func applyPaneState(msg *focusPreviewMsg, reply string) {
 		return
 	}
 	msg.paneStateOK = true
-	if strings.TrimSpace(parts[2]) == "1" {
-		msg.cursorX, msg.cursorY, msg.cursorOK = x, y, true
-	}
+	msg.cursorX, msg.cursorY = x, y
+	msg.cursorOK = strings.TrimSpace(parts[2]) == "1"
 	msg.paneMouse = strings.Contains(parts[3], "1")
 	if historySize > 0 {
 		msg.historySize = historySize

--- a/internal/ui/focuswatch_test.go
+++ b/internal/ui/focuswatch_test.go
@@ -275,6 +275,9 @@ func TestFocusWatchHonorsHiddenCursor(t *testing.T) {
 			if !preview.paneStateOK || preview.cursorOK {
 				continue
 			}
+			if preview.cursorX != len("hidden-cursor") || preview.cursorY != 0 {
+				t.Fatalf("hidden cursor position = %d,%d", preview.cursorX, preview.cursorY)
+			}
 			return
 		case <-deadline:
 			t.Fatal("no hidden-cursor preview reported the cursor hidden")
@@ -314,7 +317,7 @@ func TestApplyPaneState(t *testing.T) {
 
 	var hidden focusPreviewMsg
 	applyPaneState(&hidden, "7,8,0,000,0,0,0")
-	if !hidden.paneStateOK || hidden.cursorOK {
+	if !hidden.paneStateOK || hidden.cursorOK || hidden.cursorX != 7 || hidden.cursorY != 8 {
 		t.Fatalf("hidden cursor pane state = %+v", hidden)
 	}
 

--- a/internal/ui/fulllayout_test.go
+++ b/internal/ui/fulllayout_test.go
@@ -222,8 +222,9 @@ func TestFullLayoutRightOpensFullWidthFocus(t *testing.T) {
 	if !m.pane.box.ok || m.pane.box.x != 0 || m.pane.box.width != m.width {
 		t.Fatalf("pane box = %+v, want the whole width at column 0", m.pane.box)
 	}
-	if m.pane.box.y != m.listChromeRows() {
-		t.Fatalf("pane box starts at row %d, want right under the focus rule at %d", m.pane.box.y, m.listChromeRows())
+	wantPaneY := m.listChromeRows() + m.listBodyHeight() - 1
+	if m.pane.box.y != wantPaneY {
+		t.Fatalf("pane box starts at row %d, want compact content at the bottom row %d", m.pane.box.y, wantPaneY)
 	}
 
 	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlQ})

--- a/internal/ui/listview.go
+++ b/internal/ui/listview.go
@@ -1110,10 +1110,12 @@ func ringLoader(width, height int, label string, phase int) []string {
 }
 
 // previewLines is the captured pane, filling every row under the detail
-// separator. The captured rows are marked raw and drawn without the
-// column's gutters: painting our backdrop behind an agent's own CLI colors
-// would replace the background it drew itself, and insetting its output
-// would put a margin around a terminal that has its own.
+// separator. Compact content sits at the bottom, where an agent's composer
+// remains beside the manager footer instead of floating above a blank tail.
+// The captured rows are marked raw and drawn without the column's gutters:
+// painting our backdrop behind an agent's own CLI colors would replace the
+// background it drew itself, and insetting its output would put a margin
+// around a terminal that has its own.
 func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 	var lines []contentLine
 	loader := m.startupLoader(width, height)
@@ -1130,18 +1132,23 @@ func (m *Model) previewLines(width, height int, gutter string) []contentLine {
 		}
 		return append(lines, contentLine{text: gutter + mutedStyle.Render("(no output yet)")})
 	}
+	topPadding := height - len(pane)
+	for len(lines) < topPadding {
+		lines = append(lines, contentLine{raw: true})
+	}
 	// Record where these rows land so mouse hit-testing reads the same
 	// geometry the paint used.
 	m.pane.box = paneBox{
 		x:      m.paneOriginX(),
-		y:      m.listChromeRows() + m.previewBodyOffset,
+		y:      m.listChromeRows() + m.previewBodyOffset + topPadding,
 		width:  width,
 		height: len(pane),
 		ok:     true,
 	}
 	for i, line := range pane {
-		if i < len(loader) && loader[i] != "" {
-			lines = append(lines, contentLine{text: previewLine(loader[i], width), raw: true})
+		screenRow := topPadding + i
+		if screenRow < len(loader) && loader[screenRow] != "" {
+			lines = append(lines, contentLine{text: previewLine(loader[screenRow], width), raw: true})
 			continue
 		}
 		lines = append(lines, contentLine{text: m.renderPaneRow(i, line, width), raw: true})

--- a/internal/ui/listview_test.go
+++ b/internal/ui/listview_test.go
@@ -927,6 +927,24 @@ func previewText(m *Model) string {
 	return strings.Join(out, "\n")
 }
 
+func TestPreviewBottomAlignsCompactPane(t *testing.T) {
+	m := previewModel(status.Finished, "todo\ncomposer"+strings.Repeat("\n", 10))
+	lines := strings.Split(previewText(m), "\n")
+	if strings.TrimSpace(lines[10]) != "todo" || strings.TrimSpace(lines[11]) != "composer" {
+		t.Fatalf("compact pane was not bottom aligned: %q", lines)
+	}
+	wantY := m.listChromeRows() + 10
+	if !m.pane.box.ok || m.pane.box.y != wantY || m.pane.box.height != 2 {
+		t.Fatalf("pane box = %+v, want two rows starting at %d", m.pane.box, wantY)
+	}
+	if _, _, ok := m.paneCell(m.pane.box.x, m.pane.box.y-1); ok {
+		t.Fatal("padding above a compact pane became hit-testable")
+	}
+	if row, _, ok := m.paneCell(m.pane.box.x, m.pane.box.y); !ok || row != 0 {
+		t.Fatalf("first compact pane row maps to (%d,%v), want pane row zero", row, ok)
+	}
+}
+
 // A launching agent paints nothing for a while, and the blank block that
 // leaves reads as a broken session; the preview says it is coming up. The
 // blank rows are still the session's pane, so they stay hit-testable.
@@ -1047,8 +1065,8 @@ func TestPreviewLoaderFramesAreNotStatusMarks(t *testing.T) {
 	}
 }
 
-// A focused pane is the screen the user types on, so it keeps its own first
-// row and the caret drawn there rather than the loader.
+// A focused pane is the screen the user types on, so its first captured row
+// keeps the caret drawn there rather than the loader.
 func TestPreviewLeavesTheFocusedPaneAlone(t *testing.T) {
 	prev := lipgloss.ColorProfile()
 	lipgloss.SetColorProfile(termenv.TrueColor)
@@ -1058,7 +1076,8 @@ func TestPreviewLeavesTheFocusedPaneAlone(t *testing.T) {
 	m.mode = modeFocus
 	m.cursorOn = true
 	m.pane.cursor = paneCursor{ok: true}
-	first := m.previewLines(80, 12, "  ")[0].text
+	lines := m.previewLines(80, 12, "  ")
+	first := lines[m.pane.box.y-m.listChromeRows()].text
 	if strings.Contains(ansi.Strip(first), "starting up") {
 		t.Fatalf("the loader took the focused pane's first row: %q", first)
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1540,7 +1540,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.preview = msg.preview
-		m.pane.cursor = paneCursor{x: msg.cursorX, y: msg.cursorY, ok: msg.cursorOK}
+		m.pane.cursor = paneCursor{
+			x: msg.cursorX, y: msg.cursorY,
+			ok: msg.cursorOK, positionOK: msg.paneStateOK,
+		}
 		return m, nil
 
 	case previewMsg:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -416,12 +416,9 @@ func expandPaneTabs(line string, width int) string {
 
 // paneWindow picks the half-open row range of a capture the panel shows.
 // A pane is left taller than the panel on purpose, since shrinking it
-// costs agents like Codex their whole scrollback (#369), so a plain crop
-// would show the blank tail such a pane leaves under short output and drop
-// the output itself. The window instead ends at the last painted row, but
-// never retreats past the panel's own row count (short output keeps its
-// top anchor, and a not-yet-painted pane keeps its blank rows hit-testable)
-// or past the caret's row, which is the cell someone is typing into.
+// costs agents like Codex their whole scrollback (#369), so the window
+// drops a blank tail instead. A completely blank, not-yet-painted pane
+// keeps its rows hit-testable, and a live caret keeps its row in view.
 func paneWindow(pane string, n, caretRow int) (lines []string, start int) {
 	if n <= 0 || pane == "" {
 		return nil, 0
@@ -432,8 +429,8 @@ func paneWindow(pane string, n, caretRow int) (lines []string, start int) {
 	for end > 0 && blankPaneRow(lines[end-1]) {
 		end--
 	}
-	if end < n {
-		end = n
+	if end == 0 {
+		end = min(n, len(lines))
 	}
 	if caretRow+1 > end {
 		end = caretRow + 1

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -57,13 +57,13 @@ func TestPaneExactPreservesBlanks(t *testing.T) {
 
 // A pane held taller than the panel (kept tall on purpose, since a height
 // shrink costs Codex its scrollback, #369) carries a blank tail under
-// short output. The crop ends at the content so the output stays visible,
-// top-anchored the way a terminal shows it.
+// short output. The crop returns only its content so the renderer can
+// align it without carrying the dead rows along.
 func TestPaneWindowCropsBlankTailNotContent(t *testing.T) {
 	tall := "one\ntwo" + strings.Repeat("\n", 40)
 	lines, start := paneWindow(tall, 5, -1)
-	if start != 0 || len(lines) != 5 || lines[0] != "one" || lines[1] != "two" {
-		t.Fatalf("short output in a tall pane = start %d rows %q, want its top rows", start, lines)
+	if start != 0 || len(lines) != 2 || lines[0] != "one" || lines[1] != "two" {
+		t.Fatalf("short output in a tall pane = start %d rows %q, want content only", start, lines)
 	}
 
 	full := strings.TrimSuffix(strings.Repeat("line\n", 40), "\n")


### PR DESCRIPTION
## What changed

Keep tmux's cursor position when an app hides the terminal cursor, without drawing it in agent-manager.

A zero-width `input_prefix` can use that known position. This lets pi tell an empty input row from a draft while keeping the exception limited to tools that explicitly declare a bare input row. Other hidden cursors stay ignored.

This PR is stacked on #437.

## Why

pi hides the terminal cursor and paints its own. tmux still reports the right cell with `cursor_flag=0`.

#437 separates a known cursor position from a visible cursor, but `applyPaneState` still only copies x/y when `cursor_flag=1`. Hidden positions therefore arrive as 0,0. Its focus check also accepts hidden positions only for tools where `ParksItsCaret` is true. That is false for pi because it has no `composer_placeholder`.

On pi 0.85.0, #437 still forwards `←` in every case. It appears to do nothing on an empty input because there is nowhere for the cursor to move. Drafts still receive it.

Keeping the real x/y matters once pi is allowed to use a hidden position. Without it, the check would read 0,0 instead of the input row and could take `←` away from a draft.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] Focused cursor and arrow tests pass
- [x] Full race suite passes with an empty `ZDOTDIR`
- [ ] GitHub Actions test passes
- [x] Ran it against a real pi 0.85.0 session on an isolated tmux socket

The exact full race command with my normal zsh config still fails in `TestReviveStartsTheAgentAgainInALivePane`: syntax highlighting adds ANSI codes to the captured command. The same test fails on untouched #437 at `93acda6`. With an empty `ZDOTDIR`, `go test -race ./... -count=1` passes.

## Visual evidence

Text capture is clearer here. The visible change is which view remains after one key press.

**Empty input:** tmux reported `cursor=0,26 flag=0`. `→` showed `FOCUS`; `←` returned to `View`.

**Draft:** after typing `xy`, tmux reported `cursor=2,26 flag=0`. `←` kept `FOCUS` and moved the cursor to `1,26`.
