### PR TITLE
Add Junie to supported tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Not here yet: cost tracking and mouse-driven list navigation.
 
 ## Supported tools
 
-Status detection supports **Claude Code**, **OpenCode**, **Codex**, **Grok Build**, **Gemini CLI**, **Pi**, **Command Code**, and **Hermes Agent** by default. Other CLI tools can run as sessions. Add a `[tools.<name>]` block to give another tool live status rules (see [Configuration](docs/configuration.md)).
+Status detection supports **Claude Code**, **OpenCode**, **Codex**, **Grok Build**, **Gemini CLI**, **Pi**, **Command Code**, **Hermes Agent**, and **Junie** by default. Other CLI tools can run as sessions. Add a `[tools.<name>]` block to give another tool live status rules (see [Configuration](docs/configuration.md)).
 
 ## Install
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -866,4 +866,22 @@ rules = [
   { state = "working", pattern = "(?m)^ [·○◇☆✧⌘] [^\\n]*?(?:esc to interrupt[ \\t]*•[ \\t]*[\\dhms. ]*[\\ds]| [\\dhms. ]*[\\ds])([ \\t]*•[ \\t]*[↓↑] [\\d.]+k?)?$" },
   { state = "errored", pattern = "(?im)^\\s*(?:⚠ )?Error:" },
 ]
+
+[tools.junie]
+command = "junie"
+# Junie is JetBrains' agentic coding CLI (https://junie.jetbrains.com). Its
+# interactive TUI offers the next prompt on a "> " composer row, streams a
+# "Working…" status while a turn runs, and asks to approve risky actions with
+# an "Always allow" option. These rules follow Junie's documented TUI
+# behaviour; refine them against a live session if the maintainers prefer.
+default_status = "idle"
+# the composer row: "> " when Junie is idle and ready for the next prompt
+activity_cutoff = "(?m)^\\s*> "
+input_prefix = "(?m)^\\s*> "
+rules = [
+  # permission prompt: Junie offers "Always allow" while it waits for approval
+  { state = "waiting", pattern = "Always allow" },
+  # active turn: Junie streams a "Working…" status while the agent runs
+  { state = "working", pattern = "Working(?:…|\\.\\.\\.)" },
+]
 `


### PR DESCRIPTION
## Add Junie to agent-manager

Hi, and thanks for maintaining agent-manager! 👋

This PR adds **Junie** to your **Supported tools** list (with a matching `[tools.junie]` status-detection block).

### What is Junie?

[Junie](https://junie.jetbrains.com) is JetBrains' agentic coding tool. It provides an interactive terminal CLI and a [GitHub Action](https://github.com/JetBrains/junie-github-action) for autonomous, headless runs, and integrates with JetBrains IDEs. It works across many languages and stacks and can be driven both interactively and non-interactively (CI/CD).

### Why it fits here

agent-manager runs any AI coding CLI in its own persistent tmux session and shows each one's live status side by side — Junie is exactly that kind of interactive coding CLI, so it belongs alongside Claude Code, Codex, Gemini CLI, Pi, and the others.

### What this PR changes

- Adds a `[tools.junie]` block to the built-in default config (`internal/config/config.go`) so Junie gets live status detection by default, matching the shape of the existing tool blocks.
- Lists **Junie** in the README **Supported tools** section.
- The change is intentionally **minimal** — no unrelated edits.

The status rules follow Junie's documented TUI behaviour: a `> ` composer row when idle, a `Working…` status while a turn runs, and an `Always allow` option on its approval prompt. They're a good starting point — please feel free to refine the regexes against a live Junie session to match your detection conventions exactly.

### Notes

- This is a **proposal** — please review and adjust as you see fit; feel free to request changes or tweak wording/rules to match your conventions.
- Links: [junie.jetbrains.com](https://junie.jetbrains.com) · [docs](https://www.jetbrains.com/help/junie/) · [Junie GitHub Action](https://github.com/JetBrains/junie-github-action)

Thanks for considering it! 🙌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default status detection support for the Junie CLI.
  * Junie activity is now recognized as idle, waiting for approval, or working based on its displayed status.
  * Listed Junie among the supported tools in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->