### PR TITLE
docs(feed): drop the v0.37.0 entry that restated the release highlights

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -1,18 +1,5 @@
 [
   {
-    "id": "tools-from-the-binary-v0370",
-    "banner": "new: tool rules come with the release",
-    "title": "v0.37.0: tool rules come with the release. Were you using a custom block?",
-    "body": [
-      "Command and status rules for every CLI now come from the release, not from [tools.*] in config.toml.",
-      "A leftover block is ignored and listed until you dismiss the notice. Nothing on disk is rewritten. T opens $SHELL.",
-      "The thread this entry opens is for people who had a custom tool block, or who want a CLI added.",
-      "Update with `agent-manager update`, `brew upgrade yoanwai/tap/agent-manager`, or your package manager."
-    ],
-    "url": "https://github.com/YoanWai/agent-manager/discussions/492",
-    "max_version": "0.37.0"
-  },
-  {
     "id": "keys-are-yours-v0360",
     "banner": "new: every key is configurable",
     "title": "v0.36.0: set your own keys, and tell us which defaults should change",


### PR DESCRIPTION
## What changed

Removes the `tools-from-the-binary-v0370` entry from `docs/messages.json\).

## Why

The entry restated the v0.37.0 Highlights mechanics plus update instructions, so running installs saw the same tool-rules message twice: once in the update notice, once as a feed row, each popping the messages modal. Release notes keep all 6 highlights and all 6 thanks lines; discussion #492 stays open for custom-block users.

## Scope

### Required behavior

One announcement per message: the update notice carries Highlights and Thank you, the feed carries only non-release information.

### Why this approach

Revert of #493, 13-line deletion, no id changes, no bounds changes. Remaining entries untouched.

## How it was verified

- [x] `gofmt -l docs internal/feed` prints nothing
- [ ] `go vet ./...` passes
- [x] `go test ./internal/feed/` passes (TestShippedFeedFileIsRenderableAndRetires green)
- [ ] `go test -race ./...` passes
- [ ] Ran it against real sessions
- [x] Holds for every supported agent CLI and platform: feed payload only, no tool or platform surface

## Visual evidence

**Not applicable because:** JSON deletion, no visual state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an outdated release message about tool rules moving from configuration into the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->