### PR TITLE
fix(status): quote grok's last reply instead of chrome

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,8 +220,13 @@ const busyLineAgentsOnly = `^[✻✳✶✽✢·✦✧+*] Waiting for \d+ backgro
 const oldClaudeChromeLine = `^\s*[─q]{4,}.*$|^[\s─q]*$`
 
 // This exact cutoff was written before grok's minimal mode, which draws a
-// flush-left composer with no box. Hand-edited patterns remain untouched.
-const grokBoxedCutoff = `(?m)^\s*│ ❯`
+// flush-left composer with no box. oldGrokChromeLine is the box-only chrome
+// from before the list row had to step over the opt-in card and the minimal
+// hint. Hand-edited patterns remain untouched.
+const (
+	grokBoxedCutoff   = `(?m)^\s*│ ❯`
+	oldGrokChromeLine = `^\s*[┃❙│─╭╮╰╯█]*\s*$`
+)
 
 // Codex used to end every command-running turn with a timed divider. Current
 // builds can draw a bare divider instead, so stored defaults need the wider
@@ -315,8 +320,13 @@ func mergeTool(name string, user, def Tool) Tool {
 			user.ChromeLine = def.ChromeLine
 		}
 	}
-	if name == "grok" && user.ActivityCutoff == grokBoxedCutoff {
-		user.ActivityCutoff = def.ActivityCutoff
+	if name == "grok" {
+		if user.ActivityCutoff == grokBoxedCutoff {
+			user.ActivityCutoff = def.ActivityCutoff
+		}
+		if user.ChromeLine == oldGrokChromeLine {
+			user.ChromeLine = def.ChromeLine
+		}
 	}
 	if name == "codex" && user.TurnEnd == oldCodexTurnEnd {
 		user.TurnEnd = def.TurnEnd
@@ -640,8 +650,10 @@ activity_cutoff = "(?m)^(?:\\s*│ )?❯"
 # timer while subagents run; only the real end line gains "stop" (and usually
 # "[hooks: N]"). Trailing period after the duration is optional.
 turn_end = "(?m)^\\s*Worked for [\\dhms. ]+s\\.?(?:\\s|$).*\\bstop\\b"
-# input-box borders plus the right-edge scrollbar block on overflow panes
-chrome_line = "^\\s*[┃❙│─╭╮╰╯█]*\\s*$"
+# box, scrollbar, header, opt-in card, minimal hint, model footer, hook rows
+chrome_line = "^\\s*[┃❙│─━╭╮╰╯█▴▾]*\\s*$|^\\s*⎇ |^\\s*Help improve Grok\\b|^\\s*Off by default\\. Opt-in|^\\s*Read Terms and Privacy Policy|^\\s*minimal ·|^\\s*Grok \\d|^\\s*◆ (?:user_prompt_submit|session_start)\\b|^\\s*✓ |^\\s*Shift\\+Tab:"
+# the duration line sits under the reply; LastMessage steps over it so the row quotes the reply
+trailing_note = "^Worked for "
 limit_line = "(?i)You've hit the rate limit|You hit your free usage limit|You've reached your free Grok Build usage limit|usage limit reached|out of credits"
 rules = [
   # first-run "Do you trust this directory?" and other y/n prompts block on the user

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,6 +59,12 @@ func TestLoadWritesAndParsesDefault(t *testing.T) {
 	if got := cfg.Tools["grok"].ActivityCutoff; got != `(?m)^(?:\s*│ )?❯` {
 		t.Fatalf("grok activity_cutoff = %q want boxed-or-minimal composer", got)
 	}
+	if !strings.Contains(cfg.Tools["grok"].ChromeLine, "Help improve Grok") {
+		t.Fatalf("grok chrome_line missing the opt-in card: %q", cfg.Tools["grok"].ChromeLine)
+	}
+	if got := cfg.Tools["grok"].TrailingNote; got != "^Worked for " {
+		t.Fatalf("grok trailing_note = %q want the duration line", got)
+	}
 	if _, ok := cfg.Tools["gemini"]; !ok {
 		t.Fatal("expected gemini tool in default config")
 	}
@@ -223,13 +229,14 @@ chrome_line = '` + oldClaudeChromeLine + `'
 	}
 }
 
-func TestLoadDirUpgradesLegacyGrokCutoff(t *testing.T) {
+func TestLoadDirUpgradesLegacyGrokRowPatterns(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	legacy := `
 [tools.grok]
 command = "grok"
 activity_cutoff = '` + grokBoxedCutoff + `'
