### PR TITLE
fix(notify): restore macOS notification sounds

### DIFF
--- a/internal/notify/helper_darwin_test.go
+++ b/internal/notify/helper_darwin_test.go
@@ -3,6 +3,7 @@
 package notify
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,60 @@ import (
 	"testing"
 	"time"
 )
+
+func TestInstallHelperSound(t *testing.T) {
+	for _, kind := range []Kind{Waiting, Finished, Errored} {
+		detail, _ := describe(kind)
+		t.Run(detail.macSound, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			name, err := installHelperSound(detail.macSound)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := "agent-manager-" + detail.macSound + ".aiff"; name != want {
+				t.Fatalf("sound name = %q, want %q", name, want)
+			}
+			path := filepath.Join(home, "Library", "Sounds", name)
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := os.ReadFile(filepath.Join("/System/Library/Sounds", detail.macSound+".aiff"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatal("installed sound differs from the system sound")
+			}
+			installed := time.Unix(1000, 0)
+			if err := os.Chtimes(path, installed, installed); err != nil {
+				t.Fatal(err)
+			}
+			if reused, err := installHelperSound(detail.macSound); err != nil || reused != name {
+				t.Fatalf("reuse sound = %q, %v", reused, err)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !info.ModTime().Equal(installed) {
+				t.Fatal("existing sound was rewritten")
+			}
+		})
+	}
+}
+
+func TestInstallHelperSoundWriteFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "Library"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installHelperSound("Funk"); err == nil {
+		t.Fatal("install succeeded with a file blocking the sound directory")
+	}
+}
 
 // The bundle built by the live test holds a copy of this test binary, and
 // a clicked banner relaunches that copy with no arguments. Handing it to
@@ -40,8 +95,13 @@ func TestHelperPostsLiveBanner(t *testing.T) {
 	}
 	defer restore()()
 	configDir = func() (string, error) { return dir, nil }
