### PR TITLE
chore(release): open an Announcements discussion for every release

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,7 +68,8 @@ it. Fill the Scope section: what the change has to do and why this shape. A typo
 or a one-line fix answers both in a sentence, and a review reads them to tell
 the change you meant from the change you made. Say there too when the change
 reaches only some of the agent CLIs or platforms we support, and what covering
-the rest would take.
+the rest would take. If the change grew out of a Discussion, or you opened one
+about it, link it there.
 Complete the Visual evidence section for every pull request. Include before
 and after screenshots whenever the change can be shown visually; use a short
 recording when interaction or motion is clearer that way. If useful visual

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,7 @@ changelog:
   use: github-native
 
 release:
+  discussion_category_name: Announcements
   header: |
     Run every AI coding agent from one terminal. Claude Code, Codex, OpenCode, Grok, Gemini CLI, and Pi run side by side, each in its own tmux session, with live status, a project tree, quick prompts, and full-file diff review. Runs on macOS and Linux, and on Windows inside WSL2. [See it running](https://github.com/YoanWai/agent-manager#agent-manager).
 


### PR DESCRIPTION
## What changed

- `.goreleaser.yaml` sets `release.discussion_category_name: Announcements`, so each published release opens a Discussion in that category with the release body attached.
- `CONTRIBUTING.md` asks a pull request that grew out of a Discussion, or that opened one, to link it in the description.

## Why

Release conversation gets one linkable home next to the code. The in-app messages feed can point at that discussion, so a click from the TUI lands where people can reply. Discussions are indexed by search engines, so answers given there keep working for the next person.

## Scope

### Required behavior

Publishing a release creates a linked Announcements discussion. Contributors know to link a related Discussion from their pull request.

### Why this approach

GoReleaser passes the category name straight to the GitHub release API, which creates and links the discussion in the same call. One config line, no extra step in the cut.

## How it was verified

- `goreleaser check` validates the config: `1 configuration file(s) validated`.
- The `Announcements` category exists in this repository's Discussions.
- GitHub's release API documents `discussion_category_name` as creating a discussion of an existing category and returns `discussion_url` on the release object.

- [x] `gofmt -l .` prints nothing (no Go changes)
- [x] `go vet ./...` passes (no Go changes)
- [x] `go test -race ./...` passes (no Go changes)
- [x] `go build ./...` passes (no Go changes)
- [ ] Ran it against real sessions
- [x] Holds for every supported agent CLI and platform, or the description names what it leaves out

## Visual evidence

**Not applicable because:** configuration and contributor documentation only; the effect shows on the next release cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidelines to request links to related Discussions in pull request descriptions when applicable.

- **Release Improvements**
  - GitHub releases are now associated with the “Announcements” discussion category, making release-related discussions easier to find.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->