### PR TITLE
docs(feed): send the v0.36.0 entry to the key bindings thread

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -8,10 +8,10 @@
       "The keybindings row in Settings opens a picker; r puts the shipped keys back.",
       "Focus mode keeps up with a streaming pane, and Left leaves Command Code and pi again when they hide the cursor.",
       "A notification click lands on the session that sent it, on macOS, Linux and WSL.",
-      "Which default keys got in your way? Say so in discussion #455, that thread decides what changes.",
+      "Which default keys got in your way? Say so in the discussion this entry opens, that thread decides what changes.",
       "Update with `agent-manager update`, `brew upgrade yoanwai/tap/agent-manager`, or your package manager."
     ],
-    "url": "https://github.com/YoanWai/agent-manager/discussions/454",
+    "url": "https://github.com/YoanWai/agent-manager/discussions/455",
     "max_version": "0.36.0"
   },
   {


### PR DESCRIPTION
## What changed

The v0.36.0 feed entry now opens discussion #455, the key bindings thread, and its body names that thread instead of a number.

## Why

One discussion per release. The auto-created announcement (#454) duplicated the release page and was deleted, so the entry points at the thread where the defaults are being decided.

## How it was verified

- TestShippedFeedFileIsRenderableAndRetires passes
- body line 5 is 112 chars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the first changelog entry’s wording and link to reference the correct discussion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->