### PR TITLE
docs: establish thin wrapper integration principles

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,6 +15,12 @@ Send it. Typos, broken links, a one-line fix, a status rule for a tool you use: 
 
 For a large change (new UI, new keybinding, reworked status detection), an issue first gets you a read on the approach so the work lands the first time. Optional, and worth it.
 
+Follow the [Thin Wrapper Principle](../PRODUCT.md#thin-wrapper-principle): preserve
+each agent TUI's defaults and user configuration, keep shared features generic,
+and avoid integrations that need updates whenever an upstream tool changes.
+For example, a model picker needs reliable dynamic discovery across supported
+tools; a maintained list of model names does not belong in agent-manager.
+
 ## Setup
 
 You need Go 1.26+ and tmux.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,16 @@ for in [REVIEW.md](REVIEW.md). Fill the Scope section of the pull request
 template: a review reads it to tell the change you meant from the change you
 made.
 
+## Product boundary
+
+Keep agent-manager a thin wrapper around the supported TUIs. Preserve upstream
+defaults and user configuration; avoid hardcoded models, version-specific
+behavior, and recreating upstream settings. Apply the
+[Thin Wrapper Principle](PRODUCT.md#thin-wrapper-principle) to every integration,
+including shared controls, capability discovery, and status detection.
+Provider-specific features multiply ongoing maintenance. Supporting a TUI does
+not mean mirroring its feature set; prefer workspace features shared across tools.
+
 ## Build and test
 
 ```bash

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -12,6 +12,20 @@ Developers who run several AI coding agents at once, often inside a dense termin
 
 agent-manager makes many independent agent sessions feel like one dependable workspace. It should reveal which sessions need attention, preserve each agent's context, and make common actions immediate without obscuring the underlying CLIs.
 
+## Thin Wrapper Principle
+
+agent-manager manages the workspace around agent TUIs. Each TUI owns its models, configuration, and interaction. Keep the wrapper generic and give upstream tools as little custom configuration as possible, so their upgrades do not require matching agent-manager releases.
+
+This is a project sustainability constraint. Provider-specific features multiply the maintenance burden across features, providers, and upstream releases. A growing collection of individually useful integrations can become impossible to keep working. Supporting a TUI means making it usable in the workspace; it does not commit agent-manager to exposing every feature that provider offers.
+
+- Prefer workspace features that work across tools with little or no provider-specific code. Evaluate the ongoing cost across all supported providers before adding an integration; ease of implementing the first provider is not enough.
+- Preserve each tool's defaults and the user's configuration. Add launch flags or configuration only when required for session management or explicitly requested by the user; do not choose a model on their behalf.
+- Do not hardcode model names, model catalogs, or other values that change with upstream releases. Leave those choices in the underlying TUI unless a documented, stable interface can discover them dynamically.
+- Design shared controls for all supported TUIs. Dynamic discovery for one tool alone does not justify a shared model selector: establish reliable discovery across the supported tools and how unavailable capabilities are handled before adding the control.
+- Prefer stable, documented interfaces. Avoid version checks, private configuration formats, and parsing human-facing output to recreate upstream settings. If a feature needs those mechanisms, keep it in the underlying TUI.
+- Status detection already carries an ongoing maintenance cost. Keep necessary tool-specific detection isolated; it is not a precedent for adding more coupling. Missing discovery or an unrecognized status must leave ordinary launch and interaction usable.
+- Judge every integration by what happens when an upstream tool updates, across all supported TUIs. Verify the interface and failure behavior; prefer a smaller dependable feature over one that needs recurring fixes for individual tools or versions.
+
 ## Brand Personality
 
 Precise, quiet, and capable. The interface should feel like a well-made terminal instrument: dense without being cramped, expressive without decoration, and trustworthy under sustained use.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -16,5 +16,12 @@ the tools in `defaultConfig` in `internal/config/config.go`, and the platforms
 left out and what supporting them would take, and let the maintainer decide.
 Opening the pull request first and settling that in review is the right order.
 
+For integrations, apply the [Thin Wrapper Principle](PRODUCT.md#thin-wrapper-principle).
+Check for overridden upstream defaults, hardcoded model catalogs, and dependencies
+on particular tool versions. Verify that unavailable capabilities leave ordinary
+launch and interaction usable.
+Assess ongoing maintenance across providers and releases, including whether the
+feature requires a separate implementation for each provider.
+
 When the need for a change depends on product intent that nobody wrote down,
 ask for a maintainer decision. An unanswered question stays a question.


### PR DESCRIPTION
## What changed

Establish a Thin Wrapper Principle in PRODUCT.md and connect it to agent instructions, contributor guidance, and review policy. Preserve upstream defaults and user configuration, avoid hardcoded model catalogs and version-specific integrations, and require reliable discovery before adding shared capability controls.

## Why

Provider-specific features multiply ongoing maintenance across features, providers, and upstream releases. Supporting an agent TUI should keep it usable in the workspace without committing agent-manager to mirroring its feature set.

## Scope

### Required behavior

Document the maintainer's product boundary and make it part of implementation and review decisions for all supported TUIs. Missing capabilities or status detection must leave ordinary launch and interaction usable.

### Why this approach

Keep the full principle in PRODUCT.md, with concise guidance and links at the points where agents, contributors, and reviewers encounter repository rules. This change contains documentation only; implementation of new integrations or changes to existing launch behavior is outside its scope. The principle applies to every supported provider and platform.

## How it was verified

- `git diff --check` passes.
- `gofmt -l .` prints nothing.
- `go vet ./...` passes.
- `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./...` passes.
- `go build ./...` passes.
- GitHub CI (test, gitleaks, govulncheck) and CodeQL pass.
- The separate GitHub AI security review failed before reviewing with `400 The requested model is not supported`; GitHub does not allow retrying that run. It is not a required merge check.
- Reviewed wording and relative links across the four documents.

## Visual evidence

Not applicable because this change updates repository policy documents and has no application UI change.
