### PR TITLE
fix(ui): defer pending input until a turn ends

### DIFF
--- a/internal/ui/poller.go
+++ b/internal/ui/poller.go
@@ -525,7 +525,20 @@ func (p *poller) refreshOnce() tea.Msg {
 			agentAlive := !stat.OK || stat.Procs > 1
 			if pane, err := p.tmux.CapturePane(sess.ID); err == nil {
 				paneLastLines[sess.ID], panePrompts[sess.ID] = p.rowLines(sess, pane)
-				sent, err := p.maybeSendPendingInput(sess, pane, agentAlive)
+				derived, err := p.derivePaneStatus(sess, pane, agentAlive, paneHashes)
+				if err != nil {
+					return errMsg{err}
+				}
+				newStatus = derived
+				// Hold the launch state until the agent first paints its pane,
+				// so a just-created session reads "starting up" rather than
+				// flashing idle before it has booted. A grace cap keeps a tool
+				// that never paints from sticking on starting forever.
+				if sess.Status == status.Starting && !paneBooted(pane) &&
+					time.Since(sess.LaunchTime()) < startingGrace {
+					newStatus = status.Starting
+				}
+				sent, err := p.maybeSendPendingInputWhenReady(sess, pane, newStatus, agentAlive)
 				if err != nil {
 					return errMsg{err}
 				}
@@ -538,11 +551,6 @@ func (p *poller) refreshOnce() tea.Msg {
 					}
 					sessions[i].PendingInputs = sessions[i].PendingInputs[1:]
 				}
-				derived, err := p.derivePaneStatus(sess, pane, agentAlive, paneHashes)
-				if err != nil {
-					return errMsg{err}
-				}
-				newStatus = derived
 				// Launch inputs open the conversation, so they go first; a
 				// message from another agent waits its turn behind them.
 				// A launch input sent this tick leaves pane and derived
@@ -553,14 +561,6 @@ func (p *poller) refreshOnce() tea.Msg {
 					if err := p.maybeDeliverInbox(sess, pane, derived, agentAlive); err != nil {
 						return errMsg{err}
 					}
-				}
-				// Hold the launch state until the agent first paints its pane,
-				// so a just-created session reads "starting up" rather than
-				// flashing idle before it has booted. A grace cap keeps a tool
-				// that never paints from sticking on starting forever.
-				if sess.Status == status.Starting && !paneBooted(pane) &&
-					time.Since(sess.LaunchTime()) < startingGrace {
-					newStatus = status.Starting
 				}
 				// Any real transition re-arms the finished alert.
 				if sess.Acked && newStatus != status.Idle && newStatus != status.Finished {
@@ -831,6 +831,13 @@ func (p *poller) clearRecaptureSeen(sessID string) {
 // A durable claim makes automatic delivery at-most-once: after a process or
 // database failure, an ambiguous input is dropped and surfaced rather than
 // risking the same task or slash command running twice.
+func (p *poller) maybeSendPendingInputWhenReady(sess store.Session, pane, derived string, agentAlive bool) (bool, error) {
+	if !sess.PendingInputClaimed && !inboxDeliverable(derived) {
+		return false, nil
+	}
+	return p.maybeSendPendingInput(sess, pane, agentAlive)
+}
+
 func (p *poller) maybeSendPendingInput(sess store.Session, pane string, agentAlive bool) (bool, error) {
 	if len(sess.PendingInputs) == 0 {
 		return false, nil
@@ -849,7 +856,11 @@ func (p *poller) maybeSendPendingInput(sess store.Session, pane string, agentAli
 	if !agentAlive {
 		return false, nil
 	}
-	region, ready := p.engine.ActivityRegion(sess.Tool, ansi.Strip(pane))
+	clean := ansi.Strip(pane)
+	if p.engine.TypingHold(sess.Tool, clean) != "" {
+		return false, nil
+	}
+	region, ready := p.engine.ActivityRegion(sess.Tool, clean)
 	if !ready {
 		return false, nil
 	}

--- a/internal/ui/poller_test.go
+++ b/internal/ui/poller_test.go
@@ -1684,6 +1684,40 @@ func TestPendingInputWaitsForTheLaunchPrompt(t *testing.T) {
 	}
 }
 
+func TestPendingInputWaitsForBetweenTurn(t *testing.T) {
+	m := buildModel(t)
+	if err := m.spawnSession("ready-tool", "ready-tool-abcd", t.TempDir(), "", "", true, false); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	sess, err := m.store.Get(m.sessionRows()[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sent, err := m.poller.maybeSendPendingInputWhenReady(sess, "❯ ", status.Working, true)
+	if err != nil {
+		t.Fatalf("send while working: %v", err)
+	}
+	if sent {
+		t.Fatal("pending input was delivered during a live turn")
+	}
+	queued, err := m.store.Get(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(queued.PendingInputs) == 0 {
+		t.Fatal("pending input was consumed during a live turn")
+	}
+
+	sent, err = m.poller.maybeSendPendingInputWhenReady(sess, "❯ ", status.Idle, true)
+	if err != nil {
+		t.Fatalf("send while idle: %v", err)
+	}
+	if !sent {
+		t.Fatal("pending input was not delivered between turns")
+	}
+}
+
 // A prompt that never reaches the pane, because it scrolled out or the agent
 // never drew it, must not hold pending input past the grace.
 func TestLaunchPromptTakenGivesUpAfterTheGrace(t *testing.T) {


### PR DESCRIPTION
## What changed

Pending inputs now wait until the captured pane is in a between-turn state before agent-manager sends them. This keeps the deferred rename directive out of an active first response.

## Why

The launch prompt could be visible while the agent was already working, so the next pending input was pasted into a live turn and stayed queued in the agent UI.

Addresses the pending-input timing part of #447. Queued-message parsing is separate.

## Scope

### Required behavior

A pending input remains queued during an active turn and is delivered once the same session returns to a safe prompt.

### Why this approach

The poller now derives the captured pane state before the existing FIFO delivery path and applies the same between-turn and typing-hold checks used for inbox delivery. It does not add provider-specific status rules or change message quoting.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amtest go test -race ./...` passes
- [x] `go build ./...` passes
- [x] The regression keeps a pending directive queued while working, then delivers it while idle

## Visual evidence

The tmux integration test covers queued input during a busy turn, an unfinished draft, and delivery after the prompt becomes idle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending input now waits until the session is between turns before being delivered.
  * Input already claimed for delivery can still be sent when the pane is not otherwise ready.
  * Pending input delivery is paused while the engine detects active typing or an unfinished draft in the pane.
  * Pending input resumes delivery after typed draft text is cleared and the pane is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
