### PR TITLE
fix(ui): keep typing responsive while the focused pane streams

### DIFF
--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -326,6 +326,13 @@ func (m *Model) handleFocusKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if err := m.tmux.SendRaw(command); err != nil {
 			m.errBar.text = err.Error()
 		}
+		// Without the client the echo only shows on the poll cadence, a
+		// second or more after each key. Typing is as deliberate as
+		// focusing, so it lifts the failure backoff and reopens now.
+		if m.focus != nil {
+			m.focus.retryNow()
+			m.watchSelection()
+		}
 	}
 	return m, resume
 }

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -1205,3 +1205,71 @@ func TestFocusModeRemappedReviewAndEditorKeys(t *testing.T) {
 		t.Fatalf("closing review should return to focus, mode = %v", m.mode)
 	}
 }
+
+// Typing into a session whose control client is in failure backoff reopens
+// the client at once: a keystroke is the same deliberate act as focusing,
+// and without the client the typed text only shows on the poll cadence,
+// a second or more after each key.
+func TestFocusKeyRetriesADeadWatcher(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "retype", t.TempDir(), "")
+	m.selectSessionRow(t, "retype")
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+	if m.mode != modeFocus {
+		t.Fatalf("after enter, mode = %v, err = %q", m.mode, m.errBar.text)
+	}
+	sess := m.rows[m.cursor].sess
+
+	m.focus = newFocusWatch(m.tmux, func(tea.Msg) {})
+	t.Cleanup(m.focus.Close)
+	m.focus.mu.Lock()
+	m.focus.failedID, m.focus.failedAt = sess.ID, time.Now()
+	m.focus.mu.Unlock()
+	m.focus.setFocus(sess.ID)
+	if m.focus.watching() != "" {
+		t.Fatal("backoff did not hold before the keystroke")
+	}
+
+	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	*m = *updated.(*Model)
+	if m.errBar.text != "" {
+		t.Fatalf("forwarding set err: %q", m.errBar.text)
+	}
+	if m.focus.watching() != sess.ID {
+		t.Fatalf("keystroke left the watcher on %q, want %q", m.focus.watching(), sess.ID)
+	}
+}
+
+// Killing the focused session is deliberate, so the watcher losing its
+// client there is not a failure to report; only a client that dies under
+// the watcher is.
+func TestKillingTheFocusedSessionReportsNoLoss(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "doomed-focus", t.TempDir(), "")
+	m.selectSessionRow(t, "doomed-focus")
+	sess := m.rows[m.cursor].sess
+
+	msgs := make(chan tea.Msg, 64)
+	m.focus = newFocusWatch(m.tmux, func(msg tea.Msg) { msgs <- msg })
+	t.Cleanup(m.focus.Close)
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	*m = *updated.(*Model)
+	waitFocusPreview(t, msgs, sess.ID, "")
+
+	if err := m.killSession(sess); err != nil {
+		t.Fatalf("killSession: %v", err)
+	}
+	quiet := time.After(time.Second)
+	for {
+		select {
+		case msg := <-msgs:
+			if failure, ok := msg.(errMsg); ok {
+				t.Fatalf("deliberate kill reported %q", failure.err)
+			}
+		case <-quiet:
+			return
+		}
+	}
+}

