### PR TITLE
fix(ui): skip preview connections for missing sessions

### DIFF
--- a/internal/ui/focuswatch.go
+++ b/internal/ui/focuswatch.go
@@ -205,6 +205,10 @@ func (w *focusWatch) retryNow() {
 }
 
 func (w *focusWatch) watch(id string, stop chan struct{}) {
+	if !w.driver.Exists(id) {
+		w.clearIfCurrent(id, stop)
+		return
+	}
 	control, err := w.driver.OpenControl(id)
 	if err != nil {
 		// No control client, no pushed previews; the settle/tick capture

--- a/internal/ui/focuswatch_test.go
+++ b/internal/ui/focuswatch_test.go
@@ -400,3 +400,14 @@ func TestFocusWatchReportsALostClient(t *testing.T) {
 		}
 	}
 }
+
+func TestFocusWatchSkipsMissingSession(t *testing.T) {
+	driver := requireFocusDriver(t)
+	id := "missing" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
+	watch := newFocusWatch(driver, func(msg tea.Msg) {
+		t.Errorf("missing session produced a preview notification: %#v", msg)
+	})
+	t.Cleanup(watch.Close)
+
+	watch.watch(id, make(chan struct{}))
+}

--- a/internal/ui/focuswatch_test.go
+++ b/internal/ui/focuswatch_test.go
@@ -401,13 +401,36 @@ func TestFocusWatchReportsALostClient(t *testing.T) {
 	}
 }
 
+// A session whose terminal is already gone is an expected state, not a
+// failure: selecting its row stays quiet and leaves the id unclaimed so a
+// later revive opens a fresh client.
 func TestFocusWatchSkipsMissingSession(t *testing.T) {
 	driver := requireFocusDriver(t)
 	id := "missing" + strings.ReplaceAll(time.Now().Format("150405.000000"), ".", "")
-	watch := newFocusWatch(driver, func(msg tea.Msg) {
-		t.Errorf("missing session produced a preview notification: %#v", msg)
-	})
+	msgs := make(chan tea.Msg, 8)
+	watch := newFocusWatch(driver, func(msg tea.Msg) { msgs <- msg })
 	t.Cleanup(watch.Close)
 
-	watch.watch(id, make(chan struct{}))
+	watch.setFocus(id)
+	deadline := time.After(2 * time.Second)
+	for {
+		watch.mu.Lock()
+		claimed, failed := watch.id, watch.failedID
+		watch.mu.Unlock()
+		if claimed == "" && failed == id {
+			break
+		}
+		select {
+		case msg := <-msgs:
+			t.Fatalf("missing session produced a notification: %#v", msg)
+		case <-deadline:
+			t.Fatalf("watcher still claims %q, backed off %q", claimed, failed)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	select {
+	case msg := <-msgs:
+		t.Fatalf("missing session produced a notification: %#v", msg)
+	default:
+	}
 }


### PR DESCRIPTION
## What changed

Selecting a session whose tmux terminal is already gone no longer opens a preview connection and reports `preview client for <id>: control client exited`.

## Why

Moving between dead session rows repeatedly surfaced an expected missing terminal as an error notification.

## Scope

### Required behavior

Keep missing sessions quiet while preserving live preview updates, saved-output fallback, retry backoff, and reports of unexpected loss of an established connection.

### Why this approach

Check tmux session existence in the watcher goroutine before opening its control client. This uses terminal existence rather than the potentially stale agent status and adds four lines to the existing watcher. It applies to every tool without provider-specific behavior.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amdp-check go test -race ./...` passes; the socket directory was created before running
- [x] `go build ./...` passes
- [x] Real tmux session tests cover live updates, missing sessions, retry backoff, unexpected client loss, and deliberate kills
- [x] macOS/Linux amd64/arm64 builds pass; runtime testing was on macOS arm64. Linux and macOS amd64 runtime testing, and interactive runs of every supported agent CLI, were not performed. The change uses the shared tmux driver and has no provider-specific branches.

The new regression test failed before the fix by receiving the preview error and passed afterward. An unchanged baseline run also exposed unrelated failures in `TestReviveStartsTheAgentAgainInALivePane` and `TestPendingInputWaitsForTheLaunchPrompt`; the final full race run on this branch passed.

## Visual evidence

**Before:** Pausing on a dead session row displayed `preview client for 18468f1c: control client exited` in the error toast.

**After:** The missing-session watcher returns without emitting a preview or error notification.

No before/after screenshots are attached: a still image of the normal list cannot establish that the asynchronous toast stays absent. The regression verifies that absence at its message source against real tmux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-watching reliability when a watched session is no longer available.
  * Prevented unnecessary notifications for sessions that have disappeared.
  * Ensured unavailable sessions are marked as failed and removed from active watch state.
  * Avoided attempts to connect to or control sessions that no longer exist.
  * Prevented stale watch requests from remaining queued.
* **Tests**
  * Added coverage to verify that missing sessions are handled without notifications or lingering requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->