+chrome_line = '` + oldGrokChromeLine + `'
 `
 	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
 		t.Fatal(err)
@@ -241,21 +248,32 @@ activity_cutoff = '` + grokBoxedCutoff + `'
 	if got := cfg.Tools["grok"].ActivityCutoff; got != `(?m)^(?:\s*│ )?❯` {
 		t.Fatalf("legacy grok activity_cutoff was not upgraded: %q", got)
 	}
+	if !strings.Contains(cfg.Tools["grok"].ChromeLine, "Help improve Grok") {
+		t.Fatalf("legacy grok chrome_line was not upgraded: %q", cfg.Tools["grok"].ChromeLine)
+	}
 }
 
-func TestLoadDirPreservesCustomGrokCutoff(t *testing.T) {
+func TestLoadDirPreservesCustomGrokRowPatterns(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
-	custom := `(?m)^GROK>`
-	if err := os.WriteFile(path, []byte("[tools.grok]\ncommand = \"grok\"\nactivity_cutoff = '"+custom+"'\n"), 0o644); err != nil {
+	custom := `
+[tools.grok]
+command = "grok"
+activity_cutoff = '(?m)^GROK>'
+chrome_line = 'my own chrome'
+`
+	if err := os.WriteFile(path, []byte(custom), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	cfg, err := LoadDir(dir)
 	if err != nil {
 		t.Fatalf("LoadDir: %v", err)
 	}
-	if got := cfg.Tools["grok"].ActivityCutoff; got != custom {
+	if got := cfg.Tools["grok"].ActivityCutoff; got != `(?m)^GROK>` {
 		t.Fatalf("custom grok activity_cutoff was overwritten: %q", got)
+	}
+	if got := cfg.Tools["grok"].ChromeLine; got != "my own chrome" {
+		t.Fatalf("custom grok chrome_line was overwritten: %q", got)
 	}
 }
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -368,6 +368,9 @@ func (e *Engine) LastMessage(tool, pane string) (line string, anchored, ok bool)
 		if tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
 			return true
 		}
+		if tr.trailingNote != nil && tr.trailingNote.MatchString(strings.TrimLeft(line, " \t")) {
+			return true
+		}
 		return tr.matchesWorkingRule(line)
 	}
 	start, lastContent := -1, -1

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1073,6 +1073,51 @@ func TestCommandCodeRowShapes(t *testing.T) {
 	}
 }
 
+func TestGrokLastMessageSkipsChrome(t *testing.T) {
+	engine := defaultEngine(t)
+
+	fullscreen := "    created pr?                                          2:14 AM\n" +
+		"    ◆ user_prompt_submit  [hooks: 1]\n" +
+		"    No PR yet. I'll commit the worktree branch and open one.  2:14 AM\n" +
+		"    COPIED (53 bytes, 1 line)\n" +
+		"    Worked for 1m27s\n" +
+		" Help improve Grok                               [Opt out] [Opt in]\n" +
+		" Off by default. Opt-in to allow SpaceXAI to retain coding data, e.g., prompts,\n" +
+		" Read Terms and Privacy Policy.\n" +
+		" ╭────────────────────────────╮\n" +
+		" │ ❯                        │\n" +
+		" ╰──────────── Grok 4.6 (high) ─╯\n"
+	line, anchored, ok := engine.LastMessage("grok", fullscreen)
+	if !ok || anchored {
+		t.Fatalf("fullscreen grok: anchored=%v ok=%v, want unanchored ok", anchored, ok)
+	}
+	if line != "COPIED (53 bytes, 1 line)" {
+		t.Fatalf("fullscreen grok quote = %q, want the last reply line", line)
+	}
+
+	minimal := "◆ session_start\n" +
+		"      ✓ global/settings:session_start[0].hooks[0] (70ms)\n" +
+		"reply with the single word pong and nothing else\n" +
+		"◆ user_prompt_submit\n" +
+		"      ✓ global/computer-use:user_prompt_submit[0].hooks[0] (83ms)\n" +
+		"pong\n" +
+		"Worked for 3.7s\n" +
+		"minimal · /help\n" +
+		"❯\n" +
+		"Grok 4.6 (xhigh) · always-approve · 33K / 500K (7%) · ctrl+o transcript\n"
+	line, anchored, ok = engine.LastMessage("grok", minimal)
+	if !ok || anchored {
+		t.Fatalf("minimal grok: anchored=%v ok=%v, want unanchored ok", anchored, ok)
+	}
+	if line != "pong" {
+		t.Fatalf("minimal grok quote = %q, want the reply", line)
+	}
+
+	if echoed, ok := engine.LastUserEcho("grok", fullscreen); ok {
+		t.Fatalf("grok has no user_echo, LastUserEcho ok=%v echo=%q", ok, echoed)
+	}
+}
+
 // A degenerate cutoff like ^ matches every row at zero width. InputPrefix
 // refuses it for tools that did not declare a prefix, and the row-matcher
 // behind MatchesActivityCutoff refuses it just the same, so neither door


### PR DESCRIPTION
## What changed

Grok's list-row quote now skips the fullscreen opt-in card, the minimal hint row, hook lines, and the `Worked for` duration, and it finds the flush-left `❯` composer in `--minimal`. A stored config that still has the old boxed cutoff or box-only chrome is upgraded on load.

On a finished turn the rail quotes the last reply line (`pong` in `--minimal`; the last assistant line in fullscreen) instead of `Read Terms and Privacy Policy.` or `minimal · /help`.

## Why

`LastMessage` takes the newest non-chrome line above the composer. Grok draws chrome there, and `--minimal` never matched the boxed cutoff, so the row quoted the card or the footer.

Closes #473

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `go test ./internal/config ./internal/status` passes, including `TestGrokLastMessageSkipsChrome` (fullscreen + `--minimal` fixtures from grok 1.0.13)
- [x] `go build ./...` passes
- [x] `go test ./internal/ui` passes except the pre-existing `TestGuardedMouseCommandFollowsTheLiveFlag` duplicate-session flake on this host
- [x] Replayed a live fullscreen pane: quote is no longer the privacy card
- [x] Holds for grok; other tools keep their own chrome and markers

#471 (Left unfocus in grok minimal) was re-tested on its worktree: `TestCaretOnGrokComposer` and the grok prefix/cutoff tests pass.

## Visual evidence

**Not applicable because:** this is list-row text derived from captured pane contents. The grok 1.0.13 fullscreen and `--minimal` panes are the reproducible evidence and are now regression tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Grok response parsing by ignoring interface elements such as help text, hook logs, composer boxes, and status footers.
  - Trailing recap or duration notes are no longer incorrectly included in quoted replies.
  - Grok’s default pattern matching now recognizes additional interface elements.

- **Compatibility**
  - Existing Grok configurations are migrated to current defaults while preserving custom activity and interface patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->