-	if err := postThroughHelper("live-session", "live-test · codex", "● Finished", "Hero"); err != nil {
-		t.Fatalf("post through helper: %v", err)
+	for _, kind := range []Kind{Waiting, Finished, Errored} {
+		detail, _ := describe(kind)
+		t.Run(detail.macSound, func(t *testing.T) {
+			if err := postThroughHelper("live-session", "live-test · codex", detail.body, detail.macSound); err != nil {
+				t.Fatalf("post through helper: %v", err)
+			}
+		})
 	}
 	source, err := os.Executable()
 	if err != nil {

--- a/internal/notify/mac_darwin.go
+++ b/internal/notify/mac_darwin.go
@@ -20,6 +20,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/YoanWai/agent-manager/internal/atomicfile"
 	"github.com/ebitengine/purego"
 	"github.com/ebitengine/purego/objc"
 )
@@ -53,8 +54,6 @@ const (
 	versionRetention = 7 * 24 * time.Hour
 )
 
-var helperSounds = []string{"Funk", "Hero", "Basso"}
-
 var materializeMu sync.Mutex
 
 func postThroughHelper(sessionID, subtitle, body, sound string) error {
@@ -74,6 +73,10 @@ func postThroughHelper(sessionID, subtitle, body, sound string) error {
 }
 
 func runHelper(dir, sessionID, subtitle, body, sound string) error {
+	soundName, err := installHelperSound(sound)
+	if err != nil {
+		return err
+	}
 	helper, err := materializeHelper(dir)
 	if err != nil {
 		return err
@@ -81,7 +84,7 @@ func runHelper(dir, sessionID, subtitle, body, sound string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), helperTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, helper, "post",
-		"agent-manager", subtitle, body, sound+".aiff", getenv("__CFBundleIdentifier"),
+		"agent-manager", subtitle, body, soundName, getenv("__CFBundleIdentifier"),
 		sessionID, strconv.Itoa(os.Getpid()))
 	err = cmd.Run()
 	var exit *exec.ExitError
@@ -89,6 +92,30 @@ func runHelper(dir, sessionID, subtitle, body, sound string) error {
 		return errDenied
 	}
 	return err
+}
+
+// Notification Center can resolve the bundle ID to an older helper, so
+// sounds live in the user's Library/Sounds independently of helper builds.
+func installHelperSound(sound string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	name := "agent-manager-" + sound + ".aiff"
+	path := filepath.Join(home, "Library", "Sounds", name)
+	if _, err := os.Stat(path); err == nil {
+		return name, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	data, err := os.ReadFile(filepath.Join("/System/Library/Sounds", sound+".aiff"))
+	if err != nil {
+		return "", err
+	}
+	if err := atomicfile.WriteFile(path, data, 0o644); err != nil {
+		return "", err
+	}
+	return name, nil
 }
 
 // helperHome keeps the builds of one installed binary apart from every
@@ -198,12 +225,6 @@ func buildHelper(bundle, source, stamp string) error {
 	}
 	if err := copyFile(source, filepath.Join(macos, helperExecutable), 0o755); err != nil {
 		return err
-	}
-	for _, sound := range helperSounds {
-		name := sound + ".aiff"
-		if err := copyFile(filepath.Join("/System/Library/Sounds", name), filepath.Join(resources, name), 0o644); err != nil {
-			return err
-		}
 	}
 	if err := os.WriteFile(filepath.Join(resources, "agent-manager.icns"), helperIcon, 0o644); err != nil {
 		return err


### PR DESCRIPTION
## What changed

Restore Funk, Hero, and Basso for macOS notifications by installing namespaced copies in `~/Library/Sounds` and passing those filenames to the notification helper. Sounds are written atomically, reused on later notifications, and no longer copied into each helper bundle.

## Why

Banners appeared without sound because Notification Center resolved the shared bundle ID to an older helper. Logs showed it trying to open `Hero.aiff` in an old test bundle and failing with audio service error `-1500`, even though a different helper had posted the banner.

## Scope

### Required behavior

Waiting, finished, and errored notifications retain their distinct sounds across helper upgrades and multiple installs. Existing banner delivery, notification permissions, and click handling continue to use the same helper.

### Why this approach

The user's sound directory gives every helper version the same sound location. The `agent-manager-` prefix keeps the filenames specific to this app. Live playback confirmed that the original system AIFF files work without conversion.

## How it was verified

- [x] `gofmt -l .` prints nothing
- [x] `go vet ./...` passes
- [x] `env -u TMUX TMUX_TMPDIR=/tmp/amsound-race go test -race ./...` passes, with the socket directory explicitly created first
- [x] `go build ./...` passes
- [x] Built all release targets: macOS/Linux, arm64/amd64, with `CGO_ENABLED=0`
- [x] Posted real notifications through the helper for all three states; Notification Center logs confirmed playback of `agent-manager-Funk.aiff`, `agent-manager-Hero.aiff`, and `agent-manager-Basso.aiff`
- [x] Added tests for all three sound installations, reuse, and installation failure; expanded the opt-in live banner test to cover all three sounds

The first full-suite runs collided on tmux test sockets because their requested directories did not exist. After creating the isolated directory, the full race suite passed. Live verification was on macOS arm64. Linux and macOS amd64 were cross-built, not runtime-tested. The change is confined to the shared macOS notification backend and does not add provider-specific behavior.

## Visual evidence

**Not applicable because:** the visible banners are unchanged; the regression is audible. Before the fix, Notification Center logged `Couldn't create audio service reference` for an old helper's `Hero.aiff` with error `-1500`. After the fix, it logged `Playing sound agent-manager-Hero.aiff`, with equivalent successful playback entries for Funk and Basso.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS notifications now provide distinct live banners and sounds for waiting, finished, and errored states.
  * Notification sounds are installed for system-wide reuse and preserved when already available.

* **Bug Fixes**
  * Improved handling when notification sound installation cannot write to the sound directory, with an appropriate error reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->