### PR TITLE
chore(release): open a release discussion only when there is one to write

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,7 +31,6 @@ changelog:
   use: github-native
 
 release:
-  discussion_category_name: Announcements
   header: |
     Run every AI coding agent from one terminal. Claude Code, Codex, OpenCode, Grok, Gemini CLI, and Pi run side by side, each in its own tmux session, with live status, a project tree, quick prompts, and full-file diff review. Runs on macOS and Linux, and on Windows inside WSL2. [See it running](https://github.com/YoanWai/agent-manager#agent-manager).
 


### PR DESCRIPTION
## What changed

`release.discussion_category_name` is gone from `.goreleaser.yaml`, so publishing a release no longer opens an Announcements discussion.

## Why

v0.36.0 ended up with two threads: the auto-created copy of the release body (#454, since deleted) and the key bindings thread (#455) that was actually worth discussing. A release gets a hand-written discussion when it has something to talk about, and none otherwise; the feed entry links wherever that conversation is.

## How it was verified

- `goreleaser check` passes on the edited config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * GitHub releases will no longer be associated with the “Announcements” discussion category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->