### PR TITLE
fix(keybind): let a key the file names take it from a default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,7 +47,7 @@ A `fork_command` references its source through `{id}` or `{session_file}`, so on
 
 ## Key bindings
 
-Two tables in config.toml name the keys: `[keybindings.session]` for the keys the manager keeps inside a session, and `[keybindings.list]` for the keys of its own list. Each action takes one key or a list of keys, `"none"` turns it off, and an action left out keeps its default. One key serves one action within a table.
+Two tables in config.toml name the keys: `[keybindings.session]` for the keys the manager keeps inside a session, and `[keybindings.list]` for the keys of its own list. Each action takes one key or a list of keys, `"none"` turns it off, and an action left out keeps its default. One key serves one action within a table: a key you name is yours, and an action that only held it by default gives it up and is left without one.
 
 ### Inside a session
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -835,8 +835,6 @@ func TestLoadDirRefusesAKeyTableThatCannotWork(t *testing.T) {
 		{"session", `editor = "ctrl+i"`, "ctrl+i is tab"},
 		{"session", `editor = "o"`, `"o" is a plain key, which reaches the agent`},
 		{"session", `detach = "none"`, "detach needs at least one key"},
-		{"session", `review = "f3"`, "f3 is bound to both review and editor"},
-		{"list", `kill = "n"`, "n is bound to both new_session and kill"},
 		{"list", `settings = "none"`, "settings needs at least one key"},
 		{"list", `quit = "esc"`, "stays as it is"},
 		{"list", `detach = "f9"`, `no action named "detach"`},

--- a/internal/keybind/keybind.go
+++ b/internal/keybind/keybind.go
@@ -370,10 +370,42 @@ func build(scope string, actions []Action, written map[string]Binding) (Table, e
 		}
 		table.bound[name] = written[name]
 	}
+	table.yieldDefaults(written)
 	if err := table.Validate(); err != nil {
 		return Table{}, err
 	}
 	return table, nil
