### PR TITLE
fix(test): remove the tmux socket file after each harness kill-server

### DIFF
--- a/internal/sessioncmd/session_test.go
+++ b/internal/sessioncmd/session_test.go
@@ -138,6 +138,7 @@ func newSessionHarness(t *testing.T) *sessionHarness {
 			!strings.Contains(string(out), "server exited unexpectedly") {
 			t.Errorf("kill test tmux server: %v: %s", err, strings.TrimSpace(string(out)))
 		}
+		_ = os.Remove(driver.SocketPath())
 		_ = st.Close()
 	})
 	return h
@@ -1034,5 +1035,18 @@ func TestHeadlessLaunchesUseTheManagersPaneSize(t *testing.T) {
 	}
 	if width, height := paneWindowSize(t, h.driver, created.ID); width != 131 || height != 47 {
 		t.Fatalf("revived pane = %dx%d, want 131x47", width, height)
+	}
+}
+
+func TestSessionHarnessCleanupRemovesSocket(t *testing.T) {
+	var socket string
+	t.Run("harness", func(t *testing.T) {
+		socket = newSessionHarness(t).driver.SocketPath()
+	})
+	if socket == "" {
+		t.Skip("tmux not installed")
+	}
+	if _, err := os.Stat(socket); !os.IsNotExist(err) {
+		t.Fatalf("socket %q survived harness cleanup: %v", socket, err)
 	}
 }

--- a/internal/sessioncmd/terminal_test.go
+++ b/internal/sessioncmd/terminal_test.go
@@ -77,6 +77,7 @@ default_status = "idle"
 		if out, err := exec.Command("tmux", "-L", driver.SocketName(), "kill-server").CombinedOutput(); err != nil && !strings.Contains(string(out), "no server running") {
 			t.Errorf("kill test tmux server: %v: %s", err, strings.TrimSpace(string(out)))
 		}
+		_ = os.Remove(driver.SocketPath())
 		_ = st.Close()
 	})
 	return h
@@ -558,5 +559,18 @@ func TestTerminalsCreateUsesTheManagersPaneSize(t *testing.T) {
 	}
 	if width, height := paneWindowSize(t, h.driver, terminal.ID); width != 131 || height != 47 {
 		t.Fatalf("terminal pane = %dx%d, want 131x47", width, height)
+	}
+}
+
+func TestTerminalHarnessCleanupRemovesSocket(t *testing.T) {
+	var socket string
+	t.Run("harness", func(t *testing.T) {
+		socket = newTerminalHarness(t).driver.SocketPath()
+	})
+	if socket == "" {
+		t.Skip("tmux not installed")
+	}
+	if _, err := os.Stat(socket); !os.IsNotExist(err) {
+		t.Fatalf("socket %q survived harness cleanup: %v", socket, err)
 	}
 }


### PR DESCRIPTION
## What

The `sessioncmd` session and terminal harnesses remove their tmux socket file after `kill-server`, and a test per harness asserts the socket is gone once cleanup has run.

## Why

Each harness runs on a fresh UUID-named socket, and `kill-server` stops the server while leaving the socket file in `$TMUX_TMPDIR/tmux-<uid>/`. Every `go test` run therefore added one dead file per harness; 436 (`amsesstest-*` and `amtermtest-*`) had built up on one machine.

## Verified

- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./internal/tmux/ ./internal/sessioncmd/` on `origin/main`: 47 `amsesstest` + 17 `amtermtest` files left behind. On this branch: 0, only the fixed-name sockets remain.
- The two new tests fail on `origin/main` (`socket ".../amsesstest-46c76faf" survived harness cleanup`) and pass with the change.
- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test ./...`: 28 packages ok. `gofmt -l .` empty, `go vet ./...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved terminal session test cleanup by removing temporary socket files after server shutdown.
  * Added coverage confirming socket files are absent after the test harness stops.
  * Applied consistent cleanup checks across session and terminal test environments.
  * Tests now skip applicable checks when the required terminal tooling is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->