### PR TITLE
feat(ui): copy a session's newest reply with y

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,7 @@ The actions are `detach` (default `["ctrl+q", "ctrl+\\"]`), `review` (default `"
 
 ### In the list
 
-Every key the list answers to is an action in `[keybindings.list]`, listed in full here and in the picker under Settings: `up`, `down`, `open`, `attach`, `step_in`, `step_out`, `reorder_up`, `reorder_down`, `new_session`, `terminal`, `new_group`, `fork`, `prompt`, `review`, `mark_idle`, `rename`, `move`, `editor`, `restart`, `kill`, `kill_all`, `revive`, `revive_all`, `archive`, `restore`, `delete`, `search`, `filter`, `archived`, `empty_groups`, `fold_all`, `resize`, `settings`, `messages`, `help` and `quit`.
+Every key the list answers to is an action in `[keybindings.list]`, listed in full here and in the picker under Settings: `up`, `down`, `open`, `attach`, `step_in`, `step_out`, `reorder_up`, `reorder_down`, `new_session`, `terminal`, `new_group`, `fork`, `prompt`, `copy_reply`, `review`, `mark_idle`, `rename`, `move`, `editor`, `restart`, `kill`, `kill_all`, `revive`, `revive_all`, `archive`, `restore`, `delete`, `search`, `filter`, `archived`, `empty_groups`, `fold_all`, `resize`, `settings`, `messages`, `help` and `quit`.
 
 ```toml
 [keybindings.list]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,6 +30,7 @@ Tell your agent what you want to review in Agent Manager. Your agent will set up
 | `K` / `J` (or `shift+↑` / `shift+↓`) | Reorder session or group among its visible siblings |
 | `m` | Move a session to a group, a terminal into a session, or a group under another group |
 | `r` | Rename session / edit tool; edit group name and default path |
+| `y` | Copy the selected session's newest reply to the system clipboard, without attaching |
 | `x` | Kill the selected session, or every live session under a group: frees the RAM their agents hold, and the rows stay for `v` |
 | `X` | Kill every live session in view |
 | `v` | Revive a dead session, or every dead session under a group |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,10 @@ type Tool struct {
 	// caller quoting the last reply starts at its beginning rather than
 	// its tail. Tools without one quote the newest content line instead.
 	MessageStart string `toml:"message_start"`
+	// ToolResult marks the row a tool call's result is drawn under, which
+	// a copied reply leaves out. Narrower than chrome_line, which every
+	// caller drops: the row quote keeps these.
+	ToolResult string `toml:"tool_result"`
 	// InputPlaceholder is the hint a composer paints on its empty input
 	// row; a draft matching it is the tool's wording, not the user's.
 	InputPlaceholder string `toml:"input_placeholder"`
@@ -219,8 +223,8 @@ const busyLineAgentsOnly = `^[✻✳✶✽✢·✦✧+*] Waiting for \d+ backgro
 // banner beneath completed turns. Hand-edited patterns remain untouched.
 const oldClaudeChromeLine = `^\s*[─q]{4,}.*$|^[\s─q]*$`
 
-// The same pattern once the updater banner was added, but before Claude
-// started printing its "new task?" nudge above the composer.
+// This exact chrome pattern was written after Claude added its updater
+// banner, but before the "new task?" nudge above its composer.
 const oldClaudeChromeLineNoHint = `^\s*[─q]{4,}.*$|^[\s─q]*$|^\s*✔ Update installed · Restart to update\s*$`
 
 // This exact cutoff was written before grok's minimal mode, which draws a
@@ -309,6 +313,7 @@ func mergeTool(name string, user, def Tool) Tool {
 	fill(&user.BlockedLine, def.BlockedLine)
 	fill(&user.TrailingNote, def.TrailingNote)
 	fill(&user.MessageStart, def.MessageStart)
+	fill(&user.ToolResult, def.ToolResult)
 	fill(&user.InputPlaceholder, def.InputPlaceholder)
 	fill(&user.UserEcho, def.UserEcho)
 	fill(&user.BusyLine, def.BusyLine)
@@ -549,6 +554,9 @@ limit_line = "(?m)You've hit your .+limit"
 # every message and tool call opens on a bullet at the left edge; the
 # glyph is ⏺ on current Claude Code and ● on older releases
 message_start = "^[●⏺] "
+# a tool call's result is drawn under this glyph, Claude Code's alone:
+# the box-drawing characters a table is built from open content rows too
+tool_result = "^\\s*⎿"
 # a submitted prompt echoes into the transcript on its own ❯ line
 user_echo = "^❯ "
 rules = [
@@ -621,6 +629,8 @@ turn_end = "(?m)^(?:─+ Worked for [\\dhms. ]+─+|─+)$"
 chrome_line = "^\\s*─*\\s*$"
 # every message and tool call opens on a "• " bullet
 message_start = "^• "
+# a command's output is drawn under this glyph, on its own indented row
+tool_result = "^\\s*└ "
 input_placeholder = "^Ask Codex to do anything"
 # a submitted prompt echoes into the transcript on its own › line
 user_echo = "^› "

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,10 @@ const busyLineAgentsOnly = `^[✻✳✶✽✢·✦✧+*] Waiting for \d+ backgro
 // banner beneath completed turns. Hand-edited patterns remain untouched.
 const oldClaudeChromeLine = `^\s*[─q]{4,}.*$|^[\s─q]*$`
 
+// The same pattern once the updater banner was added, but before Claude
+// started printing its "new task?" nudge above the composer.
+const oldClaudeChromeLineNoHint = `^\s*[─q]{4,}.*$|^[\s─q]*$|^\s*✔ Update installed · Restart to update\s*$`
+
 // This exact cutoff was written before grok's minimal mode, which draws a
 // flush-left composer with no box. oldGrokChromeLine is the box-only chrome
 // from before the list row had to step over the opt-in card and the minimal
@@ -316,7 +320,7 @@ func mergeTool(name string, user, def Tool) Tool {
 		if user.BusyLine == busyLineAgentsOnly {
 			user.BusyLine = def.BusyLine
 		}
-		if user.ChromeLine == oldClaudeChromeLine {
+		if user.ChromeLine == oldClaudeChromeLine || user.ChromeLine == oldClaudeChromeLineNoHint {
 			user.ChromeLine = def.ChromeLine
 		}
 	}
@@ -527,7 +531,7 @@ status_source = "claude-hooks"
 default_status = "idle"
 activity_cutoff = "(?m)^❯"
 turn_end = "^[✻✳✶✽✢·✦✧+*] \\S+ for \\d.*$"
-chrome_line = "^\\s*[─q]{4,}.*$|^[\\s─q]*$|^\\s*✔ Update installed · Restart to update\\s*$"
+chrome_line = "^\\s*[─q]{4,}.*$|^[\\s─q]*$|^\\s*✔ Update installed · Restart to update\\s*$|^\\s*new task\\? /clear to save .*$"
 blocked_line = "Interrupted ·"
 # recap blocks ("※ recap: …") render below the turn-end summary
 trailing_note = "^※"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -236,6 +236,15 @@ const (
 	oldGrokChromeLine = `^\s*[┃❙│─╭╮╰╯█]*\s*$`
 )
 
+// The gemini approval-mode banner as it was matched before gemini began
+// drawing a right-aligned skills count on the same row.
+const oldGeminiChromeLine = `^\s*[╭╮╰╯│─▄▀█]*\s*$|^\s*\? for shortcuts\s*$|^\s*press tab twice for more\s*$|^\s*Press Ctrl\+O to show more lines.*$|(?i)^\s*(auto-accept edits |plan |yolo )?\S*tab\S* to (accept edits|manual|plan|auto-accept edits)\s*$`
+
+// The hermes frame as it was matched before its titled boxes - the
+// reasoning block, the reply block - were read as frame rather than as
+// something the agent wrote.
+const oldHermesChromeLine = `^\s*[─╭╮╰╯│]*\s*$|^\s*⚕ .*$`
+
 // Codex used to end every command-running turn with a timed divider. Current
 // builds can draw a bare divider instead, so stored defaults need the wider
 // shape while hand-edited rules remain untouched.
@@ -336,6 +345,12 @@ func mergeTool(name string, user, def Tool) Tool {
 		if user.ChromeLine == oldGrokChromeLine {
 			user.ChromeLine = def.ChromeLine
 		}
+	}
+	if name == "gemini" && user.ChromeLine == oldGeminiChromeLine {
+		user.ChromeLine = def.ChromeLine
+	}
+	if name == "hermes" && user.ChromeLine == oldHermesChromeLine {
+		user.ChromeLine = def.ChromeLine
 	}
 	if name == "codex" && user.TurnEnd == oldCodexTurnEnd {
 		user.TurnEnd = def.TurnEnd
@@ -704,7 +719,7 @@ activity_cutoff = "(?m)^\\s*[>!*] "
 # "? for shortcuts" hint (its ? must not read as a question) and the
 # approval-mode banner ("Shift+Tab to accept edits", "auto-accept edits
 # shift+tab to manual", ...) are all chrome above the composer
-chrome_line = "^\\s*[╭╮╰╯│─▄▀█]*\\s*$|^\\s*\\? for shortcuts\\s*$|^\\s*press tab twice for more\\s*$|^\\s*Press Ctrl\\+O to show more lines.*$|(?i)^\\s*(auto-accept edits |plan |yolo )?\\S*tab\\S* to (accept edits|manual|plan|auto-accept edits)\\s*$"
+chrome_line = "^\\s*[╭╮╰╯│─▄▀█]*\\s*$|^\\s*\\? for shortcuts\\s*$|^\\s*press tab twice for more\\s*$|^\\s*Press Ctrl\\+O to show more lines.*$|(?i)^\\s*(auto-accept edits |plan |yolo )?\\S*tab\\S* to (accept edits|manual|plan|auto-accept edits)\\b.*$"
 limit_line = "Usage limit reached"
 # model replies open on a "✦ " glyph
 message_start = "^\\s*✦ "
@@ -741,7 +756,10 @@ prompt_mode = "send"
 mcp = "hermes"
 default_status = "idle"
 activity_cutoff = "(?m)^\\s*(?:\\S+\\s+)?[❯>$#›»→]\\s"
-chrome_line = "^\\s*[─╭╮╰╯│]*\\s*$|^\\s*⚕ .*$"
+chrome_line = "^\\s*[─╭╮╰╯│┌┐└┘]*\\s*$|^\\s*⚕ .*$|^\\s*[┌╭]─+ .+ ─+[┐╮]\\s*$|^\\s*Initializing agent\\.\\.\\.\\s*$"
+# a submitted prompt echoes into the transcript on its own "● " row,
+# between the short rules hermes brackets it with
+user_echo = "^● "
 busy_line = "(?:▶|⚙|⛓) \\d+"
 limit_line = "(?i)Rate limited|usage limit reached|Nous Portal rate limit"
 rules = [

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -229,6 +229,39 @@ chrome_line = '` + oldClaudeChromeLine + `'
 	}
 }
 
+// A config.toml stored before claude began printing its "new task?"
+// nudge carries the chrome rule of that release verbatim, and keeps it
+// over any new default unless the old wording is recognised.
+func TestLoadDirUpgradesClaudeChromeToTheComposerHint(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	stored := `
+[tools.claude]
+command = "claude"
+chrome_line = '` + oldClaudeChromeLineNoHint + `'
+`
+	if err := os.WriteFile(path, []byte(stored), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if !strings.Contains(cfg.Tools["claude"].ChromeLine, "new task") {
+		t.Fatalf("stored claude chrome_line was not upgraded: %q", cfg.Tools["claude"].ChromeLine)
+	}
+	// The rewrite only fires on the exact wording that shipped, so the
+	// constant has to stay the current default minus the nudge.
+	def, err := Default()
+	if err != nil {
+		t.Fatalf("built-in config: %v", err)
+	}
+	if !strings.HasPrefix(def.Tools["claude"].ChromeLine, oldClaudeChromeLineNoHint) {
+		t.Fatalf("oldClaudeChromeLineNoHint drifted from the default:\n%q\n%q",
+			oldClaudeChromeLineNoHint, def.Tools["claude"].ChromeLine)
+	}
+}
+
 func TestLoadDirUpgradesLegacyGrokRowPatterns(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -229,6 +229,50 @@ chrome_line = '` + oldClaudeChromeLine + `'
 	}
 }
 
+// A config.toml stored before hermes's titled boxes were read as frame
+// carries the narrower rule, which leaves those borders in a copied reply.
+func TestLoadDirUpgradesHermesChromeToItsTitledBoxes(t *testing.T) {
+	dir := t.TempDir()
+	stored := "\n[tools.hermes]\ncommand = \"hermes --cli\"\nchrome_line = '" + oldHermesChromeLine + "'\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(stored), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	border := "╭─ ⚕ Hermes ─────╮"
+	if !regexp.MustCompile(cfg.Tools["hermes"].ChromeLine).MatchString(border) {
+		t.Fatalf("stored hermes chrome_line was not upgraded: %q", cfg.Tools["hermes"].ChromeLine)
+	}
+	if regexp.MustCompile(oldHermesChromeLine).MatchString(border) {
+		t.Fatal("oldHermesChromeLine drifted: it already matches the row the upgrade exists for")
+	}
+}
+
+// A config.toml stored before gemini drew a skills count beside its
+// approval banner carries the narrower rule, which no longer matches the
+// row it was written for.
+func TestLoadDirUpgradesGeminiChromeToTheSkillsCount(t *testing.T) {
+	dir := t.TempDir()
+	stored := "\n[tools.gemini]\ncommand = \"gemini\"\nchrome_line = '" + oldGeminiChromeLine + "'\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(stored), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	banner := " Shift+Tab to accept edits                          2 skills"
+	rule := regexp.MustCompile(cfg.Tools["gemini"].ChromeLine)
+	if !rule.MatchString(banner) {
+		t.Fatalf("stored gemini chrome_line was not upgraded: %q", cfg.Tools["gemini"].ChromeLine)
+	}
+	if regexp.MustCompile(oldGeminiChromeLine).MatchString(banner) {
+		t.Fatal("oldGeminiChromeLine drifted: it already matches the row the upgrade exists for")
+	}
+}
+
 // A config.toml stored before claude began printing its "new task?"
 // nudge carries the chrome rule of that release verbatim, and keeps it
 // over any new default unless the old wording is recognised.

--- a/internal/config/keys_test.go
+++ b/internal/config/keys_test.go
@@ -239,3 +239,36 @@ editor = "none"
 		t.Fatalf("the list table should be replaced in place:\n%s", saved)
 	}
 }
+
+func TestCopyReplyUpgradePreservesWrittenKeys(t *testing.T) {
+	dir, _ := writeConfig(t, `[keybindings.list]
+archive = "y"
+fork = "ctrl+f"
+rename = "ctrl+n"
+`)
+	loaded, err := LoadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action, _ := loaded.ListKeys.ActionFor("y"); action != keybind.Archive {
+		t.Fatalf("y = %q", action)
+	}
+	if len(loaded.ListKeys.Binding(keybind.CopyReply).Keys()) != 0 {
+		t.Fatal("copy_reply must yield y")
+	}
+	if err := SaveKeys(dir, loaded.ListKeys); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := LoadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.ListKeys.Equal(reloaded.ListKeys) {
+		t.Fatal("saving changed the resolved keys")
+	}
+	for key, want := range map[string]string{"ctrl+f": keybind.Fork, "ctrl+n": keybind.Rename, "y": keybind.Archive} {
+		if got, _ := reloaded.ListKeys.ActionFor(key); got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}

--- a/internal/keybind/keybind.go
+++ b/internal/keybind/keybind.go
@@ -242,6 +242,7 @@ const (
 	NewGroup    = "new_group"
 	Fork        = "fork"
 	Prompt      = "prompt"
+	CopyReply   = "copy_reply"
 	MarkIdle    = "mark_idle"
 	Rename      = "rename"
 	Move        = "move"
@@ -289,6 +290,7 @@ var listActions = []Action{
 	{NewGroup, "new group", keys("g")},
 	{Fork, "fork the session", keys("f")},
 	{Prompt, "quick prompt", keys("space")},
+	{CopyReply, "copy the session's newest reply to the clipboard", keys("y")},
 	{Review, "review the session's diff", keys("ctrl+r")},
 	{MarkIdle, "mark a finished session idle", keys(".")},
 	{Rename, "rename the session, edit the group", keys("r")},

--- a/internal/keybind/keybind_test.go
+++ b/internal/keybind/keybind_test.go
@@ -337,6 +337,7 @@ func decodeSession(t *testing.T, text string) (Table, error) {
 	}
 	return SessionTable(file.Session)
 }
+
 // y copies the selected session's reply, and shares its key with nothing
 // else in the list.
 func TestCopyReplyIsBoundToY(t *testing.T) {

--- a/internal/keybind/keybind_test.go
+++ b/internal/keybind/keybind_test.go
@@ -337,3 +337,12 @@ func decodeSession(t *testing.T, text string) (Table, error) {
 	}
 	return SessionTable(file.Session)
 }
+// y copies the selected session's reply, and shares its key with nothing
+// else in the list.
+func TestCopyReplyIsBoundToY(t *testing.T) {
+	list := DefaultList()
+	action, ok := list.ActionFor("y")
+	if !ok || action != CopyReply {
+		t.Fatalf("y = %q ok=%v, want %q", action, ok, CopyReply)
+	}
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"regexp"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -423,31 +424,61 @@ func (tr toolRules) isStructural(line string) bool {
 // marker, which drops every earlier paragraph of a reply that opened
 // several.
 //
-// ok is false under the same conditions as ActivityRegion: the tool
-// declares no activity_cutoff, or the pane holds none.
-func (e *Engine) FullTurnText(tool, pane string) (text string, ok bool) {
+// bounded says a prompt echo or a turn summary marked where the turn
+// began. Where neither is in frame the text is the whole region, which
+// can hold several turns: grok keeps no prompt in its transcript, and
+// any tool's summary can sit above the capture.
+//
+// ok is false where no reply can be read at all: the tool declares no
+// activity_cutoff, the pane holds none, or its region is frame only, as
+// pi's is by design.
+func (e *Engine) FullTurnText(tool, pane string) (text string, bounded, ok bool) {
 	tr, ok := e.tools[tool]
 	if !ok {
-		return "", false
+		return "", false, false
 	}
 	region, ok := tr.activityRegion(pane)
 	if !ok {
-		return "", false
+		return "", false, false
 	}
 	lines := strings.Split(region, "\n")
-	body, afterEcho := tr.newestTurn(lines)
-	if text := tr.turnProse(body, afterEcho); text != "" {
-		return text, true
+	fromPane := false
+	if !slices.ContainsFunc(lines, tr.isContent) {
+		// pi opens its region at the pane origin on purpose, so that a
+		// reflow can never read as fresh output. Nothing is there to copy,
+		// and the pane itself is what the user is looking at.
+		lines, fromPane = tr.paneAboveComposer(pane), true
+		if !slices.ContainsFunc(lines, tr.isContent) {
+			return "", false, false
+		}
 	}
+	body, afterEcho, bounded := tr.newestTurn(lines)
+	text = tr.turnProse(body, afterEcho)
 	// A prompt sent while the last turn was still being read leaves the
 	// newest turn empty, and the answer the user is looking at is the one
 	// above it. Cut the prompt row itself with it, or the same empty turn
 	// comes back.
-	if start := len(lines) - len(body); start > 0 {
-		above, aboveEcho := tr.newestTurn(lines[:start-1])
-		return tr.turnProse(above, aboveEcho), true
+	if start := len(lines) - len(body); text == "" && start > 0 {
+		body, afterEcho, bounded = tr.newestTurn(lines[:start-1])
+		text = tr.turnProse(body, afterEcho)
 	}
-	return "", true
+	return text, bounded && !fromPane, true
+}
+
+// paneAboveComposer is the pane without the composer its tool draws at the
+// bottom: everything above the last row of the tool's own frame. It is the
+// fallback for a tool whose activity region holds no content of its own.
+func (tr toolRules) paneAboveComposer(pane string) []string {
+	lines := strings.Split(pane, "\n")
+	if tr.chromeLine == nil {
+		return lines
+	}
+	for i := len(lines) - 1; i >= 0; i-- {
+		if tr.chromeLine.MatchString(strings.TrimRight(lines[i], " \t")) {
+			return lines[:i]
+		}
+	}
+	return lines
 }
 
 // turnProse is the reply inside one turn's rows: paragraph breaks kept,
@@ -522,23 +553,23 @@ func (tr toolRules) contentRows(body []string, trimPrompt bool) []string {
 // on screen. With no prompt in frame either way, the summary that closed
 // the previous turn bounds it instead. afterEcho reports that a prompt
 // was found, so the rows under it can still be its wrapped tail.
-func (tr toolRules) newestTurn(lines []string) (body []string, afterEcho bool) {
+func (tr toolRules) newestTurn(lines []string) (body []string, afterEcho, bounded bool) {
 	if tr.userEcho != nil {
 		if i := tr.lastEchoIndex(lines); i >= 0 {
-			return lines[i+1:], true
+			return lines[i+1:], true, true
 		}
 	} else {
 		for i := len(lines) - 1; i >= 0; i-- {
 			line := strings.TrimRight(lines[i], " \t")
 			if tr.inputRow(line) && !tr.matchesAnyRule(line) {
-				return lines[i+1:], true
+				return lines[i+1:], true, true
 			}
 		}
 	}
 	if i := tr.previousTurnEndIndex(lines); i >= 0 {
-		return lines[i+1:], false
+		return lines[i+1:], false, true
 	}
-	return lines, false
+	return lines, false, false
 }
 
 // previousTurnEndIndex is the turn summary that closed the turn before

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -41,6 +41,7 @@ type toolRules struct {
 	busyLine       *regexp.Regexp
 	limitLine      *regexp.Regexp
 	messageStart   *regexp.Regexp
+	toolResult     *regexp.Regexp
 	placeholder    *regexp.Regexp
 	userEcho       *regexp.Regexp
 	dialogFooter   *regexp.Regexp
@@ -79,6 +80,7 @@ func NewEngine(cfg config.Config) (*Engine, error) {
 			{tool.BusyLine, &tr.busyLine},
 			{tool.LimitLine, &tr.limitLine},
 			{tool.MessageStart, &tr.messageStart},
+			{tool.ToolResult, &tr.toolResult},
 			{tool.InputPlaceholder, &tr.placeholder},
 			{tool.UserEcho, &tr.userEcho},
 			{tool.DialogFooter, &tr.dialogFooter},
@@ -395,15 +397,10 @@ func (e *Engine) LastMessage(tool, pane string) (line string, anchored, ok bool)
 	return strings.TrimSpace(strings.Join(parts, " ")), true, true
 }
 
-// toolResultRow matches the row a tool call's result is drawn under.
-// Only claude's own glyph: the box-drawing characters a table is built
-// from open rows too, and those are content.
-var toolResultRow = regexp.MustCompile(`^\s*⎿`)
-
-// isStructural reports whether line is chrome, a busy spinner, or a
-// turn-end summary rather than message content: the one check shared by
-// LastMessage's marker search and FullTurnText's whole-region copy, so a
-// rule added to one is never missed by the other.
+// isStructural reports whether line is the tool's own frame - chrome, a
+// spinner, a turn summary, a trailing note - rather than message content.
+// LastMessage and FullTurnText share it so a rule added to one is never
+// missed by the other.
 func (tr toolRules) isStructural(line string) bool {
 	if tr.chromeLine != nil && tr.chromeLine.MatchString(line) {
 		return true
@@ -420,20 +417,14 @@ func (tr toolRules) isStructural(line string) bool {
 	return tr.matchesWorkingRule(line)
 }
 
-// FullTurnText is the newest turn's prose: everything the agent wrote
-// after the last prompt, with tool calls, their results and the tool's
-// own chrome left out.
+// FullTurnText is the newest turn's prose with its paragraph breaks kept:
+// everything the agent wrote after the last prompt, without tool results
+// or the tool's own frame. LastMessage anchors to one message_start
+// marker, which drops every earlier paragraph of a reply that opened
+// several.
 //
-// The turn starts after the last user_echo (the prompt the tool echoed
-// back), or after the last turn_end for a tool that echoes nothing.
-// Without that bound this would return every turn still on screen, since
-// activityRegion is only bounded below, by the composer. A wrapped
-// prompt's continuation rows are dropped with it: user_echo only matches
-// the first row, so anything between it and the first real content row
-// belongs to the prompt too.
-//
-// ok is false under the same conditions as ActivityRegion: no
-// activity_cutoff configured, or none found in pane.
+// ok is false under the same conditions as ActivityRegion: the tool
+// declares no activity_cutoff, or the pane holds none.
 func (e *Engine) FullTurnText(tool, pane string) (text string, ok bool) {
 	tr, ok := e.tools[tool]
 	if !ok {
@@ -444,53 +435,166 @@ func (e *Engine) FullTurnText(tool, pane string) (text string, ok bool) {
 		return "", false
 	}
 	lines := strings.Split(region, "\n")
-	start := 0
-	sawPrompt := false
-	for i, raw := range lines {
-		line := strings.TrimRight(raw, " \t")
-		if tr.userEcho != nil && tr.userEcho.MatchString(line) {
-			start, sawPrompt = i+1, true
-			continue
-		}
-		if tr.userEcho == nil && tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
-			start = i + 1
+	body, afterEcho := tr.newestTurn(lines)
+	if text := tr.turnProse(body, afterEcho); text != "" {
+		return text, true
+	}
+	// A prompt sent while the last turn was still being read leaves the
+	// newest turn empty, and the answer the user is looking at is the one
+	// above it. Cut the prompt row itself with it, or the same empty turn
+	// comes back.
+	if start := len(lines) - len(body); start > 0 {
+		above, aboveEcho := tr.newestTurn(lines[:start-1])
+		return tr.turnProse(above, aboveEcho), true
+	}
+	return "", true
+}
+
+// turnProse is the reply inside one turn's rows: paragraph breaks kept,
+// tool results and the tool's own frame dropped. afterEcho says a prompt
+// sits above these rows, so the wrapped tail of it may still be among
+// them; where that trim would leave nothing, the rows were the reply.
+func (tr toolRules) turnProse(body []string, afterEcho bool) string {
+	// The reply's own opening marker beats guessing where the prompt
+	// ended, so take it whenever the turn's start is in frame.
+	if afterEcho {
+		if marked := tr.firstMessageIndex(body); marked >= 0 {
+			body, afterEcho = body[marked:], false
 		}
 	}
-	out := make([]string, 0, len(lines)-start)
-	// A reply long enough to outrun the capture leaves its prompt off the
-	// top of it. Nothing was skipped, so nothing below is prompt tail
-	// either: the region opens mid-reply and every row of it is content.
-	started := !sawPrompt
-	for _, raw := range lines[start:] {
+	// Indentation is all that marks a wrapped prompt's continuation rows,
+	// and only a tool whose replies open on a marker can be read that
+	// way: an unmarked reply here starts at the left edge.
+	trimPrompt := afterEcho && tr.messageStart != nil
+	out := tr.contentRows(body, trimPrompt)
+	if len(out) == 0 && trimPrompt {
+		out = tr.contentRows(body, false)
+	}
+	return strings.Join(out, "\n")
+}
+
+// contentRows is body without the tool's frame, its tool results and
+// their wrapped rows, stopping at the summary that closes the turn.
+// trimPrompt drops indented rows until the first row at the left edge.
+func (tr toolRules) contentRows(body []string, trimPrompt bool) []string {
+	out := make([]string, 0, len(body))
+	inResult := false
+	for _, raw := range body {
 		line := strings.TrimRight(raw, " \t")
 		if strings.TrimSpace(line) == "" {
+			inResult = false
 			if len(out) > 0 && out[len(out)-1] != "" {
 				out = append(out, "")
 			}
 			continue
 		}
-		if toolResultRow.MatchString(line) {
+		if tr.toolResult != nil && tr.toolResult.MatchString(line) {
+			inResult = true
 			continue
 		}
+		// A result runs past its own marker row onto the rows it wrapped
+		// onto, which carry no marker of their own.
+		if inResult && wrapsAbove(line) {
+			continue
+		}
+		inResult = false
 		if tr.isStructural(line) {
-			// A turn_end after content closes the turn: a notice printed
-			// below it (a plugin banner, an update note) is not the reply.
-			if started && tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
+			// A turn_end closes the turn, so a notice printed below it
+			// belongs to no reply.
+			if tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
 				break
 			}
 			continue
 		}
-		if !started && strings.HasPrefix(raw, " ") {
-			// Still inside the prompt: a wrapped user_echo's own
-			// continuation rows are indented under it, and nothing else
-			// marks them. Only before the turn's first content row - a
-			// reply's own wrapped lines are indented the same way.
+		if trimPrompt && len(out) == 0 && wrapsAbove(line) {
 			continue
 		}
-		started = true
 		out = append(out, line)
 	}
-	return strings.TrimSpace(strings.Join(out, "\n")), true
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// newestTurn is the region past its newest prompt: the row after the
+// prompt the tool echoed, or after the last composer row for a tool that
+// echoes nothing (grok, hermes), whose cutoff draws every prompt it kept
+// on screen. With no prompt in frame either way, the summary that closed
+// the previous turn bounds it instead. afterEcho reports that a prompt
+// was found, so the rows under it can still be its wrapped tail.
+func (tr toolRules) newestTurn(lines []string) (body []string, afterEcho bool) {
+	if tr.userEcho != nil {
+		if i := tr.lastEchoIndex(lines); i >= 0 {
+			return lines[i+1:], true
+		}
+	} else {
+		for i := len(lines) - 1; i >= 0; i-- {
+			line := strings.TrimRight(lines[i], " \t")
+			if tr.inputRow(line) && !tr.matchesAnyRule(line) {
+				return lines[i+1:], true
+			}
+		}
+	}
+	if i := tr.previousTurnEndIndex(lines); i >= 0 {
+		return lines[i+1:], false
+	}
+	return lines, false
+}
+
+// previousTurnEndIndex is the turn summary that closed the turn before
+// the newest one, the bound left when no prompt is in frame: a tool that
+// keeps none (grok), or a prompt the capture cut off or a status rule
+// claimed. A running turn has drawn no summary of its own yet, so the
+// last one is that boundary; once it ends, the last summary is its own
+// and the one above it opens the turn. -1 when neither is in frame.
+func (tr toolRules) previousTurnEndIndex(lines []string) int {
+	if tr.turnEnd == nil {
+		return -1
+	}
+	previous, last := -1, -1
+	contentBelow := false
+	for i, raw := range lines {
+		line := strings.TrimRight(raw, " \t")
+		if tr.turnEnd.MatchString(line) {
+			previous, last, contentBelow = last, i, false
+			continue
+		}
+		if tr.isContent(line) {
+			contentBelow = true
+		}
+	}
+	if contentBelow {
+		return last
+	}
+	return previous
+}
+
+// firstMessageIndex is the first row opening a message the tool printed,
+// or -1 for a turn that rendered none.
+func (tr toolRules) firstMessageIndex(lines []string) int {
+	if tr.messageStart == nil {
+		return -1
+	}
+	for i, raw := range lines {
+		line := strings.TrimRight(raw, " \t")
+		if !tr.isContent(line) {
+			continue
+		}
+		if tr.messageStart.MatchString(line) {
+			return i
+		}
+	}
+	return -1
+}
+
+// isContent reports whether a row carries something the agent wrote,
+// rather than a blank, the tool's own frame, or a tool result.
+func (tr toolRules) isContent(line string) bool {
+	if strings.TrimSpace(line) == "" || tr.isStructural(line) {
+		return false
+	}
+	return tr.toolResult == nil || !tr.toolResult.MatchString(line)
 }
 
 // HasMessageStart reports whether the tool declared a message_start
@@ -523,20 +627,36 @@ func (e *Engine) LastUserEcho(tool, pane string) (string, bool) {
 		return "", false
 	}
 	lines := strings.Split(region, "\n")
+	i := tr.lastEchoIndex(lines)
+	if i < 0 {
+		return "", true
+	}
+	line := strings.TrimRight(lines[i], " \t")
+	loc := tr.userEcho.FindStringIndex(line)
+	return strings.TrimSpace(line[loc[1]:]), true
+}
+
+// lastEchoIndex is the row carrying the newest prompt the tool echoed, or
+// -1 when the region holds none.
+func (tr toolRules) lastEchoIndex(lines []string) int {
+	if tr.userEcho == nil {
+		return -1
+	}
+	end := len(lines)
 	// A composer drawn above the cutoff (opencode's ┃ gutter) is a run of
 	// input_prefix rows hugging the region's end; the echoes live higher,
 	// so the trailing run is the composer's, not a message.
 	if tr.inputPrefix != nil {
-		for len(lines) > 0 {
-			last := lines[len(lines)-1]
+		for end > 0 {
+			last := lines[end-1]
 			if strings.TrimSpace(last) == "" || tr.inputPrefix.MatchString(last) {
-				lines = lines[:len(lines)-1]
+				end--
 				continue
 			}
 			break
 		}
 	}
-	for i := len(lines) - 1; i >= 0; i-- {
+	for i := end - 1; i >= 0; i-- {
 		line := strings.TrimRight(lines[i], " \t")
 		loc := tr.userEcho.FindStringIndex(line)
 		if loc == nil {
@@ -555,9 +675,9 @@ func (e *Engine) LastUserEcho(tool, pane string) (string, bool) {
 		if tr.placeholder != nil && tr.placeholder.MatchString(echoed) {
 			continue
 		}
-		return echoed, true
+		return i
 	}
-	return "", true
+	return -1
 }
 
 func (tr toolRules) matchesAnyRule(line string) bool {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -453,7 +453,7 @@ func (e *Engine) FullTurnText(tool, pane string) (text string, ok bool) {
 // turnProse is the reply inside one turn's rows: paragraph breaks kept,
 // tool results and the tool's own frame dropped. afterEcho says a prompt
 // sits above these rows, so the wrapped tail of it may still be among
-// them; where that trim would leave nothing, the rows were the reply.
+// them; a completed turn can also hold an entirely unmarked reply.
 func (tr toolRules) turnProse(body []string, afterEcho bool) string {
 	// The reply's own opening marker beats guessing where the prompt
 	// ended, so take it whenever the turn's start is in frame.
@@ -467,7 +467,7 @@ func (tr toolRules) turnProse(body []string, afterEcho bool) string {
 	// way: an unmarked reply here starts at the left edge.
 	trimPrompt := afterEcho && tr.messageStart != nil
 	out := tr.contentRows(body, trimPrompt)
-	if len(out) == 0 && trimPrompt {
+	if len(out) == 0 && trimPrompt && tr.turnEnd != nil && tr.lastTurnEndIndex(body) >= 0 {
 		out = tr.contentRows(body, false)
 	}
 	return strings.Join(out, "\n")
@@ -482,7 +482,6 @@ func (tr toolRules) contentRows(body []string, trimPrompt bool) []string {
 	for _, raw := range body {
 		line := strings.TrimRight(raw, " \t")
 		if strings.TrimSpace(line) == "" {
-			inResult = false
 			if len(out) > 0 && out[len(out)-1] != "" {
 				out = append(out, "")
 			}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -358,25 +358,10 @@ func (e *Engine) LastMessage(tool, pane string) (line string, anchored, ok bool)
 		return "", false, false
 	}
 	lines := strings.Split(region, "\n")
-	structural := func(line string) bool {
-		if tr.chromeLine != nil && tr.chromeLine.MatchString(line) {
-			return true
-		}
-		if tr.busyLine != nil && tr.busyLine.MatchString(line) {
-			return true
-		}
-		if tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
-			return true
-		}
-		if tr.trailingNote != nil && tr.trailingNote.MatchString(strings.TrimLeft(line, " \t")) {
-			return true
-		}
-		return tr.matchesWorkingRule(line)
-	}
 	start, lastContent := -1, -1
 	for i, raw := range lines {
 		line := strings.TrimRight(raw, " \t")
-		if strings.TrimSpace(line) == "" || structural(line) {
+		if strings.TrimSpace(line) == "" || tr.isStructural(line) {
 			continue
 		}
 		lastContent = i
@@ -402,12 +387,110 @@ func (e *Engine) LastMessage(tool, pane string) (line string, anchored, ok bool)
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		if structural(line) {
+		if tr.isStructural(line) {
 			break
 		}
 		parts = append(parts, strings.TrimSpace(line))
 	}
 	return strings.TrimSpace(strings.Join(parts, " ")), true, true
+}
+
+// toolResultRow matches the row a tool call's result is drawn under.
+// Only claude's own glyph: the box-drawing characters a table is built
+// from open rows too, and those are content.
+var toolResultRow = regexp.MustCompile(`^\s*⎿`)
+
+// isStructural reports whether line is chrome, a busy spinner, or a
+// turn-end summary rather than message content: the one check shared by
+// LastMessage's marker search and FullTurnText's whole-region copy, so a
+// rule added to one is never missed by the other.
+func (tr toolRules) isStructural(line string) bool {
+	if tr.chromeLine != nil && tr.chromeLine.MatchString(line) {
+		return true
+	}
+	if tr.busyLine != nil && tr.busyLine.MatchString(line) {
+		return true
+	}
+	if tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
+		return true
+	}
+	if tr.trailingNote != nil && tr.trailingNote.MatchString(strings.TrimLeft(line, " \t")) {
+		return true
+	}
+	return tr.matchesWorkingRule(line)
+}
+
+// FullTurnText is the newest turn's prose: everything the agent wrote
+// after the last prompt, with tool calls, their results and the tool's
+// own chrome left out.
+//
+// The turn starts after the last user_echo (the prompt the tool echoed
+// back), or after the last turn_end for a tool that echoes nothing.
+// Without that bound this would return every turn still on screen, since
+// activityRegion is only bounded below, by the composer. A wrapped
+// prompt's continuation rows are dropped with it: user_echo only matches
+// the first row, so anything between it and the first real content row
+// belongs to the prompt too.
+//
+// ok is false under the same conditions as ActivityRegion: no
+// activity_cutoff configured, or none found in pane.
+func (e *Engine) FullTurnText(tool, pane string) (text string, ok bool) {
+	tr, ok := e.tools[tool]
+	if !ok {
+		return "", false
+	}
+	region, ok := tr.activityRegion(pane)
+	if !ok {
+		return "", false
+	}
+	lines := strings.Split(region, "\n")
+	start := 0
+	sawPrompt := false
+	for i, raw := range lines {
+		line := strings.TrimRight(raw, " \t")
+		if tr.userEcho != nil && tr.userEcho.MatchString(line) {
+			start, sawPrompt = i+1, true
+			continue
+		}
+		if tr.userEcho == nil && tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
+			start = i + 1
+		}
+	}
+	out := make([]string, 0, len(lines)-start)
+	// A reply long enough to outrun the capture leaves its prompt off the
+	// top of it. Nothing was skipped, so nothing below is prompt tail
+	// either: the region opens mid-reply and every row of it is content.
+	started := !sawPrompt
+	for _, raw := range lines[start:] {
+		line := strings.TrimRight(raw, " \t")
+		if strings.TrimSpace(line) == "" {
+			if len(out) > 0 && out[len(out)-1] != "" {
+				out = append(out, "")
+			}
+			continue
+		}
+		if toolResultRow.MatchString(line) {
+			continue
+		}
+		if tr.isStructural(line) {
+			// A turn_end after content closes the turn: a notice printed
+			// below it (a plugin banner, an update note) is not the reply.
+			if started && tr.turnEnd != nil && tr.turnEnd.MatchString(line) {
+				break
+			}
+			continue
+		}
+		if !started && strings.HasPrefix(raw, " ") {
+			// Still inside the prompt: a wrapped user_echo's own
+			// continuation rows are indented under it, and nothing else
+			// marks them. Only before the turn's first content row - a
+			// reply's own wrapped lines are indented the same way.
+			continue
+		}
+		started = true
+		out = append(out, line)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n")), true
 }
 
 // HasMessageStart reports whether the tool declared a message_start

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1178,3 +1178,157 @@ func TestComposerIsEmpty(t *testing.T) {
 		t.Fatal("a tool without a declared placeholder took the parked-caret path")
 	}
 }
+
+// FullTurnText keeps every marker-led paragraph in the turn, where
+// LastMessage/LastMessageText anchor to only the newest one.
+func TestFullTurnText(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ Reply with exactly this sentence and nothing else: some prompt text\n" +
+		"⏺ First paragraph about the topic.\n" +
+		"  continued content of first paragraph.\n" +
+		"\n" +
+		"\n" +
+		"⏺ Second paragraph, a different topic.\n" +
+		"\n" +
+		"⏺ Third and final paragraph.\n" +
+		"\n" +
+		"✻ Crunched for 3s\n" +
+		"────────────────────\n" +
+		"❯ "
+	want := "⏺ First paragraph about the topic.\n" +
+		"  continued content of first paragraph.\n" +
+		"\n" +
+		"⏺ Second paragraph, a different topic.\n" +
+		"\n" +
+		"⏺ Third and final paragraph."
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("claude has an activity cutoff, ok should be true")
+	}
+	if text != want {
+		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
+	}
+
+	if _, ok := engine.FullTurnText("no-such-tool", pane); ok {
+		t.Fatal("unknown tool should report it cannot tell")
+	}
+	if _, ok := engine.FullTurnText("claude", "just text, no input box"); ok {
+		t.Fatal("pane without the cutoff should report it cannot tell")
+	}
+}
+
+// FullTurnText copies the newest turn, not every turn still on screen:
+// a pane holding two exchanges must return only the second one's prose.
+func TestFullTurnTextStopsAtPreviousTurn(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ first prompt\n" +
+		"⏺ first answer\n" +
+		"✻ Crunched for 1s\n" +
+		"❯ second prompt\n" +
+		"⏺ second answer\n" +
+		"✻ Crunched for 2s\n" +
+		"❯ "
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != "⏺ second answer" {
+		t.Fatalf("FullTurnText = %q, want only the newest turn", text)
+	}
+}
+
+// A prompt long enough to wrap echoes over several rows, but user_echo
+// only matches the first: the rest are still the prompt, not the reply.
+// Tool calls and their result rows are not prose either, and a notice
+// printed after the turn-end summary is past the reply entirely.
+func TestFullTurnTextDropsPromptTailAndToolRows(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ a prompt long enough that the composer wrapped it onto\n" +
+		"  a second row and then a third row as well\n" +
+		"⏺ Read(internal/status/status.go)\n" +
+		"  ⎿  Read 120 lines\n" +
+		"⏺ The answer itself.\n" +
+		"✻ Crunched for 3s\n" +
+		"✔ Update installed · Restart to update\n" +
+		"❯ "
+	want := "⏺ Read(internal/status/status.go)\n" +
+		"⏺ The answer itself."
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != want {
+		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
+	}
+}
+
+// Claude prints a "new task?" nudge above the composer once context use
+// runs high. It is chrome, and belongs to no turn.
+func TestFullTurnTextDropsComposerHint(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ a prompt\n" +
+		"⏺ The answer.\n" +
+		"                          new task? /clear to save 421.3k tokens\n" +
+		"❯ "
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != "⏺ The answer." {
+		t.Fatalf("FullTurnText = %q, want the nudge dropped", text)
+	}
+}
+
+// Not every reply opens on a message_start marker: a turn can render as
+// plain unmarked prose, and dropping it as prompt tail would copy
+// nothing at all.
+func TestFullTurnTextKeepsUnmarkedReply(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ a prompt\n" +
+		"Regression test. Some unmarked prose.\n" +
+		"  its own wrapped continuation row.\n" +
+		"\n" +
+		"Docs. A second unmarked paragraph.\n" +
+		"✻ Baked for 1m 33s\n" +
+		"❯ "
+	want := "Regression test. Some unmarked prose.\n" +
+		"  its own wrapped continuation row.\n" +
+		"\n" +
+		"Docs. A second unmarked paragraph."
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != want {
+		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
+	}
+}
+
+// A table's rows open on the same box-drawing characters a tool result
+// is drawn under, and they are content: only claude's own ⎿ marks a
+// result row.
+func TestFullTurnTextKeepsTableRows(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "❯ a prompt\n" +
+		"⏺ Here is the table.\n" +
+		"  ┌───────┬───────┐\n" +
+		"  │ Raw   │ Under │\n" +
+		"  ├───────┼───────┤\n" +
+		"  │ 0.50  │ 23.00 │\n" +
+		"  └───────┴───────┘\n" +
+		"  ⎿  Read 120 lines\n" +
+		"❯ "
+	want := "⏺ Here is the table.\n" +
+		"  ┌───────┬───────┐\n" +
+		"  │ Raw   │ Under │\n" +
+		"  ├───────┼───────┤\n" +
+		"  │ 0.50  │ 23.00 │\n" +
+		"  └───────┴───────┘"
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != want {
+		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
+	}
+}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1201,7 +1201,7 @@ func TestFullTurnText(t *testing.T) {
 		"⏺ Second paragraph, a different topic.\n" +
 		"\n" +
 		"⏺ Third and final paragraph."
-	text, ok := engine.FullTurnText("claude", pane)
+	text, _, ok := engine.FullTurnText("claude", pane)
 	if !ok {
 		t.Fatal("claude has an activity cutoff, ok should be true")
 	}
@@ -1212,13 +1212,13 @@ func TestFullTurnText(t *testing.T) {
 		t.Fatalf("LastMessage = %q, want only the newest paragraph", line)
 	}
 
-	if text, _ := engine.FullTurnText("claude", "❯ the only question\n❯ "); text != "" {
+	if text, _, _ := engine.FullTurnText("claude", "❯ the only question\n❯ "); text != "" {
 		t.Fatalf("a prompt with no answer yet = %q, want empty", text)
 	}
-	if _, ok := engine.FullTurnText("no-such-tool", pane); ok {
+	if _, _, ok := engine.FullTurnText("no-such-tool", pane); ok {
 		t.Fatal("unknown tool should report it cannot tell")
 	}
-	if _, ok := engine.FullTurnText("claude", "just text, no input box"); ok {
+	if _, _, ok := engine.FullTurnText("claude", "just text, no input box"); ok {
 		t.Fatal("pane without the cutoff should report it cannot tell")
 	}
 }
@@ -1233,7 +1233,7 @@ func TestFullTurnTextStopsAtPreviousTurn(t *testing.T) {
 		"⏺ second answer\n" +
 		"✻ Crunched for 2s\n" +
 		"❯ "
-	text, ok := engine.FullTurnText("claude", pane)
+	text, _, ok := engine.FullTurnText("claude", pane)
 	if !ok {
 		t.Fatal("ok should be true")
 	}
@@ -1258,7 +1258,7 @@ func TestFullTurnTextDropsPromptTailAndToolRows(t *testing.T) {
 		"❯ "
 	want := "⏺ Read(internal/status/status.go)\n" +
 		"⏺ The answer itself."
-	text, ok := engine.FullTurnText("claude", pane)
+	text, _, ok := engine.FullTurnText("claude", pane)
 	if !ok {
 		t.Fatal("ok should be true")
 	}
@@ -1275,7 +1275,7 @@ func TestFullTurnTextDropsComposerHint(t *testing.T) {
 		"⏺ The answer.\n" +
 		"                          new task? /clear to save 421.3k tokens\n" +
 		"❯ "
-	text, ok := engine.FullTurnText("claude", pane)
+	text, _, ok := engine.FullTurnText("claude", pane)
 	if !ok {
 		t.Fatal("ok should be true")
 	}
@@ -1299,7 +1299,7 @@ func TestFullTurnTextKeepsUnmarkedReply(t *testing.T) {
 		"  its own wrapped continuation row.\n" +
 		"\n" +
 		"Docs. A second unmarked paragraph."
-	text, ok := engine.FullTurnText("claude", pane)
+	text, _, ok := engine.FullTurnText("claude", pane)
 	if !ok {
 		t.Fatal("ok should be true")
 	}
@@ -1318,7 +1318,7 @@ func TestFullTurnTextKeepsReplyThatOutrunsTheCapture(t *testing.T) {
 		"❯ "
 	want := "  a wrapped row of the reply, its marker scrolled away.\n" +
 		"⏺ A later paragraph of the same reply."
-	text, ok := engine.FullTurnText("claude", pane)
+	text, _, ok := engine.FullTurnText("claude", pane)
 	if !ok {
 		t.Fatal("ok should be true")
 	}
@@ -1346,7 +1346,7 @@ func TestFullTurnTextKeepsTableRows(t *testing.T) {
 		"  ├───────┼───────┤\n" +
 		"  │ 0.50  │ 23.00 │\n" +
 		"  └───────┴───────┘"
-	text, ok := engine.FullTurnText("claude", pane)
+	text, _, ok := engine.FullTurnText("claude", pane)
 	if !ok {
 		t.Fatal("ok should be true")
 	}
@@ -1402,6 +1402,16 @@ func TestFullTurnTextPerTool(t *testing.T) {
 				"                  ? for shortcuts\n" +
 				" >   Type your message or @path/to/file",
 			want: "✦ GEMINI ECHO TEST DONE.\n  a second row of the same reply.",
+		},
+		{
+			name: "gemini drops its approval banner beside a skills count",
+			tool: "gemini",
+			pane: " > Reply with exactly: GEMINI ECHO TEST DONE.\n" +
+				"✦ GEMINI ECHO TEST DONE.\n" +
+				"                  ? for shortcuts\n" +
+				" Shift+Tab to accept edits                          2 skills\n" +
+				" >   Type your message or @path/to/file",
+			want: "✦ GEMINI ECHO TEST DONE.",
 		},
 		{
 			name: "command-code keeps both rows of the reply",
@@ -1511,17 +1521,31 @@ func TestFullTurnTextPerTool(t *testing.T) {
 		{
 			name: "hermes stops at the newest prompt it drew",
 			tool: "hermes",
-			pane: "❯ first prompt\n" +
+			pane: "────────────────\n" +
+				"● first prompt\n" +
+				"────────────────\n" +
+				"╭─ ⚕ Hermes ─────╮\n" +
 				"first answer\n" +
-				"❯ second prompt\n" +
+				"╰────────────────╯\n" +
+				"────────────────\n" +
+				"● second prompt\n" +
+				"Initializing agent...\n" +
+				"────────────────\n" +
+				"┌─ Reasoning ────┐\n" +
+				"thinking about it\n" +
+				"└────────────────┘\n" +
+				"╭─ ⚕ Hermes ─────╮\n" +
 				"second answer\n" +
+				"╰────────────────╯\n" +
+				" ⚕ grok-4.6 │ 22.2K/500K │ 23s\n" +
+				"────────────────\n" +
 				"❯ ",
-			want: "second answer",
+			want: "thinking about it\nsecond answer",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			text, ok := engine.FullTurnText(tc.tool, tc.pane)
+			text, _, ok := engine.FullTurnText(tc.tool, tc.pane)
 			if !ok {
 				t.Fatalf("%s: ok should be true", tc.tool)
 			}
@@ -1529,6 +1553,43 @@ func TestFullTurnTextPerTool(t *testing.T) {
 				t.Fatalf("FullTurnText(%s) =\n%q\nwant\n%q", tc.tool, text, tc.want)
 			}
 		})
+	}
+}
+
+// Where nothing in the pane says the turn began - grok keeps no prompt in
+// its transcript, and its summary can sit above the capture - the text is
+// the whole region, and the caller is told so. pi draws no readable region
+// at all, so no reply can be read from it.
+func TestFullTurnTextReportsAnUnboundedCopy(t *testing.T) {
+	engine := defaultEngine(t)
+	bounded := "│ ❯ a prompt\nGrok answered it.\n│ ❯ "
+	if text, isBounded, ok := engine.FullTurnText("grok", bounded); !ok || !isBounded || text != "Grok answered it." {
+		t.Fatalf("bounded grok turn = %q bounded=%v ok=%v", text, isBounded, ok)
+	}
+	unbounded := "Grok answered something older.\nGrok answered this too.\n│ ❯ "
+	text, isBounded, ok := engine.FullTurnText("grok", unbounded)
+	if !ok {
+		t.Fatal("a grok pane with a composer has a region")
+	}
+	if isBounded {
+		t.Fatal("no prompt and no summary in frame is not a bounded turn")
+	}
+	if text != "Grok answered something older.\nGrok answered this too." {
+		t.Fatalf("unbounded grok copy = %q, want the whole region", text)
+	}
+
+	// pi opens its region at the pane origin, so the copy falls back to
+	// the pane above the composer rather than reporting nothing.
+	pi := "  a pi reply row\n────────────\n\n────────────\n/tmp (main)\n"
+	text, isBounded, ok = engine.FullTurnText("pi", pi)
+	if !ok {
+		t.Fatal("pi should copy the pane its region leaves empty")
+	}
+	if isBounded {
+		t.Fatal("a pane read without a turn boundary is not bounded")
+	}
+	if text != "  a pi reply row" {
+		t.Fatalf("pi copy = %q, want the reply row above the composer", text)
 	}
 }
 
@@ -1550,7 +1611,7 @@ func TestFullTurnTextPendingWrappedPrompt(t *testing.T) {
 					pane = tc.prompt + "original question\n" + tc.answer + "\n" + tc.end + "\n" + pending
 					want = tc.answer
 				}
-				if got, ok := engine.FullTurnText(tc.tool, pane); !ok || got != want {
+				if got, _, ok := engine.FullTurnText(tc.tool, pane); !ok || got != want {
 					t.Fatalf("answered=%v: copied %q, ok=%v; want %q", answered, got, ok, want)
 				}
 			}
@@ -1569,7 +1630,7 @@ func TestFullTurnTextResultWithBlankLine(t *testing.T) {
 		t.Run(tc.tool, func(t *testing.T) {
 			pane := tc.prompt + "question\n" + tc.call + "\n" + tc.result + "\n\n    second output line\n" + tc.answer + "\n  reply continuation\n" + tc.prompt
 			want := tc.call + "\n\n" + tc.answer + "\n  reply continuation"
-			if got, ok := engine.FullTurnText(tc.tool, pane); !ok || got != want {
+			if got, _, ok := engine.FullTurnText(tc.tool, pane); !ok || got != want {
 				t.Fatalf("copied %q, ok=%v; want %q", got, ok, want)
 			}
 		})

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1179,8 +1179,8 @@ func TestComposerIsEmpty(t *testing.T) {
 	}
 }
 
-// FullTurnText keeps every marker-led paragraph in the turn, where
-// LastMessage/LastMessageText anchor to only the newest one.
+// FullTurnText keeps every marker-led paragraph of the turn, where
+// LastMessage anchors to only the newest one.
 func TestFullTurnText(t *testing.T) {
 	engine := defaultEngine(t)
 	pane := "❯ Reply with exactly this sentence and nothing else: some prompt text\n" +
@@ -1208,7 +1208,13 @@ func TestFullTurnText(t *testing.T) {
 	if text != want {
 		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
 	}
+	if line, _, _ := engine.LastMessage("claude", pane); line != "Third and final paragraph." {
+		t.Fatalf("LastMessage = %q, want only the newest paragraph", line)
+	}
 
+	if text, _ := engine.FullTurnText("claude", "❯ the only question\n❯ "); text != "" {
+		t.Fatalf("a prompt with no answer yet = %q, want empty", text)
+	}
 	if _, ok := engine.FullTurnText("no-such-tool", pane); ok {
 		t.Fatal("unknown tool should report it cannot tell")
 	}
@@ -1217,8 +1223,7 @@ func TestFullTurnText(t *testing.T) {
 	}
 }
 
-// FullTurnText copies the newest turn, not every turn still on screen:
-// a pane holding two exchanges must return only the second one's prose.
+// A pane holding two exchanges yields only the newest one's prose.
 func TestFullTurnTextStopsAtPreviousTurn(t *testing.T) {
 	engine := defaultEngine(t)
 	pane := "❯ first prompt\n" +
@@ -1238,9 +1243,9 @@ func TestFullTurnTextStopsAtPreviousTurn(t *testing.T) {
 }
 
 // A prompt long enough to wrap echoes over several rows, but user_echo
-// only matches the first: the rest are still the prompt, not the reply.
-// Tool calls and their result rows are not prose either, and a notice
-// printed after the turn-end summary is past the reply entirely.
+// only matches the first: the reply's own marker is what opens the turn.
+// Tool result rows are not prose, and a notice printed under the turn-end
+// summary is past the reply entirely.
 func TestFullTurnTextDropsPromptTailAndToolRows(t *testing.T) {
 	engine := defaultEngine(t)
 	pane := "❯ a prompt long enough that the composer wrapped it onto\n" +
@@ -1280,8 +1285,7 @@ func TestFullTurnTextDropsComposerHint(t *testing.T) {
 }
 
 // Not every reply opens on a message_start marker: a turn can render as
-// plain unmarked prose, and dropping it as prompt tail would copy
-// nothing at all.
+// plain unmarked prose, and dropping it as prompt tail would copy nothing.
 func TestFullTurnTextKeepsUnmarkedReply(t *testing.T) {
 	engine := defaultEngine(t)
 	pane := "❯ a prompt\n" +
@@ -1304,9 +1308,27 @@ func TestFullTurnTextKeepsUnmarkedReply(t *testing.T) {
 	}
 }
 
-// A table's rows open on the same box-drawing characters a tool result
-// is drawn under, and they are content: only claude's own ⎿ marks a
-// result row.
+// A reply taller than the capture has no prompt above it, so the region
+// opens mid-reply and every row of it is content.
+func TestFullTurnTextKeepsReplyThatOutrunsTheCapture(t *testing.T) {
+	engine := defaultEngine(t)
+	pane := "  a wrapped row of the reply, its marker scrolled away.\n" +
+		"⏺ A later paragraph of the same reply.\n" +
+		"✻ Crunched for 9s\n" +
+		"❯ "
+	want := "  a wrapped row of the reply, its marker scrolled away.\n" +
+		"⏺ A later paragraph of the same reply."
+	text, ok := engine.FullTurnText("claude", pane)
+	if !ok {
+		t.Fatal("ok should be true")
+	}
+	if text != want {
+		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
+	}
+}
+
+// A table's rows open on the same box-drawing characters a tool result is
+// drawn under, and they are content: only claude's own ⎿ marks a result.
 func TestFullTurnTextKeepsTableRows(t *testing.T) {
 	engine := defaultEngine(t)
 	pane := "❯ a prompt\n" +
@@ -1330,5 +1352,182 @@ func TestFullTurnTextKeepsTableRows(t *testing.T) {
 	}
 	if text != want {
 		t.Fatalf("FullTurnText =\n%q\nwant\n%q", text, want)
+	}
+}
+
+// The turn bound reads a prompt the way LastUserEcho does, so the rows a
+// tool draws behind its own composer marker cannot pass for one: opencode
+// spells its model footer in the ┃ gutter its echoes use, and codex draws
+// an open dialog's options behind ›. Row shapes as verified live in
+// TestLastUserEchoPerTool. Tools that echo nothing (grok, hermes) take the
+// composer row itself as the bound, and a reply body that renders indented
+// (opencode) is content, not a wrapped prompt's tail.
+func TestFullTurnTextPerTool(t *testing.T) {
+	engine := defaultEngine(t)
+	cases := []struct {
+		name, tool, pane, want string
+	}{
+		{
+			name: "opencode keeps an indented reply under its gutter footer",
+			tool: "opencode",
+			pane: "  ┃\n" +
+				"  ┃  Reply with exactly: OPENCODE ECHO TEST DONE.\n" +
+				"  ┃\n" +
+				"     OPENCODE ECHO TEST DONE.\n" +
+				"     ▣  Build · Gemini 3.6 Flash · 2.6s\n" +
+				"  ┃\n" +
+				"  ┃  Build · Gemini 3.6 Flash Google\n" +
+				"  ╹▀▀▀▀▀▀▀▀▀▀▀▀",
+			want: "     OPENCODE ECHO TEST DONE.",
+		},
+		{
+			name: "codex keeps the reply while a permission dialog is open",
+			tool: "codex",
+			pane: "› Reply with exactly: CODEX ECHO TEST DONE.\n" +
+				"• CODEX ECHO TEST DONE.\n" +
+				"─── Worked for 2s ───\n" +
+				"  Allow codex to run this command?\n" +
+				"› 1. Yes, allow\n" +
+				"  2. No\n" +
+				"› Ask Codex to do anything",
+			want: "• CODEX ECHO TEST DONE.",
+		},
+		{
+			name: "gemini opens on its indented marker",
+			tool: "gemini",
+			pane: " > Reply with exactly: GEMINI ECHO TEST DONE.\n" +
+				"▀▀▀▀▀▀▀▀▀▀▀▀\n" +
+				"✦ GEMINI ECHO TEST DONE.\n" +
+				"  a second row of the same reply.\n" +
+				"                  ? for shortcuts\n" +
+				" >   Type your message or @path/to/file",
+			want: "✦ GEMINI ECHO TEST DONE.\n  a second row of the same reply.",
+		},
+		{
+			name: "command-code keeps both rows of the reply",
+			tool: "command-code",
+			pane: "❯ Reply with exactly: CMD ECHO TEST DONE.\n" +
+				"⠶ CMD ECHO TEST DONE.\n" +
+				"  And a second line of the reply.\n" +
+				"❯ Ask your question...",
+			want: "⠶ CMD ECHO TEST DONE.\n  And a second line of the reply.",
+		},
+		{
+			name: "grok bounds on its composer row, not its turn summary",
+			tool: "grok",
+			pane: "│ ❯ first prompt\n" +
+				"Grok answer paragraph one.\n" +
+				"Grok answer paragraph two.\n" +
+				"  Worked for 3s. Press ctrl+c to stop\n" +
+				"│ ❯ ",
+			want: "Grok answer paragraph one.\nGrok answer paragraph two.",
+		},
+		{
+			name: "grok keeps no prompt, so its previous turn summary bounds",
+			tool: "grok",
+			pane: "Grok answer to the first question.\n" +
+				"  Worked for 3s. Press ctrl+c to stop\n" +
+				"Grok answer to the second question.\n" +
+				"  Worked for 5s. Press ctrl+c to stop\n" +
+				"│ ❯ ",
+			want: "Grok answer to the second question.",
+		},
+		{
+			name: "grok mid-turn bounds on the summary it already drew",
+			tool: "grok",
+			pane: "Grok answer to the first question.\n" +
+				"  Worked for 3s. Press ctrl+c to stop\n" +
+				"Grok is answering the second question.\n" +
+				"│ ❯ ",
+			want: "Grok is answering the second question.",
+		},
+		{
+			name: "claude falls back to the previous summary with no prompt in frame",
+			tool: "claude",
+			pane: "⏺ The answer to a question that scrolled away.\n" +
+				"✻ Crunched for 1s\n" +
+				"⏺ The answer we want.\n" +
+				"✻ Crunched for 2s\n" +
+				"❯ ",
+			want: "⏺ The answer we want.",
+		},
+		{
+			name: "claude drops a tool result with the rows it wrapped onto",
+			tool: "claude",
+			pane: "❯ a prompt\n" +
+				"⏺ Read(file.go)\n" +
+				"  ⎿  Read 120 lines\n" +
+				"     line two of the result\n" +
+				"     line three of the result\n" +
+				"⏺ The answer.\n" +
+				"✻ Crunched for 1s\n" +
+				"❯ ",
+			want: "⏺ Read(file.go)\n⏺ The answer.",
+		},
+		{
+			name: "codex drops a command's output under its own glyph",
+			tool: "codex",
+			pane: "› a prompt\n" +
+				"• Ran command\n" +
+				"  └ ok\n" +
+				"    more output\n" +
+				"• The answer.\n" +
+				"─── Worked for 2s ───\n" +
+				"› ",
+			want: "• Ran command\n• The answer.",
+		},
+		{
+			name: "a result row under the last summary is not content",
+			tool: "claude",
+			pane: "⏺ answer one\n" +
+				"✻ Crunched for 1s\n" +
+				"⏺ the answer we want\n" +
+				"✻ Crunched for 2s\n" +
+				"  ⎿  a result row drawn under the summary\n" +
+				"❯ ",
+			want: "⏺ the answer we want",
+		},
+		{
+			name: "an unmarked indented reply beats a notice below the summary",
+			tool: "claude",
+			pane: "❯ a prompt\n" +
+				"  an indented unmarked reply row\n" +
+				"✻ Crunched for 1s\n" +
+				"A left-aligned notice printed after the turn\n" +
+				"❯ ",
+			want: "  an indented unmarked reply row",
+		},
+		{
+			name: "a follow-up sent mid-read falls back to the answer above",
+			tool: "claude",
+			pane: "❯ the real question\n" +
+				"⏺ The answer the user is reading.\n" +
+				"  a second row of it.\n" +
+				"✻ Crunched for 12s\n" +
+				"❯ a follow-up typed while it was working\n" +
+				"❯ ",
+			want: "⏺ The answer the user is reading.\n  a second row of it.",
+		},
+		{
+			name: "hermes stops at the newest prompt it drew",
+			tool: "hermes",
+			pane: "❯ first prompt\n" +
+				"first answer\n" +
+				"❯ second prompt\n" +
+				"second answer\n" +
+				"❯ ",
+			want: "second answer",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			text, ok := engine.FullTurnText(tc.tool, tc.pane)
+			if !ok {
+				t.Fatalf("%s: ok should be true", tc.tool)
+			}
+			if text != tc.want {
+				t.Fatalf("FullTurnText(%s) =\n%q\nwant\n%q", tc.tool, text, tc.want)
+			}
+		})
 	}
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1531,3 +1531,47 @@ func TestFullTurnTextPerTool(t *testing.T) {
 		})
 	}
 }
+
+func TestFullTurnTextPendingWrappedPrompt(t *testing.T) {
+	engine := defaultEngine(t)
+	for _, tc := range []struct {
+		tool, prompt, answer, end string
+	}{
+		{"claude", "❯ ", "⏺ Previous answer.", "✻ Crunched for 1s"},
+		{"codex", "› ", "• Previous answer.", "─── Worked for 2s ───"},
+		{"gemini", " > ", "✦ Previous answer.", ""},
+		{"command-code", "❯ ", "⠶ Previous answer.", ""},
+	} {
+		t.Run(tc.tool, func(t *testing.T) {
+			pending := tc.prompt + "new question that wraps\n  continuation of the new question\n" + tc.prompt
+			for _, answered := range []bool{false, true} {
+				pane, want := pending, ""
+				if answered {
+					pane = tc.prompt + "original question\n" + tc.answer + "\n" + tc.end + "\n" + pending
+					want = tc.answer
+				}
+				if got, ok := engine.FullTurnText(tc.tool, pane); !ok || got != want {
+					t.Fatalf("answered=%v: copied %q, ok=%v; want %q", answered, got, ok, want)
+				}
+			}
+		})
+	}
+}
+
+func TestFullTurnTextResultWithBlankLine(t *testing.T) {
+	engine := defaultEngine(t)
+	for _, tc := range []struct {
+		tool, prompt, call, result, answer string
+	}{
+		{"claude", "❯ ", "⏺ Read(file.go)", "  ⎿ first output line", "⏺ Answer."},
+		{"codex", "› ", "• Ran command", "  └ first output line", "• Answer."},
+	} {
+		t.Run(tc.tool, func(t *testing.T) {
+			pane := tc.prompt + "question\n" + tc.call + "\n" + tc.result + "\n\n    second output line\n" + tc.answer + "\n  reply continuation\n" + tc.prompt
+			want := tc.call + "\n\n" + tc.answer + "\n  reply continuation"
+			if got, ok := engine.FullTurnText(tc.tool, pane); !ok || got != want {
+				t.Fatalf("copied %q, ok=%v; want %q", got, ok, want)
+			}
+		})
+	}
+}

--- a/internal/ui/controlbytes_test.go
+++ b/internal/ui/controlbytes_test.go
@@ -161,7 +161,7 @@ func TestSessionNameCannotDriveTheTerminal(t *testing.T) {
 	}
 	m.diff.notice = ""
 	m.errBar.text = "rename failed for rev\x1b]0;PWNED\x07iew"
-	if stray := strayControl(m.statusMessage("✕", "●")); stray != "" {
+	if stray := strayControl(m.statusMessage("✕", "●", "▲")); stray != "" {
 		t.Errorf("the status bar leaks a control byte near %q", stray)
 	}
 }

--- a/internal/ui/diffrender.go
+++ b/internal/ui/diffrender.go
@@ -1007,7 +1007,7 @@ func (m *Model) renderSideCell(fd *diff.FileDiff, hl *fileHL, index, width int, 
 
 func (m *Model) viewDiffStatus() string {
 	if m.errBar.text != "" {
-		return padRight(m.statusMessage(" ✖", " ✔"), m.width)
+		return padRight(m.statusMessage(" ✖", " ✔", " ▲"), m.width)
 	}
 	if m.diff.notice != "" {
 		return padRight(doneStyle.Render(" ✔ "+escapeControlsInline(m.diff.notice)), m.width)

--- a/internal/ui/focussel.go
+++ b/internal/ui/focussel.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/YoanWai/agent-manager/internal/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
@@ -531,11 +532,20 @@ func (m *Model) copySelectionCmd() tea.Cmd {
 		return nil
 	}
 	gen := m.copyGen
+	return copyTextCmd(text, func(chars int) tea.Msg {
+		return focusCopiedMsg{chars: chars, gen: gen}
+	})
+}
+
+// copyTextCmd writes text to the system clipboard off the update loop:
+// WriteText waits up to three seconds on the platform's copy command,
+// which would freeze the UI for that long.
+func copyTextCmd(text string, done func(chars int) tea.Msg) tea.Cmd {
 	return func() tea.Msg {
 		if err := clipboard.WriteText(text); err != nil {
 			return errMsg{err}
 		}
-		return focusCopiedMsg{chars: len([]rune(text)), gen: gen}
+		return done(utf8.RuneCountInString(text))
 	}
 }
 

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -108,6 +108,7 @@ func sessionRowHelpRows(list keybind.Table) [][2]string {
 	h.fixed("", "settings swap what the two do")
 	h.action("mark it idle when it is finished, without entering it", keybind.MarkIdle)
 	h.action("quick prompt: answer the session without attaching", keybind.Prompt)
+	h.action("copy its newest reply to the clipboard", keybind.CopyReply)
 	h.action("review its diff", keybind.Review)
 	h.action("fork it into a new session in the same group", keybind.Fork)
 	h.action("rename it, and re-pick its tool", keybind.Rename)

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -129,8 +129,6 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openGroupForm()
 	case keybind.Fork:
 		m.openFork()
-	case keybind.CopyReply:
-		return m.copyLastOutput()
 	case keybind.Revive:
 		return m.reviveSelected()
 	case keybind.MarkIdle:
@@ -151,6 +149,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.prepareDelete()
 	case keybind.Prompt:
 		m.openQuickMode()
+	case keybind.CopyReply:
+		return m.copyReplySelected()
 	case keybind.FoldAll:
 		m.toggleCollapseAll()
 	case keybind.Filter:

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -129,6 +129,8 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.openGroupForm()
 	case keybind.Fork:
 		m.openFork()
+	case keybind.CopyReply:
+		return m.copyLastOutput()
 	case keybind.Revive:
 		return m.reviveSelected()
 	case keybind.MarkIdle:

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -134,26 +134,30 @@ func (m *Model) copyReplySelected() (tea.Model, tea.Cmd) {
 		if err != nil {
 			return errMsg{err}
 		}
-		text, ok := engine.FullTurnText(sess.Tool, ansi.Strip(pane))
+		text, bounded, ok := engine.FullTurnText(sess.Tool, ansi.Strip(pane))
 		if !ok {
-			return replyCopiedMsg{name: sess.Name, unreadable: true}
+			return replyCopiedMsg{name: sess.Name, tool: sess.Tool, unreadable: true}
 		}
 		if strings.TrimSpace(text) == "" {
-			return replyCopiedMsg{name: sess.Name}
+			return replyCopiedMsg{name: sess.Name, tool: sess.Tool}
 		}
 		return copyTextCmd(text, func(chars int) tea.Msg {
-			return replyCopiedMsg{chars: chars, name: sess.Name}
+			return replyCopiedMsg{chars: chars, name: sess.Name, tool: sess.Tool, unbounded: !bounded}
 		})()
 	}
 }
 
 // replyCopiedMsg reports a finished copy. No chars means the turn held
 // nothing; unreadable means the tool draws no region a reply can be read
-// from, which no amount of retrying will change.
+// from, which no amount of retrying will change; unbounded means nothing
+// in the pane said where the turn began, so the copy is the whole screen
+// rather than one answer.
 type replyCopiedMsg struct {
 	chars      int
 	name       string
+	tool       string
 	unreadable bool
+	unbounded  bool
 }
 
 // reviveSelected relaunches a dead session's tmux session under the same

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/launch"
 	"github.com/YoanWai/agent-manager/internal/sessioncmd"
@@ -111,16 +110,21 @@ func (m *Model) reattach(id string, diffGen int) tea.Cmd {
 	}
 }
 
-// copyLastOutput copies the selected session's newest reply to the
-// system clipboard without attaching to it. Capture and clipboard write
-// both run inside the returned command: WriteText can block for seconds,
-// which would freeze Update.
-func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
+// copyReplySelected puts the selected session's newest reply on the system
+// clipboard without entering it.
+func (m *Model) copyReplySelected() (tea.Model, tea.Cmd) {
 	entry, ok := m.selectedRow()
 	if !ok || entry.isGroup || m.engine == nil || m.tmux == nil {
 		return m, nil
 	}
 	sess := entry.sess
+	m.errBar.text = ""
+	// A shell has no reply, and its scrollback is the user's own commands
+	// and their output rather than anything an agent said.
+	if m.isShell(sess.Tool) {
+		m.errBar.text = shellPromptHint(sess.Name)
+		return m, nil
+	}
 	if !m.tmux.Exists(sess.ID) {
 		m.errBar.text = deadSessionHint
 		return m, nil
@@ -132,21 +136,25 @@ func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
 			return errMsg{err}
 		}
 		text, ok := engine.FullTurnText(sess.Tool, ansi.Strip(pane))
-		if !ok || strings.TrimSpace(text) == "" {
-			return copyLastOutputMsg{}
+		if !ok {
+			return replyCopiedMsg{name: sess.Name, unreadable: true}
 		}
-		if err := clipboard.WriteText(text); err != nil {
-			return errMsg{err}
+		if strings.TrimSpace(text) == "" {
+			return replyCopiedMsg{name: sess.Name}
 		}
-		return copyLastOutputMsg{chars: len([]rune(text)), name: sess.Name}
+		return copyTextCmd(text, func(chars int) tea.Msg {
+			return replyCopiedMsg{chars: chars, name: sess.Name}
+		})()
 	}
 }
 
-// copyLastOutputMsg reports a finished y copy. A zero chars means the
-// turn held nothing to copy.
-type copyLastOutputMsg struct {
-	chars int
-	name  string
+// replyCopiedMsg reports a finished copy. No chars means the turn held
+// nothing; unreadable means the tool draws no region a reply can be read
+// from, which no amount of retrying will change.
+type replyCopiedMsg struct {
+	chars      int
+	name       string
+	unreadable bool
 }
 
 // reviveSelected relaunches a dead session's tmux session under the same

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -125,12 +125,11 @@ func (m *Model) copyReplySelected() (tea.Model, tea.Cmd) {
 		m.errBar.text = shellPromptHint(sess.Name)
 		return m, nil
 	}
-	if !m.tmux.Exists(sess.ID) {
-		m.errBar.text = deadSessionHint
-		return m, nil
-	}
 	engine, driver := m.engine, m.tmux
 	return m, func() tea.Msg {
+		if !driver.Exists(sess.ID) {
+			return errMsg{errors.New(deadSessionHint)}
+		}
 		pane, err := driver.CapturePaneHistory(sess.ID, quoteHistoryLines)
 		if err != nil {
 			return errMsg{err}

--- a/internal/ui/lifecycle.go
+++ b/internal/ui/lifecycle.go
@@ -6,12 +6,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/YoanWai/agent-manager/internal/clipboard"
 	"github.com/YoanWai/agent-manager/internal/config"
 	"github.com/YoanWai/agent-manager/internal/launch"
 	"github.com/YoanWai/agent-manager/internal/sessioncmd"
 	"github.com/YoanWai/agent-manager/internal/status"
 	"github.com/YoanWai/agent-manager/internal/store"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/google/uuid"
 )
 
@@ -107,6 +109,44 @@ func (m *Model) reattach(id string, diffGen int) tea.Cmd {
 		}
 		return reattachPreparedMsg{sessID: id, diffGen: diffGen, warn: warn}
 	}
+}
+
+// copyLastOutput copies the selected session's newest reply to the
+// system clipboard without attaching to it. Capture and clipboard write
+// both run inside the returned command: WriteText can block for seconds,
+// which would freeze Update.
+func (m *Model) copyLastOutput() (tea.Model, tea.Cmd) {
+	entry, ok := m.selectedRow()
+	if !ok || entry.isGroup || m.engine == nil || m.tmux == nil {
+		return m, nil
+	}
+	sess := entry.sess
+	if !m.tmux.Exists(sess.ID) {
+		m.errBar.text = deadSessionHint
+		return m, nil
+	}
+	engine, driver := m.engine, m.tmux
+	return m, func() tea.Msg {
+		pane, err := driver.CapturePaneHistory(sess.ID, quoteHistoryLines)
+		if err != nil {
+			return errMsg{err}
+		}
+		text, ok := engine.FullTurnText(sess.Tool, ansi.Strip(pane))
+		if !ok || strings.TrimSpace(text) == "" {
+			return copyLastOutputMsg{}
+		}
+		if err := clipboard.WriteText(text); err != nil {
+			return errMsg{err}
+		}
+		return copyLastOutputMsg{chars: len([]rune(text)), name: sess.Name}
+	}
+}
+
+// copyLastOutputMsg reports a finished y copy. A zero chars means the
+// turn held nothing to copy.
+type copyLastOutputMsg struct {
+	chars int
+	name  string
 }
 
 // reviveSelected relaunches a dead session's tmux session under the same

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -1938,9 +1938,13 @@ func TestCopyReplyOnADeadSessionHints(t *testing.T) {
 	}
 	m.selectSessionRow(t, "alpha")
 	_, cmd := m.copyReplySelected()
-	if cmd != nil {
-		t.Fatal("a dead session should not run a capture")
+	if cmd == nil {
+		t.Fatal("checking the session should run asynchronously")
 	}
+	if m.errBar.text != "" {
+		t.Fatalf("copy reported %q before the command ran", m.errBar.text)
+	}
+	m.applyCmd(t, cmd)
 	if m.errBar.text != deadSessionHint {
 		t.Fatalf("errBar = %q, want %q", m.errBar.text, deadSessionHint)
 	}

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -1986,3 +1986,26 @@ func TestReplyCopiedMsgReports(t *testing.T) {
 		t.Fatalf("errBar = %q done = %q", m.errBar.text, m.errBar.done)
 	}
 }
+
+// A copy the pane could not bound, and a pane no reply can be read from,
+// both name the tool behind the caveat and read as warnings rather than
+// as outcomes or failures.
+func TestReplyCopiedMsgWarnsOnAnUnboundedCopy(t *testing.T) {
+	m := buildModel(t)
+	m.Update(replyCopiedMsg{chars: 12426, name: "alpha", tool: "grok", unbounded: true})
+	if !strings.Contains(m.errBar.text, "grok marks no turn start here") {
+		t.Fatalf("errBar = %q, want the tool named", m.errBar.text)
+	}
+	if !m.errBar.warned() || m.errBar.worked() {
+		t.Fatalf("an unbounded copy should warn, not report success: %+v", m.errBar)
+	}
+
+	m = buildModel(t)
+	m.Update(replyCopiedMsg{name: "beta", tool: "pi", unreadable: true})
+	if !strings.Contains(m.errBar.text, "a pi pane is not read that way") {
+		t.Fatalf("errBar = %q, want the tool named", m.errBar.text)
+	}
+	if !m.errBar.warned() {
+		t.Fatalf("an unreadable pane should warn: %+v", m.errBar)
+	}
+}

--- a/internal/ui/lifecycle_test.go
+++ b/internal/ui/lifecycle_test.go
@@ -1926,3 +1926,59 @@ func TestConfirmedGroupArchiveHidesTheSubtreeAtOnce(t *testing.T) {
 		}
 	}
 }
+
+// y on a dead row names the way back, the way every other lifecycle key
+// does, instead of letting the capture fail with raw tmux stderr.
+func TestCopyReplyOnADeadSessionHints(t *testing.T) {
+	m := buildModel(t)
+	createSession(t, m, "alpha", t.TempDir(), "")
+	sess := m.sessionRows()[0]
+	if err := m.tmux.Kill(sess.ID); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	m.selectSessionRow(t, "alpha")
+	_, cmd := m.copyReplySelected()
+	if cmd != nil {
+		t.Fatal("a dead session should not run a capture")
+	}
+	if m.errBar.text != deadSessionHint {
+		t.Fatalf("errBar = %q, want %q", m.errBar.text, deadSessionHint)
+	}
+}
+
+// A group has no reply of its own, so y on one does nothing at all.
+func TestCopyReplyIgnoresGroupRows(t *testing.T) {
+	m := buildModel(t)
+	dir := t.TempDir()
+	if err := m.store.CreateGroup("team", dir); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	m.applyCmd(t, m.refreshCmd())
+	createSession(t, m, "alpha", dir, "team")
+	m.selectGroupRow(t, "team")
+	_, cmd := m.copyReplySelected()
+	if cmd != nil {
+		t.Fatal("a group row should not run a capture")
+	}
+	if m.errBar.text != "" {
+		t.Fatalf("errBar = %q, want no message", m.errBar.text)
+	}
+}
+
+// The copy reports what landed on the clipboard, and says so plainly when
+// the turn held nothing worth copying.
+func TestReplyCopiedMsgReports(t *testing.T) {
+	m := buildModel(t)
+	if _, cmd := m.Update(replyCopiedMsg{name: "alpha"}); cmd != nil {
+		t.Fatal("an empty copy should not queue more work")
+	}
+	if m.errBar.text != "nothing to copy from alpha" {
+		t.Fatalf("errBar = %q", m.errBar.text)
+	}
+	if _, cmd := m.Update(replyCopiedMsg{chars: 42, name: "alpha"}); cmd != nil {
+		t.Fatal("a finished copy should not queue more work")
+	}
+	if m.errBar.text != "copied 42 chars from alpha" || m.errBar.done != m.errBar.text {
+		t.Fatalf("errBar = %q done = %q", m.errBar.text, m.errBar.done)
+	}
+}

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -57,7 +57,7 @@ func (m *Model) flexCardWidth(title, body string, hint [][2]string) int {
 	measure(cardTitle(title))
 	measure(legendInline(hint, 1<<30))
 	if m.errBar.text != "" {
-		measure(m.statusMessage("⚠", "●"))
+		measure(m.statusMessage("⚠", "●", "▲"))
 	}
 	if m.width >= 28 && need > m.width-4 {
 		need = m.width - 4
@@ -89,7 +89,7 @@ func (m *Model) cardSized(width int, title, body string, hint [][2]string) strin
 		lines = append(lines, row(line))
 	}
 	if m.errBar.text != "" {
-		lines = append(lines, row(""), row(m.statusMessage("⚠", "●")))
+		lines = append(lines, row(""), row(m.statusMessage("⚠", "●", "▲")))
 	}
 	lines = append(lines, row(""))
 	if len(hint) > 0 {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"hash/fnv"
 	"sort"
 	"strings"
@@ -1581,6 +1582,14 @@ func (m *Model) handleMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case pasteSweepTickMsg:
 		return m, tea.Batch(m.sweepPastes, m.pasteSweepTick())
+
+	case copyLastOutputMsg:
+		if msg.chars == 0 {
+			m.errBar.text = "nothing to copy"
+			return m, nil
+		}
+		m.reportDone(fmt.Sprintf("copied %d chars from %s", msg.chars, msg.name))
+		return m, nil
 
 	case previewSettleMsg:
 		if msg.gen != m.previewGen {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -318,6 +318,7 @@ type paneMirror struct {
 type errBar struct {
 	text  string
 	done  string
+	warn  string
 	shown string
 	age   int
 }
@@ -328,9 +329,20 @@ type errBar struct {
 // behind, so a message says it worked or reads as a failure.
 func (e errBar) worked() bool { return e.text != "" && e.text == e.done }
 
+// warned reports whether the message is an action that went through with
+// a caveat the reader has to see, which reads as neither outcome nor
+// failure.
+func (e errBar) warned() bool { return e.text != "" && e.text == e.warn }
+
 // reportDone puts an action that went through on the status bar.
 func (m *Model) reportDone(text string) {
 	m.errBar.text, m.errBar.done = text, text
+}
+
+// reportWarn puts an action that went through with a caveat on the status
+// bar.
+func (m *Model) reportWarn(text string) {
+	m.errBar.text, m.errBar.warn = text, text
 }
 
 // splitState is the horizontal sessions/sidebar split. ratio is the left
@@ -1585,11 +1597,16 @@ func (m *Model) handleMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case replyCopiedMsg:
 		if msg.unreadable {
-			m.errBar.text = "cannot read a reply from " + msg.name
+			m.reportWarn(fmt.Sprintf("no reply to read in %s: a %s pane is not read that way", msg.name, msg.tool))
 			return m, nil
 		}
 		if msg.chars == 0 {
 			m.errBar.text = "nothing to copy from " + msg.name
+			return m, nil
+		}
+		if msg.unbounded {
+			m.reportWarn(fmt.Sprintf("copied %d chars from %s: %s marks no turn start here, so this is the whole pane",
+				msg.chars, msg.name, msg.tool))
 			return m, nil
 		}
 		m.reportDone(fmt.Sprintf("copied %d chars from %s", msg.chars, msg.name))

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1583,9 +1583,13 @@ func (m *Model) handleMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case pasteSweepTickMsg:
 		return m, tea.Batch(m.sweepPastes, m.pasteSweepTick())
 
-	case copyLastOutputMsg:
+	case replyCopiedMsg:
+		if msg.unreadable {
+			m.errBar.text = "cannot read a reply from " + msg.name
+			return m, nil
+		}
 		if msg.chars == 0 {
-			m.errBar.text = "nothing to copy"
+			m.errBar.text = "nothing to copy from " + msg.name
 			return m, nil
 		}
 		m.reportDone(fmt.Sprintf("copied %d chars from %s", msg.chars, msg.name))

--- a/internal/ui/notices.go
+++ b/internal/ui/notices.go
@@ -771,7 +771,7 @@ func (m *Model) noticeTail(notices []notice, inner int) []string {
 		tail = append(tail, lipgloss.NewStyle().Foreground(colorAccent).Render("↓ downloading "+m.update.latest+"…"))
 	}
 	if m.errBar.text != "" {
-		tail = append(tail, m.statusMessage("✕", "●"))
+		tail = append(tail, m.statusMessage("✕", "●", "▲"))
 	}
 	return tail
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -41,6 +41,7 @@ var (
 	labelStyle  lipgloss.Style
 	errStyle    lipgloss.Style
 	doneStyle   lipgloss.Style
+	warnStyle   lipgloss.Style
 	keyStyle    lipgloss.Style
 
 	annotationStyle lipgloss.Style
@@ -72,6 +73,7 @@ func rebuildStyles() {
 	labelStyle = lipgloss.NewStyle().Foreground(colorSubtle)
 	errStyle = lipgloss.NewStyle().Foreground(colorErrored).Bold(true)
 	doneStyle = lipgloss.NewStyle().Foreground(colorFinished)
+	warnStyle = lipgloss.NewStyle().Foreground(colorWorking).Bold(true)
 	keyStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 
 	annotationStyle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)

--- a/internal/ui/terminal_test.go
+++ b/internal/ui/terminal_test.go
@@ -408,7 +408,7 @@ func TestShellRowLegendDropsTheConversationKeys(t *testing.T) {
 	}
 	for _, pair := range legend.pairs {
 		switch pair[0] {
-		case "space", "ctrl+r", "f":
+		case "space", "y", "ctrl+r", "f":
 			t.Fatalf("legend offers %q on a shell row, which refuses it", pair[0])
 		}
 	}
@@ -427,7 +427,7 @@ func TestAgentRowLegendKeepsTheConversationKeys(t *testing.T) {
 	if legend.title != "Session" {
 		t.Fatalf("legend title = %q, want Session", legend.title)
 	}
-	for _, key := range []string{"space", "ctrl+r", "f"} {
+	for _, key := range []string{"space", "y", "ctrl+r", "f"} {
 		if !slices.ContainsFunc(legend.pairs, func(pair [2]string) bool { return pair[0] == key }) {
 			t.Fatalf("legend should offer %q on an agent row", key)
 		}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -166,7 +166,7 @@ func (m *Model) statusLine() string {
 	// Errors outrank the focus notices: a scrolled or focused pane must
 	// not hide a failure report.
 	case m.mode == modeFocus && m.errBar.text != "":
-		return m.statusMessage("✕", "●")
+		return m.statusMessage("✕", "●", "▲")
 	case m.scrolledBack():
 		return keyStyle.Render("scrolled ") +
 			subtleStyle.Render(fmt.Sprintf("%d lines back · wheel down or type to catch up", m.focusScroll))
@@ -180,7 +180,7 @@ func (m *Model) statusLine() string {
 		}
 		return keyStyle.Render("resize ") + subtleStyle.Render(hint)
 	case m.errBar.text != "":
-		return m.statusMessage("✕", "●")
+		return m.statusMessage("✕", "●", "▲")
 	case m.diff.notice != "":
 		return doneStyle.Render("● " + escapeControlsInline(m.diff.notice))
 	default:
@@ -189,12 +189,16 @@ func (m *Model) statusLine() string {
 }
 
 // statusMessage styles whatever sits on the status bar: an action that went
-// through reads as an outcome, everything else as a failure, in the glyphs
-// the calling surface marks the two with.
-func (m *Model) statusMessage(fail, done string) string {
+// through reads as an outcome, one that went through with a caveat as a
+// warning, everything else as a failure, in the glyphs the calling surface
+// marks the three with.
+func (m *Model) statusMessage(fail, done, warn string) string {
 	text := escapeControlsInline(m.errBar.text)
-	if m.errBar.worked() {
+	switch {
+	case m.errBar.worked():
 		return doneStyle.Render(done + " " + text)
+	case m.errBar.warned():
+		return warnStyle.Render(warn + " " + text)
 	}
 	return errStyle.Render(fail + " " + text)
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -578,7 +578,7 @@ func (m *Model) rowLegend() legendSection {
 		return legendSection{title: "Group", pairs: legendPairsBound(pairs)}
 	}
 	title := "Session"
-	conversation := [][2]string{{k(keybind.Prompt), "prompt"}, {k(keybind.Review), "review"}, {k(keybind.Fork), "fork"}}
+	conversation := [][2]string{{k(keybind.Prompt), "prompt"}, {k(keybind.CopyReply), "copy"}, {k(keybind.Review), "review"}, {k(keybind.Fork), "fork"}}
 	if m.isShell(row.sess.Tool) {
 		// A shell has no conversation, so the keys that would prompt,
 		// review or fork one are left off rather than offered and refused.

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -702,10 +702,10 @@ func TestStatusMessageEscapesControlBytes(t *testing.T) {
 
 	var m Model
 	m.errBar.text = payload
-	if got := ansi.Strip(m.statusMessage("✖", "✔")); !strings.Contains(got, want) {
+	if got := ansi.Strip(m.statusMessage("✖", "✔", "▲")); !strings.Contains(got, want) {
 		t.Errorf("failure branch should read as caret notation, got %q", got)
 	}
-	if stray := strayControl(m.statusMessage("✖", "✔")); stray != "" {
+	if stray := strayControl(m.statusMessage("✖", "✔", "▲")); stray != "" {
 		t.Errorf("failure branch leaks a control byte near %q", stray)
 	}
 
@@ -713,11 +713,30 @@ func TestStatusMessageEscapesControlBytes(t *testing.T) {
 	if !m.errBar.worked() {
 		t.Fatal("matching text and done should read as an outcome")
 	}
-	if got := ansi.Strip(m.statusMessage("✖", "✔")); !strings.Contains(got, want) {
+	if got := ansi.Strip(m.statusMessage("✖", "✔", "▲")); !strings.Contains(got, want) {
 		t.Errorf("outcome branch should read as caret notation, got %q", got)
 	}
-	if stray := strayControl(m.statusMessage("✖", "✔")); stray != "" {
+	if stray := strayControl(m.statusMessage("✖", "✔", "▲")); stray != "" {
 		t.Errorf("outcome branch leaks a control byte near %q", stray)
+	}
+}
+
+// A copy that went through with a caveat reads as neither the green
+// outcome nor the red failure: it takes the warning glyph and the tone the
+// theme gives work in progress.
+func TestStatusMessageWarnsInItsOwnTone(t *testing.T) {
+	var m Model
+	m.reportWarn("copied the whole pane")
+
+	got := m.statusMessage("✖", "✔", "▲")
+	if !strings.Contains(ansi.Strip(got), "▲ copied the whole pane") {
+		t.Fatalf("warning should take the warning glyph, got %q", ansi.Strip(got))
+	}
+	if got != warnStyle.Render("▲ copied the whole pane") {
+		t.Fatalf("warning should render in the warning style, got %q", got)
+	}
+	if got == doneStyle.Render("✔ copied the whole pane") || got == errStyle.Render("✖ copied the whole pane") {
+		t.Fatal("warning must not read as an outcome or a failure")
 	}
 }
 

--- a/skills/agent-manager/SKILL.md
+++ b/skills/agent-manager/SKILL.md
@@ -51,6 +51,7 @@ prebuilt binary from the releases page.
 | `alt+w` | Spawns the agent into a fresh git worktree and branch. |
 | `ctrl+r` | Opens a full-screen whole-file diff whose line comments go back to the agent as one review prompt. |
 | `v` | Revives a dead session on the conversation it held. |
+| `y` | Copies the selected session's newest reply to the system clipboard, without attaching. |
 
 ## Status colours
 


### PR DESCRIPTION
Pressing `y` on a session row copies the newest reply, keeping every paragraph instead of only the last message block. Continues @zavatskiy's contribution in #439.

**Merge with rebase to preserve the contributor's authored commit.** #481 has landed and this branch is rebased onto it.

## Scope

Copy the newest readable reply without entering the session or blocking the UI. Reuse the existing pane capture, tool rules and clipboard writer. The new `FullTurnText` reader shares the guarded prompt scanner with `LastUserEcho`, and the list's one-line quote keeps its existing behavior.

- Preserve paragraph breaks, tables and replies whose opening has scrolled out of capture.
- Exclude prompt echoes, known tool-result rows and their continuations, and tool chrome. Blank lines inside tool output do not end filtering.
- A pending wrapped follow-up falls back to the previous answer. For tools with message markers, entirely indented, unmarked text after a prompt needs a completed-turn marker before it is treated as an answer. While pending, it is indistinguishable from wrapped prompt text.
- Run session existence checks, capture and clipboard writes in the returned command, outside Bubble Tea's update loop.
- Preserve stored bindings: if a user's existing action owns `y`, `copy_reply` stays unbound until configured. Loading, saving and reloading retain those bindings.
- `y copy` sits in the session row legend beside `space prompt`, and stays off shell rows with the other conversation keys.

Claude's composer nudge joins its chrome rule, including migration of the old shipped rule. Custom patterns remain unchanged.

## Every supported tool copies a reply

Each tool was driven live and the copy read off its real pane.

| tool | copy |
| --- | --- |
| claude | the turn, bounded by the prompt echo |
| codex | the turn, bounded by the prompt echo |
| gemini | the turn, with its approval banner now read as chrome beside the skills count it gained |
| opencode | the turn, bounded by its gutter echo |
| command-code | the turn, bounded by its turn summary |
| hermes | the turn: it echoes prompts on a `●` row, and its titled reasoning and reply boxes read as frame |
| grok | the pane, with a warning: grok keeps no prompt in its transcript, so a turn is bounded only while its summary is in the capture |
| pi | the pane above the composer, with a warning: pi's region opens at the pane origin by design, so there is nothing else to read |
| terminal | a shell holds no reply, and says so |

A copy nothing in the pane could bound reports itself on the status bar in its own warning tone, naming the tool: the text is what is on screen rather than one answer. Three stored patterns upgrade to the current defaults (claude's composer nudge, gemini's skills count, hermes's titled boxes). Hand-edited patterns stay untouched.

Tool-result stripping is configured for Claude and Codex only. Other tools include tool output until their result markers are measured. Capture is limited to 300 history rows plus the visible pane, and alternate-screen tools such as Claude can expose only the visible screen. This adds no transcript ingestion or provider-specific API.

## Verification

- Live end to end on macOS: every tool above was launched, prompted and copied through the built binary or its captured pane, including `y` on a real session (`copied 179 chars`), on a grok row (the warning, whole pane on the clipboard), on a pi row and on a shell row.
- Focused race tests cover wrapped follow-ups on four marker-based tools, blank lines in Claude/Codex tool results, dead-session feedback, copy reporting, the bounded and unbounded copies, the legend, the warning tone and all three config upgrades, each with a drift guard.
- Full `go test -race ./...` passes on macOS with `TMUX` unset and an isolated socket directory. `gofmt -l .`, `go vet ./...` and `go build ./...` pass. Cross-builds pass for darwin/linux on amd64/arm64. Linux CI runs the same full race suite.
- The live macOS clipboard test passed and restored the previous clipboard text.

## Visual evidence

The fixes change clipboard contents and when tmux work executes. Regression tests assert the exact copied text and deferred error handling, which screenshots would not show. The live pane review verified paragraph boundaries, the warning row and the visible-screen capture limit.
