### PR TITLE
fix(tmux): resolve the session's prefix from the global option when unset

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -368,14 +368,31 @@ func (d *Driver) installSessionUX(name string) error {
 	return err
 }
 
+// Reads a session-scoped option, falling back to the server's global value.
+// Tmux answers an un-overridden session option with an empty string rather than the global option.
+func (d *Driver) resolvedOption(name, option string) (string, error) {
+	value, err := d.run("show-options", "-t", name, "-v", option)
+	if err != nil {
+		return "", err
+	}
+	if value = strings.TrimSpace(value); value != "" {
+		return value, nil
+	}
+	global, err := d.run("show-options", "-g", "-v", option)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(global), nil
+}
+
 // styleStatusBar sets a session's status bar chrome, leaving status-left (the
 // name label) untouched so re-styling a live session keeps its label.
 func (d *Driver) styleStatusBar(name string) error {
-	primary, err := d.run("show-options", "-t", name, "-v", "prefix")
+	primary, err := d.resolvedOption(name, "prefix")
 	if err != nil {
 		return err
 	}
-	secondary, err := d.run("show-options", "-t", name, "-v", "prefix2")
+	secondary, err := d.resolvedOption(name, "prefix2")
 	if err != nil {
 		return err
 	}
@@ -384,7 +401,7 @@ func (d *Driver) styleStatusBar(name string) error {
 		// The default status-right-length of 40 truncates the hints, so widen it
 		// to fit the whole footer, including the configured-prefix fallback.
 		{"set-option", "-t", name, "status-right-length", "100"},
-		{"set-option", "-t", name, "status-right", attachStatusRight(strings.TrimSpace(primary), strings.TrimSpace(secondary), d.currentSessionKeys())},
+		{"set-option", "-t", name, "status-right", attachStatusRight(primary, secondary, d.currentSessionKeys())},
 		{"set-option", "-t", name, "status-style", "bg=colour236,fg=colour249"},
 		// hide the "0:windowname*" window list; it reads as noise here
 		{"set-option", "-t", name, "window-status-format", ""},

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -368,7 +368,6 @@ func (d *Driver) installSessionUX(name string) error {
 	return err
 }
 
-// Reads a session-scoped option, falling back to the server's global value.
 // Tmux answers an un-overridden session option with an empty string rather than the global option.
 func (d *Driver) resolvedOption(name, option string) (string, error) {
 	value, err := d.run("show-options", "-t", name, "-v", option)

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -133,6 +133,23 @@ func TestPrepareAttachFallsBackWhenLatestRejected(t *testing.T) {
 	}
 }
 
+// resolvedOption's global fallback can fail on its own (no server, a
+// stale socket); that error must reach the caller, not just the
+// session-scoped read's.
+func TestResolvedOptionPropagatesTheGlobalFallbackError(t *testing.T) {
+	dir := t.TempDir()
+	stub := dir + "/tmux"
+	script := "#!/bin/sh\ncase \"$*\" in *'-g -v prefix'*) echo 'no server running' >&2; exit 1;; esac\nexit 0\n"
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil {
+		t.Fatalf("stub: %v", err)
+	}
+	driver := &Driver{bin: stub, socket: testSocket}
+
+	if _, err := driver.resolvedOption("x1", "prefix"); err == nil {
+		t.Fatal("resolvedOption should propagate the global fallback's error")
+	}
+}
+
 func TestSetLabelNeutralizesFormatStrings(t *testing.T) {
 	driver := requireTmux(t)
 	id := "lbl" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
@@ -609,7 +626,9 @@ func restorePrefix(t *testing.T) {
 	}
 	snapshot := strings.TrimSpace(string(original))
 	t.Cleanup(func() {
-		tmuxCmd("set-option", "-g", "prefix", snapshot).Run()
+		if out, err := tmuxCmd("set-option", "-g", "prefix", snapshot).CombinedOutput(); err != nil {
+			t.Errorf("restore prefix: %v: %s", err, out)
+		}
 	})
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -599,6 +599,51 @@ func TestRefreshChromeKeepsLabelAndAddsSessionHints(t *testing.T) {
 	}
 }
 
+// restorePrefix snapshots and restores the server's global prefix, so a
+// test that sets one does not leak it into the next.
+func restorePrefix(t *testing.T) {
+	t.Helper()
+	original, err := tmuxCmd("show-options", "-g", "-v", "prefix").CombinedOutput()
+	if err != nil {
+		t.Fatalf("show-options prefix: %v: %s", err, original)
+	}
+	snapshot := strings.TrimSpace(string(original))
+	t.Cleanup(func() {
+		tmuxCmd("set-option", "-g", "prefix", snapshot).Run()
+	})
+}
+
+// A tmux.conf almost always sets the prefix with "set -g", which
+// TestRefreshChromeKeepsLabelAndAddsSessionHints never exercises (it
+// always overrides "-t <session>" directly).
+func TestRefreshChromeResolvesAGloballySetPrefix(t *testing.T) {
+	driver := requireTmux(t)
+	restorePrefix(t)
+	id := "globalprefix" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	if err := driver.Create(id, "/tmp", "", nil, 0, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { driver.Kill(id) })
+
+	if out, err := tmuxCmd("set-option", "-g", "prefix", "C-q").CombinedOutput(); err != nil {
+		t.Fatalf("set global prefix: %v: %s", err, out)
+	}
+	if err := driver.RefreshChrome(id); err != nil {
+		t.Fatalf("RefreshChrome: %v", err)
+	}
+
+	right, err := tmuxCmd("display-message", "-p", "-t", "am_"+id, "#{T:status-right}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("status-right: %v", err)
+	}
+	if strings.Contains(string(right), "Ctrl+q /") {
+		t.Fatalf("footer should hide the default detach key claimed by a globally-set prefix, got %q", right)
+	}
+	if !strings.Contains(string(right), "C-q d = back") {
+		t.Fatalf("footer should advertise the prefix escape for a globally-set prefix, got %q", right)
+	}
+}
+
 // clearPaneTheme drops the server-global colors a pane-theme test left
 // behind, so the rest of the package sees an unstyled server.
 func clearPaneTheme(t *testing.T) {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -616,10 +616,11 @@ func TestRefreshChromeKeepsLabelAndAddsSessionHints(t *testing.T) {
 	}
 }
 
-// restorePrefix snapshots and restores the server's global prefix, so a
-// test that sets one does not leak it into the next.
-func restorePrefix(t *testing.T) {
-	t.Helper()
+// A tmux.conf almost always sets the prefix with "set -g", which
+// TestRefreshChromeKeepsLabelAndAddsSessionHints never exercises (it
+// always overrides "-t <session>" directly).
+func TestRefreshChromeResolvesAGloballySetPrefix(t *testing.T) {
+	driver := requireTmux(t)
 	original, err := tmuxCmd("show-options", "-g", "-v", "prefix").CombinedOutput()
 	if err != nil {
 		t.Fatalf("show-options prefix: %v: %s", err, original)
@@ -630,14 +631,7 @@ func restorePrefix(t *testing.T) {
 			t.Errorf("restore prefix: %v: %s", err, out)
 		}
 	})
-}
 
-// A tmux.conf almost always sets the prefix with "set -g", which
-// TestRefreshChromeKeepsLabelAndAddsSessionHints never exercises (it
-// always overrides "-t <session>" directly).
-func TestRefreshChromeResolvesAGloballySetPrefix(t *testing.T) {
-	driver := requireTmux(t)
-	restorePrefix(t)
 	id := "globalprefix" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
 	if err := driver.Create(id, "/tmp", "", nil, 0, 0); err != nil {
 		t.Fatalf("Create: %v", err)


### PR DESCRIPTION
## What changed

`styleStatusBar` now reads a session's tmux `prefix`/`prefix2` through a new `resolvedOption` helper that falls back to the server-global value when the session-scoped option is unset, instead of calling `show-options -t <session> -v prefix` directly.

## Why

`show-options -t <session> -v prefix` answers the session specific option withouth falling back on the global default. Thus, it usually returns with an empty string. This results in the footer never detected a collision when the prefix was only ever set globally in tmux. 

It therefore never added the `<prefix> d` fallback hint, and it kept advertising a colliding direct key (e.g. `ctrl+q`) as if it still worked, when tmux actually swallows that keystroke into its prefix table first.

Addresses part of #461.

## Scope

### Required behavior

The footer must correctly detect a collision between a `[keybindings.session]` key and a globally-set tmux prefix, the same as it already does for a prefix set per-session.

### Why this approach

tmux's own option-resolution semantics require a `-g` fallback read to get the value a session's prefix actually resolves to — there is no other call that returns "the prefix this session effectively answers to."

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] `go build ./...` passes
- [x] Ran it against real sessions
- [x] Holds for every supported agent CLI and platform

Ran both the unpatched v0.36.0 binary and a patched build against the same colliding-prefix setup (globally-set prefix matching a `[keybindings.session]` key). Patched version gave the "+ d" keybind.

## Visual evidence

Maybe not the best case for visual evidence, but here is the visual inside the attached window. 

### production build 
<img width="215" height="40" alt="am-prefix-fix-before" src="https://github.com/user-attachments/assets/5cddb843-d3aa-4f1c-983c-38b07095e952" />

### Fixed build
<img width="583" height="52" alt="am-prefix-fix-after" src="https://github.com/user-attachments/assets/698ed3ec-6324-4467-aa35-087e98f089e1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The status bar now correctly reflects globally configured tmux prefix keys when no session-specific prefix is set.
  - Footer controls now display appropriate detach and escape-key guidance based on the effective tmux configuration.
  - Errors encountered while reading fallback configuration are now surfaced instead of being silently ignored.
  - Prefix settings are consistently resolved before status bar information is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->