### PR TITLE
docs(feed): announce v0.37.0 highlights with per-row thanks

### DIFF
--- a/docs/messages.json
+++ b/docs/messages.json
@@ -1,5 +1,22 @@
 [
   {
+    "id": "v0370-release-highlights",
+    "banner": "v0.37.0 release highlights:",
+    "title": "v0.37.0 release highlights:",
+    "body": [
+      "Features:",
+      "• Tool settings now ship with the update; custom [tools.*] blocks are ignored. Thanks @pandysp.",
+      "• Pressing y copies the session's newest reply. Thanks @zavatskiy.",
+      "• Hermes without its MCP SDK gets a pip install offer.",
+      "• A key you set keeps working when new defaults arrive. Thanks @pandysp.",
+      "Bugs fixed:",
+      "• macOS notification sounds play again.",
+      "• Left leaves a working pi, and grok in minimal mode. Thanks @pandysp."
+    ],
+    "url": "https://github.com/YoanWai/agent-manager/releases/tag/v0.37.0",
+    "max_version": "0.37.0"
+  },
+  {
     "id": "keys-are-yours-v0360",
     "banner": "new: every key is configurable",
     "title": "v0.36.0: set your own keys, and tell us which defaults should change",


### PR DESCRIPTION
## What changed

Prepends a `v0370-release-highlights` entry to `docs/messages.json`.

## Why

Follows the removal of the duplicative entry in #494: one feed row carrying the v0.37.0 highlights with Features/Bugs sections and per-row thanks, retiring at `max_version 0.37.0`.

## Scope

### Required behavior

Running installs on v0.37.0 and below see the highlights row with thanks next to each contributor row.

### Why this approach

New id (the removed id stays burned for anyone who dismissed it). 8 body lines at cap, longest 95 chars, release-tag url, no update instructions.

## How it was verified

- [x] `go test ./internal/feed/` passes (TestShippedFeedFileIsRenderableAndRetires green)
- [x] `gofmt -l .` prints nothing, `go vet ./internal/feed/` clean
- [ ] `go test -race ./...` passes
- [ ] Ran it against real sessions
- [x] Holds for every supported agent CLI and platform: feed payload only

## Visual evidence

**Not applicable because:** JSON payload, no visual state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tool settings are now included with the update; custom `[tools.*]` blocks are ignored.
  - Press `y` to copy the session’s newest reply.
  - Hermes can be installed with pip without the MCP SDK.
  - User-configured keys persist when new defaults are added.

- **Bug Fixes**
  - macOS notification sounds play correctly again.
  - The Left Arrow key works reliably with pi and grok in minimal mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->