+}
+
+// yieldDefaults takes a key away from the action that only holds it by
+// default, wherever the file gives that key to something else. A table
+// cannot know to move out of the way of an action added after it was
+// written, so without this the day such an action ships its default key
+// is the day everyone who spent that key is locked out of the manager,
+// and their running sessions with it. What the file asks for wins; the
+// action that yielded is left unbound, and the picker can give it a key.
+func (t Table) yieldDefaults(written map[string]Binding) {
+	claimed := make(map[string]bool, len(written))
+	for name := range written {
+		for _, key := range written[name].keys {
+			claimed[key.tea] = true
+		}
+	}
+	for _, action := range t.actions {
+		if _, spoken := written[action.Name]; spoken {
+			continue
+		}
+		bound := t.bound[action.Name].keys
+		kept := make([]Key, 0, len(bound))
+		for _, key := range bound {
+			if !claimed[key.tea] {
+				kept = append(kept, key)
+			}
+		}
+		if len(kept) != len(bound) {
+			t.bound[action.Name] = Binding{keys: kept}
+		}
+	}
 }
 
 func (t Table) names() string {

--- a/internal/keybind/keybind_test.go
+++ b/internal/keybind/keybind_test.go
@@ -184,7 +184,6 @@ func TestSessionTableRefusesASharedKeyANoneDetachAndAPlainKey(t *testing.T) {
 		t.Fatalf("defaults: %v", err)
 	}
 	for _, tc := range []struct{ text, reason string }{
-		{`review = "ctrl+q"`, "ctrl+q is bound to both detach and review"},
 		{`detach = "none"`, "detach needs at least one key"},
 		{`editor = "o"`, `keybindings.session.editor: "o" is a plain key, which reaches the agent`},
 		{`detach = "enter"`, "plain key"},
@@ -259,7 +258,6 @@ prompt = ["space", "p"]
 	}
 
 	for _, tc := range []struct{ text, reason string }{
-		{`kill = "n"`, "n is bound to both new_session and kill"},
 		{`settings = "none"`, "settings needs at least one key"},
 		{`detach = "f9"`, `no action named "detach"`},
 	} {
@@ -282,4 +280,60 @@ func TestWithLeavesTheReceiverAlone(t *testing.T) {
 	if got, _ := moved.ActionFor("Q"); got != Quit {
 		t.Errorf("moved table should quit on Q, got %q", got)
 	}
+}
+
+// A key the file spends is the file's: the action that only held it by
+// default gives it up and is left unbound. Without that, the day an
+// action ships a default key every table that already spent it stops
+// the manager from opening, over a table its author could not have
+// written any other way.
+func TestAWrittenKeyTakesItFromADefault(t *testing.T) {
+	file, err := decode(t, "[list]\nkill = \"n\"\n")
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	list, err := ListTable(file.List)
+	if err != nil {
+		t.Fatalf("ListTable: %v", err)
+	}
+	if action, ok := list.ActionFor("n"); !ok || action != Kill {
+		t.Fatalf("n = %q ok=%v, want kill", action, ok)
+	}
+	if keys := list.Binding(NewSession).Keys(); len(keys) != 0 {
+		t.Fatalf("new_session = %v, want it to have yielded n", keys)
+	}
+	// Only the key it lost: an action with a second default keeps it.
+	session, err := decodeSession(t, "review = \"ctrl+q\"")
+	if err != nil {
+		t.Fatalf("SessionTable: %v", err)
+	}
+	if action, ok := session.ActionFor("ctrl+q"); !ok || action != Review {
+		t.Fatalf("ctrl+q = %q ok=%v, want review", action, ok)
+	}
+	if action, ok := session.ActionFor(`ctrl+\`); !ok || action != Detach {
+		t.Fatalf(`ctrl+\ = %q ok=%v, want detach to keep it`, action, ok)
+	}
+}
+
+// Yielding cannot empty an action the manager needs a key for: taking
+// every key detach holds is still refused, so there is always a way back
+// from a focused session.
+func TestYieldingCannotStrandTheUser(t *testing.T) {
+	file, err := decode(t, "[session]\nreview = \"ctrl+q\"\neditor = \"ctrl+\\\\\"\n")
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, err := SessionTable(file.Session); err == nil ||
+		!strings.Contains(err.Error(), "detach needs at least one key") {
+		t.Fatalf("err = %v, want detach to be protected", err)
+	}
+}
+
+func decodeSession(t *testing.T, text string) (Table, error) {
+	t.Helper()
+	file, err := decode(t, "[session]\n"+text)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return SessionTable(file.Session)
 }


### PR DESCRIPTION
A `[keybindings]` table that spends a key on one action collided with another action's default, and the manager refused to open: `config.Load` returned the error, `run()` returned it, `main` printed it and exited, with the user's sessions still running behind it.

Nobody can write that table any other way. An action added after the file was written cannot be moved out of the way in advance, so the day such an action ships a default key is the day everyone already spending it is locked out. `keysBlock` writes every action into `config.toml`, so the people most exposed are the ones who have used the picker.

Found while reviewing #480 (feat(ui): copy a session's newest reply with y), which adds `copy_reply` on `y`:

```
keybindings.list: y is bound to both copy_reply and archive
```

## What changes

What the file names wins. The action that held the key only by default gives it up and is left unbound, where the picker can give it another one.

```toml
[keybindings.list]
kill = "n"     # n kills; new_session is left without a key
```

An action with a second default keeps it, so `review = "ctrl+q"` leaves `detach` on `ctrl+\`. An action the manager needs a key for is still refused when nothing is left: `detach` keeps the way back from a focused session, `settings` keeps the way to the picker. Every other reason a table is refused is unchanged, wording included.

The picker is untouched. It still names what would move and asks, which a file cannot do.

## Two tables now resolve that used to be refused

`kill = "n"` against `new_session`, and `review = "ctrl+q"` against `detach`. The tests that pinned those errors pin the yield instead, plus a new one proving a yield cannot strand the user by emptying `detach`.

## What this replaces

The first version of this PR fell the whole scope back to its defaults and put the reason on the error bar. Review found that loses data: the picker then shows defaults, and `keysBlock` writes every action, so the first save overwrites the user's stored table. Verified on a table holding `fork = "ctrl+f"` and `rename = "ctrl+n"` beside the colliding key - both were gone from `config.toml` after one save. It also dead-ended the repair path, since `SaveKeys` validates both scopes and a broken session table made every list save fail.

Resolving the collision where it arises keeps the user's whole table, leaves only the new action unbound, and needs none of that machinery.

## Still out of scope

A key spec that never becomes a binding (`ctrl+i is tab`, `esc stays as it is`) fails during TOML decode, before any table exists, so it still stops the manager. The same upgrade dynamic applies there the day a release reserves a spelling it used to accept. Closing that means deferring key parsing off `Binding.UnmarshalTOML`, which reshapes what the picker reads; worth its own change.
