### PR TITLE
fix(ui): let Left leave focus while pi is working

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,6 +253,13 @@ const (
 // working default.
 const oldPiOwnLineWorkingRule = `(?ms)^[ \t]*[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \t]+(?:Working|Running|Retrying|Compacting context|Auto-compacting|Context overflow detected, Auto-compacting|Summarizing branch)\b[^\n]*\n[ \t]*\n─{8,}[ \t]*\n(?:[ \t]*\n)*─{8,}[ \t]*` + newPiFooterTail
 
+// The pi activity cutoff written before pi 0.85 moved the spinner into the
+// composer's top border. It knows only the plain rule as the input box's
+// edge, so the border with a spinner in it read as draft text and Left
+// stayed with the agent for the length of every turn. Hand-edited patterns
+// remain untouched.
+const oldPiActivityCutoff = `(?ms)\A.*^─{8,}[ \t]*$`
+
 // mergeTool returns user with any zero-value field filled from def.
 //
 // Shell is deliberately not among them. "terminal" is a plausible name for
@@ -319,6 +326,9 @@ func mergeTool(name string, user, def Tool) Tool {
 		}
 	}
 	if name == "pi" {
+		if user.ActivityCutoff == oldPiActivityCutoff {
+			user.ActivityCutoff = def.ActivityCutoff
+		}
 		for i, rule := range user.Rules {
 			switch rule.Pattern {
 			case oldPiIdleRule, oldPiErrorRule, oldPiRateLimitRule, oldPiQuestionRule:
@@ -733,8 +743,11 @@ default_status = "finished"
 # draft out.
 input_prefix = "^"
 # Start the activity region at the pane origin. Pane reflow then cannot look
-# like streaming output when Agent Manager attaches or detaches.
-activity_cutoff = "(?ms)\\A.*^─{8,}[ \\t]*$"
+# like streaming output when Agent Manager attaches or detaches. The rows
+# that bound the composer are the plain rule and, since pi 0.85, the top
+# one with the spinner drawn inside it ("── ⠹ Working ───"); the arrow-step
+# head check reads either as the input box's edge rather than a draft.
+activity_cutoff = "(?ms)\\A.*^(?:─+[ \\t]+[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][ \\t]+[^\\n]*?[ \\t]+)?─{8,}[ \\t]*$"
 chrome_line = "^[ \\t]*─{8,}[ \\t]*$"
 rules = [
   { state = "idle", pattern = "(?ms)^[ \\t]*Resumed session[ \\t]*\\n[ \\t]*\\n─{8,}[ \\t]*\\n(?:[ \\t]*\\n)*─{8,}[ \\t]*(?:\\n[^\\n]*){2,5}[ \\t]*(?:\\n[ \\t]*)*\\z" },

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -635,6 +636,63 @@ func TestMigratesStalePiFooterRules(t *testing.T) {
 	}
 	if got := tool.Rules[6].Pattern; got != handEdited {
 		t.Fatalf("hand-edited rule = %q, want kept as written", got)
+	}
+}
+
+// A config.toml written before pi 0.85 carries an activity_cutoff that
+// knows only the plain rule as the input box's edge, so the composer's top
+// border read as draft text for the length of every turn once the spinner
+// moved into it. The stale string is rewritten to the current default; a
+// hand-edited one is kept.
+func TestMigratesStalePiActivityCutoff(t *testing.T) {
+	def, err := Default()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	for _, c := range []struct {
+		name, stored, want string
+	}{
+		{"stale default", oldPiActivityCutoff, def.Tools["pi"].ActivityCutoff},
+		{"hand-edited", `(?m)^my own cutoff$`, `(?m)^my own cutoff$`},
+	} {
+		cfg := Config{Tools: map[string]Tool{"pi": {Command: "pi", ActivityCutoff: c.stored}}}
+		if err := cfg.backfillToolDefaults(); err != nil {
+			t.Fatalf("%s: backfill: %v", c.name, err)
+		}
+		if got := cfg.Tools["pi"].ActivityCutoff; got != c.want {
+			t.Fatalf("%s: activity_cutoff = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// The shipped pi activity_cutoff, read against a single row, takes both
+// rules that bound the composer: the top one with or without the spinner pi
+// 0.85 draws inside it. The scroll indicator a tall draft puts on that
+// border is not an edge: the row under it is the middle of the draft, and
+// Left there belongs to pi. Read against a whole pane it still cuts at the
+// bottom rule, so the activity region stays anchored at the origin.
+func TestPiActivityCutoffReadsTheSpinnerBorder(t *testing.T) {
+	def, err := Default()
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	cutoff := regexp.MustCompile(def.Tools["pi"].ActivityCutoff)
+	for row, want := range map[string]bool{
+		"──────────────────────────────────────────────────": true,
+		"── ⠧ Working ─────────────────────────────────────": true,
+		"── ⠹ Compacting context ─────────────────────────":  true,
+		"─── ↑ 2 more ─────────────────────────────────────": false,
+		"─── ↓ 1 more ─────────────────────────────────────": false,
+		"a draft that trails off ────────────":               false,
+		"⠧ Working": false,
+	} {
+		if got := cutoff.MatchString(row); got != want {
+			t.Errorf("activity_cutoff on %q = %v, want %v", row, got, want)
+		}
+	}
+	pane := "output\n── ⠧ Working ──────────\n\n──────────────────\n~\n$0.000"
+	if loc := cutoff.FindStringIndex(pane); loc == nil || loc[0] != 0 || pane[loc[1]:] != "\n~\n$0.000" {
+		t.Fatalf("whole-pane cutoff = %v on %q, want one match from the origin to the bottom rule", loc, pane)
 	}
 }
 

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -724,6 +724,71 @@ func TestCaretOnPisBareComposerRow(t *testing.T) {
 	}
 }
 
+// pi 0.85 paints its spinner inside the composer's top border while a turn
+// runs ("── ⠧ Working ───", shape taken from a live pane). That border is
+// furniture like the plain rule it replaces: an empty composer under it
+// still lets Left leave, and a draft typed mid-turn still keeps it. The
+// shipped defaults decide this, since that is the config that regressed.
+func TestCaretOnPisComposerRowWhileWorking(t *testing.T) {
+	cfg, err := config.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, err := status.NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("engine: %v", err)
+	}
+	build := func(x int, rows ...string) *Model {
+		m := &Model{engine: engine, mode: modeFocus}
+		m.preview = strings.Join(rows, "\n") + "\n"
+		m.pane.forID = "s1"
+		m.pane.cursor = paneCursor{x: x, y: 2, positionOK: true}
+		return m
+	}
+
+	border := "── ⠧ Working ─────────────"
+	footer := []string{"──────────────────────────", "~", "$0.000"}
+	m := build(0, append([]string{"output", border, ""}, footer...)...)
+	if !m.caretAtInputStart("s1", "pi") {
+		t.Fatal("the empty composer under pi's working border was not recognised")
+	}
+	m = build(2, append([]string{"output", border, "zz"}, footer...)...)
+	if m.caretAtInputStart("s1", "pi") {
+		t.Fatal("a draft typed mid-turn was read as input start")
+	}
+	m = build(0, append([]string{"output", "─── ↑ 2 more ─────────────", ""}, footer...)...)
+	if m.caretAtInputStart("s1", "pi") {
+		t.Fatal("a scrolled draft's continuation row was read as input start")
+	}
+}
+
+// The rows the head check steps over are the ones that bound the input
+// box, never every chrome row: opencode's shipped chrome_line takes any
+// gutter row, draft text and all, so reading chrome as "not a draft" would
+// let Left leave from the middle of a multi-line opencode draft. Decided on
+// the shipped defaults, where that overlap lives.
+func TestCaretOnOpencodesMultiLineDraftWithShippedDefaults(t *testing.T) {
+	cfg, err := config.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, err := status.NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("engine: %v", err)
+	}
+	m := &Model{engine: engine, mode: modeFocus}
+	m.preview = strings.Join([]string{"", "  ┃  first line", "  ┃", "  ┃", "  ┃  Build · model", "  ╹▀▀▀▀▀▀"}, "\n") + "\n"
+	m.pane.forID = "s1"
+	m.pane.cursor = paneCursor{x: 5, y: 2, ok: true}
+	if m.caretAtInputStart("s1", "opencode") {
+		t.Fatal("a multi-line draft's continuation row was read as input start")
+	}
+	m.preview = strings.Join([]string{"", "  ┃", "  ┃", "  ┃", "  ┃  Build · model", "  ╹▀▀▀▀▀▀"}, "\n") + "\n"
+	if !m.caretAtInputStart("s1", "opencode") {
+		t.Fatal("the empty composer's caret row was not recognised")
+	}
+}
+
 // The mirror belongs to whichever session pushed it, and a scrolled-back
 // pane's rows no longer line up with the live caret: neither can decide.
 func TestCaretAtInputStartNeedsCurrentPane(t *testing.T) {


### PR DESCRIPTION
## What changed

Left now leaves focus on an empty pi composer while a turn is running, not only once the turn has ended. pi's `activity_cutoff` takes the composer's top border with the spinner drawn inside it (`── ⠹ Working ───`) alongside the plain rule, so the arrow-step head check reads it as the input box's edge rather than a draft line above the caret. A stored `config.toml` carrying the old pi `activity_cutoff` verbatim is rewritten to the current default on load, the way the pi working rule already is; a hand-edited one is kept.

One config field and its migration; no Go logic changes outside `mergeTool`.

## Why

pi 0.85 moved the spinner into the composer's top border. #445 taught the status rules that shape, but `caretRowEndsAPromptHead` steps over the row above the caret only when it matches the tool's `activity_cutoff`, which for pi knew only the plain rule. With pi's zero-width `input_prefix` every row carries "the marker", so the spinner border read as a draft line with text past it, and Left stayed with pi for the length of every turn. #453 could not see it: its cases put a plain rule above the composer, which is what an idle pi draws.

## Scope

### Required behavior

- Focused on pi mid-turn, empty composer, caret at the prompt head: Left leaves focus.
- Focused on pi mid-turn with a draft typed: Left moves pi's caret; focus stays.
- A tall draft whose border carries the scroll indicator (`─── ↑ 2 more ───`) is not an edge: the row under it is the middle of the draft, and Left stays with pi.
- The stored pi `activity_cutoff` an older release wrote is upgraded; a hand-edited one is untouched.
- Read against a whole pane, the cutoff still ends at the bottom rule: pi's activity region stays anchored at the origin, so no status result moves.
- Other tools are untouched: the row above reaches the cutoff check only when it matches their input marker, and their cutoffs are those markers.

### Why this approach

`activity_cutoff` is the field `MatchesActivityCutoff` already documents as "the rows that bound its input box", and the spinner border is that box's top edge; it is where pi 0.85 put the spinner, and the working rule already reads it as the composer's border. Matching on the spinner glyph inside a rule rather than the label list keeps a custom loader message from turning the border back into draft text.

A first cut let the head check step over any `chrome_line` match instead. opencode's shipped `chrome_line` is `^\s*(┃.*)?$`, every gutter row with the draft text on it, so that read Left as free from the middle of a multi-line opencode draft. `chrome_line` means "not content for the status engine"; it does not mean "not a draft". `TestCaretOnOpencodesMultiLineDraftWithShippedDefaults` pins that on the shipped defaults, where the overlap lives (the existing opencode test builds a minimal engine without a `chrome_line`), and goes red against the chrome-based cut.

## How it was verified

- `gofmt -l .` prints nothing
- `go vet ./...` passes
- `go build ./...` passes
- `TestCaretOnPisComposerRowWhileWorking` on the shipped defaults: red before the change, green after
- `go test ./...` on the isolated socket: everything passes except `TestInboxDeliversToARestingAgentWithItsSenderNamed`, which fails identically on untouched `main` (7c456e2) in this environment, with and without `-race`; under a zsh `SHELL`, `TestReviveStartsTheAgentAgainInALivePane` also fails on untouched `main` (the prompt's syntax highlighting puts colour codes inside the string the assertion looks for) and passes with `SHELL=/bin/bash`
- Ran it against a real pi 0.85 session in an isolated harness (separate `HOME`, `TMUX_TMPDIR`, config), one turn running `sleep 240`, the manager focused with the `FOCUS` badge and `── ⠇ Working ───` on screen, caret at column 0 of the empty composer, swapping binaries on the same turn
  - v0.36.0: Left, `FOCUS` badge still shown, agent caret unchanged
  - this branch: Left, back on the list, agent still working
  - this branch with `ab` typed mid-turn: Left moves the agent caret 2→1, focus stays
- Loaded my own stored `config.toml` (written by 0.36.0, old pi `activity_cutoff` verbatim) through `LoadDir`: the pi `activity_cutoff` comes back as the new default
- Holds for pi; every other tool's Left behaviour is unchanged by construction (see Scope)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Pi activity detection to support the newer spinner-in-border display.
  - Existing configurations using the previous activity pattern are automatically updated to the current default.
  - Improved recognition of empty composer rows in Pi and multiline composer input in OpenCode, while preserving draft and continuation text handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->