### PR TITLE
fix(ui): let Left leave grok focus in minimal mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,10 @@ const busyLineAgentsOnly = `^[✻✳✶✽✢·✦✧+*] Waiting for \d+ backgro
 // banner beneath completed turns. Hand-edited patterns remain untouched.
 const oldClaudeChromeLine = `^\s*[─q]{4,}.*$|^[\s─q]*$`
 
+// This exact cutoff was written before grok's minimal mode, which draws a
+// flush-left composer with no box. Hand-edited patterns remain untouched.
+const grokBoxedCutoff = `(?m)^\s*│ ❯`
+
 // The command-code matching rules #385 shipped, which no longer match the
 // shapes current Command Code draws. A stored config.toml carries these
 // verbatim and keeps them over any new default, so mergeTool rewrites
@@ -298,6 +302,9 @@ func mergeTool(name string, user, def Tool) Tool {
 		if user.ChromeLine == oldClaudeChromeLine {
 			user.ChromeLine = def.ChromeLine
 		}
+	}
+	if name == "grok" && user.ActivityCutoff == grokBoxedCutoff {
+		user.ActivityCutoff = def.ActivityCutoff
 	}
 	if name == "command-code" {
 		if user.TurnEnd == oldCmdTurnEnd {
@@ -610,7 +617,8 @@ resume_picker_command = "grok"
 # fallback: resumes the most recent session for the working directory
 revive_command = "grok --continue"
 default_status = "idle"
-activity_cutoff = "(?m)^\\s*│ ❯"
+# boxed fullscreen and flush-left minimal; indented transcript prompt lines stay out
+activity_cutoff = "(?m)^(?:\\s*│ )?❯"
 # turn summary above the input box. Grok prints a live "Worked for 1m20s"
 # timer while subagents run; only the real end line gains "stop" (and usually
 # "[hooks: N]"). Trailing period after the duration is optional.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,6 +55,9 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if got := cfg.Tools["grok"].PromptFlag; got != "" {
 		t.Fatalf("grok prompt_flag = %q want empty (positional prompt)", got)
 	}
+	if got := cfg.Tools["grok"].ActivityCutoff; got != `(?m)^(?:\s*│ )?❯` {
+		t.Fatalf("grok activity_cutoff = %q want boxed-or-minimal composer", got)
+	}
 	if _, ok := cfg.Tools["gemini"]; !ok {
 		t.Fatal("expected gemini tool in default config")
 	}
@@ -216,6 +219,42 @@ chrome_line = '` + oldClaudeChromeLine + `'
 	}
 	if !strings.Contains(cfg.Tools["claude"].ChromeLine, "Update installed") {
 		t.Fatalf("legacy claude chrome_line was not upgraded: %q", cfg.Tools["claude"].ChromeLine)
+	}
+}
+
+func TestLoadDirUpgradesLegacyGrokCutoff(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	legacy := `
+[tools.grok]
+command = "grok"
+activity_cutoff = '` + grokBoxedCutoff + `'
+`
+	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if got := cfg.Tools["grok"].ActivityCutoff; got != `(?m)^(?:\s*│ )?❯` {
+		t.Fatalf("legacy grok activity_cutoff was not upgraded: %q", got)
+	}
+}
+
+func TestLoadDirPreservesCustomGrokCutoff(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	custom := `(?m)^GROK>`
+	if err := os.WriteFile(path, []byte("[tools.grok]\ncommand = \"grok\"\nactivity_cutoff = '"+custom+"'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if got := cfg.Tools["grok"].ActivityCutoff; got != custom {
+		t.Fatalf("custom grok activity_cutoff was overwritten: %q", got)
 	}
 }
 

--- a/internal/status/inputprefix_test.go
+++ b/internal/status/inputprefix_test.go
@@ -47,6 +47,38 @@ func TestInputPrefix(t *testing.T) {
 	}
 }
 
+func TestGrokInputPrefixBoxedAndMinimal(t *testing.T) {
+	cfg, err := config.Default()
+	if err != nil {
+		t.Fatalf("built-in config: %v", err)
+	}
+	engine, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("engine: %v", err)
+	}
+	cases := []struct {
+		name   string
+		row    string
+		prefix string
+		ok     bool
+	}{
+		{"boxed empty", " │ ❯                        │", " │ ❯", true},
+		{"boxed draft", " │ ❯ hello                  │", " │ ❯", true},
+		{"minimal empty", "❯", "❯", true},
+		{"minimal draft", "❯ hello", "❯", true},
+		{"indented user turn", "     ❯ count from 1 to 5", "", false},
+		{"shortcuts bar", " →:expand  │  Ctrl+e:collapse thinking  │  Ctrl+x:shortcuts", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			prefix, ok := engine.InputPrefix("grok", c.row)
+			if prefix != c.prefix || ok != c.ok {
+				t.Fatalf("InputPrefix = (%q, %v), want (%q, %v)", prefix, ok, c.prefix, c.ok)
+			}
+		})
+	}
+}
+
 // A tool whose composer row carries no marker can declare its own input
 // line with input_prefix. Pi composes on a bare blank row and opencode on
 // one of its blank gutter rows, so their declared prefixes are zero-width

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/YoanWai/agent-manager/internal/config"
@@ -367,6 +368,23 @@ func TestGrokRealPanes(t *testing.T) {
 				t.Fatalf("Match(%s) = %q want %q", tc.name, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestGrokActivityRegionBoxedAndMinimal(t *testing.T) {
+	engine := defaultEngine(t)
+	boxed := "     ❯ count from 1 to 5\n  ╭────╮\n  │ ❯                        │\n"
+	region, ok := engine.ActivityRegion("grok", boxed)
+	if !ok || !strings.Contains(region, "count from 1 to 5") {
+		t.Fatalf("boxed region = %q ok=%v", region, ok)
+	}
+	minimal := "◆ session_start\nminimal · /help\n❯\nGrok 4.6 (medium)\n"
+	region, ok = engine.ActivityRegion("grok", minimal)
+	if !ok || !strings.Contains(region, "session_start") {
+		t.Fatalf("minimal region = %q ok=%v", region, ok)
+	}
+	if _, ok := engine.ActivityRegion("grok", "     ❯ count from 1 to 5\n     done\n"); ok {
+		t.Fatal("an indented grok user turn was treated as the composer")
 	}
 }
 

--- a/internal/ui/focuskeys_test.go
+++ b/internal/ui/focuskeys_test.go
@@ -686,6 +686,50 @@ func TestCaretAtInputStartMeasuresMarkerInCells(t *testing.T) {
 	}
 }
 
+func TestCaretOnGrokComposer(t *testing.T) {
+	cfg, err := config.Default()
+	if err != nil {
+		t.Fatalf("built-in config: %v", err)
+	}
+	engine, err := status.NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("engine: %v", err)
+	}
+	build := func(x int, y int, rows ...string) *Model {
+		m := &Model{engine: engine, mode: modeFocus}
+		m.preview = strings.Join(rows, "\n") + "\n"
+		m.pane.forID = "s1"
+		m.pane.cursor = paneCursor{x: x, y: y, ok: true}
+		return m
+	}
+
+	m := build(5, 1, " ╭────╮", " │ ❯                        │", " ╰──── Grok 4.6 ─╯")
+	if !m.caretAtInputStart("s1", "grok") {
+		t.Fatal("boxed empty composer was not recognised")
+	}
+	m = build(2, 1, "minimal · /help", "❯", "Grok 4.6 (medium)")
+	if !m.caretAtInputStart("s1", "grok") {
+		t.Fatal("minimal empty composer was not recognised")
+	}
+	m = build(7, 1, "minimal · /help", "❯ hello", "Grok 4.6 (medium)")
+	if m.caretAtInputStart("s1", "grok") {
+		t.Fatal("a typed grok draft was read as input start")
+	}
+	m = build(7, 0, "     ❯ count from 1 to 5", " │ ❯                        │")
+	if m.caretAtInputStart("s1", "grok") {
+		t.Fatal("an indented grok user turn was read as the composer")
+	}
+	m = build(59, 3,
+		"│   ◆ session_start",
+		" │ ❯ Build anything",
+		" ╰──── Grok 4.6 ─╯",
+		" →:expand  │  Ctrl+e:collapse thinking  │  Ctrl+x:shortcuts",
+	)
+	if m.caretAtInputStart("s1", "grok") {
+		t.Fatal("a highlighted grok entry parked on the shortcuts bar was read as input start")
+	}
+}
+
 // pi composes on a bare row between rules, hides the terminal cursor and
 // paints its own reverse-video caret. tmux still reports the right cell, so
 // its zero-width prefix can read the hidden position as the prompt head;


### PR DESCRIPTION
## What changed

Grok's `activity_cutoff` now matches both the boxed fullscreen composer and the flush-left minimal-mode marker. Existing configs that still carry the boxed-only pattern are upgraded on load; a cutoff someone wrote by hand is kept.

Left at an empty grok prompt therefore leaves focus in both render modes. A highlighted scrollback entry still receives Left, which is grok's collapse key.

## Why

Grok's minimal mode draws `❯` with no box. The previous cutoff required `│ ❯`, so the caret-at-prompt-head check never fired and Left stayed with the agent.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test ./internal/config ./internal/status` and the grok caret/prefix tests pass
- [x] `go build ./...` passes
- [ ] `go test -race ./...` (full `internal/ui` run hits an unrelated `am_guard-probe` duplicate-session flake already present on main)
- [x] Captured live grok 1.0.13 panes in an isolated tmux (`--minimal` and `/fullscreen`) and replayed those rows in the new tests

Focused tests: `TestCaretOnGrokComposer`, `TestGrokInputPrefixBoxedAndMinimal`, `TestGrokActivityRegionBoxedAndMinimal`, `TestLoadDirUpgradesLegacyGrokCutoff`, `TestLoadDirPreservesCustomGrokCutoff`, `TestGrokRealPanes`.

Holds for grok. Other tools keep their own cutoffs.

## Visual evidence

**Not applicable because:** this is caret detection on captured pane text. The live grok rows (boxed ` │ ❯` at column 5, minimal `❯` at column 2, highlighted entry parked on the shortcuts bar) are the reproducible evidence and are now regression tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Legacy Grok activity cutoff settings are now migrated automatically.
  - Activity detection now supports boxed and minimal composer layouts.
  - Indented transcript content is no longer mistaken for the active composer.
  - Input-prefix and caret detection now works across empty composers, typed drafts, and shortcut-bar states.

- **Tests**
  - Added coverage for Grok composer layouts, activity detection, caret and input-prefix behavior, and configuration migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->