--- a/internal/ui/focuswatch.go
+++ b/internal/ui/focuswatch.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,7 +34,12 @@ type focusPreviewMsg struct {
 
 // focusDebounce is how long the watcher lets a paint burst settle before
 // capturing, so a stream of tmux output events becomes a few captures.
-const focusDebounce = 25 * time.Millisecond
+// It is also the preview's frame budget: every capture repaints the
+// preview in the outer terminal, and a scrolling agent captured at 25ms
+// drove forty full-frame repaints a second through it, which is what
+// made the terminal fall behind the keyboard. At 80ms a typed key still
+// echoes within a frame while a stream costs the terminal a third.
+const focusDebounce = 80 * time.Millisecond
 
 // focusWatch keeps one tmux control-mode client on the selected session.
 // tmux pushes an event the moment the pane paints and the capture rides
@@ -150,6 +156,16 @@ func (w *focusWatch) query(command string) (string, bool) {
 	return out, true
 }
 
+// unwatch stops the watcher when it is on id.
+func (w *focusWatch) unwatch(id string) {
+	w.mu.Lock()
+	if w.id == id {
+		w.stopLocked()
+		w.id = ""
+	}
+	w.mu.Unlock()
+}
+
 // stopLocked signals the watcher and returns immediately. It must never
 // wait: it runs inside Update, and the watcher may at that moment be
 // blocked in send, which only the Update loop can drain — waiting here
@@ -214,6 +230,7 @@ func (w *focusWatch) watch(id string, stop chan struct{}) {
 	capture := func() bool {
 		pane, err := control.Command("capture-pane -p -e -t " + target)
 		if err != nil {
+			w.report(stop, fmt.Errorf("preview client for %s: %w", id, err))
 			return false
 		}
 		msg := focusPreviewMsg{sessID: id, preview: matchExecShape(pane)}
@@ -249,6 +266,11 @@ func (w *focusWatch) watch(id string, stop chan struct{}) {
 			return
 		case <-control.Done():
 			w.clearIfCurrent(id, stop)
+			lost := fmt.Errorf("preview client for %s exited", id)
+			if err := control.Err(); err != nil {
+				lost = fmt.Errorf("%w: %w", lost, err)
+			}
+			w.report(stop, lost)
 			return
 		case <-control.Events():
 		}
@@ -268,6 +290,19 @@ func (w *focusWatch) watch(id string, stop chan struct{}) {
 			return
 		}
 	}
+}
+
+// report surfaces a client the watcher lost, so the preview dropping to
+// the poll cadence shows its reason instead of reading as lag. A stopped
+// watcher stays quiet: its send could block on the UI loop for a frame,
+// and the loss was asked for.
+func (w *focusWatch) report(stop chan struct{}, err error) {
+	select {
+	case <-stop:
+		return
+	default:
+	}
+	w.send(errMsg{err})
 }
 
 // matchExecShape gives the control-pipe capture the same shape the exec

--- a/internal/ui/focuswatch.go
+++ b/internal/ui/focuswatch.go
@@ -156,7 +156,6 @@ func (w *focusWatch) query(command string) (string, bool) {
 	return out, true
 }
 
-// unwatch stops the watcher when it is on id.
 func (w *focusWatch) unwatch(id string) {
 	w.mu.Lock()
 	if w.id == id {

--- a/internal/ui/focuswatch_test.go
+++ b/internal/ui/focuswatch_test.go
@@ -361,3 +361,39 @@ func TestControlCaptureKeepsTrailingBlankRows(t *testing.T) {
 		t.Fatalf("matchExecShape(%q) = %q, want %q", "a\nb", got, want)
 	}
 }
+
+// A client that dies under the watcher is reported, not swallowed: the
+// preview silently dropping to the poll cadence reads as the manager
+// lagging, with nothing on screen saying why.
+func TestFocusWatchReportsALostClient(t *testing.T) {
+	driver := requireFocusDriver(t)
+	id := "lost" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "", nil, 80, 24); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+
+	msgs := make(chan tea.Msg, 64)
+	watch := newFocusWatch(driver, func(msg tea.Msg) { msgs <- msg })
+	t.Cleanup(watch.Close)
+	watch.setFocus(id)
+	waitFocusPreview(t, msgs, id, "")
+
+	// Killing the session detaches its control client out from under the
+	// watcher, which is one of the ways the client goes away in use.
+	driver.Kill(id)
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case msg := <-msgs:
+			if failure, ok := msg.(errMsg); ok {
+				if !strings.Contains(failure.err.Error(), "preview") {
+					t.Fatalf("lost client reported as %q", failure.err)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("lost control client was never reported")
+		}
+	}
+}

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -549,6 +549,14 @@ func (m *Model) liveSessions(sessions []store.Session) ([]store.Session, error) 
 	return live, nil
 }
 
+// unwatch stops the focus watcher before a session is killed on purpose:
+// the client going away then is the plan, not a loss to report.
+func (m *Model) unwatch(id string) {
+	if m.focus != nil {
+		m.focus.unwatch(id)
+	}
+}
+
 // killSession ends one session's tmux window, freeing everything its agent
 // held, while the store row keeps the name, group, history and conversation
 // id that revive needs. The pane is captured first so the preview still
@@ -562,6 +570,7 @@ func (m *Model) killSession(sess store.Session) error {
 			return err
 		}
 	}
+	m.unwatch(sess.ID)
 	var killErr error
 	// Runs under the poller's lock so no pass can capture a half-killed
 	// pane, and drops the pane hash the revived session would be compared
@@ -1045,6 +1054,7 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.errBar.text = ""
 		case actionDelete:
 			for _, sess := range childrenFirst(m.confirm.sessions) {
+				m.unwatch(sess.ID)
 				if err := m.tmux.Kill(sess.ID); err != nil {
 					m.errBar.text = err.Error()
 					return m, nil


### PR DESCRIPTION
## What

- The focus watcher's settle is now the preview's frame budget: 80ms instead of 25ms, so a streaming pane repaints the preview at most about twelve times a second.
- A keystroke into a focused session whose control client is in failure backoff lifts the backoff and reopens the client at once.
- A control client that dies under the watcher is reported in the error bar. Killing, deleting or archiving the focused session stops the watcher first, so a client that goes away on purpose stays quiet.

## Why

Typing into a focused session lagged: keys landed late and read as swallowed. Two measured causes.

A focused agent that scrolls its pane drove the preview at up to forty full-frame repaints a second, 2.5MB of escapes over four seconds. On the machine where this was measured iTerm2 went from 20% to 80% CPU during such a stream while agent-manager stayed at 15% and tmux at 5%, so the outer terminal was what fell behind the keyboard. At 80ms the same stream costs the terminal a third of the bytes and a typed key still echoes within a frame.

When the control client died, the watcher sat in its fifteen second backoff and the preview fell back to the poll cadence, so each typed character showed up to a second later, with nothing on screen saying why.

## Verified

- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...` green, `go vet ./...` and `gofmt -l .` clean.
- New tests: a keystroke reopens a watcher in backoff, a lost client is reported, a deliberate kill is not.
- Isolated harness (real binary under a fake HOME, outer tmux 182x51, a raw-mode spinner pane): typed-key echo 47ms before and after; a four second stream wrote 2,540,177 bytes in 135 frames before and 926,595 bytes in 56 frames after; after killing the control client the echo went from a median of 960ms to 55ms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Focused keystrokes now retry promptly when the control connection is temporarily unavailable.
  * Preview failures and unexpected connection losses now surface an error instead of silently waiting for the next update.
  * Deliberately closing a focused session no longer reports a misleading preview-loss error.
  * Focus updates are debounced more smoothly to improve responsiveness and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->