### PR TITLE
docs(feed): announce v0.36.0

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "keys-are-yours-v0360",
+    "banner": "new: every key is configurable",
+    "title": "v0.36.0: set your own keys, and tell us which defaults should change",
+    "body": [
+      "[keybindings.session] and [keybindings.list] in config.toml name every key the manager answers to.",
+      "The keybindings row in Settings opens a picker; r puts the shipped keys back.",
+      "Focus mode keeps up with a streaming pane, and Left leaves Command Code and pi again when they hide the cursor.",
+      "A notification click lands on the session that sent it, on macOS, Linux and WSL.",
+      "Which default keys got in your way? Say so in discussion #455, that thread decides what changes.",
+      "Update with `agent-manager update`, `brew upgrade yoanwai/tap/agent-manager`, or your package manager."
+    ],
+    "url": "https://github.com/YoanWai/agent-manager/discussions/454",
+    "max_version": "0.36.0"
+  },
+  {
     "id": "full-screen-sessions",
     "banner": "new: the session list can take the whole terminal",
     "title": "Full-screen sessions, with rows that read as a conversation",


### PR DESCRIPTION
## What changed

One entry at the top of docs/messages.json for v0.36.0: it links the Announcements discussion (#454), points people at the key bindings thread (#455), and retires at max_version 0.36.0.

## Why

Running installs read the feed every 10 minutes; without an entry the release conversation has no way in from the app.

## How it was verified

- TestShippedFeedFileIsRenderableAndRetires passes against the edited file
- every body line under 120 chars, banner 30, title 68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release messaging for version 0.36.0.
  - Documented configurable keybindings and the keybindings picker.
  - Described focus-mode behavior and navigation when notifications are clicked.
  - Added update instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->