### PR TITLE
ci: run govulncheck on every push and pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: golang/govulncheck-action@v1
+      - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
           go-version-file: go.mod
           go-package: ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v3
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_COMMENTS: false
@@ -46,7 +46,7 @@ jobs:
       - name: Test
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.out
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_COMMENTS: false
 
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: go.mod
+          go-package: ./...
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What changed

CI gains a `govulncheck` job that runs the official `golang/govulncheck-action` (v1.1.0) against `./...` on every push to `main` and every pull request, reading the Go version from `go.mod`.

The three third-party actions in the workflow (`govulncheck-action`, `gitleaks-action`, `codecov-action`) are pinned to the commit behind their current release tag, with the version kept in a trailing comment for dependabot. The extended CodeQL suite, enabled on this repository today, flags a mutable tag on a third-party action; the first-party `actions/*` pins publish immutable releases and pass as they are.

## Why

Dependabot alerts fire on the versions listed in `go.sum`. `govulncheck` walks the call graph and reports a vulnerability only when the module calls the affected code, so a red job means the binary is exposed. It is the Go team's recommended check for Go modules and completes in under a minute on this repository.

## Scope

### Required behavior

One CI job, independent of `test`, that fails the workflow when a reachable vulnerability is present in the module's dependencies.

### Why this approach

The official action installs Go and checks out the repository itself, so the job is four lines. Pinning to the `v1` release tag matches every other action in the workflow and lets dependabot bump it.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] `go build ./...` passes
- [ ] Ran it against real sessions
- [x] Holds for every supported agent CLI and platform, or the description names what it leaves out

`govulncheck ./...` run locally on this branch prints `No vulnerabilities found.` The CI run on this pull request is the live verification of the job itself.

## Visual evidence

**Not applicable because:** the change is a CI job with no user-facing surface; the workflow run on this pull request is the evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added automated vulnerability scanning across the full application codebase.
  - Improved the consistency of security and code coverage checks by using fixed action versions.

- **Chores**
  - Expanded continuous integration checks to detect known vulnerabilities during automated builds.
  - Stabilized workflow behavior by pinning selected automation tools to specific versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->