### PR TITLE
docs(feed): announce v0.37.0

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "tools-from-the-binary-v0370",
+    "banner": "new: tool rules come with the release",
+    "title": "v0.37.0: tool rules come with the release. Were you using a custom block?",
+    "body": [
+      "Command and status rules for every CLI now come from the release, not from [tools.*] in config.toml.",
+      "A leftover block is ignored and listed until you dismiss the notice. Nothing on disk is rewritten. T opens $SHELL.",
+      "The thread this entry opens is for people who had a custom tool block, or who want a CLI added.",
+      "Update with `agent-manager update`, `brew upgrade yoanwai/tap/agent-manager`, or your package manager."
+    ],
+    "url": "https://github.com/YoanWai/agent-manager/discussions/492",
+    "max_version": "0.37.0"
+  },
+  {
     "id": "keys-are-yours-v0360",
     "banner": "new: every key is configurable",
     "title": "v0.36.0: set your own keys, and tell us which defaults should change",


### PR DESCRIPTION
## What changed

One entry at the top of `docs/messages.json` for v0.37.0: it opens discussion #492 (tool rules now come with the release) and retires at `max_version` 0.37.0.

## Why

Running installs read the feed every 10 minutes; without an entry the release conversation has no way in from the app.

## Scope

### Required behavior

v0.36.0 and v0.37.0 installs see the entry. A later patch or minor does not. `dev` builds do not, because that version string does not parse.

### Why this approach

Same shape as the v0.36.0 entry: newest first, discussion URL, bounded so it retires.

## How it was verified

- [x] `TestShippedFeedFileIsRenderableAndRetires` passes against the edited file
- [x] sanitize at `0.36.0` and `0.37.0` serves the entry; `0.37.1`, `0.38.0`, and `dev` hide it
- [x] every body line under 120 chars, banner 37, title 73
- [ ] `go test -race ./...` (feed JSON only)
- [ ] Ran it against real sessions
- [x] Holds for every supported agent CLI and platform, or the description names what it leaves out

## Visual evidence

**Not applicable because:** this is a JSON feed entry. The in-app messages panel renders it from the file; the discussion is the destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the v0.37.0 release message.
  - Clarified that CLI command and status rules are now provided by the release instead of custom tool configuration.
  - Existing custom configuration blocks are ignored and surfaced for review until dismissed.
  - Confirmed that configuration files are not rewritten automatically.
  - Included instructions for shell access, discussion, and updating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->