### PR TITLE
fix(tui): keep a revived pane at the manager's preview size

### DIFF
--- a/internal/sessioncmd/session.go
+++ b/internal/sessioncmd/session.go
@@ -361,7 +361,7 @@ func (s *Sessions) Create(sessionID string, opts CreateSessionOptions) (Session,
 		PendingInputs:  plan.PendingInputs,
 		LaunchPrompt:   plan.LaunchPrompt,
 	}
-	if err := runtime.driver.Create(sess.ID, sess.Cwd, command, env, 0, 0); err != nil {
+	if err := runtime.createPane(sess.ID, sess.Cwd, command, env); err != nil {
 		discard()
 		return Session{}, err
 	}
@@ -751,7 +751,7 @@ func (s *Sessions) Revive(sessionID, targetID string) (Session, error) {
 	if err != nil {
 		return Session{}, err
 	}
-	if err := runtime.driver.Create(target.ID, target.Cwd, command, env, 0, 0); err != nil {
+	if err := runtime.createPane(target.ID, target.Cwd, command, env); err != nil {
 		return Session{}, err
 	}
 	launchedAt := time.Now()

--- a/internal/sessioncmd/session_test.go
+++ b/internal/sessioncmd/session_test.go
@@ -994,3 +994,53 @@ func TestSessionsCreateBindsTheConfiguredSessionKeys(t *testing.T) {
 		t.Fatalf("the default review key should not be bound alongside the configured one: %q", stale)
 	}
 }
+
+func paneWindowSize(t *testing.T, driver *tmux.Driver, id string) (int, int) {
+	t.Helper()
+	panes, err := driver.Panes()
+	if err != nil {
+		t.Fatalf("Panes: %v", err)
+	}
+	pane, ok := panes[id]
+	if !ok {
+		t.Fatalf("session %s has no pane", id)
+	}
+	return pane.Width, pane.Height
+}
+
+// Nothing outside the manager can measure the preview panel, and tmux
+// hands an unsized detached session 80x24, so every pane these tools open
+// comes up narrower than the panel that has to draw it. They take the box
+// the running manager recorded instead.
+func TestHeadlessLaunchesUseTheManagersPaneSize(t *testing.T) {
+	h := newSessionHarness(t)
+	if err := h.store.SetPaneSize(131, 47); err != nil {
+		t.Fatalf("set pane size: %v", err)
+	}
+
+	created, err := h.sessions.Create(h.caller.ID, CreateSessionOptions{Name: "worker"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if width, height := paneWindowSize(t, h.driver, created.ID); width != 131 || height != 47 {
+		t.Fatalf("created pane = %dx%d, want 131x47", width, height)
+	}
+
+	if _, err := h.sessions.Kill(h.caller.ID, created.ID); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if _, err := h.sessions.Revive(h.caller.ID, created.ID); err != nil {
+		t.Fatalf("Revive: %v", err)
+	}
+	if width, height := paneWindowSize(t, h.driver, created.ID); width != 131 || height != 47 {
+		t.Fatalf("revived pane = %dx%d, want 131x47", width, height)
+	}
+
+	terminal, err := h.terminals.Create(h.caller.ID, CreateTerminalOptions{})
+	if err != nil {
+		t.Fatalf("terminal Create: %v", err)
+	}
+	if width, height := paneWindowSize(t, h.driver, terminal.ID); width != 131 || height != 47 {
+		t.Fatalf("terminal pane = %dx%d, want 131x47", width, height)
+	}
+}

--- a/internal/sessioncmd/session_test.go
+++ b/internal/sessioncmd/session_test.go
@@ -1035,12 +1035,4 @@ func TestHeadlessLaunchesUseTheManagersPaneSize(t *testing.T) {
 	if width, height := paneWindowSize(t, h.driver, created.ID); width != 131 || height != 47 {
 		t.Fatalf("revived pane = %dx%d, want 131x47", width, height)
 	}
-
-	terminal, err := h.terminals.Create(h.caller.ID, CreateTerminalOptions{})
-	if err != nil {
-		t.Fatalf("terminal Create: %v", err)
-	}
-	if width, height := paneWindowSize(t, h.driver, terminal.ID); width != 131 || height != 47 {
-		t.Fatalf("terminal pane = %dx%d, want 131x47", width, height)
-	}
 }

--- a/internal/sessioncmd/terminal.go
+++ b/internal/sessioncmd/terminal.go
@@ -76,6 +76,18 @@ type runtime struct {
 	driver *tmux.Driver
 }
 
+// createPane opens a session's pane at the box the running manager pins
+// its panes to. Nothing here can measure the preview, and tmux hands an
+// unsized detached session 80x24, which is narrower than any manager
+// layout and holds until something resizes it.
+func (r *runtime) createPane(id, cwd, command string, env map[string]string) error {
+	width, height, err := r.store.PaneSize()
+	if err != nil {
+		return err
+	}
+	return r.driver.Create(id, cwd, command, env, width, height)
+}
+
 func (c *commands) open() (*runtime, error) {
 	cfg, err := config.LoadDir(c.configDir)
 	if err != nil {
@@ -251,7 +263,7 @@ func (t *Terminals) Create(sessionID string, opts CreateTerminalOptions) (Termin
 		Group:  group,
 		Status: status.Starting,
 	}
-	if err := runtime.driver.Create(sess.ID, sess.Cwd, tool.Command, nil, 0, 0); err != nil {
+	if err := runtime.createPane(sess.ID, sess.Cwd, tool.Command, nil); err != nil {
 		return Terminal{}, err
 	}
 	sess.TmuxSocket = runtime.driver.SocketPath()

--- a/internal/sessioncmd/terminal_test.go
+++ b/internal/sessioncmd/terminal_test.go
@@ -544,3 +544,19 @@ func TestCloseRefusesUnnestedTerminal(t *testing.T) {
 		t.Fatal("pane killed")
 	}
 }
+
+// A terminal opened from the CLI or the MCP server takes the box the running
+// manager recorded, the way an agent session does, rather than tmux's 80x24.
+func TestTerminalsCreateUsesTheManagersPaneSize(t *testing.T) {
+	h := newTerminalHarness(t)
+	if err := h.store.SetPaneSize(131, 47); err != nil {
+		t.Fatalf("set pane size: %v", err)
+	}
+	terminal, err := h.terminals.Create(h.caller.ID, CreateTerminalOptions{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if width, height := paneWindowSize(t, h.driver, terminal.ID); width != 131 || height != 47 {
+		t.Fatalf("terminal pane = %dx%d, want 131x47", width, height)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -323,6 +324,32 @@ func (s *Store) ReviewScope(sessionID string) (string, error) {
 		return "", err
 	}
 	return scope, nil
+}
+
+// paneSizeSetting carries the window size the running manager pins its
+// session panes to. The CLI and the MCP server open panes with no manager
+// to ask, and a pane born at tmux's own 80x24 default stays there until
+// something resizes it, so they read the box from here instead.
+const paneSizeSetting = "pane_size"
+
+func (s *Store) SetPaneSize(width, height int) error {
+	return s.SetSetting(paneSizeSetting, fmt.Sprintf("%dx%d", width, height))
+}
+
+// PaneSize is the box the manager last pinned panes to, zeroes when no
+// manager has recorded one yet, which leaves the size to tmux.
+func (s *Store) PaneSize() (int, int, error) {
+	value, err := s.Setting(paneSizeSetting)
+	if err != nil || value == "" {
+		return 0, 0, err
+	}
+	columns, rows, ok := strings.Cut(value, "x")
+	width, widthErr := strconv.Atoi(columns)
+	height, heightErr := strconv.Atoi(rows)
+	if !ok || widthErr != nil || heightErr != nil {
+		return 0, 0, fmt.Errorf("pane size %q in settings is not <columns>x<rows>", value)
+	}
+	return width, height, nil
 }
 
 func (s *Store) SetSetting(key, value string) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1878,3 +1878,25 @@ func TestBindAgentSessionIDClearsTheSnapshot(t *testing.T) {
 		t.Fatalf("after bind: id=%q snapshot=%v, want conv-1 and nil", got.AgentSessionID, got.RelaunchSnapshot)
 	}
 }
+
+func TestPaneSizeRoundTripsAndRefusesJunk(t *testing.T) {
+	st := newTestStore(t)
+	width, height, err := st.PaneSize()
+	if err != nil || width != 0 || height != 0 {
+		t.Fatalf("unrecorded pane size = %dx%d, err = %v", width, height, err)
+	}
+	if err := st.SetPaneSize(131, 47); err != nil {
+		t.Fatalf("SetPaneSize: %v", err)
+	}
+	if width, height, err = st.PaneSize(); err != nil || width != 131 || height != 47 {
+		t.Fatalf("pane size = %dx%d, err = %v, want 131x47", width, height, err)
+	}
+	for _, junk := range []string{"wide", "131x47zz", "131", "x47"} {
+		if err := st.SetSetting(paneSizeSetting, junk); err != nil {
+			t.Fatalf("SetSetting: %v", err)
+		}
+		if _, _, err := st.PaneSize(); err == nil {
+			t.Fatalf("pane size %q was read as a size", junk)
+		}
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -303,6 +303,12 @@ type paneMirror struct {
 	columnX int
 	cursor  paneCursor
 	geom    map[string][2]int
+	// pids is the pane process each geom entry was measured on, so a pane
+	// replaced by a relaunch can be told from the one the manager sized.
+	pids map[string]int
+	// published is the last box written to the store for the paneless
+	// launch paths to read.
+	published [2]int
 }
 
 type errBar struct {
@@ -1161,6 +1167,7 @@ func (m *Model) resizeSessions() {
 	if m.pane.geom == nil {
 		m.pane.geom = map[string][2]int{}
 	}
+	m.markReplacedPanesFresh()
 	m.seedPaneGeom()
 	// The session open full screen is pinned to the whole body by
 	// pinFullFocusPane, not to the preview box; matching it to the box
@@ -1258,6 +1265,45 @@ func (m *Model) markFreshPane(id string) {
 	m.pane.geom[id] = [2]int{0, 0}
 }
 
+// publishPaneSize records the box for the launch paths that run without a
+// manager: the CLI and the MCP server open a pane with nothing to ask for
+// the preview geometry, and tmux gives an unsized detached session 80x24.
+func (m *Model) publishPaneSize() {
+	if m.width <= 0 {
+		return
+	}
+	width, height := m.paneTargetSize()
+	if width <= 0 || height <= 0 || m.pane.published == [2]int{width, height} {
+		return
+	}
+	if err := m.store.SetPaneSize(width, height); err != nil {
+		m.errBar.text = err.Error()
+		return
+	}
+	m.pane.published = [2]int{width, height}
+}
+
+// markReplacedPanesFresh spots a session whose pane process changed since
+// its geometry was measured: a revive outside this process put the row on
+// a window the manager never sized, and the cached size of the window it
+// replaced would otherwise read as already matching the box, leaving the
+// new pane at whatever it was born with for the life of the run. The
+// replacement has no scrollback to protect, so it takes markFreshPane's
+// exact pin rather than the adopted-pane treatment that keeps a taller
+// height.
+func (m *Model) markReplacedPanesFresh() {
+	if m.pane.pids == nil {
+		m.pane.pids = map[string]int{}
+	}
+	for id, pane := range m.panes {
+		last := m.pane.pids[id]
+		m.pane.pids[id] = pane.PID
+		if last != 0 && last != pane.PID {
+			m.markFreshPane(id)
+		}
+	}
+}
+
 // seedPaneGeom fills the geometry cache from the pass's pane listing for
 // sessions this run has not sized yet, so a pane adopted from a previous
 // run is not shrunk (and its Codex scrollback cleared) just to match a box
@@ -1315,6 +1361,7 @@ func (m *Model) handleMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Re-assert the terminal backdrop: a reattach or a fresh outer
 		// terminal delivers a size message and may carry stale colors.
 		SyncTerminalBackground()
+		m.publishPaneSize()
 		m.resizeSessions()
 		if m.fullFocus() {
 			if sess, ok := m.selected(); ok {
@@ -1410,6 +1457,7 @@ func (m *Model) handleMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !m.sessionsSized && m.width > 0 && len(m.sessions) > 0 {
 			m.sessionsSized = true
 		}
+		m.publishPaneSize()
 		// The preview box changes height for more reasons than a terminal
 		// resize: the quick bar opening, the status line appearing, a new
 		// badge in the header. A pane shorter than the box paints a dead

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -244,6 +244,68 @@ func TestUnchangedWindowSizeSkipsResize(t *testing.T) {
 	}
 }
 
+// A revive that runs outside the manager, from the CLI or the MCP tool,
+// puts the row on a window this process never sized. The geometry it
+// cached for the window that died would otherwise read as already matching
+// the box, leaving the replacement at whatever it was born with. The
+// replacement is pinned to the exact box, taller or shorter, since a pane
+// born a moment ago has no scrollback to keep.
+func TestRelaunchedSessionIsRepinnedToThePreviewPanel(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	createSession(t, m, "revived", dir, "")
+	id := m.sessionRows()[0].ID
+	m.applyCmd(t, m.refreshCmd())
+	if w, _ := windowSize(t, id); w != m.previewPaneWidth() {
+		t.Fatalf("before the relaunch, window width = %d, want %d", w, m.previewPaneWidth())
+	}
+
+	// What a revive with no manager to ask does: the sized window is gone
+	// and the replacement carries tmux's own default, or a box some other
+	// manager run recorded.
+	wantW, wantH := m.previewPaneWidth(), m.previewPaneHeight()
+	for _, born := range [][2]int{{0, 0}, {wantW + 40, wantH + 20}} {
+		if err := m.tmux.Kill(id); err != nil {
+			t.Fatalf("kill: %v", err)
+		}
+		if err := m.tmux.Create(id, dir, "", nil, born[0], born[1]); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if w, h := windowSize(t, id); w == wantW && h == wantH {
+			t.Fatalf("relaunched window already at the box %dx%d, nothing to prove", w, h)
+		}
+		m.applyCmd(t, m.refreshCmd())
+		if w, h := windowSize(t, id); w != wantW || h != wantH {
+			t.Fatalf("born %dx%d: after the refresh, window = %dx%d, want %dx%d", born[0], born[1], w, h, wantW, wantH)
+		}
+	}
+}
+
+// The launch paths that run without a manager read the box out of the
+// store, so the manager has to keep it current there.
+func TestRefreshPublishesThePaneSize(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "sized", t.TempDir(), "")
+	m.applyCmd(t, m.refreshCmd())
+	width, height, err := m.store.PaneSize()
+	if err != nil {
+		t.Fatalf("pane size: %v", err)
+	}
+	if width != m.previewPaneWidth() || height != m.previewPaneHeight() {
+		t.Fatalf("published %dx%d, want %dx%d", width, height, m.previewPaneWidth(), m.previewPaneHeight())
+	}
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 150, Height: 45})
+	*m = *updated.(*Model)
+	width, height, err = m.store.PaneSize()
+	if err != nil {
+		t.Fatalf("pane size after resize: %v", err)
+	}
+	if width != m.previewPaneWidth() || height != m.previewPaneHeight() {
+		t.Fatalf("after a resize published %dx%d, want %dx%d", width, height, m.previewPaneWidth(), m.previewPaneHeight())
+	}
+}
+
 func TestRebuildRowsNestsChildrenUnderParent(t *testing.T) {
 	m := buildModel(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## What

- The manager records the box it pins session panes to (`pane_size` in the settings table, columns x rows) and keeps it current on every poll and terminal resize.
- `Sessions.Create`, `Sessions.Revive` and `Terminals.Create`, the launch paths behind the CLI and the MCP server, open their tmux window at that box. A store with no recorded box leaves the size to tmux, as before.
- The geometry cache remembers the pane process each entry was measured on. A session whose pane process changed since then is on a window this manager never sized, so it takes the same exact pin a pane the manager launched itself gets.

## Why

A session revived from the CLI or the MCP `revive_session` tool came back on a window sized 80x24, tmux's default for a detached session, and stayed there for the life of the manager: its preview drew a narrow column inside a wide panel. Measured on a live socket after 28 sessions were revived through MCP: 21 windows at 80x24 with `window-size` never set, meaning `resize-window` had never run on them, beside 11 at the 119x42 box.

Two things kept them there. The headless launch paths passed `0,0` to `Driver.Create`, so `new-session` ran without `-x`/`-y`. And the manager's cache still held the size of the window each relaunch replaced, which matched the box, so `resizeSessions` skipped the new pane on every poll; only an attach, which drops the cache entry, ever corrected it.

Keying the cache on the pane process rather than on the agent launch stamp keeps two neighbours intact: a revive inside a surviving pane keeps its process and its scrollback, so its taller height is left alone (#369), and rows that predate launch stamping work the same as any other.

## Verified

- `env -u TMUX TMUX_TMPDIR=<private dir> go test ./...` green, `go vet ./...` and `gofmt -l .` clean.
- New tests: a relaunched session is pinned to the exact box whether it was born at 80x24 or taller than the box; a refresh and a terminal resize both publish the box; headless create, revive and terminal create open at the recorded box; a junk `pane_size` value is refused. Each fails without the fix (`window = 80x24, want 82x30`, `born 122x50: window = 82x50, want 82x30`, `created pane = 80x24, want 131x47`, `published 0x0`).
- Real binary under a fake HOME on an isolated tmux socket, TUI in a 200x50 terminal: the store held `pane_size|138x42` before any session existed; a CLI `spawn` opened its pane at 138x41 straight away; with the setting deleted to recreate the old conditions, a CLI `revive` brought a killed session back at 80x24 and the running manager re-pinned it to 138x41 within 3s (`window-size manual`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * New, revived, and recreated terminal panes now open using the manager’s current dimensions instead of default sizing.
  * Relaunched sessions are automatically resized to match the preview panel.
  * Pane dimensions remain synchronized after window resizing and refreshes.
  * Pane sizing is preserved across session restarts and terminal recreation.
  * Invalid pane-size settings are rejected rather than applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->