### PR TITLE
fix(review): show changed hunks for oversized files

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,13 +1,14 @@
-// Package diff builds whole-file line models for changed files: every
-// line of the new file with deletions interleaved, ready to render with
-// changed lines highlighted in full context.
+// Package diff builds line models for changed files, using full-file
+// context for small files and changed hunks for large ones.
 package diff
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/YoanWai/agent-manager/internal/git"
 	udiff "github.com/aymanbagabas/go-udiff"
@@ -20,6 +21,7 @@ const (
 	Same LineKind = iota
 	Add
 	Del
+	Gap // a marker standing in for lines the hunk model left out
 )
 
 // Span marks a changed byte range within a line's text.
@@ -61,8 +63,20 @@ type Set struct {
 }
 
 const (
-	maxFileBytes = 1 << 20
-	maxFileLines = 10000
+	// Past either threshold the whole-file model would be too big to build
+	// or to scroll, so the file falls back to changed hunks with a little
+	// context around them.
+	maxWholeFileBytes = 1 << 20
+	maxWholeFileLines = 10000
+
+	maxHunkModelLines = 10000
+	maxHunkLineBytes  = 4096
+	hunkContext       = 3
+
+	// Past this a file is not diffed at all: reading, diffing and holding
+	// both sides costs several copies of the file.
+	maxDiffBytes = 32 << 20
+
 	maxSpanLine  = 1000
 	maxSpanBlock = 200
 )
@@ -208,7 +222,7 @@ func loadFile(driver *git.Driver, root string, scope git.Scope, baseRef string, 
 		fd.Binary = true
 		return
 	}
