### PR TITLE
fix(ui): let Left leave focus when pi hides its cursor

### DIFF
--- a/internal/ui/focuskeys.go
+++ b/internal/ui/focuskeys.go
@@ -168,12 +168,17 @@ func (m *Model) focusSelected() (tea.Model, tea.Cmd) {
 // composer row instead: the placeholder being on screen is the evidence
 // the composer is empty and its caret at the head of the prompt; a draft
 // replaces the placeholder and Left belongs to the agent.
+//
+// A zero-width input_prefix declares a bare composer row (pi's). Its
+// painted cursor is the only thing locating that row, so tmux's position
+// stays meaningful when the application hides the terminal cursor.
 func (m *Model) caretAtInputStart(sessID, tool string) bool {
 	if m.engine == nil || m.pane.forID != sessID || m.scrolledBack() {
 		return false
 	}
+	_, bareInput := m.engine.InputPrefix(tool, "")
 	caretCellKnown := m.pane.cursor.ok ||
-		(m.pane.cursor.positionOK && m.engine.ParksItsCaret(tool))
+		(m.pane.cursor.positionOK && (m.engine.ParksItsCaret(tool) || bareInput))
 	if !caretCellKnown {
 		return false
 	}

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -664,6 +664,7 @@ func TestCaretAtInputStart(t *testing.T) {
 		{"tool without a marker", "unmarked", paneCursor{x: 2, y: 0, ok: true}, []string{"❯"}, false},
 		{"unknown tool", "nosuch", paneCursor{x: 2, y: 0, ok: true}, []string{"❯"}, false},
 		{"no cursor report", "claude", paneCursor{x: 2, y: 1}, []string{"output", "❯"}, false},
+		{"hidden cursor on marked prompt", "claude", paneCursor{x: 2, y: 1, positionOK: true}, []string{"output", "❯"}, false},
 		{"cursor row past the capture", "claude", paneCursor{x: 2, y: 9, ok: true}, []string{"❯"}, false},
 	}
 	for _, c := range cases {
@@ -685,11 +686,11 @@ func TestCaretAtInputStartMeasuresMarkerInCells(t *testing.T) {
 	}
 }
 
-// pi composes on a bare row between rules and marks the caret cell with a
-// reverse-video space, so the captured row strips to one blank at column
-// zero (shapes taken from a live pane). Its zero-width prefix reads that as
-// the prompt head; text before the caret, or a wrapped line continuing from
-// above, keeps Left with the agent.
+// pi composes on a bare row between rules, hides the terminal cursor and
+// paints its own reverse-video caret. tmux still reports the right cell, so
+// its zero-width prefix can read the hidden position as the prompt head;
+// text before it, or a wrapped line continuing from above, keeps Left with
+// the agent.
 func TestCaretOnPisBareComposerRow(t *testing.T) {
 	engine, err := status.NewEngine(config.Config{Tools: map[string]config.Tool{
 		"pi": {
@@ -704,7 +705,7 @@ func TestCaretOnPisBareComposerRow(t *testing.T) {
 		m := &Model{engine: engine, mode: modeFocus}
 		m.preview = strings.Join(rows, "\n") + "\n"
 		m.pane.forID = "s1"
-		m.pane.cursor = paneCursor{x: x, y: y, ok: true}
+		m.pane.cursor = paneCursor{x: x, y: y, positionOK: true}
 		return m
 	}
 
@@ -893,9 +894,17 @@ func TestFocusLeftUnfocusesOnPiBlankComposerRow(t *testing.T) {
 	}
 	sess := m.rows[m.cursor].sess
 	m.rows[m.cursor].sess.Tool = "pi-tool"
-	m.pane.forID = sess.ID
-	m.pane.cursor = paneCursor{x: 2, y: 1, ok: true}
-	m.preview = "────────────\nxy\n────────────\n"
+	setHiddenPane := func(x int, preview string) {
+		updated, _ := m.Update(focusPreviewMsg{
+			sessID: sess.ID, preview: preview,
+			cursorX: x, cursorY: 1, paneStateOK: true,
+		})
+		*m = *updated.(*Model)
+		if m.pane.cursor.ok || !m.pane.cursor.positionOK {
+			t.Fatalf("hidden pi cursor state = %+v, want known position without a visible cursor", m.pane.cursor)
+		}
+	}
+	setHiddenPane(2, "────────────\nxy\n────────────\n")
 
 	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
 	*m = *updated.(*Model)
@@ -903,8 +912,7 @@ func TestFocusLeftUnfocusesOnPiBlankComposerRow(t *testing.T) {
 		t.Fatalf("left inside typed pi input left focus, mode = %v", m.mode)
 	}
 
-	m.preview = "────────────\n\n────────────\n"
-	m.pane.cursor = paneCursor{x: 0, y: 1, ok: true}
+	setHiddenPane(0, "────────────\n\n────────────\n")
 	updated, _ = m.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
 	*m = *updated.(*Model)
 	if m.mode != modeList {

--- a/internal/ui/focuswatch_test.go
+++ b/internal/ui/focuswatch_test.go
@@ -275,6 +275,9 @@ func TestFocusWatchHonorsHiddenCursor(t *testing.T) {
 			if !preview.paneStateOK || preview.cursorOK {
 				continue
 			}
+			if preview.cursorX != len("hidden-cursor") || preview.cursorY != 0 {
+				t.Fatalf("hidden cursor position = %d,%d", preview.cursorX, preview.cursorY)
+			}
 			return
 		case <-deadline:
 			t.Fatal("no hidden-cursor preview reported the cursor hidden")


### PR DESCRIPTION
## What changed

Andreas Spannagel's (@pandysp) commit from #446, rebased onto main with his authorship kept. A zero-width `input_prefix` now lets a hidden but known cursor position count as the caret cell, so pi's bare composer row can tell an empty input from a draft when pi hides the terminal cursor.

## Why

pi hides the terminal cursor and paints its own. #437 kept tmux's coordinates for hidden cursors but only let tools that park a caret use them, and pi has no composer placeholder, so Left was still forwarded on an empty pi input. #446 was stacked on the #437 branch and closed when that branch was deleted at merge; maintainer edits are off on it, so it lands from this branch.

## How it was verified

- `gofmt -l .` prints nothing
- `go vet ./...` passes
- `internal/ui` passes on the isolated tmux socket, including the pi bare-row and hidden-cursor cases
- Live verification against pi 0.85.0 is recorded in #446

Supersedes #446.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard focus detection for composer inputs when the terminal cursor is hidden.
  - Bare composer rows with a known cursor position are now recognized correctly, including empty and typed inputs.
  - Focus handling is more reliable for marked prompts and other interfaces that temporarily hide the cursor.
  - Cursor positioning is now validated more accurately when the cursor is hidden, reducing focus-related inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->