### PR TITLE
fix(status): clear stale Codex errors after recovery

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,11 @@ const busyLineAgentsOnly = `^[✻✳✶✽✢·✦✧+*] Waiting for \d+ backgro
 // banner beneath completed turns. Hand-edited patterns remain untouched.
 const oldClaudeChromeLine = `^\s*[─q]{4,}.*$|^[\s─q]*$`
 
+// Codex used to end every command-running turn with a timed divider. Current
+// builds can draw a bare divider instead, so stored defaults need the wider
+// shape while hand-edited rules remain untouched.
+const oldCodexTurnEnd = `(?m)^─+ Worked for [\dhms. ]+─`
+
 // The command-code matching rules #385 shipped, which no longer match the
 // shapes current Command Code draws. A stored config.toml carries these
 // verbatim and keeps them over any new default, so mergeTool rewrites
@@ -298,6 +303,9 @@ func mergeTool(name string, user, def Tool) Tool {
 		if user.ChromeLine == oldClaudeChromeLine {
 			user.ChromeLine = def.ChromeLine
 		}
+	}
+	if name == "codex" && user.TurnEnd == oldCodexTurnEnd {
+		user.TurnEnd = def.TurnEnd
 	}
 	if name == "command-code" {
 		if user.TurnEnd == oldCmdTurnEnd {
@@ -576,10 +584,9 @@ fork_command = "codex fork {id}"
 revive_command = "codex resume --last"
 default_status = "idle"
 activity_cutoff = "(?m)^›"
-# a turn that ran commands closes with a "─ Worked for 12s ─" divider above
-# the input box; purely conversational turns leave no divider and resolve
-# through the quiet-region fallback instead
-turn_end = "(?m)^─+ Worked for [\\dhms. ]+─"
+# a completed turn closes with either a "─ Worked for 12s ─" or bare divider
+# above the input box
+turn_end = "(?m)^(?:─+ Worked for [\\dhms. ]+─+|─+)$"
 chrome_line = "^\\s*─*\\s*$"
 # every message and tool call opens on a "• " bullet
 message_start = "^• "

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -594,6 +594,18 @@ func TestMigratesStaleCommandCodePatterns(t *testing.T) {
 	}
 }
 
+func TestMigratesStaleCodexTurnEnd(t *testing.T) {
+	cfg := Config{Tools: map[string]Tool{
+		"codex": {Command: "codex", TurnEnd: oldCodexTurnEnd},
+	}}
+	if err := cfg.backfillToolDefaults(); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got := cfg.Tools["codex"].TurnEnd; got == oldCodexTurnEnd || !strings.Contains(got, "|─+") {
+		t.Fatalf("migrated turn_end = %q, want the bare divider shape", got)
+	}
+}
+
 // A config.toml written before the pi footer widened carries rules that pin
 // exactly two footer lines, so a pi extension drawing more keeps every rule
 // from matching. A config written on 0.34 or 0.35 carries the widened

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -402,6 +402,8 @@ func TestCodexRealPanes(t *testing.T) {
 			"• Ran echo preparing\n  └ preparing\n\n────────────────────────────────\n\n• Final response.\n\n─ Worked for 2m 05s ─────────────\n\n› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Finished},
 		{"codex finished turn ending on a question", "codex",
 			"• Which file should I edit, A or B?\n\n─ Worked for 3s ─────────────────\n\n› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Waiting},
+		{"codex recovered after an earlier error", "codex",
+			"─ Worked for 1s ─────────────\n\n■ unexpected status 404 Not Found: Unknown error\n\n› fix it?\n\n• Fixed. PR #298792 is ready.\n\n────────────────────────────────\n\n› Ask Codex to do anything\n  gpt-5.6-terra medium · /home/dev", Finished},
 		{"codex command-approval modal", "codex",
 			"  $ echo hello world\n\n› 1. Yes, proceed (y)\n  2. Yes, and don't ask again for commands that start with `echo hello world` (p)\n  3. No, and tell Codex what to do differently (esc)\n\n  Press enter to confirm or esc to cancel", Waiting},
 		{"codex command-approval modal overrides stale working signal", "codex",


### PR DESCRIPTION
## What changed

Codex status detection now treats both timed `Worked for` dividers and bare completion dividers as turn ends. Existing configs are upgraded only when their `turn_end` is exactly the previous built-in value; hand-edited rules stay untouched.

## Why

A recovered Codex turn can close with a bare divider. Without recognizing it, the prior failed turn remains in the match scope and its old error line keeps the session `errored` after successful work.

Closes #440

## Scope

### Required behavior

After Codex recovers from an earlier error and completes a later turn, the session reports `finished` instead of retaining the stale error.

### Why this approach

This is a Codex TUI status shape, so the fix stays in its config-driven detector. Widening the built-in turn-end regex fixes fresh configs; exact-value migration makes the same fix reach existing installations without overwriting user customization.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [ ] `go test -race ./...` passes
- [x] `go build ./...` passes
- [ ] Ran it against real sessions
- [x] Holds for every supported platform; intentionally Codex-only because the changed screen shape belongs to Codex

Focused verification passed:

- `go test -race ./internal/status ./internal/config`
- a regression fixture based on #440 fails as `errored` before the change and passes as `finished` after it
- the stored-default migration test passes

The full race suite also reached the unchanged packages, but this macOS host has unrelated failures in tmux revive tests and a `gopsutil` `netstat` parser panic. The parser panic reproduces on unmodified `upstream/main`.

## Visual evidence

**Before:** The #440 captured pane classifies as `errored`.

**After:** The same pane fixture classifies as `finished`.

**Not applicable because:** This changes internal status classification; the issue's captured pane text is the reproducible evidence and is now a regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Codex conversations now correctly recognize bare divider lines as completed turns.
  - Improved recovery after an earlier error, ensuring a subsequent successful response is reported as finished.
  - Existing customized turn-completion patterns remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->