-	if len(oldContent) > maxFileBytes || len(newContent) > maxFileBytes {
+	if len(oldContent) > maxDiffBytes || len(newContent) > maxDiffBytes {
 		fd.Truncated = true
 		return
 	}
@@ -273,27 +287,45 @@ func fileSides(driver *git.Driver, root string, scope git.Scope, baseRef string,
 	return oldContent, newContent, nil
 }
 
-// BuildFile diffs two file versions into the whole-file line model:
-// every new-file line in order, with deleted old lines interleaved
-// ahead of the lines that replaced them.
+// BuildFile interleaves deletions with new-file lines. Large files show
+// only changed hunks, with gap markers for omitted context.
 func BuildFile(oldContent, newContent []byte, file git.ChangedFile, stat git.FileStat) FileDiff {
 	fd := FileDiff{File: file, Stat: stat, loaded: true}
-	oldText, oldTruncated := capLines(string(oldContent))
-	newText, newTruncated := capLines(string(newContent))
-	fd.Truncated = oldTruncated || newTruncated
+	oldText, newText := string(oldContent), string(newContent)
+	fd.OldTotal, fd.NewTotal = countLines(oldText), countLines(newText)
+
+	hunksOnly := len(oldText) > maxWholeFileBytes || len(newText) > maxWholeFileBytes ||
+		fd.OldTotal > maxWholeFileLines || fd.NewTotal > maxWholeFileLines
+	context := maxWholeFileLines * 2
+	if hunksOnly {
+		context = hunkContext
+	}
 
 	edits := udiff.Lines(oldText, newText)
-	unified, err := udiff.ToUnifiedDiff("a", "b", oldText, edits, maxFileLines*2)
+	unified, err := udiff.ToUnifiedDiff("a", "b", oldText, edits, context)
 	if err != nil {
 		fd.Err = err
 		return fd
 	}
 
-	oldNum, newNum := 0, 0
+	reached := 0
+hunks:
 	for _, hunk := range unified.Hunks {
+		if skipped := hunk.ToLine - 1 - reached; hunksOnly && skipped > 0 {
+			fd.Lines = append(fd.Lines, gapLine(fmt.Sprintf("⋯ %d unchanged lines", skipped)))
+		}
+		oldNum, newNum := hunk.FromLine-1, hunk.ToLine-1
 		for _, hunkLine := range hunk.Lines {
+			if hunksOnly && len(fd.Lines) >= maxHunkModelLines {
+				fd.Lines = append(fd.Lines[:maxHunkModelLines], gapLine("⋯ diff truncated"))
+				fd.Truncated = true
+				break hunks
+			}
 			text := strings.TrimSuffix(hunkLine.Content, "\n")
 			text = strings.ReplaceAll(strings.TrimSuffix(text, "\r"), "\t", "    ")
+			if hunksOnly {
+				text = capLine(text)
+			}
 			switch hunkLine.Kind {
 			case udiff.Equal:
 				oldNum++
@@ -307,29 +339,47 @@ func BuildFile(oldContent, newContent []byte, file git.ChangedFile, stat git.Fil
 				fd.Lines = append(fd.Lines, Line{Kind: Add, NewNum: newNum, Text: text, Pair: -1})
 			}
 		}
+		reached = newNum
 	}
-	// A no-context diff of an unchanged file yields no hunks; equal-only
-	// content still needs the full file present.
-	if len(unified.Hunks) == 0 && newText != "" {
+	if skipped := fd.NewTotal - reached; hunksOnly && !fd.Truncated && skipped > 0 {
+		fd.Lines = append(fd.Lines, gapLine(fmt.Sprintf("⋯ %d unchanged lines", skipped)))
+	}
+	// Unchanged small files still show their full content.
+	if !hunksOnly && len(unified.Hunks) == 0 && newText != "" {
 		for i, text := range strings.Split(strings.TrimSuffix(newText, "\n"), "\n") {
 			clean := strings.ReplaceAll(strings.ReplaceAll(text, "\r", ""), "\t", "    ")
 			fd.Lines = append(fd.Lines, Line{Kind: Same, OldNum: i + 1, NewNum: i + 1, Text: clean, Pair: -1})
 		}
 	}
-	fd.OldTotal = oldNum
-	fd.NewTotal = newNum
 	pairBlocks(&fd)
 	markChanges(&fd)
 	return fd
 }
 
-func capLines(text string) (string, bool) {
-	count := strings.Count(text, "\n")
-	if count <= maxFileLines {
-		return text, false
+func gapLine(text string) Line { return Line{Kind: Gap, Text: text, Pair: -1} }
+
+func countLines(text string) int {
+	if text == "" {
+		return 0
 	}
-	lines := strings.SplitAfterN(text, "\n", maxFileLines+1)
-	return strings.Join(lines[:maxFileLines], ""), true
+	count := strings.Count(text, "\n")
+	if !strings.HasSuffix(text, "\n") {
+		count++
+	}
+	return count
+}
+
+// capLine keeps one minified or data line from wrapping into thousands of
+// visual rows.
+func capLine(text string) string {
+	if len(text) <= maxHunkLineBytes {
+		return text
+	}
+	cut := maxHunkLineBytes
+	for cut > 0 && !utf8.RuneStart(text[cut]) {
+		cut--
+	}
+	return text[:cut] + "…"
 }
 
 // pairBlocks matches runs of deletions with the additions that follow
@@ -404,6 +454,10 @@ func wordSpans(dmp *diffmatchpatch.DiffMatchPatch, oldLine, newLine string) (old
 func markChanges(fd *FileDiff) {
 	previous := Same
 	for i, line := range fd.Lines {
+		if line.Kind == Gap {
+			previous = Same
+			continue
+		}
 		if line.Kind != Same && previous == Same {
 			fd.Changes = append(fd.Changes, i)
 		}
@@ -423,7 +477,7 @@ func (fd *FileDiff) SideBySideRows() []Row {
 	i := 0
 	for i < len(fd.Lines) {
 		line := fd.Lines[i]
-		if line.Kind == Same {
+		if line.Kind != Add && line.Kind != Del {
 			fd.rows = append(fd.rows, Row{i, i})
 			i++
 			continue

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/YoanWai/agent-manager/internal/git"
 	"golang.org/x/sys/unix"
@@ -197,13 +198,13 @@ func linesOf(count int) string {
 	return b.String()
 }
 
-// Regression guard: the capped model would report maxFileLines here.
+// Regression guard: the capped model would report maxWholeFileLines here.
 func TestUntrackedFileOverLineCapCountsTrueLines(t *testing.T) {
 	driver, dir := testRepo(t)
 	write(t, dir, "tracked.go", "package a\n")
 	commit(t, dir, "init")
 
-	const total = maxFileLines + 2000
+	const total = maxWholeFileLines + 2000
 	write(t, dir, "huge.txt", linesOf(total))
 
 	set, err := BuildSet(driver, dir, git.ScopeUncommitted, "")
@@ -225,21 +226,22 @@ func TestUntrackedFileOverLineCapCountsTrueLines(t *testing.T) {
 		t.Fatal("huge.txt stat should be known")
 	}
 	if huge.Stat.Adds != total {
-		t.Errorf("huge.txt adds = %d, want %d (the capped model would say %d)", huge.Stat.Adds, total, maxFileLines)
+		t.Errorf("huge.txt adds = %d, want %d (the capped model would say %d)", huge.Stat.Adds, total, maxWholeFileLines)
 	}
 	if !huge.Truncated {
 		t.Error("huge.txt should still be marked truncated for display")
 	}
 }
 
-// Regression guard: the byte cap stops the diff model, not the count.
-func TestUntrackedFileOverByteCapStillCounts(t *testing.T) {
+// Regression guard: a file past the whole-file byte threshold still counts
+// its lines, and still diffs through the hunk model.
+func TestUntrackedFileOverByteThresholdStillCounts(t *testing.T) {
 	driver, dir := testRepo(t)
 	write(t, dir, "tracked.go", "package a\n")
 	commit(t, dir, "init")
 
 	line := strings.Repeat("x", 200) + "\n"
-	total := (maxFileBytes / len(line)) + 500
+	total := (maxWholeFileBytes / len(line)) + 500
 	write(t, dir, "wide.txt", strings.Repeat(line, total))
 
 	set, err := BuildSet(driver, dir, git.ScopeUncommitted, "")
@@ -263,15 +265,17 @@ func TestUntrackedFileOverByteCapStillCounts(t *testing.T) {
 	if wide.Stat.Adds != total {
 		t.Errorf("wide.txt adds = %d, want %d", wide.Stat.Adds, total)
 	}
-	if !wide.Truncated {
-		t.Error("wide.txt should be marked too large to diff")
+	if len(wide.Lines) == 0 {
+		t.Error("wide.txt should still diff through the hunk model")
 	}
 }
 
-// Invariant: numstat wins; the truncated model must not overwrite it.
-func TestTruncatedTrackedFileKeepsNumstat(t *testing.T) {
+// Invariant: numstat wins; the hunk model must not overwrite it. The edit
+// sits past the whole-file line threshold, so it is only visible at all
+// because the file falls back to hunks.
+func TestHunkModelKeepsNumstat(t *testing.T) {
 	driver, dir := testRepo(t)
-	const total = maxFileLines + 2000
+	const total = maxWholeFileLines + 2000
 	write(t, dir, "big.txt", linesOf(total))
 	commit(t, dir, "init")
 
@@ -295,6 +299,87 @@ func TestTruncatedTrackedFileKeepsNumstat(t *testing.T) {
 	}
 	if big.Stat.Adds != 1 || big.Stat.Dels != 1 {
 		t.Errorf("big.txt stat = %+v, want 1 add 1 del from numstat", big.Stat)
+	}
+	if !hasLine(big, Add, "line 11000 edited") {
+		t.Error("the edited line past the line threshold should be in the model")
+	}
+}
+
+func hasLine(fd FileDiff, kind LineKind, text string) bool {
+	for _, line := range fd.Lines {
+		if line.Kind == kind && line.Text == text {
+			return true
+		}
+	}
+	return false
+}
+
+// A big file with one small edit shows that edit with its real line numbers,
+// the context around it, and gap markers for everything left out.
+func TestHunkModelKeepsRealLineNumbers(t *testing.T) {
+	const total = maxWholeFileLines + 2000
+	oldText := linesOf(total)
+	newText := strings.Replace(oldText, "line 11000\n", "line 11000 edited\n", 1)
+	fd := buildTestFile(t, oldText, newText)
+
+	if fd.Truncated {
+		t.Error("a small edit in a big file fits the hunk model")
+	}
+	if fd.OldTotal != total || fd.NewTotal != total {
+		t.Errorf("totals = %d/%d, want %d", fd.OldTotal, fd.NewTotal, total)
+	}
+	if len(fd.Lines) > 2*hunkContext+4 {
+		t.Errorf("model = %d lines, want one small hunk", len(fd.Lines))
+	}
+	if fd.Lines[0].Kind != Gap {
+		t.Errorf("first line = %v, want a gap for the skipped head", fd.Lines[0].Kind)
+	}
+	var edited *Line
+	for i := range fd.Lines {
+		if fd.Lines[i].Kind == Add {
+			edited = &fd.Lines[i]
+		}
+	}
+	if edited == nil {
+		t.Fatal("the edit is missing from the model")
+	}
+	// linesOf numbers from zero, so "line 11000" is the file's 11001st line.
+	const wantNum = 11001
+	if edited.NewNum != wantNum {
+		t.Errorf("edited line number = %d, want %d", edited.NewNum, wantNum)
+	}
+	if len(fd.Changes) != 1 {
+		t.Errorf("changes = %v, want one jump target", fd.Changes)
+	}
+}
+
+// A file whose hunks outgrow the model is cut off with a marker rather than
+// building a model no one can scroll.
+func TestHunkModelCapsAndMarksTruncation(t *testing.T) {
+	const total = maxHunkModelLines + 2000
+	fd := buildTestFile(t, "", linesOf(total))
+
+	if !fd.Truncated {
+		t.Error("a model over the cap is truncated")
+	}
+	if len(fd.Lines) != maxHunkModelLines+1 {
+		t.Errorf("model = %d lines, want the cap plus a marker", len(fd.Lines))
+	}
+	last := fd.Lines[len(fd.Lines)-1]
+	if last.Kind != Gap {
+		t.Errorf("last line = %v, want a gap marker", last.Kind)
+	}
+}
+
+// A minified line would otherwise wrap into thousands of visual rows.
+func TestHunkModelCapsLongLines(t *testing.T) {
+	oldText := strings.Repeat("x", maxWholeFileBytes+10) + "\n"
+	fd := buildTestFile(t, oldText, oldText+"tail\n")
+
+	for _, line := range fd.Lines {
+		if len(line.Text) > maxHunkLineBytes+len("…") {
+			t.Fatalf("line kept %d bytes, want it capped", len(line.Text))
+		}
 	}
 }
 
@@ -500,5 +585,52 @@ func TestBuildSetBranchBaseOverrideInvalid(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no-such-ref") {
 		t.Errorf("error must name the ref, got %q", err)
+	}
+}
+
+func TestHunkModelUnchangedLargeFile(t *testing.T) {
+	for _, text := range []string{linesOf(maxWholeFileLines + 1), strings.Repeat("x", maxWholeFileBytes+1)} {
+		fd := buildTestFile(t, text, text)
+		if len(fd.Lines) != 1 || fd.Lines[0].Kind != Gap || fd.Truncated || len(fd.Changes) != 0 {
+			t.Fatalf("unchanged large file should show only an unchanged-lines marker: %+v", fd)
+		}
+	}
+}
+
+func TestHunkModelMultipleHunks(t *testing.T) {
+	for _, newline := range []string{"\n", "\r\n"} {
+		t.Run(fmt.Sprintf("newline-%q", newline), func(t *testing.T) {
+			oldText := strings.ReplaceAll(linesOf(12000), "\n", newline)
+			newText := "inserted" + newline + oldText
+			newText = strings.Replace(newText, "line 6000"+newline, "", 1)
+			newText = strings.TrimSuffix(newText, newline) + newline + "tail"
+			fd := buildTestFile(t, oldText, newText)
+			oldLines := strings.Split(strings.TrimSuffix(oldText, newline), newline)
+			newLines := strings.Split(newText, newline)
+			gaps := 0
+			for _, line := range fd.Lines {
+				if line.Kind == Gap {
+					gaps++
+					continue
+				}
+				if line.OldNum > 0 && oldLines[line.OldNum-1] != line.Text {
+					t.Fatalf("old line number drifted: %+v", line)
+				}
+				if line.NewNum > 0 && newLines[line.NewNum-1] != line.Text {
+					t.Fatalf("new line number drifted: %+v", line)
+				}
+			}
+			if gaps != 2 || len(fd.Changes) != 3 || fd.OldTotal != 12000 || fd.NewTotal != 12001 {
+				t.Fatalf("gaps=%d changes=%v totals=%d/%d", gaps, fd.Changes, fd.OldTotal, fd.NewTotal)
+			}
+		})
+	}
+}
+
+func TestHunkModelLineCapPreservesUTF8(t *testing.T) {
+	text := strings.Repeat("界", maxWholeFileBytes/3+1)
+	fd := buildTestFile(t, "", text)
+	if len(fd.Lines) != 1 || !utf8.ValidString(fd.Lines[0].Text) || !strings.HasSuffix(fd.Lines[0].Text, "…") {
+		t.Fatal("capped line must preserve complete Unicode characters and show an ellipsis")
 	}
 }

--- a/internal/ui/diffrender.go
+++ b/internal/ui/diffrender.go
@@ -42,11 +42,11 @@ func brightCommentStyle() *chroma.Style {
 	return style
 }
 
-// fileHL holds one file's syntax-highlighted lines per side, indexed by
-// OldNum/NewNum minus one.
+// fileHL holds one file's syntax-highlighted lines, indexed the same way
+// as the diff's own line model: a hunk-only model skips file lines, so a
+// line's number is not its position.
 type fileHL struct {
-	oldLines []string
-	newLines []string
+	lines []string
 }
 
 type hlKey struct {
@@ -105,15 +105,45 @@ func highlightFile(fd *diff.FileDiff) *fileHL {
 		return &fileHL{}
 	}
 	lexer = chroma.Coalesce(lexer)
-	return &fileHL{
-		oldLines: highlightSide(lexer, oldText),
-		newLines: highlightSide(lexer, newText),
+	return &fileHL{lines: alignSides(fd, highlightSide(lexer, oldText), highlightSide(lexer, newText))}
+}
+
+// alignSides walks the model in the order sideTexts wrote the two sides,
+// pairing every line with its highlighted text.
+func alignSides(fd *diff.FileDiff, oldLines, newLines []string) []string {
+	lines := make([]string, len(fd.Lines))
+	oldIdx, newIdx := 0, 0
+	for i, line := range fd.Lines {
+		switch line.Kind {
+		case diff.Gap:
+			continue
+		case diff.Del:
+			if oldIdx < len(oldLines) {
+				lines[i] = oldLines[oldIdx]
+			}
+			oldIdx++
+		case diff.Add:
+			if newIdx < len(newLines) {
+				lines[i] = newLines[newIdx]
+			}
+			newIdx++
+		default:
+			if newIdx < len(newLines) {
+				lines[i] = newLines[newIdx]
+			}
+			oldIdx++
+			newIdx++
+		}
 	}
+	return lines
 }
 
 func sideTexts(fd *diff.FileDiff) (oldText, newText string) {
 	var oldBuilder, newBuilder strings.Builder
 	for _, line := range fd.Lines {
+		if line.Kind == diff.Gap {
+			continue
+		}
 		text := escapeControls(line.Text)
 		if line.Kind != diff.Add {
 			oldBuilder.WriteString(text)
@@ -150,15 +180,12 @@ func highlightSide(lexer chroma.Lexer, text string) []string {
 
 // hlLine returns the highlighted text for a diff line, falling back to
 // the raw text when highlighting is unavailable.
-func (hl *fileHL) hlLine(line diff.Line) string {
-	if hl != nil {
-		if line.Kind == diff.Del {
-			if line.OldNum >= 1 && line.OldNum <= len(hl.oldLines) {
-				return hl.oldLines[line.OldNum-1]
-			}
-		} else if line.NewNum >= 1 && line.NewNum <= len(hl.newLines) {
-			return hl.newLines[line.NewNum-1]
-		}
+func (hl *fileHL) hlLine(line diff.Line, index int) string {
+	if line.Kind == diff.Gap {
+		return mutedStyle.Render(escapeControls(line.Text))
+	}
+	if hl != nil && index < len(hl.lines) && hl.lines[index] != "" {
+		return hl.lines[index]
 	}
 	return escapeControls(line.Text)
 }
@@ -451,7 +478,7 @@ func (m *Model) renderDiffRow(fd *diff.FileDiff, hl *fileHL, index, width int, c
 	if textWidth < 4 {
 		textWidth = 4
 	}
-	textRows := wrapTinted(hl.hlLine(line), escapeSpans(line.Text, line.Spans), baseBg, spanBg, textWidth)
+	textRows := wrapTinted(hl.hlLine(line, index), escapeSpans(line.Text, line.Spans), baseBg, spanBg, textWidth)
 
 	marker := " "
 	if len(m.annotationsAt(fd.File.Path, line)) > 0 {
@@ -962,7 +989,7 @@ func (m *Model) renderSideCell(fd *diff.FileDiff, hl *fileHL, index, width int, 
 	if textWidth < 4 {
 		textWidth = 4
 	}
-	textRows := wrapTinted(hl.hlLine(line), escapeSpans(line.Text, line.Spans), baseBg, spanBg, textWidth)
+	textRows := wrapTinted(hl.hlLine(line, index), escapeSpans(line.Text, line.Spans), baseBg, spanBg, textWidth)
 	blankGutter := strings.Repeat(" ", gutterWidth)
 	out := make([]string, len(textRows))
 	for i, text := range textRows {

--- a/internal/ui/diffrender.go
+++ b/internal/ui/diffrender.go
@@ -153,6 +153,9 @@ func sideTexts(fd *diff.FileDiff) (oldText, newText string) {
 			newBuilder.WriteString(text)
 			newBuilder.WriteByte('\n')
 		}
+		if oldBuilder.Len()+newBuilder.Len() > maxHighlightBytes {
+			break
+		}
 	}
 	return oldBuilder.String(), newBuilder.String()
 }

--- a/internal/ui/diffrender_test.go
+++ b/internal/ui/diffrender_test.go
@@ -314,3 +314,13 @@ func TestReviewHeaderShowsCodeOnlyFilter(t *testing.T) {
 		t.Fatalf("header should drop the lock file's totals, got %q", header)
 	}
 }
+
+func BenchmarkHighlightLargeHunkModel(b *testing.B) {
+	fd := diff.BuildFile(nil, []byte(strings.Repeat(strings.Repeat("x", 4000)+"\n", 8000)),
+		git.ChangedFile{Path: "large.txt", Status: git.Added}, git.FileStat{})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		highlightFile(&fd)
+	}
+}

--- a/internal/ui/diffrender_test.go
+++ b/internal/ui/diffrender_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -123,15 +124,75 @@ func TestHighlightFileBothSides(t *testing.T) {
 		[]byte("package a\n\nfunc A() int { return 1 }\n"),
 		git.ChangedFile{Path: "a.go", OldPath: "a.go", Status: git.Modified}, git.FileStat{})
 	hl := highlightFile(&fd)
-	if hl == nil || len(hl.newLines) != 3 || len(hl.oldLines) != 3 {
-		t.Fatalf("hl sides = %d/%d", len(hl.oldLines), len(hl.newLines))
+	if hl == nil || len(hl.lines) != len(fd.Lines) {
+		t.Fatalf("hl lines = %d, want %d", len(hl.lines), len(fd.Lines))
 	}
-	if !strings.Contains(hl.newLines[0], "\x1b[") {
-		t.Fatalf("go source should highlight: %q", hl.newLines[0])
+	if !strings.Contains(hl.lines[0], "\x1b[") {
+		t.Fatalf("go source should highlight: %q", hl.lines[0])
 	}
-	for _, line := range fd.Lines {
-		if ansi.Strip(hl.hlLine(line)) != line.Text {
-			t.Fatalf("highlight text drifted: %q vs %q", ansi.Strip(hl.hlLine(line)), line.Text)
+	assertHighlightMatchesText(t, &fd, hl)
+}
+
+// A hunk-only model skips file lines, so highlighting keyed by line number
+// would colour every line after the first gap with another line's tokens.
+func TestHighlightFileHunkModel(t *testing.T) {
+	fd := bigEditedFile(t)
+	if fd.Lines[0].Kind != diff.Gap {
+		t.Fatalf("want a hunk model opening with a gap, got %d lines", len(fd.Lines))
+	}
+	hl := highlightFile(&fd)
+	if !strings.Contains(strings.Join(hl.lines, ""), "\x1b[") {
+		t.Fatal("go source should highlight")
+	}
+	assertHighlightMatchesText(t, &fd, hl)
+}
+
+// The point of the hunk model: one edit deep inside a file too big for the
+// whole-file model still reaches the screen.
+func TestReviewRendersHunksForBigFile(t *testing.T) {
+	fd := bigEditedFile(t)
+	m := &Model{
+		width: 100, height: 30, mode: modeDiff,
+		diff: diffState{active: true, sessID: "s", hl: newHLCache(), set: diff.Set{Files: []diff.FileDiff{fd}}},
+	}
+	for _, split := range []bool{false, true} {
+		m.diff.sideBySide = split
+		code := ansi.Strip(m.viewDiffCode(160, 20))
+		if !strings.Contains(code, `var name11000 = "edited"`) || !strings.Contains(code, "11002") {
+			t.Fatalf("split=%v: the edit and its line number should render, got:\n%s", split, code)
+		}
+		if !strings.Contains(code, "⋯") {
+			t.Fatalf("split=%v: skipped lines should be marked, got:\n%s", split, code)
+		}
+	}
+}
+
+// bigEditedFile is one edit at line 11002 of a file past the whole-file
+// line threshold, so it can only render through the hunk model.
+func bigEditedFile(t *testing.T) diff.FileDiff {
+	t.Helper()
+	var oldText strings.Builder
+	oldText.WriteString("package a\n")
+	for i := 0; i < 12000; i++ {
+		fmt.Fprintf(&oldText, "var name%d = %q\n", i, fmt.Sprintf("value %d", i))
+	}
+	newText := strings.Replace(oldText.String(), `var name11000 = "value 11000"`, `var name11000 = "edited"`, 1)
+	fd := diff.BuildFile([]byte(oldText.String()), []byte(newText),
+		git.ChangedFile{Path: "a.go", OldPath: "a.go", Status: git.Modified}, git.FileStat{Adds: 1, Dels: 1})
+	if fd.Err != nil {
+		t.Fatal(fd.Err)
+	}
+	if len(fd.Lines) == 0 {
+		t.Fatal("the hunk model is empty")
+	}
+	return fd
+}
+
+func assertHighlightMatchesText(t *testing.T, fd *diff.FileDiff, hl *fileHL) {
+	t.Helper()
+	for i, line := range fd.Lines {
+		if got := ansi.Strip(hl.hlLine(line, i)); got != line.Text {
+			t.Fatalf("line %d highlight drifted: %q vs %q", i, got, line.Text)
 		}
 	}
 }

--- a/internal/ui/diffview.go
+++ b/internal/ui/diffview.go
@@ -1452,7 +1452,7 @@ func (m *Model) openAnnotate() {
 		return
 	}
 	lineIdx := m.cursorDiffLine()
-	if lineIdx < 0 || lineIdx >= len(fd.Lines) {
+	if lineIdx < 0 || lineIdx >= len(fd.Lines) || fd.Lines[lineIdx].Kind == diff.Gap {
 		return
 	}
 	input := textarea.New()
@@ -1561,6 +1561,9 @@ func (m *Model) reanchorAnnotationsFor(path string) bool {
 		}
 		matches, target := 0, 0
 		for _, line := range fd.Lines {
+			if line.Kind == diff.Gap {
+				continue
+			}
 			num, deleted := annotationLine(line)
 			if deleted == note.deleted && excerptOf(line.Text) == note.excerpt {
 				matches++

--- a/internal/ui/diffview_test.go
+++ b/internal/ui/diffview_test.go
@@ -3399,3 +3399,22 @@ func TestAnnotationsDropControlBytes(t *testing.T) {
 		t.Fatalf("excerpt = %q, want the escape introducer gone", got)
 	}
 }
+
+func TestAnnotateSkipsHunkGaps(t *testing.T) {
+	fd := bigEditedFile(t)
+	m := &Model{diff: diffState{active: true, set: diff.Set{Files: []diff.FileDiff{fd}}}}
+	for _, split := range []bool{false, true} {
+		m.diff.sideBySide = split
+		m.diff.cursorLine = 0
+		m.openAnnotate()
+		if m.diff.annotating {
+			t.Fatalf("split=%v: gap marker must not accept comments", split)
+		}
+		m.diff.cursorLine = 1
+		m.openAnnotate()
+		if !m.diff.annotating {
+			t.Fatalf("split=%v: real context line should accept comments", split)
+		}
+		m.diff.annotating = false
+	}
+}


### PR DESCRIPTION
## What changed

Large files now open in review as changed hunks with three lines of context and markers for omitted unchanged lines. An edit at line 11002 remains visible with its real line number; previously the 10000-line cap removed it before diffing. Text files above 1 MiB can now be reviewed too.

## Why

The old size limits either refused the file or silently removed the very change someone wanted to review.

## Scope

### Required behavior

Keep full-file review for files up to 1 MiB and 10000 lines. Above either threshold, show hunks with correct line numbers, change navigation, syntax-highlight alignment, and comments on real lines in both unified and side-by-side layouts.

### Why this approach

Reuse the existing unified-diff builder with three context lines. Gap rows keep omitted context explicit without changing Git scope loading or introducing a second diff parser. Stop building the display model after 10000 rows and mark truncation; cap oversized-file lines at 4096 bytes on a UTF-8 boundary. Files above 32 MiB still show the size-limit notice. Unchanged oversized files show an unchanged-lines marker. Long lines in otherwise small files retain existing behavior. Highlight text assembly stops when it exceeds the existing 256 KiB combined limit, avoiding large allocations for models that will render without syntax coloring.

The shared review path applies to Claude, OpenCode, Codex, Grok, Gemini, Hermes, Terminal, Pi, and Command Code. There are no provider-specific changes. All four release targets cross-compile (darwin/linux × amd64/arm64); runtime validation was on macOS arm64. Linux, WSL2, and amd64 runtime behavior was not exercised locally; CI supplies Linux coverage. CRLF and LF hunk-numbering cases are tested.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amdscheck go test -race ./...` passes
- [x] `go build ./...` passes
- [x] Ran it against real sessions (automated tmux integration suite)
- [x] Holds for every supported agent CLI and platform, or the description names what it leaves out

Regression coverage includes edits beyond line 10000, multiple hunks with insertions and deletions, full-file stats, UTF-8 truncation, bounded models, unchanged oversized files, highlight alignment, both review layouts, and rejecting comments on gaps. The full baseline suite on `origin/main` and full patched race suite both pass. Socket directories were created before each run; initial runs with nonexistent directories collided on tmux’s fallback socket and were discarded. The preceding session also exercised its initial patch in a real TUI with an isolated 12000-line fixture and a 1.8 MB file; this continuation verified rendered panes directly.

A 32 MB added-file benchmark reduced highlight fallback from 41.9 ms and 160.7 MB allocated per call to 0.37 ms and 1.15 MB. The follow-up fix also passes race tests in both affected packages, vet, build, and formatting checks.

## Visual evidence

![Before and after renderer captures](https://github.com/user-attachments/assets/4dce6e7c-a9b6-4a3a-90d9-eccee2726065)

Image rendered from the before/after terminal-model captures below.

Before/after terminal-renderer captures of the same 12001-line Go file, with ANSI styling stripped for inline review. The before model ends at line 10000, so the edited line cannot be reached.

**Before:**

```text
  1   1   package a
  2   2   var name0 = "value 0"
  3   3   var name1 = "value 1"
  4   4   var name2 = "value 2"
  5   5   var name3 = "value 3"
  6   6   var name4 = "value 4"
  7   7   var name5 = "value 5"
... (the model ends at line 10000; the edit is absent)
```

**After:**

```text
              ⋯ 10998 unchanged lines
10999 10999   var name10997 = "value 10997"
11000 11000   var name10998 = "value 10998"
11001 11001   var name10999 = "value 10999"
11002        −var name11000 = "value 11000"
      11002  +var name11000 = "edited"
11003 11003   var name11001 = "value 11001"
11004 11004   var name11002 = "value 11002"
11005 11005   var name11003 = "value 11003"
              ⋯ 996 unchanged lines
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Large files now display efficiently using changed hunks, gap markers, line limits, and truncation indicators.
  - Line numbers and change statistics remain available for large-file diffs.
  - Long lines are safely shortened while preserving valid text.

- **Bug Fixes**
  - Unchanged large files render as compact gap markers.
  - Comments can no longer be added to separator rows, and annotation placement remains accurate.
  - Unified and side-by-side highlighting correctly handles omitted hunk context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
